### PR TITLE
Fix ArgumentError: remove retry_delay when retry returns {:delay, ms}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ArgumentError when retry function returns `{:delay, ms}` - removed conflicting `retry_delay` option from `ReqLLM.Step.Retry.attach/1` (Req 0.5.15+ compatibility)
 - Metadata collection timeout errors on large documents with long processing times
 - Bedrock streaming now works correctly (fixed deprecated function capture syntax)
 - Tool.Inspect protocol crash when inspecting tools with JSON Schema (map) parameter schemas

--- a/lib/req_llm/step/retry.ex
+++ b/lib/req_llm/step/retry.ex
@@ -53,7 +53,8 @@ defmodule ReqLLM.Step.Retry do
     |> Req.Request.merge_options(
       retry: &should_retry?/2,
       max_retries: 3,
-      retry_delay: fn _attempt -> 0 end,
+      # Don't set retry_delay since should_retry?/2 returns {:delay, ms}
+      # Setting both causes ArgumentError in Req 0.5.15+
       retry_log_level: false
     )
   end

--- a/test/req_llm/step/retry_provider_integration_test.exs
+++ b/test/req_llm/step/retry_provider_integration_test.exs
@@ -36,8 +36,8 @@ defmodule ReqLLM.Step.RetryProviderIntegrationTest do
 
       assert is_function(request.options[:retry], 2)
       assert request.options[:max_retries] == 3
-      assert is_function(request.options[:retry_delay], 1)
-      assert request.options[:retry_delay].(1) == 0
+      # Note: retry_delay should NOT be set since retry returns {:delay, ms}
+      refute request.options[:retry_delay]
       assert request.options[:retry_log_level] == false
     end
 
@@ -76,8 +76,8 @@ defmodule ReqLLM.Step.RetryProviderIntegrationTest do
 
       assert is_function(request.options[:retry], 2)
       assert request.options[:max_retries] == 3
-      assert is_function(request.options[:retry_delay], 1)
-      assert request.options[:retry_delay].(1) == 0
+      # Note: retry_delay should NOT be set since retry returns {:delay, ms}
+      refute request.options[:retry_delay]
       assert request.options[:retry_log_level] == false
     end
 
@@ -116,8 +116,8 @@ defmodule ReqLLM.Step.RetryProviderIntegrationTest do
 
       assert is_function(request.options[:retry], 2)
       assert request.options[:max_retries] == 3
-      assert is_function(request.options[:retry_delay], 1)
-      assert request.options[:retry_delay].(1) == 0
+      # Note: retry_delay should NOT be set since retry returns {:delay, ms}
+      refute request.options[:retry_delay]
       assert request.options[:retry_log_level] == false
     end
 
@@ -182,13 +182,10 @@ defmodule ReqLLM.Step.RetryProviderIntegrationTest do
       assert is_function(google_request.options[:retry], 2)
       assert is_function(bedrock_request.options[:retry], 2)
 
-      assert is_function(anthropic_request.options[:retry_delay], 1)
-      assert is_function(google_request.options[:retry_delay], 1)
-      assert is_function(bedrock_request.options[:retry_delay], 1)
-
-      assert anthropic_request.options[:retry_delay].(1) == 0
-      assert google_request.options[:retry_delay].(1) == 0
-      assert bedrock_request.options[:retry_delay].(1) == 0
+      # Note: retry_delay should NOT be set since retry returns {:delay, ms}
+      refute anthropic_request.options[:retry_delay]
+      refute google_request.options[:retry_delay]
+      refute bedrock_request.options[:retry_delay]
 
       assert anthropic_request.options[:retry_log_level] == false
       assert google_request.options[:retry_log_level] == false

--- a/test/req_llm/step/retry_test.exs
+++ b/test/req_llm/step/retry_test.exs
@@ -11,8 +11,8 @@ defmodule ReqLLM.Step.RetryTest do
       # Verify retry function is configured
       assert is_function(updated_request.options[:retry], 2)
       assert updated_request.options[:max_retries] == 3
-      assert is_function(updated_request.options[:retry_delay], 1)
-      assert updated_request.options[:retry_delay].(1) == 0
+      # Note: retry_delay should NOT be set since retry returns {:delay, ms}
+      refute updated_request.options[:retry_delay]
       assert updated_request.options[:retry_log_level] == false
     end
   end
@@ -85,8 +85,8 @@ defmodule ReqLLM.Step.RetryTest do
       # Verify retry is configured
       assert is_function(request.options[:retry], 2)
       assert request.options[:max_retries] == 3
-      assert is_function(request.options[:retry_delay], 1)
-      assert request.options[:retry_delay].(1) == 0
+      # Note: retry_delay should NOT be set since retry returns {:delay, ms}
+      refute request.options[:retry_delay]
     end
 
     test "retry function correctly identifies retryable errors" do


### PR DESCRIPTION
# Pull Request

## Description

Fixes ArgumentError that occurs in Req 0.5.15+ when `ReqLLM.Step.Retry.attach/1` sets both `:retry_delay` AND a `:retry` function that returns `{:delay, milliseconds}`.

The Req library validates that when a retry function returns `{:delay, ms}`, the `:retry_delay` option must not be set, since the delay is provided by the function's return value. This PR removes the conflicting `retry_delay` option.

## Type of Contribution

- [x] **Bug Fix** - Fixing existing functionality

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [ ] Documentation updated (N/A - internal fix)
- [x] CHANGELOG.md updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
N/A - This is a core library fix