### PR TITLE
Add credential fallback for fixture recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Models can specify API-specific identifiers separate from canonical IDs
   - Enables Bedrock streaming and on-demand throughput with inference profile prefixes
   - Applied to Claude Haiku 4.5, Sonnet 4.5, Opus 4.1, Llama 3.3 70B models
+- **Credential fallback for fixture recording** in providers requiring cloud credentials
+  - Automatic fallback to existing fixtures when credentials are missing during RECORD mode
+  - Provider-specific credential detection via optional `credential_missing?/1` callback
+  - Implemented in AWS Bedrock, Google, and Google Vertex AI providers
+  - Enables comprehensive test coverage without requiring all developers to configure cloud credentials
 
 ### Enhanced
 

--- a/lib/req_llm/provider.ex
+++ b/lib/req_llm/provider.ex
@@ -569,6 +569,33 @@ defmodule ReqLLM.Provider do
   @callback thinking_constraints() ::
               %{required_temperature: float(), min_max_tokens: pos_integer()} | :none
 
+  @doc """
+  Checks if an exception indicates missing credentials for this provider.
+
+  This optional callback allows providers to identify credential-related errors
+  so the fixture system can fall back to existing fixtures during recording when
+  credentials are unavailable.
+
+  ## Parameters
+
+    * `exception` - The exception to check
+
+  ## Returns
+
+    * `true` - Exception indicates missing credentials
+    * `false` - Exception is not credential-related
+
+  ## Examples
+
+      # Google provider checking for missing API key
+      def credential_missing?(%ReqLLM.Error.Invalid.Parameter{parameter: param}) do
+        String.contains?(param, "api_key") and
+          String.contains?(param, "GOOGLE_API_KEY")
+      end
+      def credential_missing?(_), do: false
+  """
+  @callback credential_missing?(Exception.t()) :: boolean()
+
   @optional_callbacks [
     normalize_model_id: 1,
     extract_usage: 2,
@@ -580,7 +607,8 @@ defmodule ReqLLM.Provider do
     flush_stream_state: 2,
     parse_stream_protocol: 2,
     attach_stream: 4,
-    thinking_constraints: 0
+    thinking_constraints: 0,
+    credential_missing?: 1
   ]
 
   defmacro __before_compile__(_env) do

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -1008,4 +1008,11 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         end
     end
   end
+
+  @impl ReqLLM.Provider
+  def credential_missing?(%ArgumentError{message: msg}) when is_binary(msg) do
+    String.contains?(msg, "AWS credentials required for Bedrock")
+  end
+
+  def credential_missing?(_), do: false
 end

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1591,4 +1591,12 @@ defmodule ReqLLM.Providers.Google do
   defp convert_google_usage_for_streaming(usage_metadata) do
     normalize_google_usage(usage_metadata)
   end
+
+  @impl ReqLLM.Provider
+  def credential_missing?(%ReqLLM.Error.Invalid.Parameter{parameter: param}) do
+    String.contains?(param, ":api_key") and
+      String.contains?(param, "GOOGLE_API_KEY")
+  end
+
+  def credential_missing?(_), do: false
 end

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -478,4 +478,11 @@ defmodule ReqLLM.Providers.GoogleVertex do
     # Use streamRawPredict for streaming
     "/v1/projects/#{project_id}/locations/#{region}/publishers/anthropic/models/#{model_id}:streamRawPredict"
   end
+
+  @impl ReqLLM.Provider
+  def credential_missing?(%ArgumentError{message: msg}) when is_binary(msg) do
+    String.contains?(msg, "Google Cloud credentials required")
+  end
+
+  def credential_missing?(_), do: false
 end

--- a/test/support/fixture.ex
+++ b/test/support/fixture.ex
@@ -80,6 +80,13 @@ defmodule ReqLLM.Step.Fixture.Backend do
       Logger.debug("Fixture mode: #{mode}")
       Logger.debug("Fixture exists: #{File.exists?(path)}")
 
+      # Store fixture metadata for potential credential fallback
+      request =
+        request
+        |> Req.Request.put_private(:llm_fixture_path, path)
+        |> Req.Request.put_private(:llm_fixture_name, safe_fixture_name)
+        |> Req.Request.put_private(:llm_fixture_model, model)
+
       if live?() do
         dbug(
           fn -> "[Fixture] RECORD mode - will save to #{Path.relative_to_cwd(path)}" end,
@@ -87,13 +94,9 @@ defmodule ReqLLM.Step.Fixture.Backend do
         )
 
         Logger.debug("Fixture RECORD mode - will save to #{Path.relative_to_cwd(path)}")
-        # Tag the request and add response steps to capture the response
-        request =
-          request
-          |> Req.Request.put_private(:llm_fixture_path, path)
-          |> Req.Request.put_private(:llm_fixture_name, safe_fixture_name)
 
-        Logger.debug("Fixture request tagged with path")
+        # Add credential fallback error handler FIRST
+        request = insert_credential_fallback_handler(request, path, model)
 
         # For streaming, fixture saving is handled in StreamServer callback
         # For non-streaming, save fixture BEFORE decoding to capture raw response
@@ -155,7 +158,12 @@ defmodule ReqLLM.Step.Fixture.Backend do
   # ---------------------------------------------------------------------------
   # Replay branch
   # ---------------------------------------------------------------------------
-  defp handle_replay(path, model) do
+  @doc """
+  Load a fixture file and return it as a Req.Response.
+
+  This function is public to support credential fallback in generation.ex.
+  """
+  def handle_replay(path, model) do
     if !File.exists?(path) do
       raise """
       Fixture not found: #{path}
@@ -422,4 +430,46 @@ defmodule ReqLLM.Step.Fixture.Backend do
   defp encode_body(bin) when is_binary(bin), do: %{"b64" => Base.encode64(bin)}
   # JSON already
   defp encode_body(other), do: other
+
+  # ---------------------------------------------------------------------------
+  # Credential fallback handler
+  # ---------------------------------------------------------------------------
+  defp insert_credential_fallback_handler(request, fixture_path, model) do
+    # Add an error handler that catches credential errors and falls back to fixture
+    Req.Request.prepend_error_steps(request,
+      llm_credential_fallback: fn {request, exception} ->
+        handle_credential_error(request, exception, fixture_path, model)
+      end
+    )
+  end
+
+  defp handle_credential_error(request, exception, fixture_path, model) do
+    # Get provider module to check if this is a credential error
+    provider_id = model.provider
+    {:ok, provider_module} = ReqLLM.Providers.get(provider_id)
+
+    is_credential_error =
+      function_exported?(provider_module, :credential_missing?, 1) and
+        provider_module.credential_missing?(exception)
+
+    fixture_exists = File.exists?(fixture_path)
+
+    if is_credential_error and fixture_exists do
+      # Log warning and fall back to fixture
+      require Logger
+
+      Logger.warning("""
+      Credentials missing for #{provider_id}:#{model.model} during fixture recording.
+      Falling back to existing fixture: #{Path.relative_to_cwd(fixture_path)}
+      """)
+
+      # Load fixture and return as if we succeeded
+      {:ok, response} = handle_replay(fixture_path, model)
+      # Return success - this stops error propagation
+      {request, response}
+    else
+      # Not a credential error or no fixture - propagate error
+      {request, exception}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds automatic fallback to existing fixtures when cloud credentials are missing during fixture recording mode. This enables comprehensive test coverage without requiring all developers to configure credentials for AWS Bedrock, Google Vertex AI, and other cloud providers.

## Changes

- Added `credential_missing?/1` callback to Provider behaviour
- Implemented credential detection in AWS Bedrock, Google, and Google Vertex AI providers
- Added error handling step that intercepts credential errors and falls back to existing fixtures
- Modified fixture recording flow to gracefully handle missing credentials

## Technical Details

When a test runs in `RECORD` mode but credentials are missing:
1. Provider-specific `credential_missing?/1` checks if error is credential-related
2. If fixture exists, loads and returns it instead of failing
3. Logs warning about credential fallback
4. Test continues using existing fixture data

This allows developers to run full test suite without needing credentials for every provider, while still enabling fixture updates when credentials are available.