### PR TITLE
Enable base_url override for testing

### DIFF
--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -159,6 +159,7 @@ defmodule ReqLLM.Provider.Options do
   # Internal keys that bypass validation (framework concerns)
   @internal_keys [
     :api_key,
+    :base_url,
     :on_unsupported,
     :fixture,
     :req_http_options,


### PR DESCRIPTION
## Summary
Add `:base_url` to the internal keys list to allow runtime base URL overrides for testing purposes.

## Problem
ReqLLM has hardcoded API endpoints with no mechanism to override them for testing against mock services like MockLLM.

## Solution
Add `:base_url` to `@internal_keys` in `provider/options.ex` to bypass validation and allow it to pass through to providers. This is a single-line change that enables testing while maintaining backwards compatibility.

## Testing
- Allows passing `:base_url` option to ReqLLM providers
- Enables integration tests with MockLLM and other mock services
- Non-breaking change - production behavior unaffected