### PR TITLE
feat: add file to google content part

### DIFF
--- a/lib/req_llm/providers/google/context.ex
+++ b/lib/req_llm/providers/google/context.ex
@@ -84,6 +84,23 @@ defimpl ReqLLM.Context.Codec, for: ReqLLM.Providers.Google.Context do
   end
 
   defp encode_content_part(%ReqLLM.Message.ContentPart{
+         type: :file,
+         data: data,
+         media_type: media_type
+       })
+       when is_binary(data) do
+    # Encode the binary data as base64 for inline transmission
+    encoded_data = Base.encode64(data)
+
+    %{
+      inline_data: %{
+        mime_type: media_type,
+        data: encoded_data
+      }
+    }
+  end
+
+  defp encode_content_part(%ReqLLM.Message.ContentPart{
          type: :tool_call,
          tool_name: name,
          input: input,


### PR DESCRIPTION
# Pull Request

## Description

This PR simply enables the uploading of a file to the google api. This feature is already mentioned in the docs, but was not possible without this change.

I was not sure whether this is intended or just an oversight, so please tell me if there is a reason behind this missing.

I manually tested this by uploading a video file and transcribing it.

Thanks for the great library!

## Type of Change

- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests
- [ ] Build/CI

## Testing

- [ ] Tests added/updated
- [x] Manual testing performed
- [x] All tests pass

## Checklist

- [x] Code formatted and linted
- [x] Code quality checks passed (dialyzer & credo warnings/errors fixed)
- [ ] Documentation updated if needed
- [ ] Breaking changes documented (if any)

## Related Issues

Closes #
