### PR TITLE
Replace claude-3-sonnet with claude-3-haiku-20240307 in docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ReqLLM.put_key(:anthropic_api_key, "sk-ant-...")
 # Application: Application.put_env(:req_llm, :anthropic_api_key, "sk-ant-...")
 # .env files are auto-loaded via JidoKeys integration
 
-model = "anthropic:claude-3-sonnet"
+model = "anthropic:claude-3-haiku-20240307"
 
 # Simple text generation
 ReqLLM.generate_text!(model, "Hello world")
@@ -190,7 +190,7 @@ context = ReqLLM.Context.new([
   ReqLLM.Context.system("You are a helpful assistant"),  
   ReqLLM.Context.user("Hello!")
 ])
-model = ReqLLM.Model.from!("anthropic:claude-3-sonnet")
+model = ReqLLM.Model.from!("anthropic:claude-3-haiku-20240307")
 
 # Option 1: Use provider's prepare_request (recommended)
 {:ok, request} = Anthropic.prepare_request(:chat, model, context, temperature: 0.7)

--- a/guides/api-reference.md
+++ b/guides/api-reference.md
@@ -17,12 +17,12 @@ Returns a canonical ReqLLM.Response with usage data, context, and metadata.
 **Examples:**
 ```elixir
 # Simple text generation
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello world")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello world")
 ReqLLM.Response.text(response)  # => "Hello! How can I assist you today?"
 
 # With options
 {:ok, response} = ReqLLM.generate_text(
-  "anthropic:claude-3-sonnet", 
+  "anthropic:claude-3-haiku-20240307", 
   "Write a haiku",
   temperature: 0.8,
   max_tokens: 100
@@ -33,7 +33,7 @@ ctx = ReqLLM.context([
   ReqLLM.Context.system("You are a helpful assistant"),
   ReqLLM.Context.user("What's 2+2?")
 ])
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", ctx)
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", ctx)
 ```
 
 ### generate_text!/3
@@ -46,7 +46,7 @@ Generate text returning only the text content.
 
 **Examples:**
 ```elixir
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello")
 # => "Hello! How can I assist you today?"
 ```
 
@@ -62,7 +62,7 @@ Returns a canonical ReqLLM.Response containing usage data and stream.
 
 **Examples:**
 ```elixir
-{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell me a story")
 ReqLLM.Response.text_stream(response) |> Enum.each(&IO.write/1)
 
 # Access usage after streaming
@@ -79,7 +79,7 @@ Stream text generation returning only the stream.
 
 **Examples:**
 ```elixir
-ReqLLM.stream_text!("anthropic:claude-3-sonnet", "Count to 10")
+ReqLLM.stream_text!("anthropic:claude-3-haiku-20240307", "Count to 10")
 |> Enum.each(&IO.write/1)
 ```
 
@@ -101,7 +101,7 @@ schema = [
   name: [type: :string, required: true],
   age: [type: :pos_integer, required: true]
 ]
-{:ok, response} = ReqLLM.generate_object("anthropic:claude-3-sonnet", "Generate a person", schema)
+{:ok, response} = ReqLLM.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
 ```
 
 ### generate_object!/4
@@ -164,14 +164,14 @@ ReqLLM accepts flexible model specifications:
 ### String Format
 ```elixir
 "provider:model"
-"anthropic:claude-3-sonnet"
+"anthropic:claude-3-haiku-20240307"
 "openai:gpt-4o"
 "ollama:llama3"
 ```
 
 ### Tuple Format
 ```elixir
-{:anthropic, "claude-3-sonnet", temperature: 0.7}
+{:anthropic, "claude-3-haiku-20240307", temperature: 0.7}
 {:openai, "gpt-4o", max_tokens: 1000}
 ```
 
@@ -179,7 +179,7 @@ ReqLLM accepts flexible model specifications:
 ```elixir
 %ReqLLM.Model{
   provider: :anthropic,
-  model: "claude-3-sonnet", 
+  model: "claude-3-haiku-20240307", 
   temperature: 0.7,
   max_tokens: 1000
 }
@@ -210,7 +210,7 @@ ReqLLM accepts flexible model specifications:
 ctx = ReqLLM.context("Hello")
 
 {:ok, response} = ReqLLM.generate_text(
-  "anthropic:claude-3-sonnet",
+  "anthropic:claude-3-haiku-20240307",
   ctx,
   temperature: 0.8,
   max_tokens: 500,
@@ -266,7 +266,7 @@ weather_tool = ReqLLM.tool(
 )
 
 {:ok, response} = ReqLLM.generate_text(
-  "anthropic:claude-3-sonnet",
+  "anthropic:claude-3-haiku-20240307",
   "What's the weather in Paris?",
   tools: [weather_tool]
 )

--- a/guides/core-concepts.md
+++ b/guides/core-concepts.md
@@ -116,7 +116,7 @@ request = Req.new()
 |> Req.Request.append_request_steps(log_request: &log_request/1)
 |> Req.Request.append_response_steps(cache_response: &cache/1)
 
-{:ok, configured} = ReqLLM.attach(request, "anthropic:claude-3-sonnet")
+{:ok, configured} = ReqLLM.attach(request, "anthropic:claude-3-haiku-20240307")
 {:ok, response} = Req.request(configured)
 ```
 
@@ -150,10 +150,10 @@ Transport vs Format separation:
 
 ```elixir
 # API call
-ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 
 # Model resolution  
-{:ok, model} = ReqLLM.Model.from("anthropic:claude-3-sonnet")
+{:ok, model} = ReqLLM.Model.from("anthropic:claude-3-haiku-20240307")
 
 # Provider lookup
 {:ok, provider} = ReqLLM.provider(:anthropic)
@@ -171,7 +171,7 @@ ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
 ### Streaming Flow
 
 ```elixir
-{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell a story")
+{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell a story")
 # Returns %ReqLLM.Response{stream?: true, stream: #Stream<...>}
 
 response.stream

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -15,10 +15,10 @@ end
 ```elixir
 # Configure your API key 
 ReqLLM.put_key(:anthropic_api_key, "sk-ant-...")
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello")
 # Returns: "Hello! How can I assist you today?"
 
-ReqLLM.stream_text!("anthropic:claude-3-sonnet", "Tell me a story")
+ReqLLM.stream_text!("anthropic:claude-3-haiku-20240307", "Tell me a story")
 |> Enum.each(&IO.write/1)
 ```
 
@@ -29,14 +29,14 @@ schema = [
   name: [type: :string, required: true],
   age: [type: :pos_integer, required: true]
 ]
-{:ok, object} = ReqLLM.generate_object("anthropic:claude-3-sonnet", "Generate a person", schema)
+{:ok, object} = ReqLLM.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
 # Returns: %{name: "John Doe", age: 30}
 ```
 
 ## Full Response with Usage
 
 ```elixir
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 text = ReqLLM.Response.text(response)
 usage = ReqLLM.Response.usage(response)
 # usage => %{input_tokens: 10, output_tokens: 8}
@@ -45,9 +45,9 @@ usage = ReqLLM.Response.usage(response)
 ## Model Specifications
 
 ```elixir
-"anthropic:claude-3-sonnet"
-{:anthropic, "claude-3-sonnet", temperature: 0.7}
-%ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet", temperature: 0.7}
+"anthropic:claude-3-haiku-20240307"
+{:anthropic, "claude-3-haiku-20240307", temperature: 0.7}
+%ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307", temperature: 0.7}
 ```
 
 ## Key Management
@@ -81,14 +81,14 @@ messages = [
   ReqLLM.Context.system("You are a helpful coding assistant"),
   ReqLLM.Context.user("Write a function to reverse a list")
 ]
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", messages)
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", messages)
 ```
 
 ## Common Options
 
 ```elixir
 ReqLLM.generate_text!(
-  "anthropic:claude-3-sonnet",
+  "anthropic:claude-3-haiku-20240307",
   "Write code",
   temperature: 0.1,      # Control randomness (0.0-2.0)
   max_tokens: 1000       # Limit response length

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -168,17 +168,17 @@ defmodule ReqLLM do
   ## Parameters
 
     * `model_spec` - Model specification in various formats:
-      - String format: `"anthropic:claude-3-sonnet"`
-      - Tuple format: `{:anthropic, "claude-3-sonnet", temperature: 0.7}`
+      - String format: `"anthropic:claude-3-haiku-20240307"`
+      - Tuple format: `{:anthropic, "claude-3-haiku-20240307", temperature: 0.7}`
       - Model struct: `%ReqLLM.Model{}`
 
   ## Examples
 
-      ReqLLM.model("anthropic:claude-3-sonnet")
-      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet"}}
+      ReqLLM.model("anthropic:claude-3-haiku-20240307")
+      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307"}}
 
-      ReqLLM.model({:anthropic, "claude-3-sonnet", temperature: 0.5})
-      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet", temperature: 0.5}}
+      ReqLLM.model({:anthropic, "claude-3-haiku-20240307", temperature: 0.5})
+      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307", temperature: 0.5}}
 
   """
   @spec model(String.t() | {atom(), keyword()} | struct()) :: {:ok, struct()} | {:error, term()}
@@ -216,7 +216,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello world")
+      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello world")
       ReqLLM.Response.text(response)
       #=> "Hello! How can I assist you today?"
 
@@ -240,7 +240,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello world")
+      ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello world")
       #=> "Hello! How can I assist you today?"
 
   """
@@ -258,7 +258,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+      {:ok, response} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell me a story")
       ReqLLM.Response.text_stream(response) |> Enum.each(&IO.write/1)
 
       # Access usage metadata after streaming
@@ -281,7 +281,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.stream_text!("anthropic:claude-3-sonnet", "Tell me a story")
+      ReqLLM.stream_text!("anthropic:claude-3-haiku-20240307", "Tell me a story")
       |> Enum.each(&IO.write/1)
 
   """
@@ -319,12 +319,12 @@ defmodule ReqLLM do
         name: [type: :string, required: true],
         age: [type: :pos_integer, required: true]
       ]
-      {:ok, object} = ReqLLM.generate_object("anthropic:claude-3-sonnet", "Generate a person", schema)
+      {:ok, object} = ReqLLM.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
       #=> {:ok, %{name: "John Doe", age: 30}}
 
       # Generate an array of objects
       {:ok, objects} = ReqLLM.generate_object(
-        "anthropic:claude-3-sonnet",
+        "anthropic:claude-3-haiku-20240307",
         "Generate 3 heroes",
         schema,
         output: :array
@@ -345,7 +345,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.generate_object!("anthropic:claude-3-sonnet", "Generate a person", schema)
+      ReqLLM.generate_object!("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
       #=> %{name: "John Doe", age: 30}
 
   """
@@ -375,7 +375,7 @@ defmodule ReqLLM do
         name: [type: :string, required: true],
         description: [type: :string, required: true]
       ]
-      {:ok, stream} = ReqLLM.stream_object("anthropic:claude-3-sonnet", "Generate a character", schema)
+      {:ok, stream} = ReqLLM.stream_object("anthropic:claude-3-haiku-20240307", "Generate a character", schema)
       stream |> Enum.each(&IO.inspect/1)
 
   """
@@ -394,7 +394,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.stream_object!("anthropic:claude-3-sonnet", "Generate a character", schema)
+      ReqLLM.stream_object!("anthropic:claude-3-haiku-20240307", "Generate a character", schema)
       |> Enum.each(&IO.inspect/1)
 
   """

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -146,7 +146,7 @@ defmodule ReqLLM.Context do
   ## Parameters
 
     * `context` - A `ReqLLM.Context` to encode
-    * `model` - Model specification (Model struct or string like "anthropic:claude-3-sonnet")
+    * `model` - Model specification (Model struct or string like "anthropic:claude-3-haiku-20240307")
 
   ## Returns
 
@@ -156,7 +156,7 @@ defmodule ReqLLM.Context do
   ## Examples
 
       # Zero-ceremony encoding with model string
-      Context.encode_request(context, "anthropic:claude-3-sonnet")
+      Context.encode_request(context, "anthropic:claude-3-haiku-20240307")
       #=> %{system: "...", messages: [...], max_tokens: 4096}
 
       # Encoding with Model struct

--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -73,7 +73,7 @@ defmodule ReqLLM.Embedding do
       ReqLLM.Embedding.validate_model("openai:text-embedding-3-small")
       #=> {:ok, %ReqLLM.Model{provider: :openai, model: "text-embedding-3-small"}}
 
-      ReqLLM.Embedding.validate_model("anthropic:claude-3-sonnet")
+      ReqLLM.Embedding.validate_model("anthropic:claude-3-haiku-20240307")
       #=> {:error, :embedding_not_supported}
 
   """

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -132,7 +132,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.generate_text("anthropic:claude-3-sonnet", "Hello world")
+      {:ok, response} = ReqLLM.Generation.generate_text("anthropic:claude-3-haiku-20240307", "Hello world")
       ReqLLM.Response.text(response)
       #=> "Hello! How can I assist you today?"
 
@@ -179,7 +179,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.generate_text!("anthropic:claude-3-sonnet", "Hello world")
+      ReqLLM.Generation.generate_text!("anthropic:claude-3-haiku-20240307", "Hello world")
       #=> "Hello! How can I assist you today?"
 
   """
@@ -207,7 +207,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+      {:ok, response} = ReqLLM.Generation.stream_text("anthropic:claude-3-haiku-20240307", "Tell me a story")
       ReqLLM.Response.text_stream(response) |> Enum.each(&IO.write/1)
 
       # Access usage metadata after streaming
@@ -254,7 +254,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.stream_text!("anthropic:claude-3-sonnet", "Tell me a story")
+      ReqLLM.Generation.stream_text!("anthropic:claude-3-haiku-20240307", "Tell me a story")
       |> Enum.each(&IO.write/1)
 
   """
@@ -383,7 +383,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.generate_object("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      {:ok, response} = ReqLLM.Generation.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       ReqLLM.Response.object(response)
       #=> %{name: "Alice Smith", age: 30, occupation: "Engineer"}
 
@@ -444,7 +444,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.stream_object("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      {:ok, response} = ReqLLM.Generation.stream_object("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       ReqLLM.Response.object_stream(response) |> Enum.each(&IO.inspect/1)
 
       # Access usage metadata after streaming
@@ -493,7 +493,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.generate_object!("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      ReqLLM.Generation.generate_object!("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       #=> %{name: "Alice Smith", age: 30, occupation: "Engineer"}
 
   """
@@ -523,7 +523,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.stream_object!("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      ReqLLM.Generation.stream_object!("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       |> Enum.each(&IO.inspect/1)
 
   """

--- a/lib/req_llm/keys.ex
+++ b/lib/req_llm/keys.ex
@@ -17,7 +17,7 @@ defmodule ReqLLM.Keys do
       ReqLLM.put_key(:anthropic_api_key, "sk-ant-...")
       
       # Works with models (extracts provider automatically)
-      model = ReqLLM.Model.from("anthropic:claude-3-sonnet")
+      model = ReqLLM.Model.from("anthropic:claude-3-haiku-20240307")
       key = ReqLLM.Keys.get!(model)
 
       # Per-request override (highest priority)

--- a/lib/req_llm/model.ex
+++ b/lib/req_llm/model.ex
@@ -18,7 +18,7 @@ defmodule ReqLLM.Model do
       {:ok, model} = ReqLLM.Model.from("anthropic:claude-3-5-sonnet")
 
       # Create a model directly
-      model = ReqLLM.Model.new(:anthropic, "claude-3-sonnet", temperature: 0.5, max_tokens: 1000)
+      model = ReqLLM.Model.new(:anthropic, "claude-3-haiku-20240307", temperature: 0.5, max_tokens: 1000)
 
   """
 
@@ -57,7 +57,7 @@ defmodule ReqLLM.Model do
   ## Parameters
 
   - `provider` - The provider atom (e.g., `:anthropic`)
-  - `model` - The model name string (e.g., `"gpt-4"`, `"claude-3-sonnet"`)
+  - `model` - The model name string (e.g., `"gpt-4"`, `"claude-3-haiku-20240307"`)
   - `opts` - Optional keyword list of parameters
 
   ## Options
@@ -74,8 +74,8 @@ defmodule ReqLLM.Model do
       iex> ReqLLM.Model.new(:anthropic, "claude-3-5-sonnet")
       %ReqLLM.Model{provider: :anthropic, model: "claude-3-5-sonnet", max_tokens: nil, max_retries: 3}
 
-      iex> ReqLLM.Model.new(:anthropic, "claude-3-sonnet", max_tokens: 1000)
-      %ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet", max_tokens: 1000, max_retries: 3}
+      iex> ReqLLM.Model.new(:anthropic, "claude-3-haiku-20240307", max_tokens: 1000)
+      %ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307", max_tokens: 1000, max_retries: 3}
 
   """
   @spec new(atom(), String.t(), keyword()) :: t()
@@ -117,7 +117,7 @@ defmodule ReqLLM.Model do
                                        capabilities: %{tool_call: true}})
 
       # From string specification
-      {:ok, model} = ReqLLM.Model.from("anthropic:claude-3-sonnet")
+      {:ok, model} = ReqLLM.Model.from("anthropic:claude-3-haiku-20240307")
 
   """
   @spec from(t() | {atom(), String.t(), keyword()} | {atom(), keyword()} | String.t()) ::
@@ -272,7 +272,7 @@ defmodule ReqLLM.Model do
 
   ## Examples
 
-      {:ok, model_with_metadata} = ReqLLM.Model.with_metadata("anthropic:claude-3-sonnet")
+      {:ok, model_with_metadata} = ReqLLM.Model.with_metadata("anthropic:claude-3-haiku-20240307")
       model_with_metadata.cost
       #=> %{"input" => 3.0, "output" => 15.0, ...}
 

--- a/lib/req_llm/provider/registry.ex
+++ b/lib/req_llm/provider/registry.ex
@@ -24,17 +24,17 @@ defmodule ReqLLM.Provider.Registry do
       module #=> ReqLLM.Providers.Anthropic
 
       # Get model information  
-      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-sonnet")
+      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-haiku-20240307")
       model.metadata.context_length #=> 200000
 
       # Check if a model exists
-      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-sonnet") #=> true
+      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-haiku-20240307") #=> true
 
       # List all providers
       ReqLLM.Provider.Registry.list_providers() #=> [:anthropic, :openai, :github_models]
 
       # List models for a provider
-      ReqLLM.Provider.Registry.list_models(:anthropic) #=> ["claude-3-sonnet", "claude-3-haiku", ...]
+      ReqLLM.Provider.Registry.list_models(:anthropic) #=> ["claude-3-haiku-20240307", "claude-3-haiku", ...]
 
   ## Integration
 
@@ -155,7 +155,7 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Examples
 
-      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-sonnet")
+      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-haiku-20240307")
       model.metadata.context_length #=> 200000
       model.metadata.pricing.input  #=> 0.003
 
@@ -209,11 +209,11 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Parameters
 
-    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-sonnet")
+    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-haiku-20240307")
 
   ## Examples
 
-      model = ReqLLM.Provider.Registry.get_model!("anthropic:claude-3-sonnet")
+      model = ReqLLM.Provider.Registry.get_model!("anthropic:claude-3-haiku-20240307")
       model.metadata.context_length #=> 200000
 
       ReqLLM.Provider.Registry.get_model!("unknown:model")
@@ -379,7 +379,7 @@ defmodule ReqLLM.Provider.Registry do
   ## Examples
 
       {:ok, models} = ReqLLM.Provider.Registry.list_models(:anthropic)
-      models #=> ["claude-3-sonnet", "claude-3-haiku", "claude-3-opus"]
+      models #=> ["claude-3-haiku-20240307", "claude-3-haiku", "claude-3-opus"]
 
       ReqLLM.Provider.Registry.list_models(:unknown)
       #=> {:error, :not_found}
@@ -414,7 +414,7 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Parameters
 
-    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-sonnet")
+    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-haiku-20240307")
 
   ## Returns
 
@@ -422,7 +422,7 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Examples
 
-      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-sonnet") #=> true
+      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-haiku-20240307") #=> true
       ReqLLM.Provider.Registry.model_exists?("unknown:model") #=> false
 
   """

--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -12,12 +12,12 @@ defmodule ReqLLM.Response do
   ## Examples
 
       # Basic response usage
-      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", context)
+      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", context)
       response.text()  #=> "Hello! I'm Claude."
       response.usage()  #=> %{input_tokens: 12, output_tokens: 4}
 
       # Multi-turn conversation (no manual context building)
-      {:ok, response2} = ReqLLM.generate_text("anthropic:claude-3-sonnet", response.context)
+      {:ok, response2} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", response.context)
 
       # Tool calling loop
       {:ok, final_response} = ReqLLM.Response.handle_tools(response, tools)
@@ -241,7 +241,7 @@ defmodule ReqLLM.Response do
   ## Parameters
 
     * `raw_data` - Raw provider response data or Stream
-    * `model` - Model specification (Model struct or string like "anthropic:claude-3-sonnet")
+    * `model` - Model specification (Model struct or string like "anthropic:claude-3-haiku-20240307")
 
   ## Returns
 
@@ -250,7 +250,7 @@ defmodule ReqLLM.Response do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Response.decode_response(raw_json, "anthropic:claude-3-sonnet")
+      {:ok, response} = ReqLLM.Response.decode_response(raw_json, "anthropic:claude-3-haiku-20240307")
       {:ok, response} = ReqLLM.Response.decode_response(raw_json, model_struct)
 
   """

--- a/lib/req_llm/stream_chunk.ex
+++ b/lib/req_llm/stream_chunk.ex
@@ -40,7 +40,7 @@ defmodule ReqLLM.StreamChunk do
 
   StreamChunk is designed to work with Elixir's Stream module:
 
-      {:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell a story")
+      {:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell a story")
       
       stream
       |> Stream.filter(&(&1.type == :content))
@@ -196,7 +196,7 @@ defmodule ReqLLM.StreamChunk do
       # Multiple metadata fields
       chunk = ReqLLM.StreamChunk.meta(%{
         finish_reason: "tool_use",
-        model: "claude-3-sonnet"
+        model: "claude-3-haiku-20240307"
       })
 
   """

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -21,12 +21,12 @@ Key concepts:
 
 ```elixir
 # Simple - good for basic usage
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 
 # Advanced - good for complex configurations  
 model = %ReqLLM.Model{
   provider: :anthropic,
-  model: "claude-3-sonnet",
+  model: "claude-3-haiku-20240307",
   temperature: 0.7,
   max_tokens: 1000
 }
@@ -41,10 +41,10 @@ model = %ReqLLM.Model{
 
 ```elixir
 # Development/simple cases
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello")
 
 # Production - need access to metadata, errors, usage data
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 response.text()   #=> "Hello! How can I help?"
 response.usage()  #=> %{input_tokens: 10, output_tokens: 8}
 ```
@@ -63,7 +63,7 @@ context = Context.new([
   user("What's 2+2?")
 ])
 
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", context)
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", context)
 ```
 
 **Avoid**: Manually constructing Message structs when helpers exist.
@@ -80,7 +80,7 @@ message = ReqLLM.Context.user([
   image_url("https://example.com/chart.png")
 ])
 
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", [message])
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", [message])
 ```
 
 ### Streaming
@@ -88,7 +88,7 @@ message = ReqLLM.Context.user([
 **Best Practice**: Filter StreamChunks by type for clean processing.
 
 ```elixir
-{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell a story")
+{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell a story")
 
 # Collect only text content
 text = stream
@@ -113,7 +113,7 @@ end)
 **Best Practice**: Pattern match on specific error types for appropriate handling.
 
 ```elixir
-case ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello") do
+case ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello") do
   {:ok, response} -> 
     handle_success(response)
     
@@ -153,7 +153,7 @@ ReqLLM.put_key("anthropic_api_key", System.get_env("ANTHROPIC_API_KEY"))
 ReqLLM.put_key("openai_api_key", System.get_env("OPENAI_API_KEY"))
 
 # Providers automatically retrieve keys via JidoKeys
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 ```
 
 ## Tool Calling
@@ -260,7 +260,7 @@ end
 **Best Practice**: Process streams incrementally for large responses.
 
 ```elixir
-{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Write a long story")
+{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Write a long story")
 
 stream
 |> Stream.filter(&(&1.type == :text))


### PR DESCRIPTION
Fixes #23\n\n- Replace invalid `anthropic:claude-3-sonnet` with `anthropic:claude-3-haiku-20240307` across documentation and example snippets only.\n- No executable logic or provider behavior changed; code references and versioned specs left intact.\n- Verified locally: `mix compile`, `mix test`, and `mix format --check-formatted` all pass.\n\nNotes:\n- Scope limited to README/guides/usage examples and inline docs.\n- Ready for review.