### PR TITLE
feat: Add gateway defaults and fix OpenAI SSE tool-call assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ReqLLM.put_key(:anthropic_api_key, "sk-ant-...")
 # Application: Application.put_env(:req_llm, :anthropic_api_key, "sk-ant-...")
 # .env files are auto-loaded via JidoKeys integration
 
-model = "anthropic:claude-3-sonnet"
+model = "anthropic:claude-3-haiku-20240307"
 
 # Simple text generation
 ReqLLM.generate_text!(model, "Hello world")
@@ -190,7 +190,7 @@ context = ReqLLM.Context.new([
   ReqLLM.Context.system("You are a helpful assistant"),  
   ReqLLM.Context.user("Hello!")
 ])
-model = ReqLLM.Model.from!("anthropic:claude-3-sonnet")
+model = ReqLLM.Model.from!("anthropic:claude-3-haiku-20240307")
 
 # Option 1: Use provider's prepare_request (recommended)
 {:ok, request} = Anthropic.prepare_request(:chat, model, context, temperature: 0.7)

--- a/guides/api-reference.md
+++ b/guides/api-reference.md
@@ -17,12 +17,12 @@ Returns a canonical ReqLLM.Response with usage data, context, and metadata.
 **Examples:**
 ```elixir
 # Simple text generation
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello world")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello world")
 ReqLLM.Response.text(response)  # => "Hello! How can I assist you today?"
 
 # With options
 {:ok, response} = ReqLLM.generate_text(
-  "anthropic:claude-3-sonnet", 
+  "anthropic:claude-3-haiku-20240307", 
   "Write a haiku",
   temperature: 0.8,
   max_tokens: 100
@@ -33,7 +33,7 @@ ctx = ReqLLM.context([
   ReqLLM.Context.system("You are a helpful assistant"),
   ReqLLM.Context.user("What's 2+2?")
 ])
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", ctx)
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", ctx)
 ```
 
 ### generate_text!/3
@@ -46,7 +46,7 @@ Generate text returning only the text content.
 
 **Examples:**
 ```elixir
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello")
 # => "Hello! How can I assist you today?"
 ```
 
@@ -62,7 +62,7 @@ Returns a canonical ReqLLM.Response containing usage data and stream.
 
 **Examples:**
 ```elixir
-{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell me a story")
 ReqLLM.Response.text_stream(response) |> Enum.each(&IO.write/1)
 
 # Access usage after streaming
@@ -79,7 +79,7 @@ Stream text generation returning only the stream.
 
 **Examples:**
 ```elixir
-ReqLLM.stream_text!("anthropic:claude-3-sonnet", "Count to 10")
+ReqLLM.stream_text!("anthropic:claude-3-haiku-20240307", "Count to 10")
 |> Enum.each(&IO.write/1)
 ```
 
@@ -101,7 +101,7 @@ schema = [
   name: [type: :string, required: true],
   age: [type: :pos_integer, required: true]
 ]
-{:ok, response} = ReqLLM.generate_object("anthropic:claude-3-sonnet", "Generate a person", schema)
+{:ok, response} = ReqLLM.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
 ```
 
 ### generate_object!/4
@@ -164,14 +164,14 @@ ReqLLM accepts flexible model specifications:
 ### String Format
 ```elixir
 "provider:model"
-"anthropic:claude-3-sonnet"
+"anthropic:claude-3-haiku-20240307"
 "openai:gpt-4o"
 "ollama:llama3"
 ```
 
 ### Tuple Format
 ```elixir
-{:anthropic, "claude-3-sonnet", temperature: 0.7}
+{:anthropic, "claude-3-haiku-20240307", temperature: 0.7}
 {:openai, "gpt-4o", max_tokens: 1000}
 ```
 
@@ -179,7 +179,7 @@ ReqLLM accepts flexible model specifications:
 ```elixir
 %ReqLLM.Model{
   provider: :anthropic,
-  model: "claude-3-sonnet", 
+  model: "claude-3-haiku-20240307", 
   temperature: 0.7,
   max_tokens: 1000
 }
@@ -210,7 +210,7 @@ ReqLLM accepts flexible model specifications:
 ctx = ReqLLM.context("Hello")
 
 {:ok, response} = ReqLLM.generate_text(
-  "anthropic:claude-3-sonnet",
+  "anthropic:claude-3-haiku-20240307",
   ctx,
   temperature: 0.8,
   max_tokens: 500,
@@ -266,7 +266,7 @@ weather_tool = ReqLLM.tool(
 )
 
 {:ok, response} = ReqLLM.generate_text(
-  "anthropic:claude-3-sonnet",
+  "anthropic:claude-3-haiku-20240307",
   "What's the weather in Paris?",
   tools: [weather_tool]
 )

--- a/guides/core-concepts.md
+++ b/guides/core-concepts.md
@@ -116,7 +116,7 @@ request = Req.new()
 |> Req.Request.append_request_steps(log_request: &log_request/1)
 |> Req.Request.append_response_steps(cache_response: &cache/1)
 
-{:ok, configured} = ReqLLM.attach(request, "anthropic:claude-3-sonnet")
+{:ok, configured} = ReqLLM.attach(request, "anthropic:claude-3-haiku-20240307")
 {:ok, response} = Req.request(configured)
 ```
 
@@ -150,10 +150,10 @@ Transport vs Format separation:
 
 ```elixir
 # API call
-ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 
 # Model resolution  
-{:ok, model} = ReqLLM.Model.from("anthropic:claude-3-sonnet")
+{:ok, model} = ReqLLM.Model.from("anthropic:claude-3-haiku-20240307")
 
 # Provider lookup
 {:ok, provider} = ReqLLM.provider(:anthropic)
@@ -171,7 +171,7 @@ ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
 ### Streaming Flow
 
 ```elixir
-{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell a story")
+{:ok, response} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell a story")
 # Returns %ReqLLM.Response{stream?: true, stream: #Stream<...>}
 
 response.stream

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -15,10 +15,10 @@ end
 ```elixir
 # Configure your API key 
 ReqLLM.put_key(:anthropic_api_key, "sk-ant-...")
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello")
 # Returns: "Hello! How can I assist you today?"
 
-ReqLLM.stream_text!("anthropic:claude-3-sonnet", "Tell me a story")
+ReqLLM.stream_text!("anthropic:claude-3-haiku-20240307", "Tell me a story")
 |> Enum.each(&IO.write/1)
 ```
 
@@ -29,14 +29,14 @@ schema = [
   name: [type: :string, required: true],
   age: [type: :pos_integer, required: true]
 ]
-{:ok, object} = ReqLLM.generate_object("anthropic:claude-3-sonnet", "Generate a person", schema)
+{:ok, object} = ReqLLM.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
 # Returns: %{name: "John Doe", age: 30}
 ```
 
 ## Full Response with Usage
 
 ```elixir
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 text = ReqLLM.Response.text(response)
 usage = ReqLLM.Response.usage(response)
 # usage => %{input_tokens: 10, output_tokens: 8}
@@ -45,9 +45,9 @@ usage = ReqLLM.Response.usage(response)
 ## Model Specifications
 
 ```elixir
-"anthropic:claude-3-sonnet"
-{:anthropic, "claude-3-sonnet", temperature: 0.7}
-%ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet", temperature: 0.7}
+"anthropic:claude-3-haiku-20240307"
+{:anthropic, "claude-3-haiku-20240307", temperature: 0.7}
+%ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307", temperature: 0.7}
 ```
 
 ## Key Management
@@ -81,14 +81,14 @@ messages = [
   ReqLLM.Context.system("You are a helpful coding assistant"),
   ReqLLM.Context.user("Write a function to reverse a list")
 ]
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", messages)
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", messages)
 ```
 
 ## Common Options
 
 ```elixir
 ReqLLM.generate_text!(
-  "anthropic:claude-3-sonnet",
+  "anthropic:claude-3-haiku-20240307",
   "Write code",
   temperature: 0.1,      # Control randomness (0.0-2.0)
   max_tokens: 1000       # Limit response length

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -168,17 +168,17 @@ defmodule ReqLLM do
   ## Parameters
 
     * `model_spec` - Model specification in various formats:
-      - String format: `"anthropic:claude-3-sonnet"`
-      - Tuple format: `{:anthropic, "claude-3-sonnet", temperature: 0.7}`
+      - String format: `"anthropic:claude-3-haiku-20240307"`
+      - Tuple format: `{:anthropic, "claude-3-haiku-20240307", temperature: 0.7}`
       - Model struct: `%ReqLLM.Model{}`
 
   ## Examples
 
-      ReqLLM.model("anthropic:claude-3-sonnet")
-      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet"}}
+      ReqLLM.model("anthropic:claude-3-haiku-20240307")
+      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307"}}
 
-      ReqLLM.model({:anthropic, "claude-3-sonnet", temperature: 0.5})
-      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet", temperature: 0.5}}
+      ReqLLM.model({:anthropic, "claude-3-haiku-20240307", temperature: 0.5})
+      #=> {:ok, %ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307", temperature: 0.5}}
 
   """
   @spec model(String.t() | {atom(), keyword()} | struct()) :: {:ok, struct()} | {:error, term()}
@@ -216,7 +216,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello world")
+      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello world")
       ReqLLM.Response.text(response)
       #=> "Hello! How can I assist you today?"
 
@@ -240,7 +240,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello world")
+      ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello world")
       #=> "Hello! How can I assist you today?"
 
   """
@@ -258,7 +258,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+      {:ok, response} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell me a story")
       ReqLLM.Response.text_stream(response) |> Enum.each(&IO.write/1)
 
       # Access usage metadata after streaming
@@ -281,7 +281,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.stream_text!("anthropic:claude-3-sonnet", "Tell me a story")
+      ReqLLM.stream_text!("anthropic:claude-3-haiku-20240307", "Tell me a story")
       |> Enum.each(&IO.write/1)
 
   """
@@ -319,12 +319,12 @@ defmodule ReqLLM do
         name: [type: :string, required: true],
         age: [type: :pos_integer, required: true]
       ]
-      {:ok, object} = ReqLLM.generate_object("anthropic:claude-3-sonnet", "Generate a person", schema)
+      {:ok, object} = ReqLLM.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
       #=> {:ok, %{name: "John Doe", age: 30}}
 
       # Generate an array of objects
       {:ok, objects} = ReqLLM.generate_object(
-        "anthropic:claude-3-sonnet",
+        "anthropic:claude-3-haiku-20240307",
         "Generate 3 heroes",
         schema,
         output: :array
@@ -345,7 +345,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.generate_object!("anthropic:claude-3-sonnet", "Generate a person", schema)
+      ReqLLM.generate_object!("anthropic:claude-3-haiku-20240307", "Generate a person", schema)
       #=> %{name: "John Doe", age: 30}
 
   """
@@ -375,7 +375,7 @@ defmodule ReqLLM do
         name: [type: :string, required: true],
         description: [type: :string, required: true]
       ]
-      {:ok, stream} = ReqLLM.stream_object("anthropic:claude-3-sonnet", "Generate a character", schema)
+      {:ok, stream} = ReqLLM.stream_object("anthropic:claude-3-haiku-20240307", "Generate a character", schema)
       stream |> Enum.each(&IO.inspect/1)
 
   """
@@ -394,7 +394,7 @@ defmodule ReqLLM do
 
   ## Examples
 
-      ReqLLM.stream_object!("anthropic:claude-3-sonnet", "Generate a character", schema)
+      ReqLLM.stream_object!("anthropic:claude-3-haiku-20240307", "Generate a character", schema)
       |> Enum.each(&IO.inspect/1)
 
   """

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -146,7 +146,7 @@ defmodule ReqLLM.Context do
   ## Parameters
 
     * `context` - A `ReqLLM.Context` to encode
-    * `model` - Model specification (Model struct or string like "anthropic:claude-3-sonnet")
+    * `model` - Model specification (Model struct or string like "anthropic:claude-3-haiku-20240307")
 
   ## Returns
 
@@ -156,7 +156,7 @@ defmodule ReqLLM.Context do
   ## Examples
 
       # Zero-ceremony encoding with model string
-      Context.encode_request(context, "anthropic:claude-3-sonnet")
+      Context.encode_request(context, "anthropic:claude-3-haiku-20240307")
       #=> %{system: "...", messages: [...], max_tokens: 4096}
 
       # Encoding with Model struct

--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -73,7 +73,7 @@ defmodule ReqLLM.Embedding do
       ReqLLM.Embedding.validate_model("openai:text-embedding-3-small")
       #=> {:ok, %ReqLLM.Model{provider: :openai, model: "text-embedding-3-small"}}
 
-      ReqLLM.Embedding.validate_model("anthropic:claude-3-sonnet")
+      ReqLLM.Embedding.validate_model("anthropic:claude-3-haiku-20240307")
       #=> {:error, :embedding_not_supported}
 
   """

--- a/lib/req_llm/gateway.ex
+++ b/lib/req_llm/gateway.ex
@@ -1,0 +1,51 @@
+defmodule ReqLLM.Gateway do
+  @moduledoc """
+  Optional gateway defaults for routing ReqLLM traffic through an edge service.
+
+  When configured, providers will default to the gateway `base_url` and attach a
+  service token header. Direct provider usage is still supported via explicit
+  `base_url` option overrides per-request.
+
+  Configuration sources (first non-empty wins):
+  - `Application.get_env(:req_llm, :gateway_base_url)`
+  - `System.get_env("RUNESTONE_URL")`
+
+  Service token sources (optional):
+  - `Application.get_env(:req_llm, :gateway_service_token)`
+  - `System.get_env("RUNESTONE_SERVICE_TOKEN")`
+  """
+
+  @doc """
+  Returns the configured gateway base URL or nil when not set.
+  """
+  @spec base_url() :: String.t() | nil
+  def base_url do
+    Application.get_env(:req_llm, :gateway_base_url) ||
+      blank_to_nil(System.get_env("RUNESTONE_URL"))
+  end
+
+  @doc """
+  Returns the configured gateway service token or nil when not set.
+  """
+  @spec service_token() :: String.t() | nil
+  def service_token do
+    Application.get_env(:req_llm, :gateway_service_token) ||
+      blank_to_nil(System.get_env("RUNESTONE_SERVICE_TOKEN"))
+  end
+
+  @doc """
+  Returns true if a gateway base_url is configured.
+  """
+  @spec enabled?() :: boolean()
+  def enabled?, do: base_url() != nil
+
+  defp blank_to_nil(nil), do: nil
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(val) when is_binary(val) do
+    case String.trim(val) do
+      "" -> nil
+      other -> other
+    end
+  end
+end
+

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -132,7 +132,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.generate_text("anthropic:claude-3-sonnet", "Hello world")
+      {:ok, response} = ReqLLM.Generation.generate_text("anthropic:claude-3-haiku-20240307", "Hello world")
       ReqLLM.Response.text(response)
       #=> "Hello! How can I assist you today?"
 
@@ -179,7 +179,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.generate_text!("anthropic:claude-3-sonnet", "Hello world")
+      ReqLLM.Generation.generate_text!("anthropic:claude-3-haiku-20240307", "Hello world")
       #=> "Hello! How can I assist you today?"
 
   """
@@ -207,7 +207,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+      {:ok, response} = ReqLLM.Generation.stream_text("anthropic:claude-3-haiku-20240307", "Tell me a story")
       ReqLLM.Response.text_stream(response) |> Enum.each(&IO.write/1)
 
       # Access usage metadata after streaming
@@ -254,7 +254,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.stream_text!("anthropic:claude-3-sonnet", "Tell me a story")
+      ReqLLM.Generation.stream_text!("anthropic:claude-3-haiku-20240307", "Tell me a story")
       |> Enum.each(&IO.write/1)
 
   """
@@ -383,7 +383,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.generate_object("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      {:ok, response} = ReqLLM.Generation.generate_object("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       ReqLLM.Response.object(response)
       #=> %{name: "Alice Smith", age: 30, occupation: "Engineer"}
 
@@ -444,7 +444,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Generation.stream_object("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      {:ok, response} = ReqLLM.Generation.stream_object("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       ReqLLM.Response.object_stream(response) |> Enum.each(&IO.inspect/1)
 
       # Access usage metadata after streaming
@@ -493,7 +493,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.generate_object!("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      ReqLLM.Generation.generate_object!("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       #=> %{name: "Alice Smith", age: 30, occupation: "Engineer"}
 
   """
@@ -523,7 +523,7 @@ defmodule ReqLLM.Generation do
 
   ## Examples
 
-      ReqLLM.Generation.stream_object!("anthropic:claude-3-sonnet", "Generate a person", person_schema)
+      ReqLLM.Generation.stream_object!("anthropic:claude-3-haiku-20240307", "Generate a person", person_schema)
       |> Enum.each(&IO.inspect/1)
 
   """

--- a/lib/req_llm/keys.ex
+++ b/lib/req_llm/keys.ex
@@ -17,7 +17,7 @@ defmodule ReqLLM.Keys do
       ReqLLM.put_key(:anthropic_api_key, "sk-ant-...")
       
       # Works with models (extracts provider automatically)
-      model = ReqLLM.Model.from("anthropic:claude-3-sonnet")
+      model = ReqLLM.Model.from("anthropic:claude-3-haiku-20240307")
       key = ReqLLM.Keys.get!(model)
 
       # Per-request override (highest priority)

--- a/lib/req_llm/model.ex
+++ b/lib/req_llm/model.ex
@@ -18,7 +18,7 @@ defmodule ReqLLM.Model do
       {:ok, model} = ReqLLM.Model.from("anthropic:claude-3-5-sonnet")
 
       # Create a model directly
-      model = ReqLLM.Model.new(:anthropic, "claude-3-sonnet", temperature: 0.5, max_tokens: 1000)
+      model = ReqLLM.Model.new(:anthropic, "claude-3-haiku-20240307", temperature: 0.5, max_tokens: 1000)
 
   """
 
@@ -57,7 +57,7 @@ defmodule ReqLLM.Model do
   ## Parameters
 
   - `provider` - The provider atom (e.g., `:anthropic`)
-  - `model` - The model name string (e.g., `"gpt-4"`, `"claude-3-sonnet"`)
+  - `model` - The model name string (e.g., `"gpt-4"`, `"claude-3-haiku-20240307"`)
   - `opts` - Optional keyword list of parameters
 
   ## Options
@@ -74,8 +74,8 @@ defmodule ReqLLM.Model do
       iex> ReqLLM.Model.new(:anthropic, "claude-3-5-sonnet")
       %ReqLLM.Model{provider: :anthropic, model: "claude-3-5-sonnet", max_tokens: nil, max_retries: 3}
 
-      iex> ReqLLM.Model.new(:anthropic, "claude-3-sonnet", max_tokens: 1000)
-      %ReqLLM.Model{provider: :anthropic, model: "claude-3-sonnet", max_tokens: 1000, max_retries: 3}
+      iex> ReqLLM.Model.new(:anthropic, "claude-3-haiku-20240307", max_tokens: 1000)
+      %ReqLLM.Model{provider: :anthropic, model: "claude-3-haiku-20240307", max_tokens: 1000, max_retries: 3}
 
   """
   @spec new(atom(), String.t(), keyword()) :: t()
@@ -117,7 +117,7 @@ defmodule ReqLLM.Model do
                                        capabilities: %{tool_call: true}})
 
       # From string specification
-      {:ok, model} = ReqLLM.Model.from("anthropic:claude-3-sonnet")
+      {:ok, model} = ReqLLM.Model.from("anthropic:claude-3-haiku-20240307")
 
   """
   @spec from(t() | {atom(), String.t(), keyword()} | {atom(), keyword()} | String.t()) ::
@@ -272,7 +272,7 @@ defmodule ReqLLM.Model do
 
   ## Examples
 
-      {:ok, model_with_metadata} = ReqLLM.Model.with_metadata("anthropic:claude-3-sonnet")
+      {:ok, model_with_metadata} = ReqLLM.Model.with_metadata("anthropic:claude-3-haiku-20240307")
       model_with_metadata.cost
       #=> %{"input" => 3.0, "output" => 15.0, ...}
 

--- a/lib/req_llm/provider/registry.ex
+++ b/lib/req_llm/provider/registry.ex
@@ -24,17 +24,17 @@ defmodule ReqLLM.Provider.Registry do
       module #=> ReqLLM.Providers.Anthropic
 
       # Get model information  
-      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-sonnet")
+      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-haiku-20240307")
       model.metadata.context_length #=> 200000
 
       # Check if a model exists
-      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-sonnet") #=> true
+      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-haiku-20240307") #=> true
 
       # List all providers
       ReqLLM.Provider.Registry.list_providers() #=> [:anthropic, :openai, :github_models]
 
       # List models for a provider
-      ReqLLM.Provider.Registry.list_models(:anthropic) #=> ["claude-3-sonnet", "claude-3-haiku", ...]
+      ReqLLM.Provider.Registry.list_models(:anthropic) #=> ["claude-3-haiku-20240307", "claude-3-haiku", ...]
 
   ## Integration
 
@@ -155,7 +155,7 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Examples
 
-      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-sonnet")
+      {:ok, model} = ReqLLM.Provider.Registry.get_model(:anthropic, "claude-3-haiku-20240307")
       model.metadata.context_length #=> 200000
       model.metadata.pricing.input  #=> 0.003
 
@@ -209,11 +209,11 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Parameters
 
-    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-sonnet")
+    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-haiku-20240307")
 
   ## Examples
 
-      model = ReqLLM.Provider.Registry.get_model!("anthropic:claude-3-sonnet")
+      model = ReqLLM.Provider.Registry.get_model!("anthropic:claude-3-haiku-20240307")
       model.metadata.context_length #=> 200000
 
       ReqLLM.Provider.Registry.get_model!("unknown:model")
@@ -379,7 +379,7 @@ defmodule ReqLLM.Provider.Registry do
   ## Examples
 
       {:ok, models} = ReqLLM.Provider.Registry.list_models(:anthropic)
-      models #=> ["claude-3-sonnet", "claude-3-haiku", "claude-3-opus"]
+      models #=> ["claude-3-haiku-20240307", "claude-3-haiku", "claude-3-opus"]
 
       ReqLLM.Provider.Registry.list_models(:unknown)
       #=> {:error, :not_found}
@@ -414,7 +414,7 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Parameters
 
-    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-sonnet")
+    * `model_spec` - Model specification string (e.g., "anthropic:claude-3-haiku-20240307")
 
   ## Returns
 
@@ -422,7 +422,7 @@ defmodule ReqLLM.Provider.Registry do
 
   ## Examples
 
-      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-sonnet") #=> true
+      ReqLLM.Provider.Registry.model_exists?("anthropic:claude-3-haiku-20240307") #=> true
       ReqLLM.Provider.Registry.model_exists?("unknown:model") #=> false
 
   """

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -154,7 +154,12 @@ defmodule ReqLLM.Providers.Anthropic do
 
     # Add tools back after validation
     opts = Keyword.put(opts, :tools, tools)
-    base_url = Keyword.get(user_opts, :base_url, default_base_url())
+
+    # Precedence: explicit :base_url option > gateway default > provider default
+    base_url =
+      Keyword.get(user_opts, :base_url) ||
+        ReqLLM.Gateway.base_url() ||
+        default_base_url()
     req_keys = __MODULE__.supported_provider_options() ++ [:model, :context]
 
     request
@@ -162,6 +167,7 @@ defmodule ReqLLM.Providers.Anthropic do
     |> Req.Request.merge_options(Keyword.take(opts, req_keys) ++ [base_url: base_url])
     |> Req.Request.put_header("x-api-key", api_key)
     |> Req.Request.put_header("anthropic-version", opts[:api_version] || @default_api_version)
+    |> maybe_put_gateway_header()
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.append_request_steps(llm_encode_body: &__MODULE__.encode_body/1)
     |> ReqLLM.Step.Stream.maybe_attach(opts[:stream])
@@ -178,6 +184,16 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   def extract_usage(_, _), do: {:error, :invalid_body}
+
+  defp maybe_put_gateway_header(%Req.Request{} = request) do
+    case ReqLLM.Gateway.service_token() do
+      token when is_binary(token) and token != "" ->
+        Req.Request.put_header(request, "x-service-token", token)
+
+      _ ->
+        request
+    end
+  end
 
   # Helper functions for beta feature support
   defp maybe_set_beta_header(request) do

--- a/lib/req_llm/providers/groq.ex
+++ b/lib/req_llm/providers/groq.ex
@@ -147,7 +147,11 @@ defmodule ReqLLM.Providers.Groq do
     # Merge provider-specific options into opts for encoding
     opts = Keyword.merge(opts, provider_opts)
 
-    base_url = Keyword.get(user_opts, :base_url, default_base_url())
+    # Precedence: explicit :base_url option > gateway default > provider default
+    base_url =
+      Keyword.get(user_opts, :base_url) ||
+        ReqLLM.Gateway.base_url() ||
+        default_base_url()
     req_keys = __MODULE__.supported_provider_options() ++ [:model, :context]
 
     request
@@ -156,6 +160,7 @@ defmodule ReqLLM.Providers.Groq do
     |> Req.Request.merge_options(
       Keyword.take(opts, req_keys) ++ [base_url: base_url, auth: {:bearer, api_key}]
     )
+    |> maybe_put_gateway_header()
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.append_request_steps(llm_encode_body: &__MODULE__.encode_body/1)
     |> ReqLLM.Step.Stream.maybe_attach(opts[:stream])
@@ -172,6 +177,16 @@ defmodule ReqLLM.Providers.Groq do
   end
 
   def extract_usage(_, _), do: {:error, :invalid_body}
+
+  defp maybe_put_gateway_header(%Req.Request{} = request) do
+    case ReqLLM.Gateway.service_token() do
+      token when is_binary(token) and token != "" ->
+        Req.Request.put_header(request, "x-service-token", token)
+
+      _ ->
+        request
+    end
+  end
 
   # Req pipeline steps
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -131,18 +131,33 @@ defmodule ReqLLM.Providers.OpenAI do
       |> maybe_put(:operation, operation)
       |> maybe_put(:text, text)
 
-    base_url = Keyword.get(user_opts, :base_url, default_base_url())
+    # Precedence: explicit :base_url option > gateway default > provider default
+    base_url =
+      Keyword.get(user_opts, :base_url) ||
+        ReqLLM.Gateway.base_url() ||
+        default_base_url()
     req_keys = __MODULE__.supported_provider_options() ++ [:model, :context, :operation, :text]
 
     request
     |> Req.Request.register_options(req_keys)
     |> Req.Request.merge_options(Keyword.take(opts, req_keys) ++ [base_url: base_url])
     |> Req.Request.put_header("authorization", "Bearer #{api_key}")
+    |> maybe_put_gateway_header()
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.append_request_steps(llm_encode_body: &__MODULE__.encode_body/1)
     |> ReqLLM.Step.Stream.maybe_attach(opts[:stream])
     |> Req.Request.append_response_steps(llm_decode_response: &__MODULE__.decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
+  end
+
+  defp maybe_put_gateway_header(%Req.Request{} = request) do
+    case ReqLLM.Gateway.service_token() do
+      token when is_binary(token) and token != "" ->
+        Req.Request.put_header(request, "x-service-token", token)
+
+      _ ->
+        request
+    end
   end
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/openai/response.ex
+++ b/lib/req_llm/providers/openai/response.ex
@@ -21,10 +21,13 @@ defimpl ReqLLM.Response.Codec, for: ReqLLM.Providers.OpenAI.Response do
   """
   def decode_response(%{payload: stream} = _wrapped_response, %Model{provider: :openai} = model)
       when is_struct(stream, Stream) do
-    # Convert SSE events to StreamChunks
+    # Convert SSE events to StreamChunks with tool-call assembly
     chunk_stream =
       stream
-      |> Stream.flat_map(&decode_sse_event/1)
+      |> Stream.transform(%{tc: %{}}, fn event, state ->
+        {chunks, new_state} = handle_sse_event(event, state)
+        {chunks, new_state}
+      end)
       |> Stream.reject(&is_nil/1)
 
     response = %Response{
@@ -58,41 +61,68 @@ defimpl ReqLLM.Response.Codec, for: ReqLLM.Providers.OpenAI.Response do
 
   def encode_request(_), do: {:error, :not_implemented}
 
-  # SSE Event decoding for streaming responses
-  defp decode_sse_event(%{event: "completion", data: %{"choices" => [%{"delta" => delta} | _]}}) do
-    decode_openai_delta(delta)
+  # SSE Event decoding and tool-call assembly
+  defp handle_sse_event(%{data: "[DONE]"}, state) do
+    {[StreamChunk.meta(%{done: true, finish_reason: :stop})], state}
   end
 
-  defp decode_sse_event(%{data: %{"choices" => [%{"delta" => delta} | _]}}) do
-    decode_openai_delta(delta)
+  defp handle_sse_event(%{event: _evt, data: %{"choices" => [%{"delta" => delta} | _]}}, state) do
+    handle_openai_delta(delta, state)
   end
 
-  defp decode_sse_event(_event), do: []
-
-  defp decode_openai_delta(%{"content" => content}) when is_binary(content) and content != "" do
-    [StreamChunk.text(content)]
+  defp handle_sse_event(%{data: %{"choices" => [%{"delta" => delta} | _]}}, state) do
+    handle_openai_delta(delta, state)
   end
 
-  defp decode_openai_delta(%{"tool_calls" => tool_calls}) when is_list(tool_calls) do
-    tool_calls
-    |> Enum.map(&decode_tool_call_delta/1)
-    |> Enum.reject(&is_nil/1)
+  defp handle_sse_event(_event, state), do: {[], state}
+
+  defp handle_openai_delta(%{"content" => content} = _delta, state)
+       when is_binary(content) and content != "" do
+    {[StreamChunk.text(content)], state}
   end
 
-  defp decode_openai_delta(_), do: []
+  defp handle_openai_delta(%{"tool_calls" => tool_calls} = _delta, state) when is_list(tool_calls) do
+    {emitted, new_state} =
+      Enum.reduce(tool_calls, {[], state}, fn tc, {acc_chunks, acc_state} ->
+        {maybe_chunk, updated_state} = assemble_tool_call(tc, acc_state)
+        chunks = if maybe_chunk, do: [maybe_chunk | acc_chunks], else: acc_chunks
+        {chunks, updated_state}
+      end)
 
-  defp decode_tool_call_delta(%{
-         "id" => id,
-         "type" => "function",
-         "function" => %{"name" => name, "arguments" => args_json}
-       }) do
-    case Jason.decode(args_json || "{}") do
-      {:ok, args} -> StreamChunk.tool_call(name, args, %{id: id})
-      {:error, _} -> nil
-    end
+    {Enum.reverse(emitted), new_state}
   end
 
-  defp decode_tool_call_delta(_), do: nil
+  defp handle_openai_delta(_delta, state), do: {[], state}
+
+  defp assemble_tool_call(%{"index" => index} = tc, %{tc: tc_state} = state) do
+    existing = Map.get(tc_state, index, %{id: nil, name: nil, args: "", emitted?: false})
+
+    id = Map.get(tc, "id", existing.id)
+    name = get_in(tc, ["function", "name"]) || existing.name
+    arg_piece = get_in(tc, ["function", "arguments"]) || ""
+    args_acc = existing.args <> arg_piece
+
+    {maybe_chunk, new_entry} =
+      case {existing.emitted?, Jason.decode(args_acc)} do
+        {true, _} ->
+          {nil, %{existing | id: id, name: name, args: args_acc}}
+
+        {false, {:ok, args_map}} when is_binary(name) and is_binary(id) ->
+          {StreamChunk.tool_call(name, args_map, %{id: id}), %{id: id, name: name, args: args_acc, emitted?: true}}
+
+        _ ->
+          {nil, %{existing | id: id, name: name, args: args_acc}}
+      end
+
+    new_state = put_in(state, [:tc, index], new_entry)
+    {maybe_chunk, new_state}
+  end
+
+  defp assemble_tool_call(tc, state) do
+    # Fallback when no index is present; use a synthetic key
+    assemble_tool_call(Map.put(tc, "index", :default), state)
+  end
+
 end
 
 defmodule ReqLLM.Providers.OpenAI.ResponseDecoder do

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -150,7 +150,12 @@ defmodule ReqLLM.Providers.OpenRouter do
 
     # Add tools back after validation
     opts = Keyword.put(opts, :tools, tools)
-    base_url = Keyword.get(user_opts, :base_url, default_base_url())
+
+    # Precedence: explicit :base_url option > gateway default > provider default
+    base_url =
+      Keyword.get(user_opts, :base_url) ||
+        ReqLLM.Gateway.base_url() ||
+        default_base_url()
     req_keys = __MODULE__.supported_provider_options() ++ [:model, :context]
 
     request
@@ -159,6 +164,7 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> Req.Request.merge_options(
       Keyword.take(opts, req_keys) ++ [base_url: base_url, auth: {:bearer, api_key}]
     )
+    |> maybe_put_gateway_header()
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.append_request_steps(llm_encode_body: &__MODULE__.encode_body/1)
     |> ReqLLM.Step.Stream.maybe_attach(opts[:stream])
@@ -175,6 +181,16 @@ defmodule ReqLLM.Providers.OpenRouter do
   end
 
   def extract_usage(_, _), do: {:error, :invalid_body}
+
+  defp maybe_put_gateway_header(%Req.Request{} = request) do
+    case ReqLLM.Gateway.service_token() do
+      token when is_binary(token) and token != "" ->
+        Req.Request.put_header(request, "x-service-token", token)
+
+      _ ->
+        request
+    end
+  end
 
   # Parameter validation helpers
   defp validate_parameter_ranges(opts) do

--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -12,12 +12,12 @@ defmodule ReqLLM.Response do
   ## Examples
 
       # Basic response usage
-      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", context)
+      {:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", context)
       response.text()  #=> "Hello! I'm Claude."
       response.usage()  #=> %{input_tokens: 12, output_tokens: 4}
 
       # Multi-turn conversation (no manual context building)
-      {:ok, response2} = ReqLLM.generate_text("anthropic:claude-3-sonnet", response.context)
+      {:ok, response2} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", response.context)
 
       # Tool calling loop
       {:ok, final_response} = ReqLLM.Response.handle_tools(response, tools)
@@ -241,7 +241,7 @@ defmodule ReqLLM.Response do
   ## Parameters
 
     * `raw_data` - Raw provider response data or Stream
-    * `model` - Model specification (Model struct or string like "anthropic:claude-3-sonnet")
+    * `model` - Model specification (Model struct or string like "anthropic:claude-3-haiku-20240307")
 
   ## Returns
 
@@ -250,7 +250,7 @@ defmodule ReqLLM.Response do
 
   ## Examples
 
-      {:ok, response} = ReqLLM.Response.decode_response(raw_json, "anthropic:claude-3-sonnet")
+      {:ok, response} = ReqLLM.Response.decode_response(raw_json, "anthropic:claude-3-haiku-20240307")
       {:ok, response} = ReqLLM.Response.decode_response(raw_json, model_struct)
 
   """

--- a/lib/req_llm/stream_chunk.ex
+++ b/lib/req_llm/stream_chunk.ex
@@ -40,7 +40,7 @@ defmodule ReqLLM.StreamChunk do
 
   StreamChunk is designed to work with Elixir's Stream module:
 
-      {:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell a story")
+      {:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell a story")
       
       stream
       |> Stream.filter(&(&1.type == :content))
@@ -196,7 +196,7 @@ defmodule ReqLLM.StreamChunk do
       # Multiple metadata fields
       chunk = ReqLLM.StreamChunk.meta(%{
         finish_reason: "tool_use",
-        model: "claude-3-sonnet"
+        model: "claude-3-haiku-20240307"
       })
 
   """

--- a/test/req_llm/gateway_defaults_test.exs
+++ b/test/req_llm/gateway_defaults_test.exs
@@ -1,0 +1,224 @@
+defmodule ReqLLM.GatewayDefaultsTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.{Context, Model}
+
+  setup do
+    # Preserve env
+    old_url = System.get_env("RUNESTONE_URL")
+    old_token = System.get_env("RUNESTONE_SERVICE_TOKEN")
+    old_openai = Application.get_env(:req_llm, :openai_api_key)
+    old_anthropic = Application.get_env(:req_llm, :anthropic_api_key)
+    old_openrouter = Application.get_env(:req_llm, :openrouter_api_key)
+    old_groq = Application.get_env(:req_llm, :groq_api_key)
+
+    on_exit(fn ->
+      if is_nil(old_url), do: System.delete_env("RUNESTONE_URL"), else: System.put_env("RUNESTONE_URL", old_url)
+      if is_nil(old_token), do: System.delete_env("RUNESTONE_SERVICE_TOKEN"), else: System.put_env("RUNESTONE_SERVICE_TOKEN", old_token)
+      Application.delete_env(:req_llm, :gateway_base_url)
+      Application.delete_env(:req_llm, :gateway_service_token)
+
+      if old_openai, do: Application.put_env(:req_llm, :openai_api_key, old_openai), else: Application.delete_env(:req_llm, :openai_api_key)
+      if old_anthropic, do: Application.put_env(:req_llm, :anthropic_api_key, old_anthropic), else: Application.delete_env(:req_llm, :anthropic_api_key)
+      if old_openrouter, do: Application.put_env(:req_llm, :openrouter_api_key, old_openrouter), else: Application.delete_env(:req_llm, :openrouter_api_key)
+      if old_groq, do: Application.put_env(:req_llm, :groq_api_key, old_groq), else: Application.delete_env(:req_llm, :groq_api_key)
+    end)
+
+    :ok
+  end
+
+  describe "OpenAI provider" do
+    test "attaches gateway base_url and service token by default when configured" do
+      # Configure gateway via env
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      System.put_env("RUNESTONE_SERVICE_TOKEN", "test-token")
+
+      # Stub API key lookup for OpenAI
+      Application.put_env(:req_llm, :openai_api_key, "sk-test")
+
+      model = Model.from!("openai:gpt-4o-mini")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenAI.prepare_request(:chat, model, ctx, [])
+
+      # Assert base_url defaulted to gateway URL
+      assert req.options[:base_url] == "https://gateway.local/v1"
+
+      # Assert service token header present
+      headers = Map.new(req.headers)
+      assert headers["x-service-token"] == ["test-token"]
+    end
+
+    test "explicit base_url overrides gateway default" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      Application.put_env(:req_llm, :openai_api_key, "sk-test")
+
+      model = Model.from!("openai:gpt-4o-mini")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenAI.prepare_request(:chat, model, ctx, [base_url: "https://custom.api/v1"])
+
+      assert req.options[:base_url] == "https://custom.api/v1"
+    end
+
+    test "falls back to provider default when no gateway configured" do
+      System.delete_env("RUNESTONE_URL")
+      Application.delete_env(:req_llm, :gateway_base_url)
+      Application.put_env(:req_llm, :openai_api_key, "sk-test")
+
+      model = Model.from!("openai:gpt-4o-mini")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenAI.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://api.openai.com/v1"
+    end
+  end
+
+  describe "Anthropic provider" do
+    test "attaches gateway base_url and service token when configured" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      System.put_env("RUNESTONE_SERVICE_TOKEN", "test-token")
+      Application.put_env(:req_llm, :anthropic_api_key, "sk-ant-test")
+
+      model = Model.from!("anthropic:claude-3-haiku-20240307")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.Anthropic.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://gateway.local/v1"
+      headers = Map.new(req.headers)
+      assert headers["x-service-token"] == ["test-token"]
+    end
+
+    test "explicit base_url overrides gateway default" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      Application.put_env(:req_llm, :anthropic_api_key, "sk-ant-test")
+
+      model = Model.from!("anthropic:claude-3-haiku-20240307")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.Anthropic.prepare_request(:chat, model, ctx, [base_url: "https://custom.api/v1"])
+
+      assert req.options[:base_url] == "https://custom.api/v1"
+    end
+
+    test "falls back to provider default when no gateway configured" do
+      System.delete_env("RUNESTONE_URL")
+      Application.delete_env(:req_llm, :gateway_base_url)
+      Application.put_env(:req_llm, :anthropic_api_key, "sk-ant-test")
+
+      model = Model.from!("anthropic:claude-3-haiku-20240307")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.Anthropic.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://api.anthropic.com/v1"
+    end
+  end
+
+  describe "OpenRouter provider" do
+    test "attaches gateway base_url and service token when configured" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      System.put_env("RUNESTONE_SERVICE_TOKEN", "test-token")
+      Application.put_env(:req_llm, :openrouter_api_key, "sk-or-test")
+
+      model = Model.from!("openrouter:anthropic/claude-3-haiku")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenRouter.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://gateway.local/v1"
+      headers = Map.new(req.headers)
+      assert headers["x-service-token"] == ["test-token"]
+    end
+
+    test "explicit base_url overrides gateway default" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      Application.put_env(:req_llm, :openrouter_api_key, "sk-or-test")
+
+      model = Model.from!("openrouter:anthropic/claude-3-haiku")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenRouter.prepare_request(:chat, model, ctx, [base_url: "https://custom.api/v1"])
+
+      assert req.options[:base_url] == "https://custom.api/v1"
+    end
+
+    test "falls back to provider default when no gateway configured" do
+      System.delete_env("RUNESTONE_URL")
+      Application.delete_env(:req_llm, :gateway_base_url)
+      Application.put_env(:req_llm, :openrouter_api_key, "sk-or-test")
+
+      model = Model.from!("openrouter:anthropic/claude-3-haiku")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenRouter.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://openrouter.ai/api/v1"
+    end
+  end
+
+  describe "Groq provider" do
+    test "attaches gateway base_url and service token when configured" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      System.put_env("RUNESTONE_SERVICE_TOKEN", "test-token")
+      Application.put_env(:req_llm, :groq_api_key, "gsk-test")
+
+      model = Model.from!("groq:llama3-8b-8192")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.Groq.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://gateway.local/v1"
+      headers = Map.new(req.headers)
+      assert headers["x-service-token"] == ["test-token"]
+    end
+
+    test "explicit base_url overrides gateway default" do
+      System.put_env("RUNESTONE_URL", "https://gateway.local/v1")
+      Application.put_env(:req_llm, :groq_api_key, "gsk-test")
+
+      model = Model.from!("groq:llama3-8b-8192")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.Groq.prepare_request(:chat, model, ctx, [base_url: "https://custom.api/v1"])
+
+      assert req.options[:base_url] == "https://custom.api/v1"
+    end
+
+    test "falls back to provider default when no gateway configured" do
+      System.delete_env("RUNESTONE_URL")
+      Application.delete_env(:req_llm, :gateway_base_url)
+      Application.put_env(:req_llm, :groq_api_key, "gsk-test")
+
+      model = Model.from!("groq:llama3-8b-8192")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.Groq.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://api.groq.com/openai/v1"
+    end
+  end
+
+  describe "gateway configuration via Application env" do
+    test "Application.put_env takes precedence over System env" do
+      System.put_env("RUNESTONE_URL", "https://system.gateway/v1")
+      System.put_env("RUNESTONE_SERVICE_TOKEN", "system-token")
+
+      Application.put_env(:req_llm, :gateway_base_url, "https://app.gateway/v1")
+      Application.put_env(:req_llm, :gateway_service_token, "app-token")
+      Application.put_env(:req_llm, :openai_api_key, "sk-test")
+
+      model = Model.from!("openai:gpt-4o-mini")
+      ctx = Context.new([Context.user("hello")])
+
+      {:ok, req} = ReqLLM.Providers.OpenAI.prepare_request(:chat, model, ctx, [])
+
+      assert req.options[:base_url] == "https://app.gateway/v1"
+      headers = Map.new(req.headers)
+      assert headers["x-service-token"] == ["app-token"]
+    end
+  end
+end
+

--- a/test/req_llm/providers/openai/sse_tool_call_test.exs
+++ b/test/req_llm/providers/openai/sse_tool_call_test.exs
@@ -1,0 +1,277 @@
+defmodule ReqLLM.Providers.OpenAI.SSEToolCallTest do
+  @moduledoc """
+  Tests for OpenAI SSE streaming tool-call assembly.
+
+  Validates the stateful assembly of tool calls across multiple SSE chunks,
+  ensuring proper JSON argument accumulation and single emission per tool call.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.StreamChunk
+  alias ReqLLM.Model
+
+  describe "SSE tool-call assembly" do
+    test "assembles single tool call across multiple chunks" do
+      # Create mock SSE events simulating incremental tool call
+      events = [
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "id" => "call_123", "function" => %{"name" => "get_weather"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => "{\"loc"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => "ation\": \"New"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => " York\", \"unit\":"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => " \"celsius\"}"}}
+        ]}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+
+      # Collect all chunks
+      chunks = Enum.to_list(response.stream)
+
+      # Should have exactly one tool_call chunk and one meta chunk
+      tool_chunks = Enum.filter(chunks, &(&1.type == :tool_call))
+      meta_chunks = Enum.filter(chunks, &(&1.type == :meta))
+
+      assert length(tool_chunks) == 1
+      assert length(meta_chunks) == 1
+
+      # Verify tool call content
+      [tool_chunk] = tool_chunks
+      assert tool_chunk.name == "get_weather"
+      assert tool_chunk.args == %{"location" => "New York", "unit" => "celsius"}
+      assert tool_chunk.meta[:id] == "call_123"
+
+      # Verify meta chunk
+      [meta_chunk] = meta_chunks
+      assert meta_chunk.meta[:done] == true
+      assert meta_chunk.meta[:finish_reason] == :stop
+    end
+
+    test "assembles multiple concurrent tool calls with different indices" do
+      events = [
+        # First tool call starts
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "id" => "call_001", "function" => %{"name" => "get_weather", "arguments" => "{\"location\":"}}
+        ]}}]}},
+        # Second tool call starts
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 1, "id" => "call_002", "function" => %{"name" => "get_news", "arguments" => "{\"topic\":"}}
+        ]}}]}},
+        # Continue first tool call
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => " \"Paris\"}"}}
+        ]}}]}},
+        # Continue second tool call
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 1, "function" => %{"arguments" => " \"tech\"}"}}
+        ]}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+      chunks = Enum.to_list(response.stream)
+
+      tool_chunks = Enum.filter(chunks, &(&1.type == :tool_call))
+      assert length(tool_chunks) == 2
+
+      # Verify both tool calls were assembled correctly
+      weather_chunk = Enum.find(tool_chunks, &(&1.name == "get_weather"))
+      assert weather_chunk.args == %{"location" => "Paris"}
+      assert weather_chunk.meta[:id] == "call_001"
+
+      news_chunk = Enum.find(tool_chunks, &(&1.name == "get_news"))
+      assert news_chunk.args == %{"topic" => "tech"}
+      assert news_chunk.meta[:id] == "call_002"
+    end
+
+    test "handles incomplete JSON gracefully" do
+      events = [
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "id" => "call_456", "function" => %{"name" => "search"}}
+        ]}}]}},
+        # Incomplete JSON - missing closing brace
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => "{\"query\": \"elixir\""}}
+        ]}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+      chunks = Enum.to_list(response.stream)
+
+      # Should NOT emit a tool_call chunk due to invalid JSON
+      tool_chunks = Enum.filter(chunks, &(&1.type == :tool_call))
+      assert length(tool_chunks) == 0
+
+      # Should still emit the done meta chunk
+      meta_chunks = Enum.filter(chunks, &(&1.type == :meta))
+      assert length(meta_chunks) == 1
+    end
+
+    test "emits tool call only once when JSON becomes valid" do
+      events = [
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "id" => "call_789", "function" => %{"name" => "calculate"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => "{\"a\": 5"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "function" => %{"arguments" => ", \"b\": 10}"}}
+        ]}}]}},
+        # Additional chunks that shouldn't trigger re-emission
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0}
+        ]}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+      chunks = Enum.to_list(response.stream)
+
+      # Should emit exactly one tool_call chunk when JSON becomes valid
+      tool_chunks = Enum.filter(chunks, &(&1.type == :tool_call))
+      assert length(tool_chunks) == 1
+
+      [tool_chunk] = tool_chunks
+      assert tool_chunk.name == "calculate"
+      assert tool_chunk.args == %{"a" => 5, "b" => 10}
+      assert tool_chunk.meta[:id] == "call_789"
+    end
+
+    test "handles mixed content and tool calls" do
+      events = [
+        %{data: %{"choices" => [%{"delta" => %{"content" => "Let me check the weather"}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => [
+          %{"index" => 0, "id" => "call_mix", "function" => %{"name" => "get_weather", "arguments" => "{\"location\": \"Tokyo\"}"}}
+        ]}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"content" => " for you."}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+      chunks = Enum.to_list(response.stream)
+
+      # Should have text chunks, tool call chunk, and meta chunk
+      text_chunks = Enum.filter(chunks, &(&1.type == :text))
+      tool_chunks = Enum.filter(chunks, &(&1.type == :tool_call))
+      meta_chunks = Enum.filter(chunks, &(&1.type == :meta))
+
+      assert length(text_chunks) == 2
+      assert length(tool_chunks) == 1
+      assert length(meta_chunks) == 1
+
+      # Verify content order and values
+      assert Enum.at(text_chunks, 0).text == "Let me check the weather"
+      assert Enum.at(text_chunks, 1).text == " for you."
+
+      [tool_chunk] = tool_chunks
+      assert tool_chunk.name == "get_weather"
+      assert tool_chunk.args == %{"location" => "Tokyo"}
+    end
+
+    test "handles empty tool call arrays gracefully" do
+      events = [
+        %{data: %{"choices" => [%{"delta" => %{"tool_calls" => []}}]}},
+        %{data: %{"choices" => [%{"delta" => %{"content" => "No tools needed"}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+      chunks = Enum.to_list(response.stream)
+
+      # Should only have text and meta chunks, no tool calls
+      text_chunks = Enum.filter(chunks, &(&1.type == :text))
+      tool_chunks = Enum.filter(chunks, &(&1.type == :tool_call))
+
+      assert length(text_chunks) == 1
+      assert length(tool_chunks) == 0
+      assert Enum.at(text_chunks, 0).text == "No tools needed"
+    end
+  end
+
+  describe "[DONE] message handling" do
+    test "emits meta chunk with done flag" do
+      events = [
+        %{data: %{"choices" => [%{"delta" => %{"content" => "Hello"}}]}},
+        %{data: "[DONE]"}
+      ]
+
+      model = %Model{provider: :openai, model: "gpt-4o-mini"}
+      wrapped_response = %ReqLLM.Providers.OpenAI.Response{
+        payload: Stream.unfold(events, fn
+          [] -> nil
+          [h | t] -> {h, t}
+        end)
+      }
+
+      response = ReqLLM.Response.Codec.decode_response(wrapped_response, model)
+      chunks = Enum.to_list(response.stream)
+
+      meta_chunks = Enum.filter(chunks, &(&1.type == :meta))
+      assert length(meta_chunks) == 1
+
+      [meta] = meta_chunks
+      assert meta.meta[:done] == true
+      assert meta.meta[:finish_reason] == :stop
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -21,12 +21,12 @@ Key concepts:
 
 ```elixir
 # Simple - good for basic usage
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 
 # Advanced - good for complex configurations  
 model = %ReqLLM.Model{
   provider: :anthropic,
-  model: "claude-3-sonnet",
+  model: "claude-3-haiku-20240307",
   temperature: 0.7,
   max_tokens: 1000
 }
@@ -41,10 +41,10 @@ model = %ReqLLM.Model{
 
 ```elixir
 # Development/simple cases
-ReqLLM.generate_text!("anthropic:claude-3-sonnet", "Hello")
+ReqLLM.generate_text!("anthropic:claude-3-haiku-20240307", "Hello")
 
 # Production - need access to metadata, errors, usage data
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 response.text()   #=> "Hello! How can I help?"
 response.usage()  #=> %{input_tokens: 10, output_tokens: 8}
 ```
@@ -63,7 +63,7 @@ context = Context.new([
   user("What's 2+2?")
 ])
 
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", context)
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", context)
 ```
 
 **Avoid**: Manually constructing Message structs when helpers exist.
@@ -80,7 +80,7 @@ message = ReqLLM.Context.user([
   image_url("https://example.com/chart.png")
 ])
 
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", [message])
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", [message])
 ```
 
 ### Streaming
@@ -88,7 +88,7 @@ message = ReqLLM.Context.user([
 **Best Practice**: Filter StreamChunks by type for clean processing.
 
 ```elixir
-{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell a story")
+{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Tell a story")
 
 # Collect only text content
 text = stream
@@ -113,7 +113,7 @@ end)
 **Best Practice**: Pattern match on specific error types for appropriate handling.
 
 ```elixir
-case ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello") do
+case ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello") do
   {:ok, response} -> 
     handle_success(response)
     
@@ -153,7 +153,7 @@ ReqLLM.put_key("anthropic_api_key", System.get_env("ANTHROPIC_API_KEY"))
 ReqLLM.put_key("openai_api_key", System.get_env("OPENAI_API_KEY"))
 
 # Providers automatically retrieve keys via JidoKeys
-{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-sonnet", "Hello")
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-3-haiku-20240307", "Hello")
 ```
 
 ## Tool Calling
@@ -260,7 +260,7 @@ end
 **Best Practice**: Process streams incrementally for large responses.
 
 ```elixir
-{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Write a long story")
+{:ok, stream} = ReqLLM.stream_text("anthropic:claude-3-haiku-20240307", "Write a long story")
 
 stream
 |> Stream.filter(&(&1.type == :text))


### PR DESCRIPTION
## Summary

This PR introduces gateway configuration support for ReqLLM and fixes critical issues with OpenAI SSE streaming tool-call assembly. These changes enable ReqLLM to work seamlessly with gateway services like Runestone while maintaining full backward compatibility with direct provider usage.

## Motivation

1. **Gateway Support**: Enable ReqLLM to route traffic through edge gateways (like Runestone) for centralized observability, rate limiting, and resilience features
2. **SSE Streaming Fix**: Resolve issues with tool-call assembly when responses are chunked across multiple SSE events
3. **Clean Separation**: Maintain clear boundaries between library (ReqLLM) and gateway (Runestone) concerns

## Changes

### 🎛️ Gateway Configuration Module

**New file: `lib/req_llm/gateway.ex`**
- Provides centralized gateway configuration helpers
- Reads from Application env or System env (`RUNESTONE_URL`, `RUNESTONE_SERVICE_TOKEN`)
- Clean API: `base_url/0`, `service_token/0`, `enabled?/0`

### 🔧 Provider Updates

All providers now support gateway defaults with proper precedence:
- **OpenAI** (`lib/req_llm/providers/openai.ex`)
- **Anthropic** (`lib/req_llm/providers/anthropic.ex`)
- **OpenRouter** (`lib/req_llm/providers/openrouter.ex`)
- **Groq** (`lib/req_llm/providers/groq.ex`)

#### Precedence Chain
1. Explicit :base_url option (highest priority)
2. Gateway default (RUNESTONE_URL)
3. Provider default (lowest priority)

#### Service Token Header
When `RUNESTONE_SERVICE_TOKEN` is configured, providers attach it as `x-service-token` header.

### 🔄 SSE Streaming Improvements

**Fixed: `lib/req_llm/providers/openai/response.ex`**
- Stateful tool-call assembly using `Stream.transform/3`
- Tracks assembly state per tool-call index
- Prevents duplicate emissions with `emitted?` flag
- Handles incremental JSON fragments correctly
- Removed unused legacy functions

### ✅ Comprehensive Tests

**New test files:**
- `test/req_llm/gateway_defaults_test.exs` - Gateway configuration tests for all providers
- `test/req_llm/providers/openai/sse_tool_call_test.exs` - SSE streaming assembly tests

**Test Coverage:**
✅ Gateway precedence for all providers
✅ Service token header attachment
✅ Fallback to provider defaults
✅ Application env vs System env precedence
✅ Single tool-call assembly across chunks
✅ Multiple concurrent tool-calls
✅ Incomplete JSON handling
✅ Mixed content and tool-calls
✅ [DONE] message handling

## Testing

All tests pass: **13 gateway tests**, **7 SSE tests**

## Breaking Changes

**None!** This maintains 100% backward compatibility.

## Migration Guide

### Optional: Enable Gateway Support

```elixir
# Option 1: Environment variables
export RUNESTONE_URL="https://gateway.example.com/v1"
export RUNESTONE_SERVICE_TOKEN="your-service-token"

# Option 2: Application config
config :req_llm,
  gateway_base_url: "https://gateway.example.com/v1",
  gateway_service_token: "your-service-token"
```

### Direct Usage (Unchanged)
```elixir
# Still works exactly as before
model = ReqLLM.Model.from!("openai:gpt-4")
{:ok, response} = ReqLLM.chat(model, "Hello!")
```

## Checklist

- [x] Provider behavior maintained
- [x] SSE streaming parser fixed
- [x] Gateway configuration with proper defaults
- [x] Service token header support
- [x] All providers updated
- [x] Comprehensive test coverage
- [x] No breaking changes
- [x] Documentation updated

## Next Steps

After this PR is merged, Runestone gateway can:
1. Import ReqLLM as a dependency
2. Implement routing, SSE proxy, error normalization
3. Call ReqLLM.Provider modules directly
4. Never duplicate provider logic

This maintains the clean boundary where **ReqLLM = library** and **Runestone = gateway**.