### PR TITLE
fix(http): Ensure req_http_options are passed to Req

### DIFF
--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -53,7 +53,7 @@ defmodule ReqLLM.Embedding do
                    doc: "Provider-specific options (keyword list or map)",
                    default: []
                  ],
-                 req_options: [
+                 req_http_options: [
                    type: {:or, [:map, {:list, :any}]},
                    doc: "Req-specific options (keyword list or map)",
                    default: []

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -86,9 +86,9 @@ defmodule ReqLLM.Generation do
                    doc: "How to handle unsupported parameter translations",
                    default: :warn
                  ],
-                 req_options: [
+                 req_http_options: [
                    type: {:or, [:map, {:list, :any}]},
-                   doc: "Req-specific options (keyword list or map)",
+                   doc: "Req-specific HTTP options (keyword list or map)",
                    default: []
                  ],
                  fixture: [

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -188,9 +188,9 @@ defmodule ReqLLM.Provider.Defaults do
     with {:ok, model} <- ReqLLM.Model.from(model_spec),
          {:ok, context} <- ReqLLM.Context.normalize(prompt, opts),
          opts_with_context = Keyword.put(opts, :context, context),
+         http_opts = Keyword.get(opts, :req_http_options, []),
          {:ok, processed_opts} <-
            ReqLLM.Provider.Options.process(provider_mod, :chat, model, opts_with_context) do
-      http_opts = Keyword.get(processed_opts, :req_http_options, [])
 
       req_keys =
         provider_mod.supported_provider_options() ++
@@ -252,9 +252,9 @@ defmodule ReqLLM.Provider.Defaults do
   def prepare_embedding_request(provider_mod, model_spec, text, opts) do
     with {:ok, model} <- ReqLLM.Model.from(model_spec),
          opts_with_text = Keyword.merge(opts, text: text, operation: :embedding),
+         http_opts = Keyword.get(opts, :req_http_options, []),
          {:ok, processed_opts} <-
            ReqLLM.Provider.Options.process(provider_mod, :embedding, model, opts_with_text) do
-      http_opts = Keyword.get(processed_opts, :req_http_options, [])
 
       req_keys =
         provider_mod.supported_provider_options() ++

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -136,7 +136,7 @@ defmodule ReqLLM.Provider.Options do
                                  doc: "How to handle unsupported parameter translations",
                                  default: :warn
                                ],
-                               req_options: [
+                               req_http_options: [
                                  type: {:list, :any},
                                  doc: "Req HTTP client options"
                                ],
@@ -152,7 +152,6 @@ defmodule ReqLLM.Provider.Options do
   # Internal keys that bypass validation (framework concerns)
   @internal_keys [
     :api_key,
-    :req_options,
     :on_unsupported,
     :fixture,
     :req_http_options,

--- a/test/req_llm/generation_test.exs
+++ b/test/req_llm/generation_test.exs
@@ -248,4 +248,17 @@ defmodule ReqLLM.GenerationTest do
       assert %Response{} = response
     end
   end
+
+  describe "generate_text/3 with req_http_options" do
+    test "correctly passes http options to Req" do
+      # We pass an intentionally invalid option to Req. If `req_http_options` are being passed correctly,
+      # Req's internal validation will raise an ArgumentError. This confirms the options are being passed
+      # all the way to `Req.new/1` without making a real network request.
+      assert_raise ArgumentError, ~r/got unsupported atom method :invalid_method/, fn ->
+        Generation.generate_text("openai:gpt-4o-mini", "Hello",
+          req_http_options: [method: :invalid_method]
+        )
+      end
+    end
+  end
 end

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -146,13 +146,13 @@ defmodule ReqLLM.Provider.OptionsTest do
     end
   end
 
-  describe "Options.process/4 - req_options handling" do
-    test "preserves req_options for merging into Req request" do
+  describe "Options.process/4 - req_http_options handling" do
+    test "preserves req_http_options for merging into Req request" do
       model = %ReqLLM.Model{provider: :mock, model: "test-model"}
 
       opts = [
         temperature: 0.7,
-        req_options: [
+        req_http_options: [
           timeout: 60_000,
           retry_attempts: 5
         ]
@@ -160,17 +160,17 @@ defmodule ReqLLM.Provider.OptionsTest do
 
       assert {:ok, processed} = Options.process(MockProvider, :chat, model, opts)
       assert processed[:temperature] == 0.7
-      assert processed[:req_options][:timeout] == 60_000
-      assert processed[:req_options][:retry_attempts] == 5
+      assert processed[:req_http_options][:timeout] == 60_000
+      assert processed[:req_http_options][:retry_attempts] == 5
     end
 
-    test "handles missing req_options gracefully" do
+    test "handles missing req_http_options gracefully" do
       model = %ReqLLM.Model{provider: :mock, model: "test-model"}
       opts = [temperature: 0.7]
 
       assert {:ok, processed} = Options.process(MockProvider, :chat, model, opts)
       assert processed[:temperature] == 0.7
-      refute Keyword.has_key?(processed, :req_options)
+      refute Keyword.has_key?(processed, :req_http_options)
     end
   end
 
@@ -226,7 +226,7 @@ defmodule ReqLLM.Provider.OptionsTest do
       opts = [
         temperature: 0.7,
         # Internal keys that should bypass validation
-        req_options: %{unknown: "value"},
+        req_http_options: %{unknown: "value"},
         fixture: :test_fixture,
         operation: :embedding,
         text: "input text",
@@ -236,7 +236,7 @@ defmodule ReqLLM.Provider.OptionsTest do
       assert {:ok, processed} = Options.process(MockProvider, :chat, model, opts)
 
       assert processed[:temperature] == 0.7
-      assert processed[:req_options] == %{unknown: "value"}
+      assert processed[:req_http_options] == %{unknown: "value"}
       assert processed[:fixture] == :test_fixture
       assert processed[:operation] == :embedding
       assert processed[:text] == "input text"


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes this bug where HTTP options passed via the `:req_http_options` key to generation functions (e.g., `generate_text/3`) were being ignored. This prevented users from configuring underlying `Req` settings, such as setting a `:proxy` or overriding the `:base_url`.

The issue was caused by two problems: a schema naming mismatch (`:req_options` vs. `:req_http_options`) and the premature filtering of these options before they could be passed to `Req.new/1`.

### Changes Made

*   Standardized the option name to `:req_http_options` across all relevant validation schemas.
*   Adjusted the option processing logic in `ReqLLM.Provider.Defaults` to ensure `:req_http_options` are extracted *before* validation and filtering, preserving them for the final `Req.new/1` call.
*   Updated existing tests that were using the old `:req_options` key to prevent regressions.
*   Added a new test case in `generation_test.exs` that verifies the fix by passing an invalid `Req` option through `:req_http_options`. The test asserts that `Req`'s internal validation raises an `ArgumentError`, confirming that the options are being passed through correctly without requiring network requests or mock servers.

## Type of Change

- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests
- [ ] Build/CI

## Testing

- [X] Tests added/updated
- [X] Manual testing performed
- [X] All tests pass

## Checklist

- [X] Code formatted and linted
- [X] Code quality checks passed (dialyzer & credo warnings/errors fixed)
- [X] Documentation updated if needed
- [X] Breaking changes documented (if any)
