### PR TITLE
Add Bedrock Anthropic prompt caching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Prompt caching support for Bedrock Anthropic models (Claude on AWS Bedrock)
+  - Auto-switches to native API when caching enabled with tools for full cache control
+  - Supports caching of system prompts and tools
+  - Provides warning when auto-switching (silenceable with explicit `use_converse` setting)
 - Structured output (`:object` operation) support for AWS Bedrock provider
   - Bedrock Anthropic sub-provider using tool-calling approach
   - Bedrock Converse API for unified structured output across all models

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -418,18 +418,21 @@ defmodule ReqLLM.Providers.Anthropic do
     not is_nil(thinking) or not is_nil(reasoning_effort) or not is_nil(provider_reasoning_effort)
   end
 
-  defp has_prompt_caching?(opts) do
+  @doc false
+  def has_prompt_caching?(opts) do
     get_option(opts, :anthropic_prompt_cache, false) == true
   end
 
-  defp cache_control_meta(opts) do
+  @doc false
+  def cache_control_meta(opts) do
     case get_option(opts, :anthropic_prompt_cache_ttl) do
       nil -> %{type: "ephemeral"}
       ttl -> %{type: "ephemeral", ttl: ttl}
     end
   end
 
-  defp maybe_apply_prompt_caching(body, opts) do
+  @doc false
+  def maybe_apply_prompt_caching(body, opts) do
     if has_prompt_caching?(opts) do
       cache_meta = cache_control_meta(opts)
 

--- a/test/req_llm/providers/amazon_bedrock_prompt_cache_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_prompt_cache_test.exs
@@ -1,0 +1,215 @@
+defmodule ReqLLM.Providers.AmazonBedrockPromptCacheTest do
+  @moduledoc """
+  Tests for Bedrock prompt caching auto-switching behavior.
+
+  Verifies that when prompt caching is enabled with tools, Bedrock automatically
+  switches to native API (use_converse: false) for full cache control.
+  """
+
+  # Logger capture needs async: false
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias ReqLLM.Providers.AmazonBedrock
+  alias ReqLLM.{Context, Model, Tool}
+
+  setup do
+    # Mock AWS credentials for testing
+    System.put_env("AWS_ACCESS_KEY_ID", "test_key")
+    System.put_env("AWS_SECRET_ACCESS_KEY", "test_secret")
+    System.put_env("AWS_REGION", "us-east-1")
+
+    context = Context.new([Context.user("test message")])
+
+    # Use a known Bedrock Claude model
+    model = Model.from!("amazon_bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    {:ok, context: context, model: model}
+  end
+
+  # Helper: Determine which API was chosen based on URL
+  defp get_api_type(request) do
+    url_str = to_string(request.url)
+
+    cond do
+      String.contains?(url_str, "converse") -> :converse
+      String.contains?(url_str, "invoke") -> :native
+      true -> :unknown
+    end
+  end
+
+  describe "auto-switching to native API for caching" do
+    test "uses Converse API by default when tools are present", %{context: context, model: model} do
+      tools = [
+        Tool.new!(
+          name: "test_tool",
+          description: "Test",
+          parameter_schema: [],
+          callback: fn _ -> {:ok, "test"} end
+        )
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, tools: tools)
+      assert get_api_type(request) == :converse
+    end
+
+    test "auto-switches to native API when caching + tools (with warning)", %{
+      context: context,
+      model: model
+    } do
+      tools = [
+        Tool.new!(
+          name: "test_tool",
+          description: "Test",
+          parameter_schema: [],
+          callback: fn _ -> {:ok, "test"} end
+        )
+      ]
+
+      log =
+        capture_log(fn ->
+          {:ok, request} =
+            AmazonBedrock.prepare_request(:chat, model, context,
+              tools: tools,
+              anthropic_prompt_cache: true
+            )
+
+          assert get_api_type(request) == :native
+        end)
+
+      assert log =~ "Bedrock prompt caching enabled with tools present"
+      assert log =~ "Auto-switching to native API"
+    end
+
+    test "respects explicit use_converse: true (no warning)", %{context: context, model: model} do
+      tools = [
+        Tool.new!(
+          name: "test_tool",
+          description: "Test",
+          parameter_schema: [],
+          callback: fn _ -> {:ok, "test"} end
+        )
+      ]
+
+      log =
+        capture_log(fn ->
+          {:ok, request} =
+            AmazonBedrock.prepare_request(:chat, model, context,
+              tools: tools,
+              anthropic_prompt_cache: true,
+              use_converse: true
+            )
+
+          assert get_api_type(request) == :converse
+        end)
+
+      refute log =~ "Auto-switching"
+    end
+
+    test "respects explicit use_converse: false (no warning)", %{context: context, model: model} do
+      tools = [
+        Tool.new!(
+          name: "test_tool",
+          description: "Test",
+          parameter_schema: [],
+          callback: fn _ -> {:ok, "test"} end
+        )
+      ]
+
+      log =
+        capture_log(fn ->
+          {:ok, request} =
+            AmazonBedrock.prepare_request(:chat, model, context,
+              tools: tools,
+              anthropic_prompt_cache: true,
+              use_converse: false
+            )
+
+          assert get_api_type(request) == :native
+        end)
+
+      refute log =~ "Auto-switching"
+    end
+
+    test "allows caching without tools (no auto-switch, no warning)", %{
+      context: context,
+      model: model
+    } do
+      log =
+        capture_log(fn ->
+          {:ok, request} =
+            AmazonBedrock.prepare_request(:chat, model, context, anthropic_prompt_cache: true)
+
+          assert get_api_type(request) == :native
+        end)
+
+      refute log =~ "Auto-switching"
+    end
+
+    test "handles empty tools list same as no tools", %{context: context, model: model} do
+      log =
+        capture_log(fn ->
+          {:ok, request} =
+            AmazonBedrock.prepare_request(:chat, model, context,
+              tools: [],
+              anthropic_prompt_cache: true
+            )
+
+          assert get_api_type(request) == :native
+        end)
+
+      refute log =~ "Auto-switching"
+    end
+  end
+
+  describe "structured output (:object) with caching" do
+    test "works with :object operation and caching", %{context: context, model: model} do
+      compiled_schema = %{schema: %{type: "object", properties: %{}}}
+
+      # :object operation creates synthetic tool, should support caching
+      {:ok, request} =
+        AmazonBedrock.prepare_request(:object, model, context,
+          compiled_schema: compiled_schema,
+          anthropic_prompt_cache: true
+        )
+
+      assert request != nil
+      # Note: :object uses different flow so we can't easily verify endpoint type in tests
+    end
+
+    test "works with explicit use_converse option", %{context: context, model: model} do
+      compiled_schema = %{schema: %{type: "object", properties: %{}}}
+
+      {:ok, request} =
+        AmazonBedrock.prepare_request(:object, model, context,
+          compiled_schema: compiled_schema,
+          anthropic_prompt_cache: true,
+          use_converse: true
+        )
+
+      assert request != nil
+    end
+  end
+
+  describe "default behavior without caching" do
+    test "uses native API when no tools", %{context: context, model: model} do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, [])
+      assert get_api_type(request) == :native
+    end
+
+    test "uses Converse API when tools present", %{context: context, model: model} do
+      tools = [
+        Tool.new!(
+          name: "test",
+          description: "Test",
+          parameter_schema: [],
+          callback: fn _ -> {:ok, "test"} end
+        )
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, tools: tools)
+      assert get_api_type(request) == :converse
+    end
+  end
+end


### PR DESCRIPTION
## Description

Extends Anthropic prompt caching to AWS Bedrock provider by reusing native Anthropic caching functions and adding smart API selection.

> **Note**: This PR replaces #133, which was inadvertently closed when PR #132 was merged. This has been rebased on the latest main to incorporate #132's changes.

## Type of Contribution

- [ ] Core Library
- [ ] New Provider
- [x] Provider Feature
- [ ] Bug Fix
- [ ] Documentation

## Changes

- Made 3 Anthropic caching functions public (`@doc false`) for Bedrock reuse
- Added tools support to Bedrock Anthropic formatter  
- Auto-switch to native API when caching enabled with tools
- Added comprehensive tests for auto-switching behavior

Bedrock Converse API only caches entire system prompts, while native API supports granular cache control on system, tools, and messages. When both caching and tools are present, automatically uses native API with a warning that can be silenced via explicit use_converse setting.

## Checklist

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)
- [ ] Documentation updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
Not applicable - extends existing Bedrock provider
```

## Testing

- 10 unit tests covering auto-switching scenarios (all passing)
- Live tested with AWS credentials showing cache creation and hit behavior
- Verified 90% cost savings on cached tokens with tools

## Related Issues

Builds on #132