### PR TITLE
Add normalize_model_id callback for inference profile pricing

### DIFF
--- a/lib/req_llm/provider.ex
+++ b/lib/req_llm/provider.ex
@@ -208,6 +208,31 @@ defmodule ReqLLM.Provider do
               {:ok, map()} | {:error, term()}
 
   @doc """
+  Normalizes a model ID for metadata lookup (optional).
+
+  This callback allows providers to normalize model identifiers before looking up
+  metadata in the provider's model registry. Useful when providers have multiple
+  aliases or formats for the same underlying model (e.g., regional inference profiles).
+
+  ## Parameters
+
+    * `model_id` - The model identifier string to normalize
+
+  ## Returns
+
+    * `String.t()` - The normalized model ID for metadata lookup
+
+  ## Examples
+
+      # AWS Bedrock inference profiles - strip region prefix for metadata lookup
+      def normalize_model_id("us.anthropic.claude-3-sonnet"), do: "anthropic.claude-3-sonnet"
+      def normalize_model_id("eu.meta.llama-3"), do: "meta.llama-3"
+      def normalize_model_id(model_id), do: model_id
+
+  If this callback is not implemented, the model ID is used as-is for metadata lookup.
+  """
+  @callback normalize_model_id(String.t()) :: String.t()
+  @doc """
   Translates canonical options to provider-specific parameters (optional).
 
   This callback allows providers to modify option keys and values before
@@ -514,6 +539,7 @@ defmodule ReqLLM.Provider do
             ) :: {:ok, Finch.Request.t()} | {:error, Exception.t()}
 
   @optional_callbacks [
+    normalize_model_id: 1,
     extract_usage: 2,
     default_env_key: 0,
     translate_options: 3,

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -623,6 +623,19 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     request
   end
 
+  @impl ReqLLM.Provider
+  def normalize_model_id(model_id) when is_binary(model_id) do
+    # Strip region prefix from inference profile IDs for metadata lookup
+    # e.g., "us.anthropic.claude-3-sonnet" -> "anthropic.claude-3-sonnet"
+    case String.split(model_id, ".", parts: 2) do
+      [possible_region, rest] when possible_region in ["us", "eu", "ap", "ca", "global"] ->
+        rest
+
+      _ ->
+        model_id
+    end
+  end
+
   defp get_formatter_module(model_family) do
     case Map.fetch(@model_families, model_family) do
       {:ok, module} ->


### PR DESCRIPTION
## Problem

AWS Bedrock requires inference profile IDs (e.g., `us.anthropic.claude-sonnet-4-5-20250929-v1:0`) for API calls, but models.dev only has standard model IDs (e.g., `anthropic.claude-sonnet-4-5-20250929-v1:0`). This results in `cost: nil` in responses.

## Solution

Add optional `normalize_model_id/1` callback to Provider behavior:
- Providers can normalize model IDs before metadata lookup
- AmazonBedrock strips region prefixes (us., eu., ap., ca., global.)
- Model struct keeps original ID for API calls
- Metadata lookup uses normalized ID for pricing

## Testing

Verified that `us.anthropic.claude-sonnet-4-5-20250929-v1:0` now returns cost metadata ($3/$15 per million tokens) by normalizing to `anthropic.claude-sonnet-4-5-20250929-v1:0` for lookup.