### PR TITLE
fix(schema): Prevent encoding of boolean as string in normalized schema

### DIFF
--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -277,7 +277,7 @@ defmodule ReqLLM.Schema do
     Enum.map(value, &normalize_json_schema/1)
   end
 
-  defp normalize_json_schema(value) when is_atom(value) do
+  defp normalize_json_schema(value) when is_atom(value) and not is_boolean(value) do
     Atom.to_string(value)
   end
 

--- a/test/req_llm/schema_zoi_test.exs
+++ b/test/req_llm/schema_zoi_test.exs
@@ -173,6 +173,17 @@ defmodule ReqLLM.Schema.ZoiTest do
       assert user_schema["properties"]["tags"]["items"]["type"] == "string"
       assert user_schema["properties"]["active"]["type"] == "boolean"
     end
+
+    test "encodes boolean additionalProperties as a boolean" do
+      schema =
+        Zoi.object(%{
+          name: Zoi.string()
+        })
+
+      result = Schema.to_json(schema)
+
+      assert result["additionalProperties"] == false
+    end
   end
 
   describe "validate/2 with Zoi schemas" do


### PR DESCRIPTION
# Pull Request

## Description

Fixes issue where the boolean property `additionalProperties` was erroneously stringified when preparing for structured output or tool calls.

## Type of Contribution

- [ ] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [ ] **Provider Feature** - Adding capabilities to existing provider
- [x] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
  - Existing unrelated warnings exist (below)
- [ ] Documentation updated

Existing warnings:
```
┃ [W] ↗ There should be no calls to `IO.inspect/1`.
┃       lib/examples/scripts/json_schema_examples.exs:146:9 #(JSONSchemaExamples.example_event)
┃ [W] ↗ There should be no calls to `IO.inspect/1`.
┃       lib/examples/scripts/json_schema_examples.exs:116:9 #(JSONSchemaExamples.example_product)
┃ [W] ↗ There should be no calls to `IO.inspect/1`.
┃       lib/examples/scripts/json_schema_examples.exs:86:9 #(JSONSchemaExamples.example_simple_person)
```

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
# Paste output if provider changes

```

## Related Issues

Closes #155 
