### PR TITLE
fix: restore file/video attachment support in Google provider

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -594,6 +594,23 @@ defmodule ReqLLM.Provider.Defaults do
     }
   end
 
+  defp encode_openai_content_part(%ReqLLM.Message.ContentPart{
+         type: :file,
+         data: data,
+         media_type: media_type
+       })
+       when is_binary(data) do
+    # Encode file as image_url data URI (OpenAI format supports various media types this way)
+    base64 = Base.encode64(data)
+
+    %{
+      type: "image_url",
+      image_url: %{
+        url: "data:#{media_type};base64,#{base64}"
+      }
+    }
+  end
+
   defp encode_openai_content_part(_), do: nil
 
   @doc """


### PR DESCRIPTION
# Pull Request

## Description

  Adds missing :file ContentPart encoding in Provider.Defaults and fixes
  Google provider to handle OpenAI-formatted data URIs. Reorders pattern
  matching to prevent generic patterns from matching before specific ones.

  Fixes regression introduced in b699102 where file attachments were
  encoded as nil, causing empty message parts.

## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests
- [ ] Build/CI

## Testing

- [ ] Tests added/updated
- [x] Manual testing performed
- [x] All tests pass

## Checklist

- [x] Code formatted and linted
- [x] Code quality checks passed (dialyzer & credo warnings/errors fixed)
- [ ] Documentation updated if needed
- [ ] Breaking changes documented (if any)

## Related Issues

Closes #74 
