### PR TITLE
accept map on generate object

### DIFF
--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -230,7 +230,7 @@ defmodule ReqLLM.Generation do
   @spec generate_object(
           String.t() | {atom(), keyword()} | struct(),
           String.t() | list(),
-          keyword() | Zoi.Type.t(),
+          keyword() | map() | Zoi.Type.t(),
           keyword()
         ) :: {:ok, Response.t()} | {:error, term()}
   def generate_object(model_spec, messages, object_schema, opts \\ []) do
@@ -285,7 +285,7 @@ defmodule ReqLLM.Generation do
   @spec generate_object!(
           String.t() | {atom(), keyword()} | struct(),
           String.t() | list(),
-          keyword() | Zoi.Type.t(),
+          keyword() | map() | Zoi.Type.t(),
           keyword()
         ) :: map() | no_return()
   def generate_object!(model_spec, messages, object_schema, opts \\ []) do


### PR DESCRIPTION
## Description

Fix incorrect `@spec` for `generate_object/4` and `generate_object!/4` in `ReqLLM.Generation`. The spec was missing `map()` as a valid type for the `object_schema` parameter, even though the implementation fully supports raw JSON Schema maps.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

N/A - This is a non-breaking fix that corrects the typespec to match existing behavior.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #

---

**Details:**

The `@spec` specified `keyword() | Zoi.Type.t()` but `Schema.compile/1` accepts `keyword() | map() | struct()`, and the documentation explicitly shows passing raw JSON Schema maps:

```elixir
array_schema = %{"type" => "array", "items" => person_schema}
ReqLLM.generate_object("openai:gpt-4o", "Generate 3 heroes", array_schema)
