### PR TITLE
Fix Gemini decoder to keep tool calls alongside text

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -404,11 +404,7 @@ defmodule ReqLLM.Provider.Defaults do
     Enum.map(messages, &encode_openai_message/1)
   end
 
-  defp encode_openai_message(%ReqLLM.Message{
-         role: role,
-         content: content,
-         tool_calls: tool_calls
-       }) do
+  defp encode_openai_message(%ReqLLM.Message{role: role, content: content, tool_calls: tool_calls}) do
     base_message = %{
       role: to_string(role),
       content: encode_openai_content(content)

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -527,15 +527,28 @@ defmodule ReqLLM.Provider.Defaults do
 
   def default_decode_sse_event(_, _model), do: []
 
-  defp decode_openai_message(%{"content" => content}) when is_binary(content) and content != "" do
-    [ReqLLM.StreamChunk.text(content)]
+  defp decode_openai_message(%{"content" => content} = message)
+       when is_binary(content) and content != "" do
+    chunks = [ReqLLM.StreamChunk.text(content)]
+    chunks ++ decode_openai_message(Map.delete(message, "content"))
   end
 
-  defp decode_openai_message(%{"content" => content}) when is_list(content) do
-    content
-    |> Enum.map(&decode_openai_content_part/1)
-    |> List.flatten()
-    |> Enum.reject(&is_nil/1)
+  defp decode_openai_message(%{"content" => content} = message) when is_list(content) do
+    chunks =
+      content
+      |> Enum.map(&decode_openai_content_part/1)
+      |> List.flatten()
+      |> Enum.reject(&is_nil/1)
+
+    chunks ++ decode_openai_message(Map.delete(message, "content"))
+  end
+
+  defp decode_openai_message(%{"content" => ""} = message) do
+    decode_openai_message(Map.delete(message, "content"))
+  end
+
+  defp decode_openai_message(%{"content" => nil} = message) do
+    decode_openai_message(Map.delete(message, "content"))
   end
 
   defp decode_openai_message(%{"tool_calls" => tool_calls}) when is_list(tool_calls) do

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -368,6 +368,65 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert ReqLLM.Response.finish_reason(response) == :stop
     end
 
+    test "decode_response preserves text and tool calls when both are present" do
+      google_response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [
+                %{"text" => "Starting your search now."},
+                %{
+                  "functionCall" => %{
+                    "name" => "lookup_results",
+                    "args" => %{
+                      "params" => %{"query" => "example", "category" => "generic"},
+                      "options" => %{"limit" => 25, "sort" => "relevance"}
+                    },
+                    "id" => "lookup-call-1"
+                  }
+                }
+              ],
+              "role" => "model"
+            },
+            "finishReason" => "STOP"
+          }
+        ],
+        "usageMetadata" => %{
+          "promptTokenCount" => 20,
+          "candidatesTokenCount" => 8,
+          "totalTokenCount" => 28
+        }
+      }
+
+      mock_resp = %Req.Response{status: 200, body: google_response}
+
+      context = context_fixture()
+
+      mock_req = %Req.Request{
+        options: [context: context, stream: false, model: "gemini-1.5-flash"]
+      }
+
+      {_req, resp} = Google.decode_response({mock_req, mock_resp})
+
+      response = resp.body
+      assert %ReqLLM.Response{} = response
+
+      assert ReqLLM.Response.text(response) == "Starting your search now."
+
+      tool_calls = ReqLLM.Response.tool_calls(response)
+
+      assert [tool_call] = tool_calls
+      assert tool_call.name == "lookup_results"
+      assert tool_call.id == "lookup-call-1"
+
+      assert tool_call.arguments == %{
+               "params" => %{"query" => "example", "category" => "generic"},
+               "options" => %{"limit" => 25, "sort" => "relevance"}
+             }
+
+      assert ReqLLM.Response.finish_reason(response) == :stop
+    end
+
     test "decode_response handles streaming responses" do
       # Create mock streaming chunks (Google format)
       stream_chunks = [


### PR DESCRIPTION
## Description

### Summary
- Gemini responses that mix free-form text with `functionCall` payloads were losing the tool invocation when decoded by our OpenAI defaults.
- Adjust the decoder to accumulate both the textual chunk and any tool call data so downstream orchestration still receives the arguments.
- Expand the Google provider contract tests with a regression case covering the mixed text + tool-call payload.

### Problem
When Gemini returns `content.parts` containing both a text entry and a `functionCall`, our default decoder hits the first clause that sees non-empty text and stops there, never emitting the tool-call chunk. As a result, `%ReqLLM.Response{}` keeps only the assistant text and `Response.tool_calls/1` comes back empty, causing orchestrators to skip the intended function execution.

### Solution
Rework the OpenAI-style message decoder to gather every chunk in the payload—text and tool calls alike—before building the response message. This ensures Gemini mixed replies preserve their tool-call metadata. Add a regression unit test in the Google provider suite to assert that text-plus-tool-call responses now return both pieces.

### Testing
```bash
mix test test/providers/google_test.exs
```

## Type of Change

- [X] Bug fix

## Testing

- [X] Tests added/updated
- [X] Manual testing performed
- [X] All tests pass

## Checklist

- [X] Code formatted and linted
- [X] Code quality checks passed (dialyzer & credo warnings/errors fixed)
- [X] Documentation updated if needed
- [X] Breaking changes documented (if any)

