### PR TITLE
Fix StreamResponse context merging

### DIFF
--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -453,7 +453,7 @@ defmodule ReqLLM.StreamResponse do
     metadata = MetadataHandle.await(stream_response.metadata_handle)
     usage = normalize_usage_fields(Map.get(metadata, :usage))
 
-    %Response{
+    base_response = %Response{
       id: generate_response_id(),
       model: stream_response.model.id,
       context: stream_response.context,
@@ -466,6 +466,8 @@ defmodule ReqLLM.StreamResponse do
       provider_meta: Map.get(metadata, :provider_meta, %{}),
       error: nil
     }
+
+    Context.merge_response(stream_response.context, base_response)
   end
 
   @doc """
@@ -599,7 +601,7 @@ defmodule ReqLLM.StreamResponse do
       usage = normalize_usage_fields(Map.get(metadata, :usage))
 
       # Create Response struct
-      response = %Response{
+      base_response = %Response{
         id: generate_response_id(),
         model: stream_response.model.id,
         context: stream_response.context,
@@ -613,7 +615,7 @@ defmodule ReqLLM.StreamResponse do
         error: nil
       }
 
-      {:ok, response}
+      {:ok, Context.merge_response(stream_response.context, base_response)}
     end
   rescue
     error -> {:error, error}
@@ -649,7 +651,7 @@ defmodule ReqLLM.StreamResponse do
             finish_reason: Map.get(metadata, :finish_reason, response.finish_reason)
         }
 
-        {:ok, response}
+        {:ok, Context.merge_response(stream_response.context, response)}
 
       {_req, error} when is_exception(error) ->
         {:error, error}


### PR DESCRIPTION
# Pull Request: Fix StreamResponse context merging

  ## Description

  Align streaming helpers with non-streaming context behavior. process_stream/2 and
  to_response/1 now merge the assistant turn into the returned context so downstream calls can
  continue the conversation without manual context stitching. Added regression tests to lock
  in the expected behavior.

  ## Type of Contribution

  - [x] Bug Fix - Fixing existing functionality
  - [ ] Core Library
  - [ ] New Provider
  - [ ] Provider Feature
  - [ ] Documentation

  ## Checklist

  - [x] Tests pass (mix test test/req_llm/stream_response_test.exs)
  - [x] Quality checks pass (mix quality)
  - [ ] Documentation updated

  ## Related Issues