### PR TITLE
fixes warning for duplicate clause

### DIFF
--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -7,7 +7,7 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   ## Key Differences from OpenAI
 
   - Uses content blocks instead of simple strings
-  - System messages are included in the messages array 
+  - System messages are included in the messages array
   - Tool calls are represented as content blocks with type "tool"
   - Different parameter names (stop_sequences vs stop)
 
@@ -43,7 +43,6 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   end
 
   defp extract_model_name(%{model: model_name}), do: model_name
-  defp extract_model_name(%ReqLLM.Model{model: model_name}), do: model_name
   defp extract_model_name(model) when is_binary(model), do: model
   defp extract_model_name(_), do: "unknown"
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes compiler warning about duplicate clause:

```
==> req_llm
Compiling 53 files (.ex)
    warning: this clause cannot match because a previous clause at line 45 matches the same pattern as this clause
    │
 46 │   defp extract_model_name(%ReqLLM.Model{model: model_name}), do: model_name
    │        ~
    │
    └─ lib/req_llm/providers/anthropic/context.ex:46:8
```

## Type of Change

- [x] Bug fix

## Testing

- [ ] Tests added/updated
- [ ] Manual testing performed
- [x] All tests pass

## Checklist

- [x] Code formatted and linted
- [ ] Code quality checks passed (dialyzer & credo warnings/errors fixed)
- [ ] Documentation updated if needed
- [ ] Breaking changes documented (if any)

