### PR TITLE
fix: increase default timeout for OpenAI reasoning models

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -93,19 +93,22 @@ config :llm_db,
           name: "GPT-5",
           family: "gpt-5",
           capabilities: %{chat: true, tools: %{enabled: true}},
-          limits: %{context: 200_000, output: 32_768}
+          limits: %{context: 200_000, output: 32_768},
+          extra: %{api: "responses"}
         },
         "gpt-5-mini" => %{
           name: "GPT-5 mini",
           family: "gpt-5",
           capabilities: %{chat: true, tools: %{enabled: true}},
-          limits: %{context: 128_000, output: 16_384}
+          limits: %{context: 128_000, output: 16_384},
+          extra: %{api: "responses"}
         },
         "gpt-5-nano" => %{
           name: "GPT-5 nano",
           family: "gpt-5",
           capabilities: %{chat: true, tools: %{enabled: true}},
-          limits: %{context: 64_000, output: 8192}
+          limits: %{context: 64_000, output: 8192},
+          extra: %{api: "responses"}
         },
         "text-embedding-3-small" => %{
           name: "Text Embedding 3 Small",


### PR DESCRIPTION
## Summary

Fixes #242 - `%Req.TransportError{reason: :closed}` constantly happening with GPT-5.1 and structured objects.

## Problem

When using `ReqLLM.generate_object/4` with GPT-5.1 and large inputs (~40k tokens), the connection was timing out with `TransportError{reason: :closed}`. The default 30 second receive timeout was too short for reasoning models which:

1. Use the Responses API (`/v1/responses`)
2. Perform extended reasoning before generating output  
3. Take longer to process large contexts

## Solution

For OpenAI reasoning models (those using the Responses API), the provider now uses the `thinking_timeout` config value (300 seconds default) instead of the standard `receive_timeout`. This matches how Anthropic handles extended thinking models.

## Changes

- **lib/req_llm/providers/openai.ex**: Added `get_timeout_for_model/2` to select appropriate timeout based on API type. Also sets `pool_timeout` and `connect_options` for consistent timeout handling.
- **config/test.exs**: Added `extra: %{api: "responses"}` to GPT-5 model variants so tests correctly detect them as reasoning models.
- **test/providers/openai_test.exs**: Added tests to verify reasoning models get longer timeouts and user-specified timeouts are respected.

## Testing

```bash
mix test test/providers/openai_test.exs  # 46 tests, 0 failures
mix quality                               # All checks pass
```