### PR TITLE
Add vllm support

### DIFF
--- a/lib/req_llm/provider/generated/valid_providers.ex
+++ b/lib/req_llm/provider/generated/valid_providers.ex
@@ -55,6 +55,7 @@ defmodule ReqLLM.Provider.Generated.ValidProviders do
     :v0,
     :venice,
     :vercel,
+    :vllm,
     :vultr,
     :wandb,
     :xai,

--- a/lib/req_llm/providers/vllm.ex
+++ b/lib/req_llm/providers/vllm.ex
@@ -1,0 +1,55 @@
+defmodule ReqLLM.Providers.VLLM do
+  @moduledoc """
+  vLLM provider – self-hosted OpenAI-compatible Chat Completions API.
+
+  ## Implementation
+
+  Uses built-in OpenAI-style encoding/decoding defaults.
+  vLLM is fully OpenAI-compatible, so no custom request/response handling is needed.
+
+  ## Self-Hosted Configuration
+
+  vLLM is a self-hosted inference server. Users must:
+
+  1. Deploy a vLLM service (via pip install, Docker, or other methods)
+  2. Configure the model to serve (e.g., `--served-model-name my-model`)
+  3. Set the base_url to point to their vLLM instance
+
+  Since vLLM runs multiple models on different ports, use the `:base_url` option
+  per-request or configure model entries with their specific URLs.
+
+  ## Authentication
+
+  By default, vLLM uses OPENAI_API_KEY as an environment variable.
+  The presence of a value is required but typically not validated by vLLM.
+  Set any non-empty value if authentication is not configured on your vLLM server.
+
+  ## Configuration
+
+      # Add to .env file (automatically loaded)
+      OPENAI_API_KEY=any-value-for-vllm
+
+  ## Examples
+
+      # Basic usage with default localhost
+      ReqLLM.generate_text("vllm:my-local-model", "Hello!")
+
+      # With custom base_url for a specific vLLM instance
+      ReqLLM.generate_text("vllm:llama-3", "Hello!",
+        base_url: "http://my-server:8001/v1"
+      )
+
+      # Streaming
+      ReqLLM.stream_text("vllm:mistral-7b", "Tell me a story")
+      |> Enum.each(&IO.write/1)
+  """
+
+  use ReqLLM.Provider,
+    id: :vllm,
+    default_base_url: "http://localhost:8000/v1",
+    default_env_key: "OPENAI_API_KEY"
+
+  use ReqLLM.Provider.Defaults
+
+  @provider_schema []
+end

--- a/test/providers/vllm_test.exs
+++ b/test/providers/vllm_test.exs
@@ -1,0 +1,217 @@
+defmodule ReqLLM.Providers.VLLMTest do
+  @moduledoc """
+  Provider-level tests for vLLM implementation.
+
+  Tests the provider contract and wiring without making live API calls.
+  vLLM is OpenAI-compatible so tests focus on configuration and routing.
+  """
+
+  use ReqLLM.ProviderCase, provider: ReqLLM.Providers.VLLM
+
+  alias ReqLLM.Providers.VLLM
+
+  defp vllm_model(model_id \\ "test-model", opts \\ []) do
+    %LLMDB.Model{
+      id: "vllm:#{model_id}",
+      model: model_id,
+      name: Keyword.get(opts, :name, "vLLM Test Model"),
+      provider: :vllm,
+      family: Keyword.get(opts, :family, "test"),
+      capabilities: Keyword.get(opts, :capabilities, %{chat: true, tools: %{enabled: true}}),
+      limits: Keyword.get(opts, :limits, %{context: 32_768, output: 4096})
+    }
+  end
+
+  describe "provider contract" do
+    test "provider identity and configuration" do
+      assert VLLM.provider_id() == :vllm
+      assert is_binary(VLLM.base_url())
+      assert VLLM.base_url() == "http://localhost:8000/v1"
+    end
+
+    test "provider uses OPENAI_API_KEY by default" do
+      assert VLLM.default_env_key() == "OPENAI_API_KEY"
+    end
+
+    test "provider schema is empty (pure OpenAI-compatible)" do
+      schema_keys = VLLM.provider_schema().schema |> Keyword.keys()
+      assert schema_keys == []
+    end
+
+    test "provider_extended_generation_schema includes all core keys" do
+      extended_schema = VLLM.provider_extended_generation_schema()
+      extended_keys = extended_schema.schema |> Keyword.keys()
+
+      core_keys = ReqLLM.Provider.Options.all_generation_keys()
+      core_without_meta = Enum.reject(core_keys, &(&1 == :provider_options))
+
+      for core_key <- core_without_meta do
+        assert core_key in extended_keys,
+               "Extended schema missing core key: #{core_key}"
+      end
+    end
+  end
+
+  describe "request preparation" do
+    test "prepare_request for :chat creates /chat/completions request" do
+      model = vllm_model()
+      prompt = "Hello world"
+      opts = [temperature: 0.7, max_tokens: 100]
+
+      {:ok, request} = VLLM.prepare_request(:chat, model, prompt, opts)
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/chat/completions"
+      assert request.method == :post
+    end
+
+    test "prepare_request for :embedding creates /embeddings request" do
+      model = vllm_model("embedding-model", capabilities: %{embeddings: true})
+      text = "Hello world"
+      opts = []
+
+      {:ok, request} = VLLM.prepare_request(:embedding, model, text, opts)
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/embeddings"
+      assert request.method == :post
+    end
+
+    test "prepare_request rejects unsupported operations" do
+      model = vllm_model()
+      context = context_fixture()
+
+      {:error, error} = VLLM.prepare_request(:unsupported, model, context, [])
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+    end
+  end
+
+  describe "authentication wiring" do
+    test "attach adds Bearer authorization header" do
+      model = vllm_model()
+      request = Req.new()
+
+      attached = VLLM.attach(request, model, [])
+
+      auth_header = attached.headers["authorization"]
+      assert auth_header != nil
+      assert String.starts_with?(List.first(auth_header), "Bearer ")
+    end
+
+    test "attach adds pipeline steps" do
+      model = vllm_model()
+      request = Req.new()
+
+      attached = VLLM.attach(request, model, [])
+
+      request_steps = Keyword.keys(attached.request_steps)
+      response_steps = Keyword.keys(attached.response_steps)
+
+      assert :llm_encode_body in request_steps
+      assert :llm_decode_response in response_steps
+    end
+  end
+
+  describe "base_url configuration" do
+    test "uses default base_url when not overridden" do
+      model = vllm_model()
+      {:ok, request} = VLLM.prepare_request(:chat, model, "Hello", [])
+
+      assert request.options[:base_url] == "http://localhost:8000/v1"
+    end
+
+    test "respects base_url option override" do
+      model = vllm_model()
+      custom_url = "http://my-vllm-server:8001/v1"
+      {:ok, request} = VLLM.prepare_request(:chat, model, "Hello", base_url: custom_url)
+
+      assert request.options[:base_url] == custom_url
+    end
+  end
+
+  describe "body encoding" do
+    test "encode_body produces valid OpenAI-compatible JSON" do
+      model = vllm_model()
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          temperature: 0.7
+        ]
+      }
+
+      updated_request = VLLM.encode_body(mock_request)
+
+      assert is_binary(updated_request.body)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["model"] == "test-model"
+      assert is_list(decoded["messages"])
+      assert decoded["stream"] == false
+    end
+
+    test "encode_body handles tools correctly" do
+      model = vllm_model()
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Get the weather",
+          parameter_schema: [
+            location: [type: :string, required: true, doc: "City name"]
+          ],
+          callback: fn _ -> {:ok, "sunny"} end
+        )
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          tools: [tool]
+        ]
+      }
+
+      updated_request = VLLM.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert is_list(decoded["tools"])
+      assert length(decoded["tools"]) == 1
+      assert hd(decoded["tools"])["function"]["name"] == "get_weather"
+    end
+  end
+
+  describe "response decoding" do
+    test "decode_response parses OpenAI-format response" do
+      mock_response_body =
+        openai_format_json_fixture(
+          model: "test-model",
+          content: "Hello from vLLM!"
+        )
+
+      mock_resp = %Req.Response{
+        status: 200,
+        body: mock_response_body
+      }
+
+      context = context_fixture()
+
+      mock_req = %Req.Request{
+        options: [
+          context: context,
+          model: "test-model",
+          operation: :chat
+        ]
+      }
+
+      {_req, decoded_resp} = VLLM.decode_response({mock_req, mock_resp})
+
+      assert %ReqLLM.Response{} = decoded_resp.body
+      assert ReqLLM.Response.text(decoded_resp.body) == "Hello from vLLM!"
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request

Adds a vLLM provider that supports self-hosted models.

As a self-hosted model, the user must configure and start a vLLM service before making ReqLLM calls against the service url.  In ReqLLM, there are some differences between continually hosted models and self-hosted models.   Self-hosted models need the ability to configure the location of the self-hosted Provider base_url.  Since, the model service is not publicly hosted, the ReqLLM Catalog capability was added to support run-time configuration of providers like vLLM.  

However, vLLM doesn't host  multiple models on the same port.  This PR also adds a Model base_url field that is used to override the Provider base_url (and port) field when setting up the HTTP request.

The capability was tested against locally hosted models.  The following small models were used to verify chat generation, chat streaming and chat with an image, HuggingFaceTB/SmolLM2-135M-Instruct and HuggingFaceTB/SmolVLM-256M-Instruct.

By default, vLLM uses OPENAI_API_KEY as an environment variable.  The presence of a value is needed but, by default, the value isn't checked.

For ReqLLM users that want to try other models, I've used the following to deploy local models.

Set up vLLM:
I have direct experience with running models on a Linux server with a small, 10G VRAM 3080 GPU.  In addition to installing vLLM as a python program, it is possible to deploy vLLM as a docker service.  For CPU serving, there is a docker configuration for CPU in the vLLM codebase.  Please refer to the vLLM documentation for further details on how to set up a service.

I found it useful to specify the --served-model-name model_name_you_choose parameter.  The model_name_you_choose becomes the model_id in a ReqLLM catalog configuration.

Set up ReqLLM:
In a client Elixir application, configure the models in environment configurations, i.e. dev.exs, etc.

Here is an example configuration:
```elixir
import Config

config :req_llm, :catalog,
  allow: %{
    vllm: ["SmolLM2-135M-Instruct"]
  },
  overrides: [],
  custom: [
    %{
      provider: %{
        id: "vllm",
        name: "vLLM Local",
        base_url: "http://localhost:8000/v1",
        env: ["OPENAI_API_KEY"]
      },
      models: [
        %{
          id: "SmolLM2-135M-Instruct",
          name: "SmolLM2 135M Instruct",
          api: "chat",
          modalities: %{
            "input" => ["text"],
            "output" => ["text"]
          },
          limit: %{
            "context" => 8192
          },
          cost: %{
            "input" => 0.0,
            "output" => 0.0
          }
        }
      ]
    }
  ]
```

When trying to test a local vLLM model , using a local clone of the ReqLLM project, it is currently a little tricky.   In the project root folder the lib/examples/scripts or iex -S mix will work when using the following steps,  The catalog_allow.exs needs to have the locally hosted models listed in the vllm_models configuration, i.e.

```elixir
vllm_models = ~w(
  SmolLM2-135M-Instruct
  SmolVLM-256M-Instruct
)
```

Additional notes:
I've found that the vllm_test.exs is a little flaky when running locally.  It might be because the test models are defined and then excluded in the model JSON files.  Running the tests multiple times, will demonstrate that they pass.

## Type of Contribution

- [ ] **Core Library** - Changes to core modules or data structures
- [X] **New Provider** - Adding a new LLM provider
- [ ] **Provider Feature** - Adding capabilities to existing provider
- [ ] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

## Checklist

- [X] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)
- [ ] Documentation updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
# Paste output if provider changes

```

## Related Issues

Closes #
