### PR TITLE
fix: Handle JSON Schema in Tool.Inspect protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Metadata collection timeout errors on large documents with long processing times
-
-### Fixed
-
 - Bedrock streaming now works correctly (fixed deprecated function capture syntax)
+- Tool.Inspect protocol crash when inspecting tools with JSON Schema (map) parameter schemas
 
 ### Changed
 

--- a/lib/req_llm/tool.ex
+++ b/lib/req_llm/tool.ex
@@ -451,8 +451,27 @@ defmodule ReqLLM.Tool do
 
   defimpl Inspect do
     def inspect(%{name: name, parameter_schema: schema}, opts) do
-      param_count = length(schema)
-      param_desc = if param_count == 0, do: "no params", else: "#{param_count} params"
+      param_desc =
+        cond do
+          # NimbleOptions format (list of keyword tuples)
+          is_list(schema) ->
+            param_count = length(schema)
+            if param_count == 0, do: "no params", else: "#{param_count} params"
+
+          # JSON Schema format (map)
+          is_map(schema) ->
+            prop_count = map_size(Map.get(schema, "properties", %{}))
+
+            if prop_count == 0 do
+              "no params (JSON Schema)"
+            else
+              "#{prop_count} params (JSON Schema)"
+            end
+
+          # Unknown format
+          true ->
+            "unknown schema format"
+        end
 
       Inspect.Algebra.concat([
         "#Tool<",


### PR DESCRIPTION
## Description

Fix `Tool.Inspect` protocol crash when inspecting tools with JSON Schema (map)
parameter schemas.

The Inspect protocol only handled NimbleOptions (keyword list) format and
crashed with `ArgumentError` when calling `length/1` on a map. This PR updates
the protocol to handle both NimbleOptions and JSON Schema formats, displaying
appropriate output for each.

**Before:** `ArgumentError` when inspecting tools with JSON Schema **After:**
`#Tool<"submit_data" 3 params (JSON Schema)>`

## Type of Contribution

- [x] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [ ] **Provider Feature** - Adding capabilities to existing provider
- [x] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [ ] Documentation updated (not applicable - internal protocol implementation)
- [x] CHANGELOG.md updated

## Changes Made

### `lib/req_llm/tool.ex`

Updated `Inspect` protocol implementation to:

- Check if `parameter_schema` is a list (NimbleOptions) or map (JSON Schema)
- Count parameters appropriately for each format
- Display "(JSON Schema)" suffix for map-based schemas
- Handle empty schemas for both formats

### `test/req_llm/tool_test.exs`

Added 4 new test cases:

1. NimbleOptions parameter schema (list)
2. JSON Schema parameter schema (map)
3. Empty NimbleOptions schema
4. Empty JSON Schema

### Output Examples

**NimbleOptions (list):**

```elixir
#Tool<"get_weather" 2 params>
#Tool<"no_params_tool" no params>
```

**JSON Schema (map):**

```elixir
#Tool<"submit_data" 3 params (JSON Schema)>
#Tool<"empty_schema" no params (JSON Schema)>
```

## Impact

- ✅ **Backward compatible** - No changes to existing NimbleOptions behavior
- ✅ **Fixes crash** - JSON Schema tools no longer crash inspect
- ✅ **Better debugging** - Clear distinction between schema formats
- ✅ **No breaking changes** - Only fixes a crash scenario

## Quality Checks

Credo clean - no warnings introduced by changes (only pre-existing suggestions
unrelated to this PR).