### PR TITLE
feat: allow task_type with google embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ req_llm-*.tar
 # Language Servers
 .elixir_ls
 .expert
+
+.env


### PR DESCRIPTION
# Pull Request

## Description

Allow to use `taskType` when generating embeddings with Google Gemini 

https://ai.google.dev/gemini-api/docs/embeddings#supported-task-types

## Type of Contribution

- [ ] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [x] **Provider Feature** - Adding capabilities to existing provider
- [ ] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [x] Documentation updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
# Paste output if provider changes

```

## Related Issues

Merge this after #142
