### PR TITLE
Improve metadata provider error handling with structured Splode errors

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -154,10 +154,13 @@ defmodule ReqLLM do
       #=> {:ok, ReqLLM.Providers.Anthropic}
 
       ReqLLM.provider(:unknown)
-      #=> {:error, :not_found}
+      #=> {:error, %ReqLLM.Error.Invalid.Provider{provider: :unknown}}
 
   """
-  @spec provider(atom()) :: {:ok, module()} | {:error, :not_found}
+  @spec provider(atom()) ::
+          {:ok, module()}
+          | {:error,
+             ReqLLM.Error.Invalid.Provider.t() | ReqLLM.Error.Invalid.Provider.NotImplemented.t()}
   def provider(provider) when is_atom(provider) do
     ReqLLM.Provider.Registry.fetch(provider)
   end

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -481,12 +481,16 @@ defmodule ReqLLM.Context do
   """
   @spec wrap(t(), ReqLLM.Model.t()) :: term()
   def wrap(%__MODULE__{} = ctx, %ReqLLM.Model{provider: provider_atom}) do
-    {:ok, provider_mod} = ReqLLM.Provider.Registry.get_provider(provider_atom)
+    case ReqLLM.Provider.Registry.get_provider(provider_atom) do
+      {:ok, provider_mod} ->
+        if function_exported?(provider_mod, :wrap_context, 1) do
+          provider_mod.wrap_context(ctx)
+        else
+          ctx
+        end
 
-    if function_exported?(provider_mod, :wrap_context, 1) do
-      provider_mod.wrap_context(ctx)
-    else
-      ctx
+      {:error, _} ->
+        ctx
     end
   end
 

--- a/lib/req_llm/error.ex
+++ b/lib/req_llm/error.ex
@@ -119,9 +119,29 @@ defmodule ReqLLM.Error do
     @moduledoc "Error for unknown or unsupported providers."
     use Splode.Error, fields: [:provider], class: :invalid
 
+    @typedoc "Error for unknown provider"
+    @type t() :: %__MODULE__{
+            provider: atom()
+          }
+
     @spec message(map()) :: String.t()
     def message(%{provider: provider}) do
       "Unknown provider: #{provider}"
+    end
+  end
+
+  defmodule Invalid.Provider.NotImplemented do
+    @moduledoc "Error for providers that exist but have no implementation (metadata-only)."
+    use Splode.Error, fields: [:provider], class: :invalid
+
+    @typedoc "Error for metadata-only providers"
+    @type t() :: %__MODULE__{
+            provider: atom()
+          }
+
+    @spec message(map()) :: String.t()
+    def message(%{provider: provider}) do
+      "Provider not implemented (metadata-only): #{provider}"
     end
   end
 

--- a/lib/req_llm/provider.ex
+++ b/lib/req_llm/provider.ex
@@ -490,8 +490,11 @@ defmodule ReqLLM.Provider do
   @spec get!(atom()) :: module()
   def get!(provider_id) do
     case ReqLLM.Provider.Registry.get_provider(provider_id) do
-      {:ok, module} -> module
-      {:error, _reason} -> raise ReqLLM.Error.Invalid.Provider.exception(provider: provider_id)
+      {:ok, module} ->
+        module
+
+      {:error, error} ->
+        raise error
     end
   end
 end

--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -62,7 +62,7 @@ defmodule ReqLLM.Response do
   Extract text content from the response message.
 
   Returns the concatenated text from all content parts in the assistant message.
-  Returns nil when no message is present. For streaming responses, this may be nil 
+  Returns nil when no message is present. For streaming responses, this may be nil
   until the stream is joined.
 
   ## Examples
@@ -295,24 +295,29 @@ defmodule ReqLLM.Response do
   @spec decode_response(term(), Model.t() | String.t()) :: {:ok, t()} | {:error, term()}
   def decode_response(raw_data, model_input) do
     model = if is_binary(model_input), do: Model.from!(model_input), else: model_input
-    {:ok, provider_mod} = ReqLLM.Provider.Registry.get_provider(model.provider)
 
-    wrapped_data =
-      if function_exported?(provider_mod, :wrap_response, 1) do
-        provider_mod.wrap_response(raw_data)
-      else
-        # fallback for providers without wrap_response/1
-        raw_data
-      end
+    case ReqLLM.Provider.Registry.get_provider(model.provider) do
+      {:ok, provider_mod} ->
+        wrapped_data =
+          if function_exported?(provider_mod, :wrap_response, 1) do
+            provider_mod.wrap_response(raw_data)
+          else
+            raw_data
+          end
 
-    # Call provider's decode_response pipeline step function directly
-    fake_request = %Req.Request{private: %{req_llm_model: model}}
-    fake_response = %Req.Response{body: wrapped_data, status: 200}
-    {_req, result} = provider_mod.decode_response({fake_request, fake_response})
+        # Construct minimal request/response structs to invoke provider's decode_response callback
+        # without an actual HTTP request (for manual decoding of saved/raw API responses)
+        fixture_request = %Req.Request{private: %{req_llm_model: model}}
+        fixture_response = %Req.Response{body: wrapped_data, status: 200}
+        {_req, result} = provider_mod.decode_response({fixture_request, fixture_response})
 
-    case result do
-      %Req.Response{body: %ReqLLM.Response{} = response} -> {:ok, response}
-      error -> {:error, error}
+        case result do
+          %Req.Response{body: %ReqLLM.Response{} = response} -> {:ok, response}
+          error -> {:error, error}
+        end
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
@@ -351,7 +356,7 @@ defmodule ReqLLM.Response do
   ## Parameters
 
     * `raw_data` - Raw provider streaming response data
-    * `model` - Model specification  
+    * `model` - Model specification
     * `schema` - Schema definition for validation
 
   ## Returns

--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -27,7 +27,8 @@ defmodule ReqLLMTest do
     end
 
     test "returns error for invalid provider" do
-      assert {:error, :not_found} = ReqLLM.provider(:nonexistent)
+      assert {:error, %ReqLLM.Error.Invalid.Provider{provider: :nonexistent}} =
+               ReqLLM.provider(:nonexistent)
     end
   end
 end


### PR DESCRIPTION
Converts provider registry error atoms to structured Splode errors for better error handling and consistency.

## Changes

- Add typedoc to `Invalid.Provider` error type
- Create new `Invalid.Provider.NotImplemented` error for metadata-only providers
- Update `Registry.get_provider/1` and `Registry.fetch/1` to return structured errors instead of atoms
- Fix crash-prone call sites in `Context` and `Response` to handle new error structs gracefully
- Simplify `Provider.get!/1` to raise any error struct directly
- Update all tests to assert against new error structs
- Add clarifying comment for fixture request/response pattern in `Response.decode_response/2`

Fixes #84