### PR TITLE
Fix tool_budget_for pattern match regression from LLMDB integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Test helper `tool_budget_for/1` pattern match regression** from LLMDB integration
+  - Fixed pattern match to use `{:ok, model}` instead of obsolete `{:ok, {provider, id, model}}`
+  - Fixed field name from `model.limit` to `model.limits`
+  - Regression introduced in v1.1.0 caused test fixtures to use incorrect `maxOutputTokens` values
+  - Primarily affected reasoning-enabled models (Gemini 2.5 Pro) where 150 token default was insufficient
 - **Google provider cached token extraction** from API responses
   - Extracts `cachedContentTokenCount` from `usageMetadata` for both implicit and explicit caching
   - Converts to OpenAI-compatible `prompt_tokens_details.cached_tokens` format

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -338,10 +338,10 @@ defmodule ReqLLM.Test.Helpers do
   """
   def tool_budget_for(model_spec) do
     case ReqLLM.model(model_spec) do
-      {:ok, {_provider, _id, model}} ->
+      {:ok, model} ->
         cond do
-          is_map(model.limit) and is_integer(model.limit[:output]) and model.limit[:output] > 0 ->
-            max(64, div(model.limit[:output], 10))
+          is_map(model.limits) and is_integer(model.limits[:output]) and model.limits[:output] > 0 ->
+            max(64, div(model.limits[:output], 10))
 
           is_map(model.cost) and is_number(model.cost[:output]) and model.cost[:output] < 0.001 ->
             500


### PR DESCRIPTION
# Pull Request

## Description

Fixes pattern match regression in test helper `tool_budget_for/1` introduced during LLMDB integration (v1.1.0). The function was using an obsolete pattern match expecting `{:ok, {provider, id, model}}` but `ReqLLM.model/1` now returns `{:ok, model}`, causing it to always return the default 150 tokens instead of calculating based on `model.limits[:output]`.

Additionally fixed field name from `model.limit` (singular) to `model.limits` (plural).

Primarily affected reasoning-enabled models like Gemini 2.5 Pro where 150 tokens was insufficient for extended reasoning, causing MAX_TOKENS errors in tool call tests.

## Type of Contribution

- [ ] Core Library
- [ ] New Provider
- [ ] Provider Feature
- [x] Bug Fix
- [ ] Documentation

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [x] Documentation updated (CHANGELOG)

### If Provider Changes
- [ ] Fixtures generated
- [ ] Model compatibility passes

## Related Issues

N/A