### PR TITLE
Custom providers defined outside req_llm

### DIFF
--- a/guides/adding_a_provider.md
+++ b/guides/adding_a_provider.md
@@ -75,12 +75,12 @@ Prefer `use ReqLLM.Provider.Defaults` to get robust OpenAI-style defaults and ov
 
 ### Registering Custom Providers
 
-If you are developing a provider outside of the `req_llm` library (e.g., in your own application), you must register it in your application configuration so `req_llm` can discover it.
+If you are developing a provider outside of the `req_llm` library (e.g., in your own application), you must register it as a custom provider in your application configuration so `req_llm` can discover it.
 
 Add the module to your `config.exs`:
 ```elixir
 # In config/config.exs
-config :req_llm, :provider_modules, [ReqLLM.Providers.Acme]
+config :req_llm, :custom_providers, [ReqLLM.Providers.Acme]
 ```
 This tells `req_llm` to load `ReqLLM.Providers.Acme` as a valid provider module alongside its built-in providers.
 

--- a/lib/req_llm/provider/registry.ex
+++ b/lib/req_llm/provider/registry.ex
@@ -693,7 +693,7 @@ defmodule ReqLLM.Provider.Registry do
     case :application.get_key(:req_llm, :modules) do
       {:ok, modules} ->
         modules
-        |> Enum.concat(Application.get_env(:req_llm, :provider_modules, []))
+        |> Enum.concat(Application.get_env(:req_llm, :custom_providers, []))
         |> Enum.filter(&provider_module?/1)
 
       :undefined ->


### PR DESCRIPTION
eg in an application using req_llm it can specify in config:
config :req_llm, :provider_modules, [ReqLLM.Providers.Venice]
then the req_llm library discovers this module as an implementation

# Pull Request

## Description

Brief description of what this PR accomplishes.

## Type of Contribution

- [x] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [ ] **Provider Feature** - Adding capabilities to existing provider
- [ ] **Bug Fix** - Fixing existing functionality
- [x] **Documentation** - Docs/guides only

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [x] Documentation updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
# Paste output if provider changes

```

## Related Issues

Closes #
