### PR TITLE
Credo Fix: Enum filter reduction

### DIFF
--- a/lib/examples/agent.ex
+++ b/lib/examples/agent.ex
@@ -194,8 +194,10 @@ defmodule ReqLLM.Examples.Agent do
     # Collect argument fragments from meta chunks
     arg_fragments =
       chunks
-      |> Enum.filter(&(&1.type == :meta))
-      |> Enum.filter(&Map.has_key?(&1.metadata, :tool_call_args))
+      |> Enum.filter(fn
+        %{type: :meta, metadata: %{tool_call_args: _}} -> true
+        _ -> false
+      end)
       |> Enum.group_by(& &1.metadata.tool_call_args.index)
       |> Map.new(fn {index, fragments} ->
         json = fragments |> Enum.map_join("", & &1.metadata.tool_call_args.fragment)

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -223,9 +223,9 @@ defmodule ReqLLM.StreamResponse do
     # Collect argument fragments from meta chunks
     arg_fragments =
       chunks
-      |> Enum.filter(&(&1.type == :meta))
-      |> Enum.filter(fn chunk ->
-        Map.has_key?(chunk.metadata, :tool_call_args)
+      |> Enum.filter(fn
+        %{type: :meta, metadata: %{tool_call_args: _}} -> true
+        _ -> false
       end)
       |> Enum.group_by(fn chunk ->
         chunk.metadata.tool_call_args.index
@@ -467,8 +467,10 @@ defmodule ReqLLM.StreamResponse do
     # Accumulate JSON fragments from meta chunks
     json_fragments_by_index =
       chunks
-      |> Enum.filter(&(&1.type == :meta))
-      |> Enum.filter(&match?(%{metadata: %{tool_call_args: %{index: _, fragment: _}}}, &1))
+      |> Enum.filter(fn
+        %{type: :meta, metadata: %{tool_call_args: %{index: _, fragment: _}}} -> true
+        _ -> false
+      end)
       |> Enum.group_by(fn chunk -> chunk.metadata.tool_call_args.index end)
       |> Map.new(fn {index, meta_chunks} ->
         json =


### PR DESCRIPTION
## Description

Fixes credo refactoring issue with an idiomatic Elixir approach

- [x]  One `Enum.filter/2` is more efficient than `Enum.filter/2 |> Enum.filter/2`

## Type of Contribution

- [ ] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [ ] **Provider Feature** - Adding capabilities to existing provider
- [x] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [ ] Documentation updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
# Paste output if provider changes

```

## Related Issues

Closes #
