### PR TITLE
Fix bugs found during Bedrock fixture generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metadata collection timeout errors on large documents with long processing times
 - Bedrock streaming now works correctly (fixed deprecated function capture syntax)
 - Tool.Inspect protocol crash when inspecting tools with JSON Schema (map) parameter schemas
+- Model compatibility task now uses `normalize_model_id` callback for registry lookups (fixes inference profile ID recognition)
+- Missing `:compiled_schema` in object streaming options causing KeyError across all providers with structured output
+- Bedrock Anthropic temperature/top_p conflicts - now delegates to native Anthropic option translation
 
 ### Changed
 

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -356,6 +356,7 @@ defmodule ReqLLM.Generation do
         |> Keyword.merge(Map.to_list(prepared_req.options))
         |> Keyword.put(:stream, true)
         |> Keyword.put_new(:operation, :object)
+        |> Keyword.put(:compiled_schema, compiled_schema)
 
       ReqLLM.Streaming.start_stream(provider_module, model, prepared_context, stream_opts)
     end

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -603,6 +603,23 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   end
 
   @impl ReqLLM.Provider
+  def translate_options(operation, model, opts) do
+    # Delegate to native Anthropic option translation for Anthropic models
+    # This ensures we get all Anthropic-specific handling (temperature/top_p conflicts,
+    # reasoning effort, etc.) for free
+    model_family = get_model_family(model.model)
+
+    case model_family do
+      "anthropic" ->
+        ReqLLM.Providers.Anthropic.translate_options(operation, model, opts)
+
+      _ ->
+        # Other model families: no translation needed yet
+        {opts, []}
+    end
+  end
+
+  @impl ReqLLM.Provider
   def encode_body(request) do
     request
   end

--- a/test/coverage/amazon_bedrock/comprehensive_test.exs
+++ b/test/coverage/amazon_bedrock/comprehensive_test.exs
@@ -1,4 +1,4 @@
-defmodule ReqLLM.Coverage.Bedrock.ComprehensiveTest do
+defmodule ReqLLM.Coverage.AmazonBedrock.ComprehensiveTest do
   @moduledoc """
   Comprehensive AWS Bedrock API feature coverage tests.
 


### PR DESCRIPTION
Found and fixed three bugs while setting up Bedrock model fixture generation for 1.0 release:

## Bug Fixes

### 1. model_compat not recognizing inference profile IDs
**Problem:** Bedrock inference profiles use region prefixes (e.g., `global.anthropic.claude-sonnet-4-5`) but model_compat only looked up the literal ID in registry, failing to find normalized versions.

**Fix:** Call provider's `normalize_model_id` callback during registry lookup in `find_model/3`. Reuses existing normalization infrastructure you added in #104.

### 2. Missing :compiled_schema in object streaming  
**Problem:** `Generation.stream_object/4` passed `:compiled_schema` to `prepare_request` but didn't include it in `stream_opts`, causing KeyError in Bedrock Anthropic formatter.

**Fix:** Add `:compiled_schema` to `stream_opts` at generation.ex:359.

### 3. Temperature/top_p conflict in Bedrock Anthropic
**Problem:** Bedrock Anthropic models reject requests with both `temperature` and `top_p` set. Native Anthropic provider handles this, but Bedrock didn't.

**Fix:** Implement `translate_options` in Bedrock provider that delegates to `Anthropic.translate_options` for Anthropic models. This is a DRY solution that gives Bedrock all Anthropic option handling (sampling params, reasoning_effort, stop parameters, etc.) automatically, and gets future improvements for free.

## Also Included

- Renamed `test/coverage/bedrock/` to `test/coverage/amazon_bedrock/` to match provider atom

## Testing

All fixes verified during Bedrock fixture generation attempts. The bugs are now fixed, though fixture generation still hits other issues (timeouts, API errors) that need investigation.