### PR TITLE
Fix mix task documentation: use model_sync instead of models

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ReqLLM.stream_text!(model, "Write a short story")
 ## Features
 
 - **Provider-agnostic model registry**  
-  - 45 providers / 665+ models auto-synced from [models.dev](https://models.dev) (`mix req_llm.models.sync`)  
+  - 45 providers / 665+ models auto-synced from [models.dev](https://models.dev) (`mix req_llm.model_sync`)  
   - Cost, context length, modality, capability and deprecation metadata included
 
 - **Canonical data model**  

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -97,4 +97,4 @@ ReqLLM.generate_text!(
 
 ## Available Providers
 
-Run `mix req_llm.models` for up-to-date list of supported models.
+Run `mix req_llm.model_sync` for up-to-date list of supported models.


### PR DESCRIPTION
Fixes incorrect documentation references to non-existent mix tasks.

## Changes
- Fix getting-started.md to use 'mix req_llm.model_sync' instead of 'mix req_llm.models'
- Fix README.md to use 'mix req_llm.model_sync' instead of 'mix req_llm.models.sync'

Resolves #32