### PR TITLE
Optimize model compatibility testing with true parallelization

### DIFF
--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   - **sample** (optional): Further reduces using `:sample_text_models` or `:sample_embedding_models`.
     If not configured, falls back to one model per provider.
 
-  **Important**: 
+  **Important**:
   - Only **implemented providers** are included (registry models without implementation are skipped)
   - Config lists (`:test_models`, `:test_embedding_models`) are defaults only, not hard filters
   - Explicit specs like `"anthropic:*"` test ALL registry models for that provider
@@ -81,15 +81,23 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
           type: :string,
           record: :boolean,
           record_all: :boolean,
-          debug: :boolean
+          debug: :boolean,
+          failed_only: :boolean,
+          record_failed: :boolean,
+          migrate: :boolean
         ]
       )
 
-    if opts[:available] do
-      list_models(opts)
-    else
-      model_spec = List.first(positional)
-      run_coverage(model_spec, opts)
+    cond do
+      opts[:migrate] ->
+        migrate_state()
+
+      opts[:available] ->
+        list_models(opts)
+
+      true ->
+        model_spec = List.first(positional)
+        run_coverage(model_spec, opts)
     end
   end
 
@@ -271,6 +279,9 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     Mix.shell().info("----------------------------------------------------\n")
 
     models = load_registry()
+
+    opts = apply_implied_flags(opts)
+
     specs = select_models(models, model_spec, opts)
 
     if Enum.empty?(specs) do
@@ -278,9 +289,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     end
 
     total_specs = length(specs)
-
     recording = opts[:record_all] || opts[:record]
-
     mode_text = if recording, do: "#{total_specs} to record", else: "replay mode"
 
     Mix.shell().info("Testing #{total_specs} model(s) (#{mode_text})...\n")
@@ -304,27 +313,26 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     run_ts = DateTime.utc_now() |> DateTime.truncate(:second)
     save_state(results, run_ts)
 
-    print_summary(results, elapsed)
+    print_summary_new(results, elapsed)
   end
 
   defp test_model(provider, model_id, opts) do
     spec = "#{provider}:#{model_id}"
     mode = if opts[:record_all] || opts[:record], do: "record", else: "replay"
     operation = parse_operation_type(opts[:type])
-    category = operation_to_category(operation)
 
     env = [
+      {"MIX_ENV", "test"},
       {"REQ_LLM_MODELS", spec},
       {"REQ_LLM_OPERATION", Atom.to_string(operation)},
-      {"REQ_LLM_FIXTURES_MODE", mode},
-      {"REQ_LLM_DEBUG", "1"},
-      {"REQ_LLM_INCLUDE_RESPONSES", "1"}
+      {"REQ_LLM_FIXTURES_MODE", mode}
     ]
+
+    env = if opts[:debug], do: [{"REQ_LLM_DEBUG", "1"} | env], else: env
 
     Mix.shell().info("  Testing #{spec} (#{operation})...")
 
-    test_args =
-      build_test_args(provider, category, operation)
+    test_args = build_test_args(provider, operation)
 
     {output, exit_code} =
       System.cmd(
@@ -343,20 +351,29 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     parse_test_result(provider, model_id, output, exit_code)
   end
 
-  defp build_test_args(provider, _category, operation) do
+  defp build_test_args(provider, operation) do
     case operation do
       :all ->
-        ["test", "--only", "provider:#{provider}"]
+        ["test", "--only", "provider:#{provider}", "--only", "coverage"]
 
       :embedding ->
-        ["test", "test/coverage/#{provider}/embedding_test.exs", "--only", "provider:#{provider}"]
+        [
+          "test",
+          "test/coverage/#{provider}/embedding_test.exs",
+          "--only",
+          "provider:#{provider}",
+          "--only",
+          "coverage"
+        ]
 
       :text ->
         [
           "test",
           "test/coverage/#{provider}/comprehensive_test.exs",
           "--only",
-          "provider:#{provider}"
+          "provider:#{provider}",
+          "--only",
+          "coverage"
         ]
     end
   end
@@ -378,7 +395,6 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
       end
 
     status = if exit_code == 0 && failed == 0, do: :pass, else: :fail
-    fixtures = extract_fixtures(output)
 
     %{
       provider: provider,
@@ -388,8 +404,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
       passed: passed,
       failed: failed,
       total: total,
-      error: if(failed > 0, do: extract_error(output)),
-      fixtures: fixtures
+      error: if(failed > 0, do: extract_error(output))
     }
   end
 
@@ -402,21 +417,48 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     |> String.slice(0..120)
   end
 
-  defp extract_fixtures(output) do
-    output
-    |> String.split("\n")
-    |> Enum.filter(&String.contains?(&1, "[Fixture] step:"))
-    |> Enum.map(fn line ->
-      case Regex.run(~r/name=(\w+)/, line) do
-        [_, name] -> name
-        _ -> nil
-      end
-    end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
+  defp save_state(results, run_ts) do
+    existing_state = load_state()
+    excluded_models = load_excluded_models()
+
+    ts = DateTime.to_iso8601(run_ts)
+
+    new_state =
+      results
+      |> Enum.reject(&(&1.status == :skipped))
+      |> Enum.reduce(existing_state, fn result, acc ->
+        status = if result.status == :pass, do: "pass", else: "fail"
+
+        Map.put(acc, result.model_spec, %{
+          "status" => status,
+          "last_checked" => ts
+        })
+      end)
+      |> then(fn state ->
+        Enum.reduce(excluded_models, state, fn spec, acc ->
+          existing_entry = Map.get(existing_state, spec, %{})
+
+          Map.put(acc, spec, %{
+            "status" => "excluded",
+            "last_checked" => Map.get(existing_entry, "last_checked")
+          })
+        end)
+      end)
+
+    write_state(new_state)
   end
 
-  defp print_summary(results, elapsed_ms) do
+  defp apply_implied_flags(opts) do
+    if opts[:record_failed] do
+      opts
+      |> Keyword.put(:failed_only, true)
+      |> Keyword.put(:record, true)
+    else
+      opts
+    end
+  end
+
+  defp print_summary_new(results, elapsed_ms) do
     Mix.shell().info("\n----------------------------------------------------")
     Mix.shell().info("  Summary")
     Mix.shell().info("----------------------------------------------------\n")
@@ -465,14 +507,16 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
     Mix.shell().info("  #{icon} #{result.model_id}#{IO.ANSI.reset()}")
 
-    if result.fixtures && !Enum.empty?(result.fixtures) do
-      fixtures_text = Enum.join(result.fixtures, ", ")
-      Mix.shell().info("       #{IO.ANSI.faint()}fixtures: #{fixtures_text}#{IO.ANSI.reset()}")
-    end
-
     if result.error do
       Mix.shell().info("       #{IO.ANSI.faint()}#{result.error}#{IO.ANSI.reset()}")
     end
+  end
+
+  defp migrate_state do
+    Mix.shell().info("Migrating supported_models.json to new schema...")
+    state = load_state()
+    write_state(state)
+    Mix.shell().info("Migration complete!")
   end
 
   defp print_model_with_status(model, provider, state) do
@@ -722,6 +766,52 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     end)
   end
 
+  defp load_state do
+    priv_dir = :code.priv_dir(:req_llm)
+    path = Path.join(priv_dir, "supported_models.json")
+
+    case File.read(path) do
+      {:ok, content} -> Jason.decode!(content)
+      {:error, _} -> %{}
+    end
+  end
+
+  defp write_state(state) do
+    priv_dir = :code.priv_dir(:req_llm)
+    path = Path.join(priv_dir, "supported_models.json")
+    File.mkdir_p!(Path.dirname(path))
+
+    json = build_sorted_json(state)
+
+    case File.read(path) do
+      {:ok, prev} when prev == json -> :ok
+      _ -> File.write!(path, json)
+    end
+  end
+
+  defp build_sorted_json(state) do
+    entries_json =
+      state
+      |> Enum.sort_by(fn {k, _} -> k end)
+      |> Enum.map_join(",\n  ", fn {k, v} ->
+        status = Map.get(v, "status")
+        last_checked = Map.get(v, "last_checked")
+
+        last_checked_json =
+          if last_checked,
+            do: ~s("last_checked": "#{last_checked}"),
+            else: ~s("last_checked": null)
+
+        ~s("#{k}": {\n    "status": "#{status}",\n    #{last_checked_json}\n  })
+      end)
+
+    """
+    {
+      #{entries_json}
+    }
+    """
+  end
+
   defp load_registry do
     priv_dir = :code.priv_dir(:req_llm)
     models_dir = Path.join(priv_dir, "models_dev")
@@ -753,86 +843,6 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     end)
     |> Enum.reject(fn {_, models} -> Enum.empty?(models) end)
     |> Map.new()
-  end
-
-  defp load_state do
-    priv_dir = :code.priv_dir(:req_llm)
-    path = Path.join(priv_dir, "supported_models.json")
-
-    case File.read(path) do
-      {:ok, content} ->
-        Jason.decode!(content)
-
-      {:error, _} ->
-        %{}
-    end
-  end
-
-  defp save_state(results, run_ts) do
-    priv_dir = :code.priv_dir(:req_llm)
-    path = Path.join(priv_dir, "supported_models.json")
-
-    existing =
-      case File.read(path) do
-        {:ok, content} -> Jason.decode!(content)
-        _ -> %{}
-      end
-
-    excluded_models = load_excluded_models()
-
-    ts = DateTime.to_iso8601(run_ts)
-
-    new_state =
-      results
-      |> Enum.reject(&(&1.status == :skipped))
-      |> Enum.reduce(existing, fn result, acc ->
-        status = if result.status == :pass, do: "pass", else: "fail"
-
-        Map.put(acc, result.model_spec, %{
-          "status" => status,
-          "last_checked" => ts
-        })
-      end)
-      |> then(fn state ->
-        Enum.reduce(excluded_models, state, fn spec, acc ->
-          existing_entry = Map.get(existing, spec, %{})
-
-          Map.put(acc, spec, %{
-            "status" => "excluded",
-            "last_checked" => Map.get(existing_entry, "last_checked")
-          })
-        end)
-      end)
-
-    json = build_sorted_json(new_state)
-
-    case File.read(path) do
-      {:ok, prev} when prev == json -> :ok
-      _ -> File.write!(path, json)
-    end
-  end
-
-  defp build_sorted_json(state) do
-    entries_json =
-      state
-      |> Enum.sort_by(fn {k, _} -> k end)
-      |> Enum.map_join(",\n  ", fn {k, v} ->
-        status = Map.get(v, "status")
-        last_checked = Map.get(v, "last_checked")
-
-        last_checked_json =
-          if last_checked,
-            do: ~s("last_checked": "#{last_checked}"),
-            else: ~s("last_checked": null)
-
-        ~s("#{k}": {\n    "status": "#{status}",\n    #{last_checked_json}\n  })
-      end)
-
-    """
-    {
-      #{entries_json}
-    }
-    """
   end
 
   defp find_model(registry, provider, model_id) do
@@ -899,10 +909,6 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   defp parse_operation_type("text"), do: :text
   defp parse_operation_type("embedding"), do: :embedding
   defp parse_operation_type(type), do: String.to_atom(type)
-
-  defp operation_to_category(:text), do: "core"
-  defp operation_to_category(:embedding), do: "embedding"
-  defp operation_to_category(_), do: "core"
 
   defp has_fixtures?(provider, model_id) do
     model_dir = model_id_to_fixture_dir(model_id)

--- a/lib/req_llm/capability.ex
+++ b/lib/req_llm/capability.ex
@@ -39,6 +39,49 @@ defmodule ReqLLM.Capability do
   end
 
   @doc """
+  Check if model supports object generation (structured output).
+
+  Different providers implement this via different mechanisms:
+  - Google: Native JSON mode via responseMimeType
+  - OpenAI: response_format with json_schema OR strict tools
+  - Anthropic/Groq/OpenRouter/XAI: Function calling with structured tool
+
+  ## Examples
+
+      iex> ReqLLM.Capability.supports_object_generation?("openai:gpt-4o")
+      true
+
+      iex> ReqLLM.Capability.supports_object_generation?("anthropic:claude-3-haiku")
+      true
+  """
+  @spec supports_object_generation?(ReqLLM.Model.t() | binary()) :: boolean()
+  def supports_object_generation?(model_input) do
+    case normalize_model(model_input) do
+      {:ok, %ReqLLM.Model{} = model} ->
+        case model.provider do
+          :google ->
+            true
+
+          :openai ->
+            json_schema_support =
+              get_in(model, [Access.key(:_metadata, %{}), "supports_json_schema_response_format"]) ==
+                true
+
+            strict_tools_support =
+              get_in(model, [Access.key(:_metadata, %{}), "supports_strict_tools"]) == true
+
+            json_schema_support or strict_tools_support
+
+          _ ->
+            supports?(model, :tool_call)
+        end
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
   Get all models from a provider that support a specific capability.
 
   ## Examples

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -187,25 +187,11 @@ defmodule ReqLLM.Providers.Anthropic do
   def encode_body(request) do
     context = request.options[:context]
     model_name = request.options[:model]
+    opts = request.options
 
-    # Use Anthropic-specific context encoding
-    body_data = ReqLLM.Providers.Anthropic.Context.encode_request(context, %{model: model_name})
-
-    # Ensure max_tokens is always present (required by Anthropic)
-    max_tokens =
-      case request.options[:max_tokens] do
-        nil -> default_max_tokens(model_name)
-        v -> v
-      end
-
-    body =
-      body_data
-      |> add_basic_options(request.options)
-      |> maybe_put(:stream, request.options[:stream])
-      |> Map.put(:max_tokens, max_tokens)
-      |> maybe_add_tools(request.options)
-
+    body = build_request_body(context, model_name, opts)
     json_body = Jason.encode!(body)
+
     %{request | body: json_body}
   end
 
@@ -230,44 +216,44 @@ defmodule ReqLLM.Providers.Anthropic do
 
   def extract_usage(_, _), do: {:error, :invalid_body}
 
-  @impl ReqLLM.Provider
-  def attach_stream(model, context, opts, _finch_name) do
+  # ========================================================================
+  # Shared Request Building Helpers (used by both Req and Finch paths)
+  # ========================================================================
+
+  defp build_request_headers(model, opts) do
     api_key = ReqLLM.Keys.get!(model, opts)
 
-    # Extract and merge provider_options for translation
-    {provider_options, standard_opts} = Keyword.pop(opts, :provider_options, [])
-    flattened_opts = Keyword.merge(standard_opts, provider_options)
-
-    # Translate provider options (including reasoning_effort) before building body
-    {translated_opts, _warnings} = translate_options(:chat, model, flattened_opts)
-
-    # Set default timeout for reasoning models
-    default_timeout =
-      if Keyword.has_key?(translated_opts, :thinking) do
-        Application.get_env(:req_llm, :thinking_timeout, 300_000)
-      else
-        Application.get_env(:req_llm, :receive_timeout, 120_000)
-      end
-
-    translated_opts =
-      Keyword.put_new(translated_opts, :receive_timeout, default_timeout)
-
-    # Build request body using provider's encode logic
-    body = build_anthropic_streaming_body(model, context, translated_opts)
-
-    # Build the URL with Anthropic's specific endpoint
-    base_url = Keyword.get(opts, :base_url, default_base_url())
-    url = "#{base_url}/v1/messages"
-
-    # Create Finch request with Anthropic's specific headers
-    headers = [
-      {"Content-Type", "application/json"},
-      {"Accept", "text/event-stream"},
+    [
+      {"content-type", "application/json"},
       {"x-api-key", api_key},
       {"anthropic-version", get_anthropic_version(opts)}
     ]
+  end
 
-    # Add beta headers for features being used
+  defp build_request_body(context, model_name, opts) do
+    # Use Anthropic-specific context encoding
+    body_data = ReqLLM.Providers.Anthropic.Context.encode_request(context, %{model: model_name})
+
+    # Ensure max_tokens is always present (required by Anthropic)
+    max_tokens =
+      case get_option(opts, :max_tokens) do
+        nil -> default_max_tokens(model_name)
+        v -> v
+      end
+
+    body_data
+    |> add_basic_options(opts)
+    |> maybe_put(:stream, get_option(opts, :stream))
+    |> Map.put(:max_tokens, max_tokens)
+    |> maybe_add_tools(opts)
+  end
+
+  defp build_request_url(opts) do
+    base_url = get_option(opts, :base_url, default_base_url())
+    "#{base_url}/v1/messages"
+  end
+
+  defp build_beta_headers(opts) do
     beta_features = []
 
     beta_features =
@@ -284,17 +270,43 @@ defmodule ReqLLM.Providers.Anthropic do
         beta_features
       end
 
-    headers =
-      case beta_features do
-        [] ->
-          headers
+    case beta_features do
+      [] -> []
+      features -> [{"anthropic-beta", Enum.join(features, ",")}]
+    end
+  end
 
-        features ->
-          beta_header = Enum.join(features, ",")
-          [{"anthropic-beta", beta_header} | headers]
+  # ========================================================================
+
+  @impl ReqLLM.Provider
+  def attach_stream(model, context, opts, _finch_name) do
+    # Extract and merge provider_options for translation
+    {provider_options, standard_opts} = Keyword.pop(opts, :provider_options, [])
+    flattened_opts = Keyword.merge(standard_opts, provider_options)
+
+    # Translate provider options (including reasoning_effort) before building body
+    {translated_opts, _warnings} = translate_options(:chat, model, flattened_opts)
+
+    # Set default timeout for reasoning models
+    default_timeout =
+      if Keyword.has_key?(translated_opts, :thinking) do
+        Application.get_env(:req_llm, :thinking_timeout, 300_000)
+      else
+        Application.get_env(:req_llm, :receive_timeout, 120_000)
       end
 
-    finch_request = Finch.build(:post, url, headers, body)
+    translated_opts = Keyword.put_new(translated_opts, :receive_timeout, default_timeout)
+
+    # Build request using shared helpers
+    headers = build_request_headers(model, translated_opts)
+    streaming_headers = [{"Accept", "text/event-stream"} | headers]
+    beta_headers = build_beta_headers(translated_opts)
+    all_headers = streaming_headers ++ beta_headers
+
+    body = build_request_body(context, model.model, translated_opts ++ [stream: true])
+    url = build_request_url(translated_opts)
+
+    finch_request = Finch.build(:post, url, all_headers, Jason.encode!(body))
     {:ok, finch_request}
   rescue
     error ->
@@ -401,15 +413,14 @@ defmodule ReqLLM.Providers.Anthropic do
     end
   end
 
-  # Handle both map and keyword list options (for tests vs real requests)
   defp get_option(options, key, default \\ nil)
-
-  defp get_option(options, key, default) when is_map(options) do
-    Map.get(options, key, default)
-  end
 
   defp get_option(options, key, default) when is_list(options) do
     Keyword.get(options, key, default)
+  end
+
+  defp get_option(options, key, default) when is_map(options) do
+    Map.get(options, key, default)
   end
 
   defp tool_to_anthropic_format(tool) do
@@ -683,26 +694,4 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   defp default_max_tokens(_model_name), do: 1024
-
-  defp build_anthropic_streaming_body(model, context, opts) do
-    # Create a minimal request struct to reuse the existing encode_body logic
-    temp_request = %Req.Request{
-      method: :post,
-      url: URI.parse("https://example.com/temp"),
-      headers: %{},
-      body: {:json, %{}},
-      options:
-        Map.new(
-          [
-            model: model.model,
-            context: context,
-            stream: true,
-            operation: :chat
-          ] ++ opts
-        )
-    }
-
-    %{body: json_body} = encode_body(temp_request)
-    json_body
-  end
 end

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -885,39 +885,16 @@ defmodule ReqLLM.Providers.Google do
   defp convert_google_usage(_),
     do: %{"prompt_tokens" => 0, "completion_tokens" => 0, "total_tokens" => 0}
 
-  @impl ReqLLM.Provider
-  def attach_stream(model, context, opts, _finch_name) do
-    req_only_keys = [:params, :model, :base_url, :finch_name, :fixture]
-    {req_opts, user_opts} = Keyword.split(opts, req_only_keys)
+  defp build_request_headers(_model, _opts), do: [{"Content-Type", "application/json"}]
 
-    operation = Keyword.get(user_opts, :operation, :chat)
-    opts_to_process = Keyword.merge(user_opts, context: context, stream: true)
+  defp build_request_url(model_name, opts) do
+    api_key = ReqLLM.Keys.get!(opts[:model_struct] || opts[:model], opts)
+    base_url = Keyword.get(opts, :base_url, default_base_url())
 
-    with {:ok, processed_opts} <-
-           ReqLLM.Provider.Options.process(__MODULE__, operation, model, opts_to_process) do
-      api_key = ReqLLM.Keys.get!(model, opts)
-      base_url = Keyword.get(req_opts, :base_url, default_base_url())
-
-      body = build_google_streaming_body(model, context, processed_opts)
-
-      url = "#{base_url}/models/#{model.model}:streamGenerateContent?key=#{api_key}"
-
-      headers = [
-        {"Content-Type", "application/json"}
-      ]
-
-      finch_request = Finch.build(:post, url, headers, body)
-      {:ok, finch_request}
-    end
-  rescue
-    error ->
-      {:error,
-       ReqLLM.Error.API.Request.exception(
-         reason: "Failed to build Google stream request: #{inspect(error)}"
-       )}
+    "#{base_url}/models/#{model_name}:streamGenerateContent?key=#{api_key}&alt=sse"
   end
 
-  defp build_google_streaming_body(model, context, opts) do
+  defp build_request_body(model, context, opts) do
     operation = Keyword.get(opts, :operation, :chat)
 
     temp_request = %Req.Request{
@@ -938,6 +915,35 @@ defmodule ReqLLM.Providers.Google do
 
     encoded_request = encode_body(temp_request)
     encoded_request.body
+  end
+
+  @impl ReqLLM.Provider
+  def attach_stream(model, context, opts, _finch_name) do
+    req_only_keys = [:params, :model, :base_url, :finch_name, :fixture]
+    {req_opts, user_opts} = Keyword.split(opts, req_only_keys)
+
+    operation = Keyword.get(user_opts, :operation, :chat)
+    opts_to_process = Keyword.merge(user_opts, context: context, stream: true)
+
+    with {:ok, processed_opts} <-
+           ReqLLM.Provider.Options.process(__MODULE__, operation, model, opts_to_process) do
+      base_url = Keyword.get(req_opts, :base_url, default_base_url())
+
+      opts_with_base = Keyword.merge(processed_opts, base_url: base_url, model_struct: model)
+
+      headers = build_request_headers(model, opts_with_base) ++ [{"Accept", "text/event-stream"}]
+      url = build_request_url(model.model, opts_with_base)
+      body = build_request_body(model, context, processed_opts)
+
+      finch_request = Finch.build(:post, url, headers, body)
+      {:ok, finch_request}
+    end
+  rescue
+    error ->
+      {:error,
+       ReqLLM.Error.API.Request.exception(
+         reason: "Failed to build Google stream request: #{inspect(error)}"
+       )}
   end
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -46,24 +46,12 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
 
   @impl true
   def encode_body(request) do
-    request = ReqLLM.Provider.Defaults.default_encode_body(request)
-    body = Jason.decode!(request.body)
+    context = request.options[:context]
+    model_name = request.options[:model]
+    operation = request.options[:operation] || :chat
+    opts = if is_map(request.options), do: Map.to_list(request.options), else: request.options
 
-    enhanced_body =
-      case request.options[:operation] do
-        :embedding ->
-          add_embedding_options(body, request.options)
-
-        _ ->
-          body
-          |> add_token_limits(request.options[:model], request.options)
-          |> add_stream_options(request.options)
-          |> add_reasoning_effort(request.options)
-          |> add_response_format(request.options)
-          |> add_parallel_tool_calls(request.options)
-          |> translate_tool_choice_format()
-          |> add_strict_to_tools()
-      end
+    enhanced_body = build_request_body(context, model_name, opts, operation)
 
     if System.get_env("REQ_LLM_DEBUG") in ["1", "true"] do
       require Logger
@@ -84,60 +72,84 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
     ReqLLM.Provider.Defaults.default_decode_sse_event(event, model)
   end
 
-  @impl true
-  def attach_stream(model, context, opts, _finch_name) do
+  # ========================================================================
+  # Shared Request Building Helpers (used by both Req and Finch paths)
+  # ========================================================================
+
+  defp build_request_headers(model, opts) do
     api_key = ReqLLM.Keys.get!(model, opts)
 
-    headers = [
+    [
       {"Authorization", "Bearer " <> api_key},
-      {"Content-Type", "application/json"},
-      {"Accept", "text/event-stream"}
+      {"Content-Type", "application/json"}
     ]
+  end
 
-    url =
-      case Keyword.get(opts, :base_url) do
-        nil -> ReqLLM.Providers.OpenAI.default_base_url() <> path()
-        base_url -> "#{base_url}#{path()}"
+  defp build_request_body(context, model_name, opts, operation \\ :chat) do
+    # Use default encoding first
+    temp_request = %Req.Request{
+      method: :post,
+      url: URI.parse("https://example.com/temp"),
+      headers: %{},
+      body: {:json, %{}},
+      options: Map.new([model: model_name, context: context, operation: operation] ++ opts)
+    }
+
+    request = ReqLLM.Provider.Defaults.default_encode_body(temp_request)
+
+    body =
+      case request.body do
+        "" -> %{}
+        json_string when is_binary(json_string) -> Jason.decode!(json_string)
       end
 
-    provider_opts = opts |> Keyword.get(:provider_options, []) |> Map.new()
+    # Convert opts to map for helper functions that expect request.options
+    opts_map = if is_list(opts), do: Map.new(opts), else: opts
+
+    # Apply ChatAPI-specific enhancements
+    case operation do
+      :embedding ->
+        add_embedding_options(body, opts_map)
+
+      _ ->
+        body
+        |> add_token_limits(model_name, opts_map)
+        |> add_stream_options(opts_map)
+        |> add_reasoning_effort(opts_map)
+        |> add_response_format(opts_map)
+        |> add_parallel_tool_calls(opts_map)
+        |> translate_tool_choice_format()
+        |> add_strict_to_tools()
+    end
+  end
+
+  defp build_request_url(opts) do
+    case Keyword.get(opts, :base_url) do
+      nil -> ReqLLM.Providers.OpenAI.default_base_url() <> path()
+      base_url -> "#{base_url}#{path()}"
+    end
+  end
+
+  # ========================================================================
+
+  @impl true
+  def attach_stream(model, context, opts, _finch_name) do
+    headers = build_request_headers(model, opts) ++ [{"Accept", "text/event-stream"}]
+
+    provider_opts = opts |> Keyword.get(:provider_options, []) |> Map.new() |> Map.to_list()
 
     cleaned_opts =
       opts
       |> Keyword.delete(:finch_name)
       |> Keyword.delete(:compiled_schema)
       |> Keyword.delete(:provider_options)
+      |> Keyword.merge(provider_opts)
+      |> Keyword.put(:stream, true)
 
-    req_opts =
-      [
-        model: model.model,
-        context: context,
-        stream: true,
-        provider_options: provider_opts
-      ] ++ cleaned_opts
+    body = build_request_body(context, model.model, cleaned_opts)
+    url = build_request_url(opts)
 
-    options =
-      req_opts
-      |> Enum.reduce(%{}, fn
-        {key, value}, acc when is_list(value) ->
-          Map.put(acc, key, Map.new(value))
-
-        {key, value}, acc ->
-          Map.put(acc, key, value)
-      end)
-
-    temp_request = %Req.Request{
-      method: :post,
-      url: URI.parse("https://example.com/temp"),
-      headers: %{},
-      body: {:json, %{}},
-      options: options
-    }
-
-    encoded_request = encode_body(temp_request)
-    body = encoded_request.body
-
-    {:ok, Finch.build(:post, url, headers, body)}
+    {:ok, Finch.build(:post, url, headers, Jason.encode!(body))}
   rescue
     error ->
       {:error,

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -61,40 +61,11 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   @impl true
   def encode_body(request) do
-    ctx = request.options[:context] || %ReqLLM.Context{messages: []}
-    provider_opts = request.options[:provider_options] || []
+    context = request.options[:context] || %ReqLLM.Context{messages: []}
+    model_name = request.options[:model]
+    opts = request.options
 
-    input =
-      Enum.map(ctx.messages, fn msg ->
-        content =
-          Enum.flat_map(msg.content, fn part ->
-            case part.type do
-              :text -> [%{"type" => "input_text", "text" => part.text}]
-              _ -> []
-            end
-          end)
-
-        %{"role" => Atom.to_string(msg.role), "content" => content}
-      end)
-
-    max_output_tokens =
-      request.options[:max_output_tokens] ||
-        request.options[:max_completion_tokens] ||
-        request.options[:max_tokens]
-
-    tools = encode_tools_if_any(request) |> ensure_deep_research_tools(request)
-    tool_choice = encode_tool_choice(request.options[:tool_choice])
-    reasoning = encode_reasoning_effort(provider_opts[:reasoning_effort])
-
-    body =
-      Map.new()
-      |> Map.put("model", request.options[:model])
-      |> Map.put("input", input)
-      |> maybe_put_string("stream", request.options[:stream])
-      |> maybe_put_string("max_output_tokens", max_output_tokens)
-      |> maybe_put_string("tools", tools)
-      |> maybe_put_string("tool_choice", tool_choice)
-      |> maybe_put_string("reasoning", reasoning)
+    body = build_request_body(context, model_name, opts, request)
 
     Map.put(request, :body, Jason.encode!(body))
   end
@@ -218,61 +189,86 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   def decode_sse_event(_event, _model), do: []
 
-  @impl true
-  def attach_stream(model, context, opts, _finch_name) do
+  # ========================================================================
+  # Shared Request Building Helpers (used by both encode_body and attach_stream)
+  # ========================================================================
+
+  defp build_request_headers(model, opts) do
     api_key = ReqLLM.Keys.get!(model, opts)
 
-    headers = [
+    [
       {"Authorization", "Bearer " <> api_key},
-      {"Content-Type", "application/json"},
-      {"Accept", "text/event-stream"}
+      {"Content-Type", "application/json"}
     ]
+  end
 
-    url =
-      case Keyword.get(opts, :base_url) do
-        nil -> ReqLLM.Providers.OpenAI.default_base_url() <> path()
-        base_url -> "#{base_url}#{path()}"
-      end
+  defp build_request_url(opts) do
+    case Keyword.get(opts, :base_url) do
+      nil -> ReqLLM.Providers.OpenAI.default_base_url() <> path()
+      base_url -> "#{base_url}#{path()}"
+    end
+  end
 
-    provider_opts = opts |> Keyword.get(:provider_options, []) |> Map.new()
+  defp build_request_body(context, model_name, opts, request) do
+    opts_map = if is_map(opts), do: opts, else: Map.new(opts)
+    provider_opts = opts_map[:provider_options] || []
+
+    input =
+      Enum.map(context.messages, fn msg ->
+        content =
+          Enum.flat_map(msg.content, fn part ->
+            case part.type do
+              :text -> [%{"type" => "input_text", "text" => part.text}]
+              _ -> []
+            end
+          end)
+
+        %{"role" => Atom.to_string(msg.role), "content" => content}
+      end)
+
+    max_output_tokens =
+      opts_map[:max_output_tokens] ||
+        opts_map[:max_completion_tokens] ||
+        opts_map[:max_tokens]
+
+    temp_request = request || %{options: opts_map}
+    tools = encode_tools_if_any(temp_request) |> ensure_deep_research_tools(temp_request)
+
+    tool_choice = encode_tool_choice(opts_map[:tool_choice])
+    reasoning = encode_reasoning_effort(provider_opts[:reasoning_effort])
+
+    Map.new()
+    |> Map.put("model", model_name)
+    |> Map.put("input", input)
+    |> maybe_put_string("stream", opts_map[:stream])
+    |> maybe_put_string("max_output_tokens", max_output_tokens)
+    |> maybe_put_string("tools", tools)
+    |> maybe_put_string("tool_choice", tool_choice)
+    |> maybe_put_string("reasoning", reasoning)
+  end
+
+  # ========================================================================
+
+  @impl true
+  def attach_stream(model, context, opts, _finch_name) do
+    headers = build_request_headers(model, opts) ++ [{"Accept", "text/event-stream"}]
+
+    provider_opts = opts |> Keyword.get(:provider_options, []) |> Map.new() |> Map.to_list()
 
     cleaned_opts =
       opts
       |> Keyword.delete(:finch_name)
       |> Keyword.delete(:compiled_schema)
       |> Keyword.delete(:provider_options)
+      |> Keyword.merge(provider_opts)
+      |> Keyword.put(:stream, true)
+      |> Keyword.put(:model, model.model)
+      |> Keyword.put(:context, context)
 
-    req_opts =
-      [
-        model: model.model,
-        context: context,
-        stream: true,
-        responses_api: true,
-        provider_options: provider_opts
-      ] ++ cleaned_opts
+    body = build_request_body(context, model.model, cleaned_opts, nil)
+    url = build_request_url(opts)
 
-    options =
-      req_opts
-      |> Enum.reduce(%{}, fn
-        {key, value}, acc when is_list(value) ->
-          Map.put(acc, key, Map.new(value))
-
-        {key, value}, acc ->
-          Map.put(acc, key, value)
-      end)
-
-    temp_request = %Req.Request{
-      method: :post,
-      url: URI.parse("https://example.com/temp"),
-      headers: %{},
-      body: {:json, %{}},
-      options: options
-    }
-
-    encoded_request = encode_body(temp_request)
-    body = encoded_request.body
-
-    {:ok, Finch.build(:post, url, headers, body)}
+    {:ok, Finch.build(:post, url, headers, Jason.encode!(body))}
   rescue
     error ->
       {:error,

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,9 @@ defmodule ReqLLM.MixProject do
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test,
-        "coveralls.github": :test
+        "coveralls.github": :test,
+        "req_llm.model_compat": :test,
+        mc: :test
       ],
 
       # Dialyzer configuration

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -38,13 +38,23 @@ mix test test/coverage/
 # All coverage tests globally
 mix test --only coverage
 
-# By category
-mix test --only "category:core"
-mix test --only "category:streaming"
-
 # By provider
 mix test --only "provider:anthropic"
 mix test --only "provider:openai"
+
+# By scenario (test type)
+mix test --only "scenario:basic"
+mix test --only "scenario:streaming"
+mix test --only "scenario:usage"
+mix test --only "scenario:tool_multi"
+
+# By model (without provider prefix)
+mix test --only "model:claude-3-5-haiku-20241022"
+mix test --only "model:gpt-4o-mini"
+
+# Combine filters for precise targeting
+mix test --only "provider:anthropic" --only "scenario:basic"
+mix test --only "model:claude-3-5-haiku-20241022" --only "scenario:streaming"
 ```
 
 ### Fixture Recording (Live API Testing)
@@ -55,12 +65,15 @@ REQ_LLM_FIXTURES_MODE=record mix test
 # Re-record specific provider fixtures
 REQ_LLM_FIXTURES_MODE=record mix test --only "provider:anthropic"
 
-# Re-record specific category
-REQ_LLM_FIXTURES_MODE=record mix test --only "category:core"
-REQ_LLM_FIXTURES_MODE=record mix test --only "category:streaming"
+# Re-record specific scenario
+REQ_LLM_FIXTURES_MODE=record mix test --only "scenario:basic"
+REQ_LLM_FIXTURES_MODE=record mix test --only "scenario:streaming"
 
 # Re-record for specific models only
 REQ_LLM_FIXTURES_MODE=record REQ_LLM_MODELS="anthropic:claude-3-5-haiku-20241022" mix test --only "provider:anthropic"
+
+# Re-record specific model + scenario combination
+REQ_LLM_FIXTURES_MODE=record mix test --only "model:claude-3-5-haiku-20241022" --only "scenario:basic"
 ```
 
 ## Fixture System
@@ -128,9 +141,21 @@ REQ_LLM_SAMPLE=1 mix test --only coverage
 
 ## Semantic Tags
 
+Tests are organized by Provider → Model → Scenario hierarchy.
+
 **Tag Dimensions:**
-- `category` - `:core`, `:streaming`, `:tools`, `:embedding`
 - `provider` - `:anthropic`, `:openai`, `:google`, `:groq`, `:openrouter`, `:xai`
+- `model` - Model identifier without provider prefix (e.g., `claude-3-5-haiku-20241022`, `gpt-4o-mini`)
+- `scenario` - Test scenario type:
+  - `:basic` - Basic generate_text (non-streaming)
+  - `:streaming` - Streaming with system context
+  - `:token_limit` - Token limit constraints
+  - `:usage` - Usage metrics and costs
+  - `:tool_multi` - Tool calling with multiple tools
+  - `:tool_none` - Tool avoidance
+  - `:object_basic` - Object generation (non-streaming)
+  - `:object_streaming` - Object generation (streaming)
+  - `:reasoning` - Reasoning/thinking tokens
 - `coverage` - Mark coverage tests with `coverage: true`
 
 ## HTTP Mocking

--- a/test/support/provider_test/comprehensive.ex
+++ b/test/support/provider_test/comprehensive.ex
@@ -2,15 +2,16 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
   @moduledoc """
   Comprehensive per-model provider tests.
 
-  Consolidates all provider capability testing into up to 8 focused tests per model:
+  Consolidates all provider capability testing into up to 9 focused tests per model:
   1. Basic generate_text (non-streaming)
   2. Streaming with system context + creative params
   3. Token limit constraints
   4. Usage metrics and cost calculations
   5. Tool calling - multi-tool selection
   6. Tool calling - no tool when inappropriate
-  7. Object generation (streaming) - only for models with :tool_call capability
-  8. Reasoning/thinking tokens - only for models with :reasoning capability
+  7. Object generation (non-streaming) - only for models with object generation support
+  8. Object generation (streaming) - only for models with object generation support
+  9. Reasoning/thinking tokens - only for models with :reasoning capability
 
   Tests use fixtures for fast, deterministic execution while supporting
   live API recording with REQ_LLM_FIXTURES_MODE=record.
@@ -27,6 +28,13 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
 
   Set REQ_LLM_DEBUG=1 to enable verbose fixture output during test runs.
   """
+
+  @doc false
+  def model_identifier(model_spec) do
+    model_spec
+    |> String.split(":", parts: 2)
+    |> List.last()
+  end
 
   defmacro __using__(opts) do
     provider = Keyword.fetch!(opts, :provider)
@@ -53,7 +61,9 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
         @model_spec model_spec
 
         describe "#{model_spec}" do
-          @tag category: :core
+          @describetag model: ReqLLM.ProviderTest.Comprehensive.model_identifier(model_spec)
+
+          @tag scenario: :basic
           test "basic generate_text (non-streaming)" do
             require Logger
 
@@ -76,7 +86,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             |> assert_basic_response()
           end
 
-          @tag category: :streaming
+          @tag scenario: :streaming
           test "stream_text with system context and creative params" do
             require Logger
 
@@ -120,7 +130,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             assert response.message.role == :assistant
           end
 
-          @tag category: :core
+          @tag scenario: :token_limit
           test "token limit constraints" do
             opts =
               param_bundles(@provider).minimal
@@ -154,7 +164,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             end
           end
 
-          @tag category: :usage
+          @tag scenario: :usage
           test "usage metrics and cost calculations" do
             require Logger
 
@@ -217,7 +227,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
           end
 
           if :tool_call in ReqLLM.capabilities(model_spec) do
-            @tag category: :tool_calling
+            @tag scenario: :tool_multi
             test "tool calling - multi-tool selection" do
               tools = [
                 ReqLLM.tool(
@@ -281,7 +291,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               end
             end
 
-            @tag category: :tool_calling
+            @tag scenario: :tool_none
             test "tool calling - no tool when inappropriate" do
               tools = [
                 ReqLLM.tool(
@@ -314,8 +324,56 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             end
           end
 
-          if :tool_call in ReqLLM.capabilities(model_spec) do
-            @tag category: :object_generation
+          if ReqLLM.Capability.supports_object_generation?(model_spec) do
+            @tag scenario: :object_basic
+            test "object generation (non-streaming)" do
+              schema = [
+                name: [type: :string, required: true, doc: "Person's full name"],
+                age: [type: :pos_integer, required: true, doc: "Person's age in years"],
+                occupation: [type: :string, doc: "Person's job or profession"]
+              ]
+
+              opts =
+                param_bundles(@provider).deterministic
+                |> Keyword.put(:max_tokens, 500)
+                |> then(&reasoning_overlay(@model_spec, @provider, &1, 500))
+
+              {:ok, response} =
+                ReqLLM.generate_object(
+                  @model_spec,
+                  "Generate a software engineer profile",
+                  schema,
+                  fixture_opts(@provider, "object_basic", opts)
+                )
+
+              assert %ReqLLM.Response{} = response
+              object = ReqLLM.Response.object(response)
+              rt = ReqLLM.Response.reasoning_tokens(response)
+
+              cond do
+                is_map(object) and map_size(object) > 0 ->
+                  assert Map.has_key?(object, "name")
+                  assert Map.has_key?(object, "age")
+                  assert is_binary(object["name"])
+                  assert object["name"] != ""
+                  assert is_integer(object["age"])
+                  assert object["age"] > 0
+
+                truncated?(response) ->
+                  assert is_number(rt) and rt >= 0
+
+                is_number(rt) and rt > 0 ->
+                  :ok
+
+                is_map(object) ->
+                  :ok
+
+                true ->
+                  flunk("Expected object or reasoning tokens but got: #{inspect(object)}")
+              end
+            end
+
+            @tag scenario: :object_streaming
             test "object generation (streaming)" do
               schema = [
                 name: [type: :string, required: true, doc: "Person's full name"],
@@ -372,7 +430,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
           end
 
           if :reasoning in ReqLLM.capabilities(model_spec) do
-            @tag category: :reasoning
+            @tag scenario: :reasoning
             test "reasoning/thinking tokens (non-streaming + streaming)" do
               if debug?() do
                 IO.puts("\n[Comprehensive] model_spec=#{@model_spec}, test=reasoning")


### PR DESCRIPTION
## Changes

- **Parallelization Fix**: Replaced ExUnit  approach with  to run separate Running ExUnit with seed: 113404, max_cases: 20
Excluding tags: [:coverage]

.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 3.1 seconds (3.0s async, 0.1s sync)
9 doctests, 1095 tests, 0 failures, 99 excluded processes per model, achieving true OS-level parallelism
- **Refactored 
11:54:08.775 [debug] JidoKeys.Server loaded 72 configuration variables

11:54:08.873 [debug] ReqLLM provider registry initialized with 50 providers (7 implemented, 43 metadata-only)

----------------------------------------------------
Model Coverage Status
----------------------------------------------------

[36m[1mAnthropic[0m
  [31m\x{2717}[0m claude-3-5-haiku-20241022
  [32m\x{2713}[0m claude-3-5-sonnet-20240620
  [31m\x{2717}[0m claude-3-5-sonnet-20241022
  [32m\x{2713}[0m claude-3-7-sonnet-20250219
  [32m\x{2713}[0m claude-3-haiku-20240307
  [32m\x{2713}[0m claude-3-opus-20240229
  [32m\x{2713}[0m claude-opus-4-1-20250805
  [32m\x{2713}[0m claude-opus-4-20250514
  [32m\x{2713}[0m claude-sonnet-4-20250514
  [32m\x{2713}[0m claude-sonnet-4-5-20250929
  [2m8 pass, 2 fail, 0 excluded, 0 untested | 80.0% coverage[0m

[36m[1mCerebras[0m
  [32m\x{2713}[0m gpt-oss-120b
  [32m\x{2713}[0m qwen-3-235b-a22b-instruct-2507
  [2m?[0m qwen-3-235b-a22b-thinking-2507
  [32m\x{2713}[0m qwen-3-coder-480b
  [2m3 pass, 0 fail, 0 excluded, 1 untested | 75.0% coverage[0m

[36m[1mGoogle[0m
  [31m\x{2717}[0m gemini-2.0-flash
  [32m\x{2713}[0m gemini-2.0-flash-lite
  [31m\x{2717}[0m gemini-2.5-flash
  [32m\x{2713}[0m gemini-2.5-flash-preview-05-20
  [32m\x{2713}[0m gemini-2.5-pro
  [32m\x{2713}[0m gemini-embedding-001
  [32m\x{2713}[0m gemini-flash-latest
  [2m5 pass, 2 fail, 0 excluded, 0 untested | 71.4% coverage[0m

[36m[1mGroq[0m
  [32m\x{2713}[0m deepseek-r1-distill-llama-70b
  [32m\x{2713}[0m llama-3.1-8b-instant
  [31m\x{2717}[0m llama-3.3-70b-versatile
  [32m\x{2713}[0m meta-llama/llama-4-maverick-17b-128e-instruct
  [32m\x{2713}[0m moonshotai/kimi-k2-instruct-0905
  [32m\x{2713}[0m openai/gpt-oss-120b
  [32m\x{2713}[0m openai/gpt-oss-20b
  [32m\x{2713}[0m qwen/qwen3-32b
  [2m7 pass, 1 fail, 0 excluded, 0 untested | 87.5% coverage[0m

[36m[1mOpenAI[0m
  [32m\x{2713}[0m codex-mini-latest
  [32m\x{2713}[0m gpt-3.5-turbo
  [32m\x{2713}[0m gpt-4
  [31m\x{2717}[0m gpt-4-turbo
  [32m\x{2713}[0m gpt-4.1
  [32m\x{2713}[0m gpt-4.1-mini
  [32m\x{2713}[0m gpt-4.1-nano
  [32m\x{2713}[0m gpt-4o
  [32m\x{2713}[0m gpt-4o-2024-05-13
  [31m\x{2717}[0m gpt-4o-2024-08-06
  [31m\x{2717}[0m gpt-4o-2024-11-20
  [31m\x{2717}[0m gpt-4o-mini
  [32m\x{2713}[0m gpt-5
  [32m\x{2713}[0m gpt-5-chat-latest
  [32m\x{2713}[0m gpt-5-codex
  [32m\x{2713}[0m gpt-5-mini
  [32m\x{2713}[0m gpt-5-nano
  [32m\x{2713}[0m o1
  [31m\x{2717}[0m o1-pro
  [32m\x{2713}[0m o3
  [31m\x{2717}[0m o3-deep-research
  [32m\x{2713}[0m o3-mini
  [32m\x{2713}[0m o3-pro
  [32m\x{2713}[0m o4-mini
  [31m\x{2717}[0m o4-mini-deep-research
  [32m\x{2713}[0m text-embedding-3-large
  [32m\x{2713}[0m text-embedding-3-small
  [32m\x{2713}[0m text-embedding-ada-002
  [2m21 pass, 7 fail, 0 excluded, 0 untested | 75.0% coverage[0m

[36m[1mOpenRouter[0m
  [32m\x{2713}[0m anthropic/claude-3.5-haiku
  [32m\x{2713}[0m anthropic/claude-3.7-sonnet
  [32m\x{2713}[0m anthropic/claude-opus-4
  [32m\x{2713}[0m anthropic/claude-opus-4.1
  [31m\x{2717}[0m anthropic/claude-sonnet-4
  [32m\x{2713}[0m anthropic/claude-sonnet-4.5
  [32m\x{2713}[0m deepseek/deepseek-chat-v3-0324
  [32m\x{2713}[0m deepseek/deepseek-chat-v3.1
  [32m\x{2713}[0m deepseek/deepseek-r1-distill-llama-70b
  [32m\x{2713}[0m deepseek/deepseek-r1-distill-qwen-14b
  [32m\x{2713}[0m deepseek/deepseek-v3.1-terminus
  [32m\x{2713}[0m google/gemini-2.0-flash-001
  [32m\x{2713}[0m google/gemini-2.5-flash
  [32m\x{2713}[0m google/gemini-2.5-pro
  [32m\x{2713}[0m google/gemini-2.5-pro-preview-05-06
  [32m\x{2713}[0m google/gemini-2.5-pro-preview-06-05
  [32m\x{2713}[0m google/gemma-3n-e4b-it
  [32m\x{2713}[0m meta-llama/llama-3.2-11b-vision-instruct
  [32m\x{2713}[0m mistralai/codestral-2508
  [31m\x{2717}[0m mistralai/devstral-medium-2507
  [31m\x{2717}[0m mistralai/devstral-small-2505
  [32m\x{2713}[0m mistralai/devstral-small-2507
  [32m\x{2713}[0m mistralai/mistral-medium-3
  [32m\x{2713}[0m mistralai/mistral-medium-3.1
  [31m\x{2717}[0m mistralai/mistral-small-3.1-24b-instruct
  [31m\x{2717}[0m mistralai/mistral-small-3.2-24b-instruct
  [32m\x{2713}[0m moonshotai/kimi-k2
  [32m\x{2713}[0m moonshotai/kimi-k2-0905
  [31m\x{2717}[0m nousresearch/hermes-4-405b
  [31m\x{2717}[0m nousresearch/hermes-4-70b
  [31m\x{2717}[0m openai/gpt-4.1
  [31m\x{2717}[0m openai/gpt-4.1-mini
  [32m\x{2713}[0m openai/gpt-4o-mini
  [32m\x{2713}[0m openai/gpt-5
  [31m\x{2717}[0m openai/gpt-5-chat
  [32m\x{2713}[0m openai/gpt-5-codex
  [31m\x{2717}[0m openai/gpt-5-mini
  [31m\x{2717}[0m openai/gpt-5-nano
  [32m\x{2713}[0m openai/gpt-oss-120b
  [31m\x{2717}[0m openai/gpt-oss-20b
  [31m\x{2717}[0m openai/o4-mini
  [32m\x{2713}[0m qwen/qwen-2.5-coder-32b-instruct
  [32m\x{2713}[0m qwen/qwen2.5-vl-72b-instruct
  [31m\x{2717}[0m qwen/qwen3-235b-a22b-07-25
  [32m\x{2713}[0m qwen/qwen3-235b-a22b-thinking-2507
  [32m\x{2713}[0m qwen/qwen3-30b-a3b-instruct-2507
  [32m\x{2713}[0m qwen/qwen3-coder
  [31m\x{2717}[0m qwen/qwen3-max
  [31m\x{2717}[0m qwen/qwen3-next-80b-a3b-instruct
  [31m\x{2717}[0m rekaai/reka-flash-3
  [32m\x{2713}[0m x-ai/grok-3
  [32m\x{2713}[0m x-ai/grok-3-beta
  [32m\x{2713}[0m x-ai/grok-3-mini
  [32m\x{2713}[0m x-ai/grok-3-mini-beta
  [32m\x{2713}[0m x-ai/grok-4
  [31m\x{2717}[0m x-ai/grok-4-fast
  [32m\x{2713}[0m x-ai/grok-code-fast-1
  [31m\x{2717}[0m z-ai/glm-4.5
  [32m\x{2713}[0m z-ai/glm-4.5-air
  [31m\x{2717}[0m z-ai/glm-4.5v
  [32m\x{2713}[0m z-ai/glm-4.6
  [2m40 pass, 21 fail, 0 excluded, 0 untested | 65.6% coverage[0m

[36m[1mxAI[0m
  [32m\x{2713}[0m grok-2
  [32m\x{2713}[0m grok-2-1212
  [31m\x{2717}[0m grok-2-latest
  [32m\x{2713}[0m grok-2-vision
  [32m\x{2713}[0m grok-2-vision-1212
  [32m\x{2713}[0m grok-2-vision-latest
  [32m\x{2713}[0m grok-3
  [32m\x{2713}[0m grok-3-fast
  [32m\x{2713}[0m grok-3-fast-latest
  [32m\x{2713}[0m grok-3-latest
  [31m\x{2717}[0m grok-3-mini
  [32m\x{2713}[0m grok-3-mini-fast
  [32m\x{2713}[0m grok-3-mini-fast-latest
  [32m\x{2713}[0m grok-3-mini-latest
  [32m\x{2713}[0m grok-4
  [32m\x{2713}[0m grok-4-fast
  [32m\x{2713}[0m grok-4-fast-non-reasoning
  [32m\x{2713}[0m grok-4-fast-reasoning
  [32m\x{2713}[0m grok-code-fast-1
  [2m17 pass, 2 fail, 0 excluded, 0 untested | 89.5% coverage[0m

Overall Coverage: 102/690 models validated (14.8%)**: Completely rewrote  to use concurrent test execution with 
- **Simplified State Management**: Removed old result collection system (, ) in favor of direct file I/O in the main task
- **Cleanup**: Removed unused  module
- **Test Configuration**: Reverted  in comprehensive tests as parallelization is now handled externally

## Performance Impact

Dramatic speedup in model compatibility testing:
- 10 Anthropic models now run in ~2.2 seconds (previously sequential)
- Parallel execution scales with available CPU cores

## Testing


11:54:09.382 [debug] JidoKeys.Server loaded 72 configuration variables

11:54:09.477 [debug] ReqLLM provider registry initialized with 50 providers (7 implemented, 43 metadata-only)

----------------------------------------------------
Model Coverage
----------------------------------------------------

Testing 10 model(s) (replay mode)...

  Testing anthropic:claude-3-5-haiku-20241022 (text)...
  Testing anthropic:claude-3-5-sonnet-20240620 (text)...
  Testing anthropic:claude-3-5-sonnet-20241022 (text)...
  Testing anthropic:claude-3-7-sonnet-20250219 (text)...
  Testing anthropic:claude-3-haiku-20240307 (text)...
  Testing anthropic:claude-3-opus-20240229 (text)...
  Testing anthropic:claude-opus-4-1-20250805 (text)...
  Testing anthropic:claude-opus-4-20250514 (text)...
  Testing anthropic:claude-sonnet-4-20250514 (text)...
  Testing anthropic:claude-sonnet-4-5-20250929 (text)...

----------------------------------------------------
  Summary
----------------------------------------------------

[36m[1mAnthropic[0m
  [31mFAIL claude-3-5-sonnet-20241022[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-3-5-sonnet-20240620[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-3-7-sonnet-20250219[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-3-5-haiku-20241022[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-opus-4-20250514[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [32mPASS claude-3-haiku-20240307[0m
  [31mFAIL claude-sonnet-4-5-20250929[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-3-opus-20240229[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-opus-4-1-20250805[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-sonnet-4-20250514[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m

[33mCoverage: 1/10 passing (10.0%)[0m in 2.2s


11:54:12.120 [debug] JidoKeys.Server loaded 72 configuration variables

11:54:12.221 [debug] ReqLLM provider registry initialized with 50 providers (7 implemented, 43 metadata-only)

----------------------------------------------------
Sample Models
----------------------------------------------------

Testing 12 model(s) (replay mode)...

  Testing anthropic:claude-3-5-haiku-20241022 (text)...
  Testing anthropic:claude-3-5-sonnet-20241022 (text)...
  Testing google:gemini-2.0-flash (text)...
  Testing google:gemini-2.5-flash (text)...
  Testing groq:deepseek-r1-distill-llama-70b (text)...
  Testing groq:llama-3.3-70b-versatile (text)...
  Testing openai:gpt-4-turbo (text)...
  Testing openai:gpt-4o-mini (text)...
  Testing openrouter:anthropic/claude-sonnet-4 (text)...
  Testing openrouter:x-ai/grok-4-fast (text)...
  Testing xai:grok-2-latest (text)...
  Testing xai:grok-3-mini (text)...

----------------------------------------------------
  Summary
----------------------------------------------------

[36m[1mAnthropic[0m
  [31mFAIL claude-3-5-haiku-20241022[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m
  [31mFAIL claude-3-5-sonnet-20241022[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/anthropic/claude_[0m

[36m[1mGoogle[0m
  [31mFAIL gemini-2.0-flash[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/google/gemini_2_0[0m
  [31mFAIL gemini-2.5-flash[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/google/gemini_2_5[0m

[36m[1mGroq[0m
  [32mPASS deepseek-r1-distill-llama-70b[0m
  [31mFAIL llama-3.3-70b-versatile[0m
       [2m     ** (Jason.DecodeError) unexpected end of input at position 0
     ** (RuntimeError) Fixture not found: /Users/mhoste[0m

[36m[1mOpenAI[0m
  [31mFAIL gpt-4o-mini[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/openai/gpt_4o_min[0m
  [31mFAIL gpt-4-turbo[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/openai/gpt_4_turb[0m

[36m[1mOpenRouter[0m
  [31mFAIL x-ai/grok-4-fast[0m
       [2m     ** (Jason.DecodeError) unexpected end of input at position 0
     ** (RuntimeError) Fixture not found: /Users/mhoste[0m
  [31mFAIL anthropic/claude-sonnet-4[0m
       [2m     ** (Jason.DecodeError) unexpected end of input at position 0
     ** (RuntimeError) Fixture not found: /Users/mhoste[0m

[36m[1mxAI[0m
  [31mFAIL grok-3-mini[0m
       [2m     ** (Jason.DecodeError) unexpected end of input at position 0
     ** (RuntimeError) Fixture not found: /Users/mhoste[0m
  [31mFAIL grok-2-latest[0m
       [2m     ** (RuntimeError) Fixture not found: /Users/mhostetler/Source/ReqLLM/req_llm/test/support/fixtures/xai/grok_2_latest[0m

[33mCoverage: 1/12 passing (8.3%)[0m in 2.6s