### PR TITLE
refactor: Rename decode_sse_event to decode_stream_event for protocol agnosticity

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -363,7 +363,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   end
 
   @impl ReqLLM.Provider
-  def decode_sse_event(event, model) when is_map(event) do
+  def decode_stream_event(event, model) when is_map(event) do
     # Decode AWS event stream events into StreamChunks
     # This is called after parse_stream_protocol returns events
     model_family = get_model_family(model.model)
@@ -376,7 +376,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     end
   end
 
-  def decode_sse_event(_data, _model) do
+  def decode_stream_event(_data, _model) do
     []
   end
 

--- a/lib/req_llm/providers/amazon_bedrock/anthropic.ex
+++ b/lib/req_llm/providers/amazon_bedrock/anthropic.ex
@@ -247,15 +247,15 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
   def parse_stream_chunk(chunk, opts) when is_map(chunk) do
     # First, unwrap the Bedrock AWS event stream encoding
     with {:ok, event} <- AmazonBedrock.Response.unwrap_stream_chunk(chunk) do
-      # Create a model struct for Anthropic.Response.decode_sse_event
+      # Create a model struct for Anthropic.Response.decode_stream_event
       model = %ReqLLM.Model{
         provider: :anthropic,
         model: opts[:model] || "bedrock-anthropic"
       }
 
       # Delegate to native Anthropic SSE event parsing
-      # decode_sse_event expects %{data: event_data} format
-      chunks = Anthropic.Response.decode_sse_event(%{data: event}, model)
+      # decode_stream_event expects %{data: event_data} format
+      chunks = Anthropic.Response.decode_stream_event(%{data: event}, model)
 
       # Return first chunk if any, or nil
       case chunks do

--- a/lib/req_llm/providers/amazon_bedrock/openai.ex
+++ b/lib/req_llm/providers/amazon_bedrock/openai.ex
@@ -233,7 +233,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAI do
           # Event is already parsed JSON, wrap in SSE format expected by decoder
           sse_event = %{data: event}
 
-          chunks = Defaults.default_decode_sse_event(sse_event, model)
+          chunks = Defaults.default_decode_stream_event(sse_event, model)
 
           # Return first chunk if any, or nil
           case chunks do

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -345,8 +345,8 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   @impl ReqLLM.Provider
-  def decode_sse_event(event, model) do
-    ReqLLM.Providers.Anthropic.Response.decode_sse_event(event, model)
+  def decode_stream_event(event, model) do
+    ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model)
   end
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -74,8 +74,8 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   @doc """
   Decode Anthropic SSE event data into StreamChunks.
   """
-  @spec decode_sse_event(map(), ReqLLM.Model.t()) :: [ReqLLM.StreamChunk.t()]
-  def decode_sse_event(%{data: data}, _model) when is_map(data) do
+  @spec decode_stream_event(map(), ReqLLM.Model.t()) :: [ReqLLM.StreamChunk.t()]
+  def decode_stream_event(%{data: data}, _model) when is_map(data) do
     case data do
       %{"type" => "message_start", "message" => message} ->
         usage_data = Map.get(message, "usage", %{})
@@ -128,7 +128,7 @@ defmodule ReqLLM.Providers.Anthropic.Response do
     end
   end
 
-  def decode_sse_event(_, _model), do: []
+  def decode_stream_event(_, _model), do: []
 
   # Private helper functions
 

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1133,7 +1133,7 @@ defmodule ReqLLM.Providers.Google do
   end
 
   @impl ReqLLM.Provider
-  def decode_sse_event(event, model) do
+  def decode_stream_event(event, model) do
     case event do
       %{data: data} when is_map(data) -> decode_google_event(data, model)
       data when is_map(data) -> decode_google_event(data, model)

--- a/lib/req_llm/providers/groq.ex
+++ b/lib/req_llm/providers/groq.ex
@@ -222,8 +222,8 @@ defmodule ReqLLM.Providers.Groq do
   Returns updated chunks and new state.
   """
   @impl ReqLLM.Provider
-  def decode_sse_event(event, model, provider_state) do
-    chunks = ReqLLM.Provider.Defaults.default_decode_sse_event(event, model)
+  def decode_stream_event(event, model, provider_state) do
+    chunks = ReqLLM.Provider.Defaults.default_decode_stream_event(event, model)
 
     Enum.reduce(chunks, {[], provider_state}, fn chunk, {acc, state} ->
       case chunk.type do

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -377,16 +377,16 @@ defmodule ReqLLM.Providers.OpenAI do
   end
 
   @doc """
-  Custom decode_sse_event to route based on model API type.
+  Custom decode_stream_event to route based on model API type.
   """
   @impl ReqLLM.Provider
-  def decode_sse_event(event, model) do
+  def decode_stream_event(event, model) do
     api_type = get_in(model, [Access.key(:_metadata, %{}), "api"])
 
     if api_type == "responses" do
-      ReqLLM.Providers.OpenAI.ResponsesAPI.decode_sse_event(event, model)
+      ReqLLM.Providers.OpenAI.ResponsesAPI.decode_stream_event(event, model)
     else
-      ReqLLM.Providers.OpenAI.ChatAPI.decode_sse_event(event, model)
+      ReqLLM.Providers.OpenAI.ChatAPI.decode_stream_event(event, model)
     end
   end
 

--- a/lib/req_llm/providers/openai/api.ex
+++ b/lib/req_llm/providers/openai/api.ex
@@ -16,7 +16,7 @@ defmodule ReqLLM.Providers.OpenAI.API do
   - `path/0` - Returns the API endpoint path
   - `encode_body/1` - Transforms request into provider-specific JSON format
   - `decode_response/1` - Parses API responses into ReqLLM structures
-  - `decode_sse_event/2` - Decodes server-sent events for streaming
+  - `decode_stream_event/2` - Decodes server-sent events for streaming
   - `attach_stream/4` - Builds Finch streaming request with proper headers/body
   """
 
@@ -24,7 +24,7 @@ defmodule ReqLLM.Providers.OpenAI.API do
   @callback encode_body(Req.Request.t()) :: Req.Request.t()
   @callback decode_response({Req.Request.t(), Req.Response.t()}) ::
               {Req.Request.t(), Req.Response.t() | Exception.t()}
-  @callback decode_sse_event(map(), ReqLLM.Model.t()) :: [ReqLLM.StreamChunk.t()]
+  @callback decode_stream_event(map(), ReqLLM.Model.t()) :: [ReqLLM.StreamChunk.t()]
   @callback attach_stream(
               ReqLLM.Model.t(),
               ReqLLM.Context.t(),

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -69,8 +69,8 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
   end
 
   @impl true
-  def decode_sse_event(event, model) do
-    ReqLLM.Provider.Defaults.default_decode_sse_event(event, model)
+  def decode_stream_event(event, model) do
+    ReqLLM.Provider.Defaults.default_decode_stream_event(event, model)
   end
 
   # ========================================================================

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -91,17 +91,17 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   @impl true
-  def decode_sse_event(%{data: "[DONE]"}, _model) do
+  def decode_stream_event(%{data: "[DONE]"}, _model) do
     [ReqLLM.StreamChunk.meta(%{terminal?: true})]
   end
 
-  def decode_sse_event(%{data: data} = event, model) when is_map(data) do
+  def decode_stream_event(%{data: data} = event, model) when is_map(data) do
     event_type =
       Map.get(event, :event) || Map.get(event, "event") || data["event"] || data["type"]
 
     Debug.dbug(
       fn ->
-        "ResponsesAPI decode_sse_event: event=#{inspect(Map.keys(event))}, event_type=#{inspect(event_type)}"
+        "ResponsesAPI decode_stream_event: event=#{inspect(Map.keys(event))}, event_type=#{inspect(event_type)}"
       end,
       component: :provider
     )
@@ -196,7 +196,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     end
   end
 
-  def decode_sse_event(_event, _model), do: []
+  def decode_stream_event(_event, _model), do: []
 
   # ========================================================================
   # Shared Request Building Helpers (used by both encode_body and attach_stream)

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -620,15 +620,15 @@ defmodule ReqLLM.StreamServer do
 
   defp decode_provider_event(event, provider_mod, model, provider_state) do
     cond do
-      function_exported?(provider_mod, :decode_sse_event, 3) ->
-        provider_mod.decode_sse_event(event, model, provider_state)
+      function_exported?(provider_mod, :decode_stream_event, 3) ->
+        provider_mod.decode_stream_event(event, model, provider_state)
 
-      function_exported?(provider_mod, :decode_sse_event, 2) ->
-        chunks = provider_mod.decode_sse_event(event, model)
+      function_exported?(provider_mod, :decode_stream_event, 2) ->
+        chunks = provider_mod.decode_stream_event(event, model)
         {chunks, provider_state}
 
       true ->
-        chunks = ReqLLM.Provider.Defaults.default_decode_sse_event(event, model)
+        chunks = ReqLLM.Provider.Defaults.default_decode_stream_event(event, model)
         {chunks, provider_state}
     end
   end

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -150,7 +150,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
     end
   end
 
-  describe "default_decode_sse_event/2" do
+  describe "default_decode_stream_event/2" do
     setup do
       %{model: %Model{provider: :openai, model: "gpt-4"}}
     end
@@ -159,7 +159,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
       # Content delta
       content_event = %{data: %{"choices" => [%{"delta" => %{"content" => "Hello"}}]}}
 
-      assert Defaults.default_decode_sse_event(content_event, model) == [
+      assert Defaults.default_decode_stream_event(content_event, model) == [
                %StreamChunk{type: :content, text: "Hello"}
              ]
 
@@ -185,7 +185,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
         }
       }
 
-      [chunk] = Defaults.default_decode_sse_event(tool_event, model)
+      [chunk] = Defaults.default_decode_stream_event(tool_event, model)
       assert chunk.type == :tool_call
       assert chunk.name == "get_weather"
       assert chunk.arguments == %{"city" => "New York"}
@@ -193,9 +193,9 @@ defmodule ReqLLM.Provider.DefaultsTest do
     end
 
     test "handles edge cases gracefully", %{model: model} do
-      assert Defaults.default_decode_sse_event(%{data: %{}}, model) == []
-      assert Defaults.default_decode_sse_event(%{}, model) == []
-      assert Defaults.default_decode_sse_event("invalid", model) == []
+      assert Defaults.default_decode_stream_event(%{data: %{}}, model) == []
+      assert Defaults.default_decode_stream_event(%{}, model) == []
+      assert Defaults.default_decode_stream_event("invalid", model) == []
 
       invalid_json_event = %{
         data: %{
@@ -215,7 +215,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
         }
       }
 
-      [chunk] = Defaults.default_decode_sse_event(invalid_json_event, model)
+      [chunk] = Defaults.default_decode_stream_event(invalid_json_event, model)
       assert chunk.type == :tool_call
       assert chunk.arguments == %{}
     end
@@ -240,7 +240,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
         }
       }
 
-      [chunk] = Defaults.default_decode_sse_event(nil_name_event, model)
+      [chunk] = Defaults.default_decode_stream_event(nil_name_event, model)
       assert chunk.type == :meta
     end
   end

--- a/test/req_llm/stream_server/provider_test.exs
+++ b/test/req_llm/stream_server/provider_test.exs
@@ -4,7 +4,7 @@ defmodule ReqLLM.StreamServer.ProviderTest.GoogleJsonProvider do
 
   alias ReqLLM.StreamChunk
 
-  def decode_sse_event(%{data: data}, _model) when is_map(data) do
+  def decode_stream_event(%{data: data}, _model) when is_map(data) do
     case data do
       %{"candidates" => [%{"content" => %{"parts" => parts}} | _]} ->
         Enum.flat_map(parts, fn part ->
@@ -19,7 +19,7 @@ defmodule ReqLLM.StreamServer.ProviderTest.GoogleJsonProvider do
     end
   end
 
-  def decode_sse_event(_event, _model), do: []
+  def decode_stream_event(_event, _model), do: []
 
   def prepare_request(_op, _model, _data, _opts), do: {:error, :not_implemented}
   def attach(_req, _model, _opts), do: {:error, :not_implemented}
@@ -33,12 +33,15 @@ defmodule ReqLLM.StreamServer.ProviderTest.OpenAIJsonProvider do
 
   alias ReqLLM.StreamChunk
 
-  def decode_sse_event(%{data: %{"choices" => [%{"delta" => %{"content" => content}}]}}, _model)
+  def decode_stream_event(
+        %{data: %{"choices" => [%{"delta" => %{"content" => content}}]}},
+        _model
+      )
       when is_binary(content) do
     [StreamChunk.text(content)]
   end
 
-  def decode_sse_event(_event, _model), do: []
+  def decode_stream_event(_event, _model), do: []
 
   def prepare_request(_op, _model, _data, _opts), do: {:error, :not_implemented}
   def attach(_req, _model, _opts), do: {:error, :not_implemented}
@@ -54,17 +57,17 @@ defmodule ReqLLM.StreamServer.ProviderTest.ProviderWithState do
 
   def init_stream_state(_model), do: %{count: 0}
 
-  def decode_sse_event(%{data: "content"}, _model, provider_state) do
+  def decode_stream_event(%{data: "content"}, _model, provider_state) do
     new_state = Map.update(provider_state, :count, 1, &(&1 + 1))
     chunk = StreamChunk.text("chunk")
     {[chunk], new_state}
   end
 
-  def decode_sse_event(%{event: "[DONE]"}, _model, _provider_state) do
+  def decode_stream_event(%{event: "[DONE]"}, _model, _provider_state) do
     {:halt, nil}
   end
 
-  def decode_sse_event(_, _model, provider_state), do: {[], provider_state}
+  def decode_stream_event(_, _model, provider_state), do: {[], provider_state}
 
   def flush_stream_state(_model, %{count: count} = provider_state) do
     {[StreamChunk.text("FLUSH:#{count}")], provider_state}
@@ -106,7 +109,7 @@ defmodule ReqLLM.StreamServer.ProviderTest do
   end
 
   describe "provider integration" do
-    test "uses provider decode_sse_event when available" do
+    test "uses provider decode_stream_event when available" do
       server = start_server()
       _task = mock_http_task(server)
 
@@ -120,7 +123,7 @@ defmodule ReqLLM.StreamServer.ProviderTest do
       StreamServer.cancel(server)
     end
 
-    test "falls back to default decoding when provider doesn't implement decode_sse_event" do
+    test "falls back to default decoding when provider doesn't implement decode_stream_event" do
       defmodule MinimalProvider do
         @behaviour ReqLLM.Provider
 
@@ -144,7 +147,7 @@ defmodule ReqLLM.StreamServer.ProviderTest do
   end
 
   describe "provider state management" do
-    test "threads provider state through decode_sse_event/3" do
+    test "threads provider state through decode_stream_event/3" do
       model = %Model{provider: ProviderWithState, model: "test"}
       server = start_server(provider_mod: ProviderWithState, model: model)
       _task = mock_http_task(server)

--- a/test/support/stream_server_helpers.ex
+++ b/test/support/stream_server_helpers.ex
@@ -3,7 +3,7 @@ defmodule ReqLLM.Test.StreamServerHelpers do
   Shared test helpers for StreamServer testing.
 
   Provides:
-  - MockProvider: A test provider implementing decode_sse_event for common SSE patterns
+  - MockProvider: A test provider implementing decode_stream_event for common SSE patterns
   - Helper functions for starting servers and mocking HTTP tasks
   - Utilities for testing StreamServer behavior in isolation
   """
@@ -15,30 +15,33 @@ defmodule ReqLLM.Test.StreamServerHelpers do
     @moduledoc """
     Mock provider for testing StreamServer SSE parsing and token queuing.
 
-    Implements decode_sse_event to handle common SSE patterns:
+    Implements decode_stream_event to handle common SSE patterns:
     - OpenAI-style: `{"choices": [{"delta": {"content": "..."}}]}`
     - Anthropic-style: `{"type": "content_block_delta", "delta": {"text": "..."}}`
     - Usage metadata: `{"usage": {...}}`
     """
     @behaviour ReqLLM.Provider
 
-    def decode_sse_event(%{data: %{"choices" => [%{"delta" => %{"content" => content}}]}}, _model)
+    def decode_stream_event(
+          %{data: %{"choices" => [%{"delta" => %{"content" => content}}]}},
+          _model
+        )
         when is_binary(content) do
       [StreamChunk.text(content)]
     end
 
-    def decode_sse_event(
+    def decode_stream_event(
           %{data: %{"type" => "content_block_delta", "delta" => %{"text" => text}}},
           _model
         ) do
       [StreamChunk.text(text)]
     end
 
-    def decode_sse_event(%{data: %{"usage" => usage}}, _model) do
+    def decode_stream_event(%{data: %{"usage" => usage}}, _model) do
       [StreamChunk.meta(%{usage: usage})]
     end
 
-    def decode_sse_event(_event, _model), do: []
+    def decode_stream_event(_event, _model), do: []
 
     def prepare_request(_op, _model, _data, _opts), do: {:error, :not_implemented}
     def attach(_req, _model, _opts), do: {:error, :not_implemented}


### PR DESCRIPTION
Addresses #153

Renames the  callback from  to  to reflect that different providers use different streaming protocols.

## Problem

The old name  was protocol-specific and misleading because:
- **OpenAI, Anthropic, Google**: Use Server-Sent Events (SSE) - text-based
- **AWS Bedrock**: Uses AWS EventStream - binary format

This created confusion when implementing non-SSE providers like Bedrock.

## Solution

Renamed to  which is protocol-agnostic and accurately describes the callback's purpose: decoding streaming events regardless of the underlying protocol.

## Changes

- Updated  behavior definition with clarified documentation
- Renamed callback in all provider implementations:
  - Anthropic
  - OpenAI (Chat API, Responses API)
  - Google
  - Groq
  - Amazon Bedrock (Anthropic/OpenAI formatters)
- Updated all tests and test helpers
- Updated provider documentation guides

## Impact

- **Internal refactoring only** - no public API changes
- All 1553 tests passing
- Non-breaking for end users