### PR TITLE
feat(context): add JSON serialization/deserialization support for Context

### DIFF
--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -529,6 +529,112 @@ defmodule ReqLLM.ContextTest do
     end
   end
 
+  describe "JSON serialization" do
+    test "serializes and deserializes context with all message types" do
+      # Create a context with various message types
+      original_context =
+        Context.new([
+          Context.system("You are a helpful assistant"),
+          Context.user("Hello, how are you?"),
+          Context.assistant("I'm doing well, thank you! How can I help you today?"),
+          Context.text(:user, "What's the weather like?", %{timestamp: "2023-01-01"})
+        ])
+
+      # Serialize to JSON
+      json_string = Jason.encode!(original_context)
+      assert is_binary(json_string)
+
+      # Deserialize back to a map (Jason doesn't automatically convert back to structs)
+      decoded_map = Jason.decode!(json_string)
+
+      assert is_map(decoded_map)
+      assert Map.has_key?(decoded_map, "messages")
+
+      # Verify the structure is preserved
+      assert length(decoded_map["messages"]) == 4
+
+      # Check first message (system) - verify core fields are preserved
+      system_msg = Enum.at(decoded_map["messages"], 0)
+      assert system_msg["role"] == "system"
+      assert length(system_msg["content"]) == 1
+
+      content_part = Enum.at(system_msg["content"], 0)
+      assert content_part["type"] == "text"
+      assert content_part["text"] == "You are a helpful assistant"
+      assert content_part["metadata"] == %{}
+
+      # Check last message with metadata
+      user_msg = Enum.at(decoded_map["messages"], 3)
+      assert user_msg["role"] == "user"
+      assert user_msg["metadata"] == %{"timestamp" => "2023-01-01"}
+
+      # Test 1: Deserialize from JSON string directly
+      {:ok, recreated_from_string} = Context.from_json(json_string)
+      assert %Context{} = recreated_from_string
+      assert length(recreated_from_string.messages) == 4
+
+      # Test 2: Deserialize from decoded map
+      {:ok, recreated_from_map} = Context.from_json(decoded_map)
+      assert %Context{} = recreated_from_map
+      assert length(recreated_from_map.messages) == 4
+
+      # Both deserialization methods should produce identical results
+      assert recreated_from_string == recreated_from_map
+
+      # Verify the recreated context has the same structure as original
+      assert length(original_context.messages) == length(recreated_from_map.messages)
+
+      # Check that the first message (system) is properly recreated
+      original_system = Enum.at(original_context.messages, 0)
+      recreated_system = Enum.at(recreated_from_map.messages, 0)
+      assert original_system.role == recreated_system.role
+      assert original_system.content == recreated_system.content
+
+      # Check that the last message with metadata is properly recreated
+      original_last = Enum.at(original_context.messages, 3)
+      recreated_last = Enum.at(recreated_from_map.messages, 3)
+      assert original_last.role == recreated_last.role
+      assert original_last.metadata == recreated_last.metadata
+
+      # Verify that the recreated context can be serialized again
+      reserialized_json = Jason.encode!(recreated_from_map)
+      assert is_binary(reserialized_json)
+    end
+
+    test "serializes and deserializes empty context" do
+      original_context = Context.new()
+
+      json_string = Jason.encode!(original_context)
+
+      # Test both JSON string and map deserialization
+      {:ok, recreated_from_string} = Context.from_json(json_string)
+
+      decoded_map = Jason.decode!(json_string)
+      {:ok, recreated_from_map} = Context.from_json(decoded_map)
+
+      # Both should be identical
+      assert recreated_from_string == recreated_from_map
+      assert recreated_from_string == original_context
+
+      assert %Context{} = recreated_from_string
+      assert recreated_from_string.messages == []
+
+      # Verify that the recreated context can be serialized again
+      reserialized_json = Jason.encode!(recreated_from_string)
+      assert is_binary(reserialized_json)
+    end
+
+    test "handles invalid JSON gracefully" do
+      # Test invalid JSON string
+      assert {:error, {:json_decode_error, _}} = Context.from_json("{invalid json")
+
+      # Test invalid map structure (all invalid inputs map to this error)
+      assert {:error, :invalid_json_structure} = Context.from_json(%{"not" => "messages"})
+      assert {:error, :invalid_json_structure} = Context.from_json(123)
+      assert {:error, :invalid_json_structure} = Context.from_json([:not, :a, :map])
+    end
+  end
+
   describe "edge cases" do
     test "empty context enumeration" do
       context = Context.new()


### PR DESCRIPTION
## Summary

Adds JSON serialization and deserialization capabilities to `ReqLLM.Context`, enabling users to serialize conversation contexts to JSON and recreate them from JSON data. This is essential for use cases like conversation persistence, caching, API data exchange, and state management.

## Changes

### Core Functionality
- **Added `Context.from_json/1`** - New public API function that accepts both JSON strings and decoded maps
- **Leverages existing `Jason.encode!/1`** - Uses the already-present `@derive Jason.Encoder` for serialization
- **Complete round-trip support** - Full serialization → deserialization → re-serialization cycle

### Implementation Details
- **Minimal API surface** - Only adds one new public function to maintain clean interface
- **Direct struct reconstruction** - Manually rebuilds `Context`, `Message`, and `ContentPart` structs from JSON data
- **Robust error handling** - Returns `{:ok, context}` or `{:error, reason}` with specific error types:
  - `{:error, {:json_decode_error, %Jason.DecodeError{}}}` for invalid JSON strings
  - `{:error, :invalid_json_structure}` for malformed data structures

### Key Features
- **Flexible input handling** - Accepts both JSON strings and pre-decoded maps
- **Metadata preservation** - Maintains all message metadata through serialization cycle
- **Multi-modal content support** - Handles all content types (text, images, etc.)
- **Type safety** - Reconstructs proper Elixir structs, not just maps

## Usage Example

```elixir
# Create a context
context = Context.new([
  Context.system("You are helpful"),
  Context.user("Hello!"),
  Context.text(:assistant, "Hi there!", %{model: "gpt-4"})
])

# Serialize to JSON
json_string = Jason.encode!(context)

# Deserialize back to Context struct
{:ok, recreated_context} = Context.from_json(json_string)

# Also works with decoded maps
decoded_map = Jason.decode!(json_string)
{:ok, same_context} = Context.from_json(decoded_map)
```

## Testing

- **Comprehensive test coverage** - Tests both success and error scenarios
- **Round-trip verification** - Ensures serialized contexts can be deserialized and re-serialized
- **Edge case handling** - Tests empty contexts, complex metadata, and invalid inputs
- **Error path validation** - Verifies proper error handling for malformed JSON and invalid structures

## Design Decisions

- **Single entry point** - Only `Context.from_json/1` is exposed publicly to minimize API surface
- **No changes to Message/ContentPart** - Keeps other modules clean by handling reconstruction internally
- **Leverages existing validation** - Uses the library's existing struct definitions and validation patterns
- **Follows project conventions** - Uses `{:ok, result}` / `{:error, reason}` tuple returns

This change enables critical functionality for conversation persistence and state management while maintaining the library's clean, minimal API design.

## Type of Change

- [X] New feature  

## Testing

- [X] Tests added/updated
- [X] Manual testing performed
- [X] All tests pass

## Checklist

- [X] Code formatted and linted
- [X] Code quality checks passed (dialyzer & credo warnings/errors fixed)
- [X] Documentation updated if needed