### PR TITLE
feat: Add thinking parameter support for Z.ai providers

### DIFF
--- a/lib/req_llm/providers/zai.ex
+++ b/lib/req_llm/providers/zai.ex
@@ -23,6 +23,20 @@ defmodule ReqLLM.Providers.Zai do
 
       # Add to .env file (automatically loaded)
       ZAI_API_KEY=your-api-key
+
+  ## Provider Options
+
+  The following options can be passed via `provider_options`:
+
+  - `:thinking` - Map to control the thinking/reasoning mode. Set to
+    `%{type: "disabled"}` to disable thinking mode for faster responses,
+    or `%{type: "enabled"}` to enable extended reasoning.
+
+  Example:
+
+      ReqLLM.generate_text("zai:glm-4.5-flash", context,
+        provider_options: [thinking: %{type: "disabled"}]
+      )
   """
 
   use ReqLLM.Provider,
@@ -292,8 +306,15 @@ defmodule ReqLLM.Providers.Zai do
     provider_opts = request.options[:provider_options] || []
     response_format = request.options[:response_format] || provider_opts[:response_format]
 
-    case response_format do
-      format when is_map(format) -> Map.put(body, :response_format, format)
+    body =
+      case response_format do
+        format when is_map(format) -> Map.put(body, :response_format, format)
+        _ -> body
+      end
+
+    # Add thinking parameter if provided (for models that support it)
+    case provider_opts[:thinking] do
+      thinking when is_map(thinking) -> Map.put(body, :thinking, thinking)
       _ -> body
     end
   end

--- a/lib/req_llm/providers/zai_coder.ex
+++ b/lib/req_llm/providers/zai_coder.ex
@@ -23,6 +23,20 @@ defmodule ReqLLM.Providers.ZaiCoder do
 
       # Add to .env file (automatically loaded)
       ZAI_API_KEY=your-api-key
+
+  ## Provider Options
+
+  The following options can be passed via `provider_options`:
+
+  - `:thinking` - Map to control the thinking/reasoning mode. Set to
+    `%{type: "disabled"}` to disable thinking mode for faster responses,
+    or `%{type: "enabled"}` to enable extended reasoning.
+
+  Example:
+
+      ReqLLM.generate_text("zai_coder:glm-4.5-flash", context,
+        provider_options: [thinking: %{type: "disabled"}]
+      )
   """
 
   use ReqLLM.Provider,
@@ -293,8 +307,15 @@ defmodule ReqLLM.Providers.ZaiCoder do
     provider_opts = request.options[:provider_options] || []
     response_format = request.options[:response_format] || provider_opts[:response_format]
 
-    case response_format do
-      format when is_map(format) -> Map.put(body, :response_format, format)
+    body =
+      case response_format do
+        format when is_map(format) -> Map.put(body, :response_format, format)
+        _ -> body
+      end
+
+    # Add thinking parameter if provided (for models that support it)
+    case provider_opts[:thinking] do
+      thinking when is_map(thinking) -> Map.put(body, :thinking, thinking)
       _ -> body
     end
   end


### PR DESCRIPTION
## Summary

- Add support for the `thinking` parameter in both `zai` and `zai_coder` providers
- Users can control the thinking/reasoning mode via `provider_options`
- Setting `type: "disabled"` provides faster responses by skipping the reasoning phase
- Setting `type: "enabled"` enables extended reasoning for more complex tasks

## Usage

```elixir
ReqLLM.generate_text("zai:glm-4.5-flash", context,
  provider_options: [thinking: %{type: "disabled"}]
)
```

## Changes

- Updated `zai.ex` to pass the `thinking` parameter from `provider_options` to the API request body
- Updated `zai_coder.ex` with the same change
- Added documentation for the new provider option in both module docs

## References

- [Z.ai API Documentation on thinking parameter](https://bigmodel.cn/dev/api/normal-model/glm-4)