### PR TITLE
feat: add load_dotenv config option to control .env file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ ReqLLM.generate_text("anthropic:claude-haiku-4-5", "Hello", api_key: "sk-ant-...
 {:ok, response} = ReqLLM.stream_text("anthropic:claude-haiku-4-5", "Story", api_key: "sk-ant-...")
 ```
 
+By default, ReqLLM loads `.env` files from the current working directory at startup. To disable this behavior (e.g., if you manage environment variables yourself):
+
+```elixir
+config :req_llm, load_dotenv: false
+```
+
 ## Usage Cost Tracking
 
 Every response includes detailed usage and cost information calculated from model metadata:

--- a/lib/req_llm/application.ex
+++ b/lib/req_llm/application.ex
@@ -5,13 +5,24 @@ defmodule ReqLLM.Application do
   Starts and supervises the Finch instance used for streaming LLM APIs.
   Provides optimized connection pools per provider with sensible defaults
   that can be overridden via application configuration.
+
+  ## Configuration
+
+  - `:load_dotenv` - Whether to automatically load `.env` files from the current
+    working directory at startup. Defaults to `true`. Set to `false` if you prefer
+    to manage environment variables yourself or use a different `.env` loading strategy.
+
+        config :req_llm, load_dotenv: false
   """
 
   use Application
 
   @impl true
   def start(_type, _args) do
-    load_dotenv()
+    if Application.get_env(:req_llm, :load_dotenv, true) do
+      load_dotenv()
+    end
+
     initialize_registry()
     initialize_schema_cache()
 

--- a/test/req_llm/application_test.exs
+++ b/test/req_llm/application_test.exs
@@ -1,0 +1,44 @@
+defmodule ReqLLM.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  describe "load_dotenv configuration" do
+    test "get_finch_config/0 returns default configuration" do
+      config = ReqLLM.Application.get_finch_config()
+
+      assert Keyword.get(config, :name) == ReqLLM.Finch
+      assert is_map(Keyword.get(config, :pools))
+    end
+
+    test "finch_name/0 returns default name" do
+      assert ReqLLM.Application.finch_name() == ReqLLM.Finch
+    end
+
+    test "load_dotenv defaults to true" do
+      original = Application.get_env(:req_llm, :load_dotenv)
+
+      try do
+        Application.delete_env(:req_llm, :load_dotenv)
+        assert Application.get_env(:req_llm, :load_dotenv, true) == true
+      after
+        if original do
+          Application.put_env(:req_llm, :load_dotenv, original)
+        end
+      end
+    end
+
+    test "load_dotenv can be set to false" do
+      original = Application.get_env(:req_llm, :load_dotenv)
+
+      try do
+        Application.put_env(:req_llm, :load_dotenv, false)
+        assert Application.get_env(:req_llm, :load_dotenv, true) == false
+      after
+        if original do
+          Application.put_env(:req_llm, :load_dotenv, original)
+        else
+          Application.delete_env(:req_llm, :load_dotenv)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `:load_dotenv` configuration option that allows users to disable automatic `.env` file loading at application startup. Defaults to `true` to maintain backward compatibility.

## Motivation

Addresses #239 where a user reported that ReqLLM's automatic `.env` loading was unexpected behavior for a library. While the existing implementation does NOT overwrite already-set environment variables (there's a guard for that), the concern that a library auto-loads `.env` files is valid.

This change allows users who prefer to manage environment variables themselves to disable this behavior:

```elixir
config :req_llm, load_dotenv: false
```

## Changes

- Add `:load_dotenv` config option in `Application.start/2` (defaults to `true`)
- Add documentation in `Application` moduledoc
- Add note in README API Key Management section
- Add tests for the configuration option

## Testing

- All existing tests pass
- New tests added for the configuration option
- Quality checks pass (`mix quality`)

Closes #239