### PR TITLE
Add Amazon Bedrock service tier support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Amazon Bedrock service tier support** for request prioritization
+  - `service_tier` option with values: `"priority"`, `"default"`, `"flex"`
+  - Priority tier provides faster responses at premium cost for mission-critical workloads
+  - Flex tier offers cost-effective processing for non-urgent tasks
+  - Supported on compatible Bedrock models (check AWS documentation for availability)
 - **Google Vertex AI Gemini model support**
   - Gemini 2.0 Flash, 2.5 Flash, 2.5 Flash Lite, and 2.5 Pro on Google Vertex AI
   - Delegates to native Google provider format with Vertex-specific quirks handled

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -371,6 +371,92 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
     end
   end
 
+  describe "service_tier parameter" do
+    test "includes service_tier in request body when specified" do
+      System.put_env("AWS_ACCESS_KEY_ID", "AKIATEST")
+      System.put_env("AWS_SECRET_ACCESS_KEY", "secretTEST")
+
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      messages = [Context.user("Hello")]
+      context = Context.new(messages)
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        service_tier: "priority"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert %Req.Request{} = request
+      body = Jason.decode!(request.body)
+      assert body["service_tier"] == "priority"
+    end
+
+    test "includes service_tier=flex in request body" do
+      System.put_env("AWS_ACCESS_KEY_ID", "AKIATEST")
+      System.put_env("AWS_SECRET_ACCESS_KEY", "secretTEST")
+
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      messages = [Context.user("Hello")]
+      context = Context.new(messages)
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        service_tier: "flex"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      body = Jason.decode!(request.body)
+      assert body["service_tier"] == "flex"
+    end
+
+    test "omits service_tier when default" do
+      System.put_env("AWS_ACCESS_KEY_ID", "AKIATEST")
+      System.put_env("AWS_SECRET_ACCESS_KEY", "secretTEST")
+
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      messages = [Context.user("Hello")]
+      context = Context.new(messages)
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        service_tier: "default"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      body = Jason.decode!(request.body)
+      refute Map.has_key?(body, "service_tier")
+    end
+
+    test "omits service_tier when not specified" do
+      System.put_env("AWS_ACCESS_KEY_ID", "AKIATEST")
+      System.put_env("AWS_SECRET_ACCESS_KEY", "secretTEST")
+
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      messages = [Context.user("Hello")]
+      context = Context.new(messages)
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      body = Jason.decode!(request.body)
+      refute Map.has_key?(body, "service_tier")
+    end
+  end
+
   # Helper to build a valid AWS Event Stream message for testing
   defp build_aws_event_stream_message(payload) when is_binary(payload) do
     headers = <<>>


### PR DESCRIPTION
## Description

Implements support for Amazon Bedrock's new service tier feature announced Nov 18, 2025, allowing users to optimize costs by matching workload performance requirements with appropriate service tiers.

## Type of Contribution

- [ ] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [x] **Provider Feature** - Adding capabilities to existing provider
- [ ] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

## Changes

- Added `service_tier` parameter to Bedrock provider schema with validation for `"priority"`, `"default"`, and `"flex"` values
- Updated `attach()` and `attach_stream()` to include `service_tier` in request body when non-default
- Added comprehensive test coverage (4 new tests covering all tier scenarios)
- Updated CHANGELOG with feature documentation

## Service Tier Options

- **Priority**: Faster responses at premium cost for mission-critical workloads (customer service chatbots, real-time translation)
- **Default**: Standard performance at regular rates for everyday AI tasks (content generation, text analysis)
- **Flex**: Cost-effective processing for non-urgent workloads (model evaluations, content summarization, agentic workflows)

## Checklist

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)
- [x] Documentation updated

### If Provider Changes
- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

**Model Compatibility Output:**
```
N/A - Parameter addition only, no model compatibility changes needed
```

## Related Issues

Reference: https://aws.amazon.com/blogs/aws/new-amazon-bedrock-service-tiers-help-you-match-ai-workload-performance-with-cost/