### PR TITLE
Document AWS Event Stream parser specialization for Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Enhanced
+
+- **AWS Event Stream parser documentation** clarifying Bedrock specialization
+  - Explains performance rationale for single-pass parsing and header specialization
+  - Documents non-goals (S3 Select, Transcribe, Kinesis incompatibility)
+
 ### Fixed
 
 - **JSV schema validation** now preserves original data types instead of returning cast values


### PR DESCRIPTION
Adds comprehensive documentation explaining why the AWS Event Stream parser is specialized for Bedrock rather than being general-purpose. I want to make it clear that this can't be reused for other AWS Event Stream parsing use cases, and also that this is the right design for our use case.

The specialization provides better performance by only parsing String (type 7) headers and integrating payload decoding in a single pass, avoiding the overhead of unused header types and multi-step decoding.

Also fixes incorrect module references in examples.