### PR TITLE
fix(bedrock): Exclude old Claude models from test suite

### DIFF
--- a/priv/models_dev/.catalog_manifest.json
+++ b/priv/models_dev/.catalog_manifest.json
@@ -67,6 +67,6 @@
     "priv/models_dev/zhipuai.json",
     "priv/models_dev/zhipuai_coding_plan.json"
   ],
-  "generated_at": "2025-10-29T19:29:15.230232Z",
-  "hash": "ede7985791eec0e9856cc18e34718546dcf75e74261be045df31973968497934"
+  "hash": "37f8af89468e0423d81295e709f7895ad6f511831642e3d118694a0fbb06b260",
+  "generated_at": "2025-11-02T20:33:50.298246Z"
 }

--- a/priv/models_dev/amazon_bedrock.json
+++ b/priv/models_dev/amazon_bedrock.json
@@ -33,45 +33,14 @@
     {
       "attachment": false,
       "cost": {
-        "cache_read": 0.00875,
-        "input": 0.035,
-        "output": 0.14
+        "input": 0.2,
+        "output": 0.4
       },
-      "id": "amazon.nova-micro-v1:0",
-      "knowledge": "2024-10",
-      "last_updated": "2024-12-03",
+      "id": "ai21.jamba-1-5-mini-v1:0",
+      "knowledge": "2024-08",
+      "last_updated": "2024-08-15",
       "limit": {
-        "context": 128000,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Nova Micro",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "amazon.nova-micro-v1:0",
-      "reasoning": false,
-      "release_date": "2024-12-03",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.1,
-        "output": 0.1
-      },
-      "id": "meta.llama3-2-1b-instruct-v1:0",
-      "knowledge": "2023-12",
-      "last_updated": "2024-09-25",
-      "limit": {
-        "context": 131000,
+        "context": 256000,
         "output": 4096
       },
       "modalities": {
@@ -82,200 +51,12 @@
           "text"
         ]
       },
-      "name": "Llama 3.2 1B Instruct",
+      "name": "Jamba 1.5 Mini",
       "open_weights": true,
       "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-2-1b-instruct-v1:0",
+      "provider_model_id": "ai21.jamba-1-5-mini-v1:0",
       "reasoning": false,
-      "release_date": "2024-09-25",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 0.3,
-        "cache_write": 3.75,
-        "input": 3,
-        "output": 15
-      },
-      "id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      "knowledge": "2024-04",
-      "last_updated": "2024-10-22",
-      "limit": {
-        "context": 200000,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Sonnet 3.5 v2",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-      "reasoning": false,
-      "release_date": "2024-10-22",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.15,
-        "output": 0.15
-      },
-      "id": "meta.llama3-2-3b-instruct-v1:0",
-      "knowledge": "2023-12",
-      "last_updated": "2024-09-25",
-      "limit": {
-        "context": 131000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 3.2 3B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-2-3b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2024-09-25",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 0.3,
-        "cache_write": 3.75,
-        "input": 3,
-        "output": 15
-      },
-      "id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2025-02-19",
-      "limit": {
-        "context": 200000,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Sonnet 3.7",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-      "reasoning": false,
-      "release_date": "2025-02-19",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.8,
-        "output": 2.4
-      },
-      "id": "anthropic.claude-instant-v1",
-      "knowledge": "2023-08",
-      "last_updated": "2023-03-01",
-      "limit": {
-        "context": 100000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Instant",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-instant-v1",
-      "reasoning": false,
-      "release_date": "2023-03-01",
-      "temperature": true,
-      "tool_call": false
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.5,
-        "output": 1.5
-      },
-      "id": "cohere.command-r-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2024-03-11",
-      "limit": {
-        "context": 128000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Command R",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "cohere.command-r-v1:0",
-      "reasoning": false,
-      "release_date": "2024-03-11",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "input": 2.5,
-        "output": 12.5
-      },
-      "id": "amazon.nova-premier-v1:0",
-      "knowledge": "2024-10",
-      "last_updated": "2024-12-03",
-      "limit": {
-        "context": 1000000,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "video"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Nova Premier",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "amazon.nova-premier-v1:0",
-      "reasoning": true,
-      "release_date": "2024-12-03",
+      "release_date": "2024-08-15",
       "temperature": true,
       "tool_call": true
     },
@@ -315,203 +96,15 @@
     {
       "attachment": false,
       "cost": {
-        "input": 2.65,
-        "output": 3.5
+        "cache_read": 0.00875,
+        "input": 0.035,
+        "output": 0.14
       },
-      "id": "meta.llama3-70b-instruct-v1:0",
-      "knowledge": "2023-12",
-      "last_updated": "2024-07-23",
-      "limit": {
-        "context": 8192,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 3 70B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-70b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2024-07-23",
-      "temperature": true,
-      "tool_call": false
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 1.5,
-        "output": 2
-      },
-      "id": "cohere.command-text-v14",
-      "knowledge": "2023-08",
-      "last_updated": "2023-11-01",
-      "limit": {
-        "context": 4096,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Command",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "cohere.command-text-v14",
-      "reasoning": false,
-      "release_date": "2023-11-01",
-      "temperature": true,
-      "tool_call": false
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 0.3,
-        "cache_write": 3.75,
-        "input": 3,
-        "output": 15
-      },
-      "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
-      "knowledge": "2025-07-31",
-      "last_updated": "2025-09-29",
-      "limit": {
-        "context": 200000,
-        "output": 64000
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Sonnet 4.5",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
-      "reasoning": true,
-      "release_date": "2025-09-29",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "input": 0.72,
-        "output": 0.72
-      },
-      "id": "meta.llama3-2-90b-instruct-v1:0",
-      "knowledge": "2023-12",
-      "last_updated": "2024-09-25",
+      "id": "amazon.nova-micro-v1:0",
+      "knowledge": "2024-10",
+      "last_updated": "2024-12-03",
       "limit": {
         "context": 128000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 3.2 90B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-2-90b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2024-09-25",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 0.3,
-        "cache_write": 3.75,
-        "input": 3,
-        "output": 15
-      },
-      "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2024-06-20",
-      "limit": {
-        "context": 200000,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Sonnet 3.5",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-      "reasoning": false,
-      "release_date": "2024-06-20",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 1.35,
-        "output": 5.4
-      },
-      "id": "deepseek.r1-v1:0",
-      "knowledge": "2024-07",
-      "last_updated": "2025-05-29",
-      "limit": {
-        "context": 128000,
-        "output": 32768
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "DeepSeek-R1",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "deepseek.r1-v1:0",
-      "reasoning": true,
-      "release_date": "2025-01-20",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 0.08,
-        "cache_write": 1,
-        "input": 0.8,
-        "output": 4
-      },
-      "id": "anthropic.claude-3-5-haiku-20241022-v1:0",
-      "knowledge": "2024-07",
-      "last_updated": "2024-10-22",
-      "limit": {
-        "context": 200000,
         "output": 8192
       },
       "modalities": {
@@ -522,54 +115,24 @@
           "text"
         ]
       },
-      "name": "Claude Haiku 3.5",
+      "name": "Nova Micro",
       "open_weights": false,
       "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-5-haiku-20241022-v1:0",
+      "provider_model_id": "amazon.nova-micro-v1:0",
       "reasoning": false,
-      "release_date": "2024-10-22",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.22,
-        "output": 1.8
-      },
-      "id": "qwen.qwen3-coder-480b-a35b-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2025-09-18",
-      "limit": {
-        "context": 131072,
-        "output": 65536
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Qwen3 Coder 480B A35B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
-      "reasoning": false,
-      "release_date": "2025-09-18",
+      "release_date": "2024-12-03",
       "temperature": true,
       "tool_call": true
     },
     {
       "attachment": true,
       "cost": {
-        "input": 0.24,
-        "output": 0.97
+        "input": 2.5,
+        "output": 12.5
       },
-      "id": "meta.llama4-maverick-17b-instruct-v1:0",
-      "knowledge": "2024-08",
-      "last_updated": "2025-04-05",
+      "id": "amazon.nova-premier-v1:0",
+      "knowledge": "2024-10",
+      "last_updated": "2024-12-03",
       "limit": {
         "context": 1000000,
         "output": 16384
@@ -577,109 +140,52 @@
       "modalities": {
         "input": [
           "text",
-          "image"
+          "image",
+          "video"
         ],
         "output": [
           "text"
         ]
       },
-      "name": "Llama 4 Maverick 17B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama4-maverick-17b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2025-04-05",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 8,
-        "output": 24
-      },
-      "id": "anthropic.claude-v2:1",
-      "knowledge": "2023-08",
-      "last_updated": "2023-11-21",
-      "limit": {
-        "context": 200000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude 2.1",
+      "name": "Nova Premier",
       "open_weights": false,
       "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-v2:1",
-      "reasoning": false,
-      "release_date": "2023-11-21",
+      "provider_model_id": "amazon.nova-premier-v1:0",
+      "reasoning": true,
+      "release_date": "2024-12-03",
       "temperature": true,
-      "tool_call": false
+      "tool_call": true
     },
     {
       "attachment": true,
       "cost": {
-        "input": 15,
-        "output": 75
+        "cache_read": 0.2,
+        "input": 0.8,
+        "output": 3.2
       },
-      "id": "anthropic.claude-3-opus-20240229-v1:0",
-      "knowledge": "2023-08",
-      "last_updated": "2024-02-29",
+      "id": "amazon.nova-pro-v1:0",
+      "knowledge": "2024-10",
+      "last_updated": "2024-12-03",
       "limit": {
-        "context": 200000,
-        "output": 4096
+        "context": 300000,
+        "output": 8192
       },
       "modalities": {
         "input": [
           "text",
-          "image"
+          "image",
+          "video"
         ],
         "output": [
           "text"
         ]
       },
-      "name": "Claude Opus 3",
+      "name": "Nova Pro",
       "open_weights": false,
       "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-opus-20240229-v1:0",
+      "provider_model_id": "amazon.nova-pro-v1:0",
       "reasoning": false,
-      "release_date": "2024-02-29",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.72,
-        "output": 0.72
-      },
-      "id": "meta.llama3-1-70b-instruct-v1:0",
-      "knowledge": "2023-12",
-      "last_updated": "2024-07-23",
-      "limit": {
-        "context": 128000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 3.1 70B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-1-70b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2024-07-23",
+      "release_date": "2024-12-03",
       "temperature": true,
       "tool_call": true
     },
@@ -717,192 +223,6 @@
       "tool_call": true
     },
     {
-      "attachment": false,
-      "cost": {
-        "input": 0.3,
-        "output": 0.6
-      },
-      "id": "meta.llama3-8b-instruct-v1:0",
-      "knowledge": "2023-03",
-      "last_updated": "2024-07-23",
-      "limit": {
-        "context": 8192,
-        "output": 2048
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 3 8B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-8b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2024-07-23",
-      "temperature": true,
-      "tool_call": false
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 0.2,
-        "input": 0.8,
-        "output": 3.2
-      },
-      "id": "amazon.nova-pro-v1:0",
-      "knowledge": "2024-10",
-      "last_updated": "2024-12-03",
-      "limit": {
-        "context": 300000,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image",
-          "video"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Nova Pro",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "amazon.nova-pro-v1:0",
-      "reasoning": false,
-      "release_date": "2024-12-03",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 3,
-        "output": 15
-      },
-      "id": "cohere.command-r-plus-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2024-04-04",
-      "limit": {
-        "context": 128000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Command R+",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "cohere.command-r-plus-v1:0",
-      "reasoning": false,
-      "release_date": "2024-04-04",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 8,
-        "output": 24
-      },
-      "id": "anthropic.claude-v2",
-      "knowledge": "2023-08",
-      "last_updated": "2023-07-11",
-      "limit": {
-        "context": 100000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude 2",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-v2",
-      "reasoning": false,
-      "release_date": "2023-07-11",
-      "temperature": true,
-      "tool_call": false
-    },
-    {
-      "attachment": false,
-      "cost": {
-        "input": 0.15,
-        "output": 0.6
-      },
-      "id": "qwen.qwen3-32b-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2025-09-18",
-      "limit": {
-        "context": 16384,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Qwen3 32B (dense)",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "qwen.qwen3-32b-v1:0",
-      "reasoning": true,
-      "release_date": "2025-09-18",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "cache_read": 1.5,
-        "cache_write": 18.75,
-        "input": 15,
-        "output": 75
-      },
-      "id": "anthropic.claude-opus-4-20250514-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2025-05-22",
-      "limit": {
-        "context": 200000,
-        "output": 32000
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Opus 4",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-opus-4-20250514-v1:0",
-      "reasoning": true,
-      "release_date": "2025-05-22",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
       "attachment": true,
       "cost": {
         "cache_read": 1.5,
@@ -936,36 +256,6 @@
       "tool_call": true
     },
     {
-      "attachment": false,
-      "cost": {
-        "input": 0.72,
-        "output": 0.72
-      },
-      "id": "meta.llama3-3-70b-instruct-v1:0",
-      "knowledge": "2023-12",
-      "last_updated": "2024-12-06",
-      "limit": {
-        "context": 128000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 3.3 70B Instruct",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-3-70b-instruct-v1:0",
-      "reasoning": false,
-      "release_date": "2024-12-06",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
       "attachment": true,
       "cost": {
         "cache_read": 0.3,
@@ -973,9 +263,9 @@
         "input": 3,
         "output": 15
       },
-      "id": "anthropic.claude-sonnet-4-20250514-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2025-05-22",
+      "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "knowledge": "2025-07-31",
+      "last_updated": "2025-09-29",
       "limit": {
         "context": 200000,
         "output": 64000
@@ -989,12 +279,12 @@
           "text"
         ]
       },
-      "name": "Claude Sonnet 4",
+      "name": "Claude Sonnet 4.5",
       "open_weights": false,
       "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-sonnet-4-20250514-v1:0",
+      "provider_model_id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
       "reasoning": true,
-      "release_date": "2025-05-22",
+      "release_date": "2025-09-29",
       "temperature": true,
       "tool_call": true
     },
@@ -1031,14 +321,14 @@
     {
       "attachment": false,
       "cost": {
-        "input": 0.2,
-        "output": 0.4
+        "input": 3,
+        "output": 15
       },
-      "id": "ai21.jamba-1-5-mini-v1:0",
-      "knowledge": "2024-08",
-      "last_updated": "2024-08-15",
+      "id": "cohere.command-r-plus-v1:0",
+      "knowledge": "2024-04",
+      "last_updated": "2024-04-04",
       "limit": {
-        "context": 256000,
+        "context": 128000,
         "output": 4096
       },
       "modalities": {
@@ -1049,12 +339,162 @@
           "text"
         ]
       },
-      "name": "Jamba 1.5 Mini",
+      "name": "Command R+",
       "open_weights": true,
       "provider": "amazon_bedrock",
-      "provider_model_id": "ai21.jamba-1-5-mini-v1:0",
+      "provider_model_id": "cohere.command-r-plus-v1:0",
       "reasoning": false,
-      "release_date": "2024-08-15",
+      "release_date": "2024-04-04",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.5,
+        "output": 1.5
+      },
+      "id": "cohere.command-r-v1:0",
+      "knowledge": "2024-04",
+      "last_updated": "2024-03-11",
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Command R",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "cohere.command-r-v1:0",
+      "reasoning": false,
+      "release_date": "2024-03-11",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 1.5,
+        "output": 2
+      },
+      "id": "cohere.command-text-v14",
+      "knowledge": "2023-08",
+      "last_updated": "2023-11-01",
+      "limit": {
+        "context": 4096,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Command",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "cohere.command-text-v14",
+      "reasoning": false,
+      "release_date": "2023-11-01",
+      "temperature": true,
+      "tool_call": false
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 1.35,
+        "output": 5.4
+      },
+      "id": "deepseek.r1-v1:0",
+      "knowledge": "2024-07",
+      "last_updated": "2025-05-29",
+      "limit": {
+        "context": 128000,
+        "output": 32768
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "DeepSeek-R1",
+      "open_weights": false,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "deepseek.r1-v1:0",
+      "reasoning": true,
+      "release_date": "2025-01-20",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.58,
+        "output": 1.68
+      },
+      "id": "deepseek.v3-v1:0",
+      "knowledge": "2024-07",
+      "last_updated": "2025-09-18",
+      "limit": {
+        "context": 163840,
+        "output": 81920
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "DeepSeek-V3.1",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "deepseek.v3-v1:0",
+      "reasoning": true,
+      "release_date": "2025-09-18",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "id": "meta.llama3-1-70b-instruct-v1:0",
+      "knowledge": "2023-12",
+      "last_updated": "2024-07-23",
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 3.1 70B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama3-1-70b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2024-07-23",
       "temperature": true,
       "tool_call": true
     },
@@ -1062,122 +502,29 @@
       "attachment": false,
       "cost": {
         "input": 0.22,
-        "output": 0.88
+        "output": 0.22
       },
-      "id": "qwen.qwen3-235b-a22b-2507-v1:0",
-      "knowledge": "2024-04",
-      "last_updated": "2025-09-18",
+      "id": "meta.llama3-1-8b-instruct-v1:0",
+      "knowledge": "2023-12",
+      "last_updated": "2024-07-23",
       "limit": {
-        "context": 262144,
-        "output": 131072
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Qwen3 235B A22B 2507",
-      "open_weights": true,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
-      "reasoning": false,
-      "release_date": "2025-09-18",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "input": 0.25,
-        "output": 1.25
-      },
-      "id": "anthropic.claude-3-haiku-20240307-v1:0",
-      "knowledge": "2024-02",
-      "last_updated": "2024-03-13",
-      "limit": {
-        "context": 200000,
+        "context": 128000,
         "output": 4096
       },
       "modalities": {
         "input": [
-          "text",
-          "image"
+          "text"
         ],
         "output": [
           "text"
         ]
       },
-      "name": "Claude Haiku 3",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-haiku-20240307-v1:0",
-      "reasoning": false,
-      "release_date": "2024-03-13",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "input": 3,
-        "output": 15
-      },
-      "id": "anthropic.claude-3-sonnet-20240229-v1:0",
-      "knowledge": "2023-08",
-      "last_updated": "2024-03-04",
-      "limit": {
-        "context": 200000,
-        "output": 4096
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Claude Sonnet 3",
-      "open_weights": false,
-      "provider": "amazon_bedrock",
-      "provider_model_id": "anthropic.claude-3-sonnet-20240229-v1:0",
-      "reasoning": false,
-      "release_date": "2024-03-04",
-      "temperature": true,
-      "tool_call": true
-    },
-    {
-      "attachment": true,
-      "cost": {
-        "input": 0.17,
-        "output": 0.66
-      },
-      "id": "meta.llama4-scout-17b-instruct-v1:0",
-      "knowledge": "2024-08",
-      "last_updated": "2025-04-05",
-      "limit": {
-        "context": 3500000,
-        "output": 16384
-      },
-      "modalities": {
-        "input": [
-          "text",
-          "image"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "name": "Llama 4 Scout 17B Instruct",
+      "name": "Llama 3.1 8B Instruct",
       "open_weights": true,
       "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama4-scout-17b-instruct-v1:0",
+      "provider_model_id": "meta.llama3-1-8b-instruct-v1:0",
       "reasoning": false,
-      "release_date": "2025-04-05",
+      "release_date": "2024-07-23",
       "temperature": true,
       "tool_call": true
     },
@@ -1215,15 +562,15 @@
     {
       "attachment": false,
       "cost": {
-        "input": 0.58,
-        "output": 1.68
+        "input": 0.1,
+        "output": 0.1
       },
-      "id": "deepseek.v3-v1:0",
-      "knowledge": "2024-07",
-      "last_updated": "2025-09-18",
+      "id": "meta.llama3-2-1b-instruct-v1:0",
+      "knowledge": "2023-12",
+      "last_updated": "2024-09-25",
       "limit": {
-        "context": 163840,
-        "output": 81920
+        "context": 131000,
+        "output": 4096
       },
       "modalities": {
         "input": [
@@ -1233,24 +580,85 @@
           "text"
         ]
       },
-      "name": "DeepSeek-V3.1",
+      "name": "Llama 3.2 1B Instruct",
       "open_weights": true,
       "provider": "amazon_bedrock",
-      "provider_model_id": "deepseek.v3-v1:0",
-      "reasoning": true,
-      "release_date": "2025-09-18",
+      "provider_model_id": "meta.llama3-2-1b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2024-09-25",
       "temperature": true,
       "tool_call": true
     },
     {
       "attachment": false,
       "cost": {
-        "input": 0.22,
-        "output": 0.22
+        "input": 0.15,
+        "output": 0.15
       },
-      "id": "meta.llama3-1-8b-instruct-v1:0",
+      "id": "meta.llama3-2-3b-instruct-v1:0",
       "knowledge": "2023-12",
-      "last_updated": "2024-07-23",
+      "last_updated": "2024-09-25",
+      "limit": {
+        "context": 131000,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 3.2 3B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama3-2-3b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2024-09-25",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": true,
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "id": "meta.llama3-2-90b-instruct-v1:0",
+      "knowledge": "2023-12",
+      "last_updated": "2024-09-25",
+      "limit": {
+        "context": 128000,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 3.2 90B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama3-2-90b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2024-09-25",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.72,
+        "output": 0.72
+      },
+      "id": "meta.llama3-3-70b-instruct-v1:0",
+      "knowledge": "2023-12",
+      "last_updated": "2024-12-06",
       "limit": {
         "context": 128000,
         "output": 4096
@@ -1263,12 +671,254 @@
           "text"
         ]
       },
-      "name": "Llama 3.1 8B Instruct",
+      "name": "Llama 3.3 70B Instruct",
       "open_weights": true,
       "provider": "amazon_bedrock",
-      "provider_model_id": "meta.llama3-1-8b-instruct-v1:0",
+      "provider_model_id": "meta.llama3-3-70b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2024-12-06",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 2.65,
+        "output": 3.5
+      },
+      "id": "meta.llama3-70b-instruct-v1:0",
+      "knowledge": "2023-12",
+      "last_updated": "2024-07-23",
+      "limit": {
+        "context": 8192,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 3 70B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama3-70b-instruct-v1:0",
       "reasoning": false,
       "release_date": "2024-07-23",
+      "temperature": true,
+      "tool_call": false
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.3,
+        "output": 0.6
+      },
+      "id": "meta.llama3-8b-instruct-v1:0",
+      "knowledge": "2023-03",
+      "last_updated": "2024-07-23",
+      "limit": {
+        "context": 8192,
+        "output": 2048
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 3 8B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama3-8b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2024-07-23",
+      "temperature": true,
+      "tool_call": false
+    },
+    {
+      "attachment": true,
+      "cost": {
+        "input": 0.24,
+        "output": 0.97
+      },
+      "id": "meta.llama4-maverick-17b-instruct-v1:0",
+      "knowledge": "2024-08",
+      "last_updated": "2025-04-05",
+      "limit": {
+        "context": 1000000,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 4 Maverick 17B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama4-maverick-17b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2025-04-05",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": true,
+      "cost": {
+        "input": 0.17,
+        "output": 0.66
+      },
+      "id": "meta.llama4-scout-17b-instruct-v1:0",
+      "knowledge": "2024-08",
+      "last_updated": "2025-04-05",
+      "limit": {
+        "context": 3500000,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Llama 4 Scout 17B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "meta.llama4-scout-17b-instruct-v1:0",
+      "reasoning": false,
+      "release_date": "2025-04-05",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.0,
+        "output": 0.0
+      },
+      "id": "openai.gpt-oss-120b-1:0",
+      "knowledge": "2024-04",
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "GPT-OSS 120B",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "openai.gpt-oss-120b-1:0",
+      "reasoning": false,
+      "release_date": "2024-06-01",
+      "system_messages": true,
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.0,
+        "output": 0.0
+      },
+      "id": "openai.gpt-oss-20b-1:0",
+      "knowledge": "2024-04",
+      "limit": {
+        "context": 8192,
+        "output": 4096
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "GPT-OSS 20B",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "openai.gpt-oss-20b-1:0",
+      "reasoning": false,
+      "release_date": "2024-06-01",
+      "system_messages": true,
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.22,
+        "output": 0.88
+      },
+      "id": "qwen.qwen3-235b-a22b-2507-v1:0",
+      "knowledge": "2024-04",
+      "last_updated": "2025-09-18",
+      "limit": {
+        "context": 262144,
+        "output": 131072
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Qwen3 235B A22B 2507",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "qwen.qwen3-235b-a22b-2507-v1:0",
+      "reasoning": false,
+      "release_date": "2025-09-18",
+      "temperature": true,
+      "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.15,
+        "output": 0.6
+      },
+      "id": "qwen.qwen3-32b-v1:0",
+      "knowledge": "2024-04",
+      "last_updated": "2025-09-18",
+      "limit": {
+        "context": 16384,
+        "output": 16384
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Qwen3 32B (dense)",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "qwen.qwen3-32b-v1:0",
+      "reasoning": true,
+      "release_date": "2025-09-18",
       "temperature": true,
       "tool_call": true
     },
@@ -1301,12 +951,45 @@
       "release_date": "2025-09-18",
       "temperature": true,
       "tool_call": true
+    },
+    {
+      "attachment": false,
+      "cost": {
+        "input": 0.22,
+        "output": 1.8
+      },
+      "id": "qwen.qwen3-coder-480b-a35b-v1:0",
+      "knowledge": "2024-04",
+      "last_updated": "2025-09-18",
+      "limit": {
+        "context": 131072,
+        "output": 65536
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "name": "Qwen3 Coder 480B A35B Instruct",
+      "open_weights": true,
+      "provider": "amazon_bedrock",
+      "provider_model_id": "qwen.qwen3-coder-480b-a35b-v1:0",
+      "reasoning": false,
+      "release_date": "2025-09-18",
+      "temperature": true,
+      "tool_call": true
     }
   ],
   "provider": {
-    "base_url": null,
-    "doc": "AI model provider",
-    "env": [],
+    "base_url": "https://bedrock-runtime.{region}.amazonaws.com",
+    "doc": "AWS Bedrock multi-provider ML platform",
+    "env": [
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY"
+    ],
     "id": "amazon_bedrock",
     "name": "Amazon Bedrock"
   }

--- a/priv/models_local/amazon_bedrock_exclude.json
+++ b/priv/models_local/amazon_bedrock_exclude.json
@@ -1,0 +1,19 @@
+{
+  "provider": {
+    "id": "amazon-bedrock"
+  },
+  "exclude": [
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-opus-20240229-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+    "anthropic.claude-sonnet-4-20250514-v1:0",
+    "anthropic.claude-opus-4-20250514-v1:0",
+    "anthropic.claude-instant-v1",
+    "anthropic.claude-v2",
+    "anthropic.claude-v2:1"
+  ]
+}


### PR DESCRIPTION
Fixes test failures for old Claude models without fixtures.

Adds exclusion file to filter out Claude 3.x and legacy 4.0 models.
Only Claude 4.5 (Haiku, Sonnet) and Claude 4.1 (Opus) remain in test coverage.

Resolves issue where tests attempted to run for models lacking fixture files.