### PR TITLE
Fix Responses API tool encoding to use flat structure

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -526,73 +526,73 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   defp encode_tool_for_responses_api(%ReqLLM.Tool{} = tool) do
     schema = ReqLLM.Tool.to_schema(tool)
     function_def = schema["function"]
-
-    function_def =
-      function_def
-      |> Map.put("strict", true)
-      |> ensure_all_properties_required()
+    params = normalize_parameters_for_strict(function_def["parameters"])
 
     %{
-      "name" => function_def["name"],
       "type" => "function",
-      "function" => function_def
+      "name" => function_def["name"],
+      "description" => function_def["description"],
+      "parameters" => params,
+      "strict" => true
     }
   end
 
   defp encode_tool_for_responses_api(tool_schema) when is_map(tool_schema) do
     function_def = tool_schema["function"] || tool_schema[:function]
 
-    function_def =
-      if is_map_key(tool_schema, "function") do
-        function_def
-        |> Map.put("strict", true)
-        |> ensure_all_properties_required()
-      else
-        function_def
-        |> Map.put(:strict, true)
-        |> ensure_all_properties_required()
-      end
+    if function_def do
+      name = function_def["name"] || function_def[:name]
+      description = function_def["description"] || function_def[:description]
+      raw_params = function_def["parameters"] || function_def[:parameters]
+      params = normalize_parameters_for_strict(raw_params)
 
-    name = function_def["name"] || function_def[:name]
+      %{
+        "type" => "function",
+        "name" => name,
+        "description" => description,
+        "parameters" => params,
+        "strict" => true
+      }
+    else
+      name = tool_schema["name"] || tool_schema[:name]
+      description = tool_schema["description"] || tool_schema[:description]
+      raw_params = tool_schema["parameters"] || tool_schema[:parameters]
+      params = normalize_parameters_for_strict(raw_params)
+
+      %{
+        "type" => "function",
+        "name" => name,
+        "description" => description,
+        "parameters" => params,
+        "strict" => true
+      }
+    end
+  end
+
+  defp normalize_parameters_for_strict(nil), do: %{"type" => "object", "properties" => %{}}
+
+  defp normalize_parameters_for_strict(params) when is_map(params) do
+    properties = params[:properties] || params["properties"] || %{}
+
+    all_property_names =
+      properties
+      |> Map.keys()
+      |> Enum.map(&to_string/1)
 
     %{
-      "name" => name,
-      "type" => "function",
-      "function" => function_def
+      "type" => "object",
+      "properties" => stringify_keys(properties),
+      "required" => all_property_names,
+      "additionalProperties" => false
     }
   end
 
-  defp ensure_all_properties_required(function) do
-    params = function[:parameters] || function["parameters"]
-
-    if params do
-      properties = params[:properties] || params["properties"]
-
-      if properties && is_map(properties) do
-        all_property_names = Map.keys(properties)
-
-        updated_params =
-          if is_map_key(params, :properties) do
-            params
-            |> Map.put(:required, all_property_names)
-            |> Map.delete(:additionalProperties)
-          else
-            params
-            |> Map.put("required", Enum.map(all_property_names, &to_string/1))
-            |> Map.delete("additionalProperties")
-          end
-
-        if is_map_key(function, :parameters) do
-          Map.put(function, :parameters, updated_params)
-        else
-          Map.put(function, "parameters", updated_params)
-        end
-      else
-        function
-      end
-    else
-      function
-    end
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} ->
+      key = if is_atom(k), do: Atom.to_string(k), else: k
+      value = if is_map(v), do: stringify_keys(v), else: v
+      {key, value}
+    end)
   end
 
   defp encode_tool_choice(nil), do: nil

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -80,8 +80,10 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
 
       assert [encoded_tool] = body["tools"]
       assert encoded_tool["type"] == "function"
-      assert encoded_tool["function"]["name"] == "get_weather"
-      assert encoded_tool["function"]["description"] == "Get weather"
+      assert encoded_tool["name"] == "get_weather"
+      assert encoded_tool["description"] == "Get weather"
+      assert encoded_tool["strict"] == true
+      assert encoded_tool["parameters"]["properties"]["location"]["type"] == "string"
     end
 
     test "omits tools when empty list" do


### PR DESCRIPTION
## Pull Request

### Description

Fix tool encoding for OpenAI Responses API to use the correct flat structure format. I'm a little less sure that this is exactly the fix you want. it was written by opus. But this library is currently broken for the OpenAI Responses API tool calling because the responses API expects a different format.

The Responses API expects function tools in a flat format:
```json
{
  "type": "function",
  "name": "get_weather",
  "description": "Get weather for a city",
  "parameters": {...},
  "strict": true
}
```

Previously, the code was incorrectly nesting these fields under a `function` key (matching Chat Completions API format):
```json
{
  "type": "function",
  "name": "get_weather",
  "function": {
    "name": "get_weather",
    "description": "...",
    "parameters": {...}
  }
}
```

This caused the API to receive empty parameters and descriptions, resulting in tool calls with empty arguments `{}` because the model couldn't see the parameter definitions.

Verified against [OpenAI's official Responses API documentation](https://platform.openai.com/docs/api-reference/responses).

### Type of Contribution

- [ ] **Core Library** - Changes to core modules or data structures
- [ ] **New Provider** - Adding a new LLM provider
- [x] **Provider Feature** - Adding capabilities to existing provider
- [x] **Bug Fix** - Fixing existing functionality
- [ ] **Documentation** - Docs/guides only

### Checklist

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)
- [x] Documentation updated

### If Provider Changes

- [ ] Fixtures generated (`mix mc "provider:*" --record`)
- [ ] Model compatibility passes (`mix mc "provider:*"`)

### Related Issues

Fixes tool calling for GPT-5.1 and other models using the Responses API.