### PR TITLE
Fix tool calling encoding for OpenAI provider

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -404,22 +404,61 @@ defmodule ReqLLM.Provider.Defaults do
     Enum.map(messages, &encode_openai_message/1)
   end
 
-  defp encode_openai_message(%ReqLLM.Message{
-         role: role,
+  defp encode_openai_message(%ReqLLM.Message{} = msg) do
+    case msg.role do
+      :assistant -> encode_openai_message_assistant(msg)
+      :tool -> encode_openai_message_tool(msg)
+      _ -> encode_openai_message_generic(msg)
+    end
+  end
+
+  defp encode_openai_message_assistant(%ReqLLM.Message{content: content, tool_calls: tool_calls}) do
+    # Only include text content parts in content; extract tool calls into top-level field
+    text_content = encode_openai_text_content_only(content)
+    calls_from_parts = extract_tool_calls_from_parts(content)
+    calls = normalize_openai_tool_calls((tool_calls || []) ++ calls_from_parts)
+
+    base =
+      %{
+        role: "assistant"
+      }
+      |> maybe_put(:content, text_content)
+
+    case calls do
+      [] -> base
+      _ -> Map.put(base, :tool_calls, calls)
+    end
+  end
+
+  defp encode_openai_message_tool(%ReqLLM.Message{
          content: content,
-         tool_calls: tool_calls
+         tool_call_id: msg_tool_call_id
        }) do
-    base_message = %{
+    # Build content string and tool_call_id from either message or first tool_result part
+    {tool_call_id, content_string} =
+      case extract_tool_result(content) do
+        {id, output} ->
+          id_to_use = msg_tool_call_id || id
+          {id_to_use, encode_tool_output_to_string(output)}
+
+        nil ->
+          # Fallback: join text parts; content must be string
+          {msg_tool_call_id, text_only_join(content)}
+      end
+
+    content_to_use = if content_string == "", do: "No output", else: content_string
+
+    %{}
+    |> Map.put(:role, "tool")
+    |> maybe_put(:tool_call_id, tool_call_id)
+    |> maybe_put(:content, content_to_use)
+  end
+
+  defp encode_openai_message_generic(%ReqLLM.Message{role: role, content: content}) do
+    %{
       role: to_string(role),
       content: encode_openai_content(content)
     }
-
-    # Add tool_calls if present and not nil
-    case tool_calls do
-      nil -> base_message
-      [] -> base_message
-      calls -> Map.put(base_message, :tool_calls, calls)
-    end
   end
 
   defp encode_openai_content(content) when is_binary(content), do: content
@@ -447,23 +486,109 @@ defmodule ReqLLM.Provider.Defaults do
     %{type: "text", text: text}
   end
 
-  defp encode_openai_content_part(%ReqLLM.Message.ContentPart{
-         type: :tool_call,
-         tool_name: name,
-         input: input,
-         tool_call_id: id
-       }) do
+  # Tool calls should NOT be encoded into content - they go to top-level tool_calls
+  defp encode_openai_content_part(%ReqLLM.Message.ContentPart{type: :tool_call}), do: nil
+
+  defp encode_openai_content_part(_), do: nil
+
+  # Helper functions for tool calling support
+
+  defp encode_openai_text_content_only(parts) when is_list(parts) do
+    encoded =
+      parts
+      |> Enum.map(&encode_openai_content_part/1)
+      |> maybe_flatten_single_text()
+
+    case encoded do
+      [] -> nil
+      "" -> nil
+      content -> content
+    end
+  end
+
+  defp text_only_join(parts) do
+    parts
+    |> Enum.filter(&(&1.type == :text))
+    |> Enum.map_join("", & &1.text)
+  end
+
+  defp extract_tool_result(parts) do
+    # Return {id, output} from the first tool_result part if present
+    Enum.find_value(parts, fn
+      %ReqLLM.Message.ContentPart{type: :tool_result, tool_call_id: id, output: output} ->
+        {id, output}
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp encode_tool_output_to_string(output) when is_binary(output), do: output
+  defp encode_tool_output_to_string(output), do: Jason.encode!(output)
+
+  defp extract_tool_calls_from_parts(parts) do
+    for %ReqLLM.Message.ContentPart{
+          type: :tool_call,
+          tool_name: name,
+          input: input,
+          tool_call_id: id
+        } <- parts do
+      %{
+        "id" => id,
+        "type" => "function",
+        "function" => %{
+          "name" => name,
+          "arguments" => input
+        }
+      }
+    end
+  end
+
+  defp normalize_openai_tool_calls(calls) when is_list(calls) do
+    calls
+    |> Enum.map(&normalize_openai_tool_call/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp normalize_openai_tool_call(%{"id" => id, "type" => "function", "function" => fnc}) do
     %{
-      id: id,
-      type: "function",
-      function: %{
-        name: name,
-        arguments: Jason.encode!(input)
+      "id" => id || generate_tool_call_id(),
+      "type" => "function",
+      "function" => %{
+        "name" => fnc["name"],
+        "arguments" => normalize_arguments(fnc["arguments"])
       }
     }
   end
 
-  defp encode_openai_content_part(_), do: nil
+  defp normalize_openai_tool_call(%{id: id, function: %{name: name, arguments: args}}) do
+    %{
+      "id" => id || generate_tool_call_id(),
+      "type" => "function",
+      "function" => %{
+        "name" => name,
+        "arguments" => normalize_arguments(args)
+      }
+    }
+  end
+
+  defp normalize_openai_tool_call(%{name: name, arguments: args} = m) do
+    %{
+      "id" => Map.get(m, :id) || Map.get(m, "id") || generate_tool_call_id(),
+      "type" => "function",
+      "function" => %{
+        "name" => name || Map.get(m, "name"),
+        "arguments" => normalize_arguments(args || Map.get(m, "arguments"))
+      }
+    }
+  end
+
+  defp normalize_openai_tool_call(_), do: nil
+
+  defp normalize_arguments(args) when is_binary(args), do: args
+  defp normalize_arguments(args), do: Jason.encode!(args || %{})
+
+  defp generate_tool_call_id, do: "call_#{System.unique_integer([:positive])}"
 
   @doc """
   Decodes OpenAI-format response body to ReqLLM.Response.

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -56,31 +56,118 @@ defmodule ReqLLM.Provider.DefaultsTest do
         ]
       }
 
-      expected_message_result = %{
+      # Both should result in the same encoding: tool_calls at the top level
+
+      result1 =
+        Defaults.encode_context_to_openai_format(
+          %Context{messages: [message_tool_calls]},
+          "gpt-4"
+        )
+
+      result2 =
+        Defaults.encode_context_to_openai_format(
+          %Context{messages: [content_tool_calls]},
+          "gpt-4"
+        )
+
+      # Both should have the same structure
+      assert %{messages: [%{role: "assistant", tool_calls: [tool_call1]}]} = result1
+      assert %{messages: [%{role: "assistant", tool_calls: [tool_call2]}]} = result2
+
+      # Verify tool call structure 
+      assert tool_call1["id"] == "call_123"
+      assert tool_call1["type"] == "function"
+      assert tool_call1["function"]["name"] == "get_weather"
+      assert tool_call1["function"]["arguments"] == ~s({"city":"New York"})
+
+      assert tool_call2["id"] == "call_123"
+      assert tool_call2["type"] == "function"
+      assert tool_call2["function"]["name"] == "get_weather"
+      assert Jason.decode!(tool_call2["function"]["arguments"]) == %{"city" => "New York"}
+    end
+
+    test "encodes tool messages correctly" do
+      # Test tool message with result
+      tool_result_message = %Message{
+        role: :tool,
+        content: [
+          %ContentPart{
+            type: :tool_result,
+            tool_call_id: "call_123",
+            output: %{temperature: "72F", condition: "sunny"}
+          }
+        ]
+      }
+
+      expected_result = %{
+        messages: [
+          %{
+            role: "tool",
+            tool_call_id: "call_123",
+            content: ~s({"temperature":"72F","condition":"sunny"})
+          }
+        ]
+      }
+
+      assert Defaults.encode_context_to_openai_format(
+               %Context{messages: [tool_result_message]},
+               "gpt-4"
+             ) == expected_result
+    end
+
+    test "normalizes tool call arguments to JSON strings" do
+      # Test with map arguments (should be JSON encoded)
+      map_args_message = %Message{
+        role: :assistant,
+        content: [],
+        tool_calls: [
+          %{
+            id: "call_456",
+            function: %{name: "calculate", arguments: %{a: 1, b: 2}}
+          }
+        ]
+      }
+
+      result =
+        Defaults.encode_context_to_openai_format(
+          %Context{messages: [map_args_message]},
+          "gpt-4"
+        )
+
+      # Extract the tool call to verify the structure and content
+      assert %{messages: [%{role: "assistant", tool_calls: [tool_call]}]} = result
+      assert tool_call["id"] == "call_456"
+      assert tool_call["type"] == "function"
+      assert tool_call["function"]["name"] == "calculate"
+      # Verify arguments is valid JSON that parses to the original map
+      assert Jason.decode!(tool_call["function"]["arguments"]) == %{"a" => 1, "b" => 2}
+    end
+
+    test "combines text content and tool calls correctly" do
+      # Assistant message with both text and tool call
+      mixed_message = %Message{
+        role: :assistant,
+        content: [
+          %ContentPart{type: :text, text: "I'll check the weather for you."},
+          %ContentPart{
+            type: :tool_call,
+            tool_name: "get_weather",
+            input: %{city: "New York"},
+            tool_call_id: "call_789"
+          }
+        ]
+      }
+
+      expected_result = %{
         messages: [
           %{
             role: "assistant",
-            content: [],
+            content: "I'll check the weather for you.",
             tool_calls: [
               %{
-                id: "call_123",
-                type: "function",
-                function: %{name: "get_weather", arguments: ~s({"city":"New York"})}
-              }
-            ]
-          }
-        ]
-      }
-
-      expected_content_result = %{
-        messages: [
-          %{
-            role: "assistant",
-            content: [
-              %{
-                id: "call_123",
-                type: "function",
-                function: %{name: "get_weather", arguments: ~s({"city":"New York"})}
+                "id" => "call_789",
+                "type" => "function",
+                "function" => %{"name" => "get_weather", "arguments" => ~s({"city":"New York"})}
               }
             ]
           }
@@ -88,14 +175,9 @@ defmodule ReqLLM.Provider.DefaultsTest do
       }
 
       assert Defaults.encode_context_to_openai_format(
-               %Context{messages: [message_tool_calls]},
+               %Context{messages: [mixed_message]},
                "gpt-4"
-             ) == expected_message_result
-
-      assert Defaults.encode_context_to_openai_format(
-               %Context{messages: [content_tool_calls]},
-               "gpt-4"
-             ) == expected_content_result
+             ) == expected_result
     end
   end
 

--- a/test/support/fixtures/openai/openai_basic_tool_call.json
+++ b/test/support/fixtures/openai/openai_basic_tool_call.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "body": {
-      "b64": "eyJtZXNzYWdlcyI6W3siY29udGVudCI6IldoYXQncyB0aGUgd2VhdGhlciBsaWtlIGluIFBhcmlzLCBGcmFuY2U/Iiwicm9sZSI6InVzZXIifV0sInN0cmVhbSI6ZmFsc2UsInRvb2xzIjpbeyJmdW5jdGlvbiI6eyJkZXNjcmlwdGlvbiI6IkdldCBjdXJyZW50IHdlYXRoZXIgaW5mb3JtYXRpb24gZm9yIGEgbG9jYXRpb24iLCJuYW1lIjoiZ2V0X3dlYXRoZXIiLCJwYXJhbWV0ZXJzIjp7InByb3BlcnRpZXMiOnsibG9jYXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgY2l0eSBhbmQgc3RhdGUsIGUuZy4gU2FuIEZyYW5jaXNjbywgQ0EiLCJ0eXBlIjoic3RyaW5nIn0sInVuaXQiOnsiZGVzY3JpcHRpb24iOiJUaGUgdGVtcGVyYXR1cmUgdW5pdCB0byB1c2UiLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJsb2NhdGlvbiJdLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoiZnVuY3Rpb24ifV0sIm1vZGVsIjoiZ3B0LTRvLW1pbmkiLCJtYXhfdG9rZW5zIjoxMDAsInRlbXBlcmF0dXJlIjowLjB9"
+      "b64": "eyJtYXhfdG9rZW5zIjoxMDAsIm1heF90b2tlbnMiOjEwMCwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOiJXaGF0J3MgdGhlIHdlYXRoZXIgbGlrZSBpbiBQYXJpcywgRnJhbmNlPyIsInJvbGUiOiJ1c2VyIn1dLCJtb2RlbCI6ImdwdC00by1taW5pIiwic2VlZCI6NDIsInN0cmVhbSI6ZmFsc2UsInRlbXBlcmF0dXJlIjowLjAsInRvb2xzIjpbeyJmdW5jdGlvbiI6eyJkZXNjcmlwdGlvbiI6IkdldCBjdXJyZW50IHdlYXRoZXIgaW5mb3JtYXRpb24gZm9yIGEgbG9jYXRpb24iLCJuYW1lIjoiZ2V0X3dlYXRoZXIiLCJwYXJhbWV0ZXJzIjp7InByb3BlcnRpZXMiOnsibG9jYXRpb24iOnsiZGVzY3JpcHRpb24iOiJUaGUgY2l0eSBhbmQgc3RhdGUsIGUuZy4gU2FuIEZyYW5jaXNjbywgQ0EiLCJ0eXBlIjoic3RyaW5nIn0sInVuaXQiOnsiZGVzY3JpcHRpb24iOiJUaGUgdGVtcGVyYXR1cmUgdW5pdCB0byB1c2UiLCJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJsb2NhdGlvbiJdLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoiZnVuY3Rpb24ifV19"
     },
     "url": "https://api.openai.com/v1/chat/completions",
     "headers": {
@@ -19,7 +19,7 @@
       ]
     },
     "method": "post",
-    "canonical_json": "{\"max_tokens\":100,\"messages\":[{\"content\":\"What's the weather like in Paris, France?\",\"role\":\"user\"}],\"model\":\"gpt-4o-mini\",\"stream\":false,\"temperature\":0.0,\"tools\":[{\"function\":{\"description\":\"Get current weather information for a location\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"The city and state, e.g. San Francisco, CA\",\"type\":\"string\"},\"unit\":{\"description\":\"The temperature unit to use\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"}]}"
+    "canonical_json": "{\"max_tokens\":100,\"messages\":[{\"content\":\"What's the weather like in Paris, France?\",\"role\":\"user\"}],\"model\":\"gpt-4o-mini\",\"seed\":42,\"stream\":false,\"temperature\":0.0,\"tools\":[{\"function\":{\"description\":\"Get current weather information for a location\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"description\":\"The city and state, e.g. San Francisco, CA\",\"type\":\"string\"},\"unit\":{\"description\":\"The temperature unit to use\",\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"}]}"
   },
   "response": {
     "status": 200,
@@ -40,15 +40,15 @@
                   "arguments": "{\"location\":\"Paris, France\"}",
                   "name": "get_weather"
                 },
-                "id": "call_1AIMktMHe16WhNOPAzY8rngy",
+                "id": "call_nM8kL8jIBRMpX1OvejcKFzuf",
                 "type": "function"
               }
             ]
           }
         }
       ],
-      "created": 1758031144,
-      "id": "chatcmpl-CGQUyFamz4AIwRTelfBz0fPBz283N",
+      "created": 1758923405,
+      "id": "chatcmpl-CKAcHcRzgkRaPEX1PPXOrnsmPtB50",
       "model": "gpt-4o-mini-2024-07-18",
       "object": "chat.completion",
       "service_tier": "default",
@@ -80,7 +80,7 @@
         "DYNAMIC"
       ],
       "cf-ray": [
-        "9800e1dd8ecda6ee-ORD"
+        "9855f98c0ba8a6ee-ORD"
       ],
       "connection": [
         "keep-alive"
@@ -89,13 +89,13 @@
         "application/json"
       ],
       "date": [
-        "Tue, 16 Sep 2025 13:59:05 GMT"
+        "Fri, 26 Sep 2025 21:50:05 GMT"
       ],
       "openai-organization": [
         "epic-creative-sogybe"
       ],
       "openai-processing-ms": [
-        "502"
+        "460"
       ],
       "openai-project": [
         "proj_j5AhgU4eLMRmsoO9FDg7BRD3"
@@ -107,8 +107,8 @@
         "cloudflare"
       ],
       "set-cookie": [
-        "__cf_bm=KciNzbeTCY4w9LHUgiDELA0I.MKIExlNQJ.7zwDvzW0-1758031145-1.0.1.1-T54rT17IhwYLjRpJfWlQXwoKvWnrC4aqC.5pJ0LsabX48cxQJGP.zqOC1Xu.96s0hlfK7wQHA0QfyktXT6Hf0V5OuXaYXsEMXxfSlD_dodk; path=/; expires=Tue, 16-Sep-25 14:29:05 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
-        "_cfuvid=OLkhK7jo9vC3r4s1RSUYxc7QvoOAtY3lD.3aUIs4uf4-1758031145256-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None"
+        "__cf_bm=QG6x7ZU_2GIut26dsSnNE3mfLNGETiBZbZ0OJgADT5U-1758923405-1.0.1.1-aQmloXS2TWye5iGef5kniXwOOVe8E3oym.bUcDtr3nOuFroGwhsLvqGTM8AqQCZqoStlipUygl77d6uHY87Bl2ledJc9gR0gY48xlDIKKrM; path=/; expires=Fri, 26-Sep-25 22:20:05 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+        "_cfuvid=f3oOpdjb8hApUJCcX7_DsVkt0MZ.6DprfEA6Zj5Un.Q-1758923405400-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None"
       ],
       "strict-transport-security": [
         "max-age=31536000; includeSubDomains; preload"
@@ -120,7 +120,7 @@
         "nosniff"
       ],
       "x-envoy-upstream-service-time": [
-        "635"
+        "722"
       ],
       "x-openai-proxy-wasm": [
         "v0.1"
@@ -144,9 +144,9 @@
         "0s"
       ],
       "x-request-id": [
-        "req_e0d3a3f1c72a43e9b4de161ffad7f2c0"
+        "req_49f9de9d97774860a5ef43a5f21e3890"
       ]
     }
   },
-  "captured_at": "2025-09-16T13:59:05.297752Z"
+  "captured_at": "2025-09-26T21:50:05.436430Z"
 }

--- a/test/support/fixtures/openai/openai_multi_tool_call.json
+++ b/test/support/fixtures/openai/openai_multi_tool_call.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "body": {
-      "b64": "eyJtZXNzYWdlcyI6W3siY29udGVudCI6IlRlbGwgbWUgYSBqb2tlIGFib3V0IHByb2dyYW1taW5nIiwicm9sZSI6InVzZXIifV0sInN0cmVhbSI6ZmFsc2UsInRvb2xzIjpbeyJmdW5jdGlvbiI6eyJkZXNjcmlwdGlvbiI6IkdldCBjdXJyZW50IHdlYXRoZXIgaW5mb3JtYXRpb24gZm9yIGEgbG9jYXRpb24iLCJuYW1lIjoiZ2V0X3dlYXRoZXIiLCJwYXJhbWV0ZXJzIjp7InByb3BlcnRpZXMiOnsibG9jYXRpb24iOnsidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibG9jYXRpb24iXSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6ImZ1bmN0aW9uIn0seyJmdW5jdGlvbiI6eyJkZXNjcmlwdGlvbiI6IlRlbGwgYSBmdW5ueSBqb2tlIiwibmFtZSI6InRlbGxfam9rZSIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6eyJ0b3BpYyI6eyJkZXNjcmlwdGlvbiI6IlRvcGljIGZvciB0aGUgam9rZSIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJmdW5jdGlvbiJ9LHsiZnVuY3Rpb24iOnsiZGVzY3JpcHRpb24iOiJHZXQgdGhlIGN1cnJlbnQgdGltZSIsIm5hbWUiOiJnZXRfdGltZSIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6e30sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJmdW5jdGlvbiJ9XSwibW9kZWwiOiJncHQtNG8tbWluaSIsIm1heF90b2tlbnMiOjEwMCwidGVtcGVyYXR1cmUiOjAuMH0="
+      "b64": "eyJtYXhfdG9rZW5zIjoxMDAsIm1heF90b2tlbnMiOjEwMCwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOiJUZWxsIG1lIGEgam9rZSBhYm91dCBwcm9ncmFtbWluZyIsInJvbGUiOiJ1c2VyIn1dLCJtb2RlbCI6ImdwdC00by1taW5pIiwic2VlZCI6NDIsInN0cmVhbSI6ZmFsc2UsInRlbXBlcmF0dXJlIjowLjAsInRvb2xzIjpbeyJmdW5jdGlvbiI6eyJkZXNjcmlwdGlvbiI6IkdldCBjdXJyZW50IHdlYXRoZXIgaW5mb3JtYXRpb24gZm9yIGEgbG9jYXRpb24iLCJuYW1lIjoiZ2V0X3dlYXRoZXIiLCJwYXJhbWV0ZXJzIjp7InByb3BlcnRpZXMiOnsibG9jYXRpb24iOnsidHlwZSI6InN0cmluZyJ9fSwicmVxdWlyZWQiOlsibG9jYXRpb24iXSwidHlwZSI6Im9iamVjdCJ9fSwidHlwZSI6ImZ1bmN0aW9uIn0seyJmdW5jdGlvbiI6eyJkZXNjcmlwdGlvbiI6IlRlbGwgYSBmdW5ueSBqb2tlIiwibmFtZSI6InRlbGxfam9rZSIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6eyJ0b3BpYyI6eyJkZXNjcmlwdGlvbiI6IlRvcGljIGZvciB0aGUgam9rZSIsInR5cGUiOiJzdHJpbmcifX0sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJmdW5jdGlvbiJ9LHsiZnVuY3Rpb24iOnsiZGVzY3JpcHRpb24iOiJHZXQgdGhlIGN1cnJlbnQgdGltZSIsIm5hbWUiOiJnZXRfdGltZSIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6e30sInR5cGUiOiJvYmplY3QifX0sInR5cGUiOiJmdW5jdGlvbiJ9XX0="
     },
     "url": "https://api.openai.com/v1/chat/completions",
     "headers": {
@@ -19,7 +19,7 @@
       ]
     },
     "method": "post",
-    "canonical_json": "{\"max_tokens\":100,\"messages\":[{\"content\":\"Tell me a joke about programming\",\"role\":\"user\"}],\"model\":\"gpt-4o-mini\",\"stream\":false,\"temperature\":0.0,\"tools\":[{\"function\":{\"description\":\"Get current weather information for a location\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"},{\"function\":{\"description\":\"Tell a funny joke\",\"name\":\"tell_joke\",\"parameters\":{\"properties\":{\"topic\":{\"description\":\"Topic for the joke\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"function\"},{\"function\":{\"description\":\"Get the current time\",\"name\":\"get_time\",\"parameters\":{\"properties\":{},\"type\":\"object\"}},\"type\":\"function\"}]}"
+    "canonical_json": "{\"max_tokens\":100,\"messages\":[{\"content\":\"Tell me a joke about programming\",\"role\":\"user\"}],\"model\":\"gpt-4o-mini\",\"seed\":42,\"stream\":false,\"temperature\":0.0,\"tools\":[{\"function\":{\"description\":\"Get current weather information for a location\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"},{\"function\":{\"description\":\"Tell a funny joke\",\"name\":\"tell_joke\",\"parameters\":{\"properties\":{\"topic\":{\"description\":\"Topic for the joke\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"function\"},{\"function\":{\"description\":\"Get the current time\",\"name\":\"get_time\",\"parameters\":{\"properties\":{},\"type\":\"object\"}},\"type\":\"function\"}]}"
   },
   "response": {
     "status": 200,
@@ -40,15 +40,15 @@
                   "arguments": "{\"topic\":\"programming\"}",
                   "name": "tell_joke"
                 },
-                "id": "call_gt6wAt8RSj7WGLhKWhmbeDX9",
+                "id": "call_6iLLk8xD0Hhj4tNNyi3N8XDd",
                 "type": "function"
               }
             ]
           }
         }
       ],
-      "created": 1758031146,
-      "id": "chatcmpl-CGQV0MR0MGvHh31nVtj59whoOez4j",
+      "created": 1758923403,
+      "id": "chatcmpl-CKAcFQT6AR2xuusWkrN3Gx7SqqwM5",
       "model": "gpt-4o-mini-2024-07-18",
       "object": "chat.completion",
       "service_tier": "default",
@@ -80,7 +80,7 @@
         "DYNAMIC"
       ],
       "cf-ray": [
-        "9800e1e79d1fa6ee-ORD"
+        "9855f9810b03a6ee-ORD"
       ],
       "connection": [
         "keep-alive"
@@ -89,13 +89,13 @@
         "application/json"
       ],
       "date": [
-        "Tue, 16 Sep 2025 13:59:07 GMT"
+        "Fri, 26 Sep 2025 21:50:04 GMT"
       ],
       "openai-organization": [
         "epic-creative-sogybe"
       ],
       "openai-processing-ms": [
-        "980"
+        "1031"
       ],
       "openai-project": [
         "proj_j5AhgU4eLMRmsoO9FDg7BRD3"
@@ -107,8 +107,8 @@
         "cloudflare"
       ],
       "set-cookie": [
-        "__cf_bm=78rSJLVSdrxjbIkuqsL_p5o0ctLB2O_eFB1fO5NZmVk-1758031147-1.0.1.1-M_DZuwijqnIRdrVF4F.dKNvxlv984L7ViAktEuh0h5fgFZ3A1CSshLgg61zdO61CJqLwM0ls.hoBzyeGXn3fH3ecS4UFCY5SwDtMLaPH.7M; path=/; expires=Tue, 16-Sep-25 14:29:07 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
-        "_cfuvid=piGX5zIgU1plVy1o6bcXkIXGXYMNrBNsfxwdV5rt9v0-1758031147240-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None"
+        "__cf_bm=GXDZxW1wI.CDi3nDZc8xzgQn3mUvFJqSQqsLQzhs_Z8-1758923404-1.0.1.1-SxaJv4ueLA92mIIeElsFsJXP3QaqTcwuOaZjoEIOxTJqjmZolwIqaU142RRKSKn6SkiVA1axtGILr65jvQmbjj2yYGJU2WpvIyHcOvSNqzM; path=/; expires=Fri, 26-Sep-25 22:20:04 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+        "_cfuvid=BdYW2XqGhneV18VueoyOOb7EFChmPCLOKMkJ6Qf16lM-1758923404119-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None"
       ],
       "strict-transport-security": [
         "max-age=31536000; includeSubDomains; preload"
@@ -120,7 +120,7 @@
         "nosniff"
       ],
       "x-envoy-upstream-service-time": [
-        "1003"
+        "1272"
       ],
       "x-openai-proxy-wasm": [
         "v0.1"
@@ -144,9 +144,9 @@
         "0s"
       ],
       "x-request-id": [
-        "req_052106e7d9964343b14b696865b02b2f"
+        "req_01e54d8b5006418aae29089165c6aa42"
       ]
     }
   },
-  "captured_at": "2025-09-16T13:59:07.264356Z"
+  "captured_at": "2025-09-26T21:50:04.088418Z"
 }

--- a/test/support/fixtures/openai/openai_no_tool_call.json
+++ b/test/support/fixtures/openai/openai_no_tool_call.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "body": {
-      "b64": "eyJtZXNzYWdlcyI6W3siY29udGVudCI6IlRlbGwgbWUgYSBqb2tlIGFib3V0IGNhdHMiLCJyb2xlIjoidXNlciJ9XSwic3RyZWFtIjpmYWxzZSwidG9vbHMiOlt7ImZ1bmN0aW9uIjp7ImRlc2NyaXB0aW9uIjoiR2V0IGN1cnJlbnQgd2VhdGhlciBpbmZvcm1hdGlvbiBmb3IgYSBsb2NhdGlvbiIsIm5hbWUiOiJnZXRfd2VhdGhlciIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6eyJsb2NhdGlvbiI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJsb2NhdGlvbiJdLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoiZnVuY3Rpb24ifV0sIm1vZGVsIjoiZ3B0LTRvLW1pbmkiLCJtYXhfdG9rZW5zIjoxMDAsInRlbXBlcmF0dXJlIjowLjB9"
+      "b64": "eyJtYXhfdG9rZW5zIjoxMDAsIm1heF90b2tlbnMiOjEwMCwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOiJUZWxsIG1lIGEgam9rZSBhYm91dCBjYXRzIiwicm9sZSI6InVzZXIifV0sIm1vZGVsIjoiZ3B0LTRvLW1pbmkiLCJzZWVkIjo0Miwic3RyZWFtIjpmYWxzZSwidGVtcGVyYXR1cmUiOjAuMCwidG9vbHMiOlt7ImZ1bmN0aW9uIjp7ImRlc2NyaXB0aW9uIjoiR2V0IGN1cnJlbnQgd2VhdGhlciBpbmZvcm1hdGlvbiBmb3IgYSBsb2NhdGlvbiIsIm5hbWUiOiJnZXRfd2VhdGhlciIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6eyJsb2NhdGlvbiI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJsb2NhdGlvbiJdLCJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoiZnVuY3Rpb24ifV19"
     },
     "url": "https://api.openai.com/v1/chat/completions",
     "headers": {
@@ -19,7 +19,7 @@
       ]
     },
     "method": "post",
-    "canonical_json": "{\"max_tokens\":100,\"messages\":[{\"content\":\"Tell me a joke about cats\",\"role\":\"user\"}],\"model\":\"gpt-4o-mini\",\"stream\":false,\"temperature\":0.0,\"tools\":[{\"function\":{\"description\":\"Get current weather information for a location\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"}]}"
+    "canonical_json": "{\"max_tokens\":100,\"messages\":[{\"content\":\"Tell me a joke about cats\",\"role\":\"user\"}],\"model\":\"gpt-4o-mini\",\"seed\":42,\"stream\":false,\"temperature\":0.0,\"tools\":[{\"function\":{\"description\":\"Get current weather information for a location\",\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"location\":{\"type\":\"string\"}},\"required\":[\"location\"],\"type\":\"object\"}},\"type\":\"function\"}]}"
   },
   "response": {
     "status": 200,
@@ -37,8 +37,8 @@
           }
         }
       ],
-      "created": 1758031145,
-      "id": "chatcmpl-CGQUzis7pEOfi1GLR0MQwmsEbtGPU",
+      "created": 1758923401,
+      "id": "chatcmpl-CKAcDSixILnp5g1AocFfd0Wm0tDLv",
       "model": "gpt-4o-mini-2024-07-18",
       "object": "chat.completion",
       "service_tier": "default",
@@ -70,7 +70,7 @@
         "DYNAMIC"
       ],
       "cf-ray": [
-        "9800e1e2bf43a6ee-ORD"
+        "9855f9780cdda6ee-ORD"
       ],
       "connection": [
         "keep-alive"
@@ -79,13 +79,13 @@
         "application/json"
       ],
       "date": [
-        "Tue, 16 Sep 2025 13:59:06 GMT"
+        "Fri, 26 Sep 2025 21:50:02 GMT"
       ],
       "openai-organization": [
         "epic-creative-sogybe"
       ],
       "openai-processing-ms": [
-        "556"
+        "623"
       ],
       "openai-project": [
         "proj_j5AhgU4eLMRmsoO9FDg7BRD3"
@@ -97,8 +97,8 @@
         "cloudflare"
       ],
       "set-cookie": [
-        "__cf_bm=Kz8vVUw7P2LVMTiW2gPlcqyi1ZxGoNJk1wHPNDL7ZAI-1758031146-1.0.1.1-SWquq0GpxOV.ql8IDL8XSwe0dwSAbhkCZ3Xcq2XWRMHYzD8BIBHG.ktamP0kxfwBurPTpHDzmAhKNKcFaa6eOF2Ydcwsjj_qCGeGSm50SqI; path=/; expires=Tue, 16-Sep-25 14:29:06 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
-        "_cfuvid=X3utQ2_vBdGO7FydQ40yQ91IgoITZaJqpEBSfmr..jY-1758031146146-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None"
+        "__cf_bm=w_FIabavvEvjuG8ZiBRBJMueQOZjbcFpkn8xf4NC5vs-1758923402-1.0.1.1-AzGGGuE3K7ai0ojK8zzXralbC6rxUdWMT2DJbXuZjwSE3zE.Tk8OjcYKcarJMDrxgRibgY5.OEHkpXjmCw0mEZi4NoSQRFkY.LyAFTUPXvk; path=/; expires=Fri, 26-Sep-25 22:20:02 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+        "_cfuvid=w5pKPovH4YocDlUR4ZkuW3UPGyyzCt7RjJ7ksS5.P_I-1758923402371-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None"
       ],
       "strict-transport-security": [
         "max-age=31536000; includeSubDomains; preload"
@@ -110,7 +110,7 @@
         "nosniff"
       ],
       "x-envoy-upstream-service-time": [
-        "700"
+        "926"
       ],
       "x-openai-proxy-wasm": [
         "v0.1"
@@ -134,9 +134,9 @@
         "0s"
       ],
       "x-request-id": [
-        "req_9630dce488844d348653ac475b17cd1f"
+        "req_12f52c08af084d8385536321803611c3"
       ]
     }
   },
-  "captured_at": "2025-09-16T13:59:06.077205Z"
+  "captured_at": "2025-09-26T21:50:02.336775Z"
 }

--- a/test/support/provider_test/tool_calling.ex
+++ b/test/support/provider_test/tool_calling.ex
@@ -57,7 +57,7 @@ defmodule ReqLLM.ProviderTest.ToolCalling do
           "What's the weather like in Paris, France?",
           fixture_opts(unquote(provider), "basic_tool_call", base_opts ++ [tools: tools])
         )
-        |> assert_basic_response()
+        |> assert_tool_calling_response()
         |> assert_tool_call_response("get_weather")
       end
 
@@ -119,7 +119,7 @@ defmodule ReqLLM.ProviderTest.ToolCalling do
           "Tell me a joke about programming",
           fixture_opts(unquote(provider), "multi_tool_call", base_opts ++ [tools: tools])
         )
-        |> assert_basic_response()
+        |> assert_tool_calling_response()
         |> assert_tool_call_response("tell_joke")
       end
 

--- a/test/support/provider_test_helpers.ex
+++ b/test/support/provider_test_helpers.ex
@@ -155,6 +155,25 @@ defmodule ReqLLM.ProviderTestHelpers do
   end
 
   @doc """
+  Assert that a tool calling response has the expected basic structure.
+
+  Verifies:
+  - Response structure is valid
+  - Context advancement (original messages + new assistant message)
+
+  Note: Does not require text content since tool calling responses may have no text.
+  """
+  def assert_tool_calling_response({:ok, %ReqLLM.Response{} = response}) do
+    response
+    |> assert_response_structure()
+    |> assert_context_advancement()
+  end
+
+  def assert_tool_calling_response(other) do
+    flunk("Expected {:ok, %ReqLLM.Response{}}, got: #{inspect(other)}")
+  end
+
+  @doc """
   Assert that the response context contains the original messages plus assistant response.
   """
   def assert_context_advancement(%ReqLLM.Response{context: context, message: message} = response)


### PR DESCRIPTION
This PR fixes the issue where Context.Codec doesn't encode tool_calls field on Messages, breaking OpenAI tool calling functionality.

## Problem
After the Codec protocol removal, the encoding logic in  had several critical issues:

1. Tool calls from ContentPart were being encoded into the  field instead of the top-level  field
2. The  field was passed through without proper normalization (function arguments weren't JSON strings)
3. Tool role messages lacked proper  handling
4. Assistant messages with only tool calls included empty content arrays instead of omitting content

## Solution
- **Role-specific message encoding**: Added dedicated encoding functions for assistant and tool messages
- **Proper tool call extraction**: Tool calls from ContentParts are now extracted into the top-level  field
- **Tool call normalization**: Function arguments are properly JSON-encoded as strings as required by OpenAI
- **Tool message encoding**: Tool role messages now include proper  and string content
- **Updated test framework**: Added  helper for testing tool calling responses
- **Comprehensive test coverage**: Added tests for all tool calling scenarios

## Testing
- All existing tests pass
- New comprehensive tests for tool calling scenarios
- Regenerated fixtures with  to ensure real API compatibility
- Quality checks pass (Dialyzer, Credo, formatting)

Fixes #44