### PR TITLE
fix(Claude): Correct cache token extraction and cost calculation

### DIFF
--- a/lib/req_llm/cost.ex
+++ b/lib/req_llm/cost.ex
@@ -1,0 +1,125 @@
+defmodule ReqLLM.Cost do
+  @moduledoc """
+  Shared cost calculation logic for token usage.
+
+  This module provides consistent cost calculation across streaming and
+  non-streaming responses, with support for cache read/write pricing.
+  """
+
+  @doc """
+  Calculates cost breakdown from normalized usage data and model cost rates.
+
+  ## Parameters
+
+  - `usage` - Map with `:input`, `:output`, `:cached_input`, and `:cache_creation` keys
+  - `cost_map` - Map with cost rates (`:input`, `:output`, `:cache_read`, `:cache_write`)
+
+  ## Returns
+
+  - `{:ok, breakdown}` with `:input_cost`, `:output_cost`, `:total_cost` keys
+  - `{:ok, nil}` if cost cannot be calculated
+
+  ## Examples
+
+      iex> usage = %{input: 1000, output: 500, cached_input: 200, cache_creation: 100}
+      iex> cost_map = %{input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75}
+      iex> ReqLLM.Cost.calculate(usage, cost_map)
+      {:ok, %{input_cost: ..., output_cost: ..., total_cost: ...}}
+  """
+  @spec calculate(map(), map() | nil) ::
+          {:ok, %{input_cost: float(), output_cost: float(), total_cost: float()} | nil}
+  def calculate(_usage, nil), do: {:ok, nil}
+
+  def calculate(%{input: input_tokens, output: output_tokens} = usage, cost_map)
+      when is_map(cost_map) do
+    input_rate = cost_map[:input] || cost_map["input"]
+    output_rate = cost_map[:output] || cost_map["output"]
+
+    # Cache read rate (tokens read from cache - typically cheaper)
+    cache_read_rate =
+      cost_map[:cached_input] || cost_map["cached_input"] ||
+        cost_map[:cache_read] || cost_map["cache_read"] ||
+        input_rate
+
+    # Cache write rate (tokens written to cache - typically 1.25x input rate)
+    cache_write_rate =
+      cost_map[:cache_write] || cost_map["cache_write"] ||
+        input_rate
+
+    with {:ok, input_num} <- safe_to_number(input_tokens),
+         {:ok, output_num} <- safe_to_number(output_tokens),
+         true <- input_rate != nil and output_rate != nil do
+      # Extract cache tokens
+      cache_read_tokens = clamp_tokens(Map.get(usage, :cached_input, 0), input_num)
+      cache_write_tokens = clamp_tokens(Map.get(usage, :cache_creation, 0), input_num)
+
+      # Regular input tokens (not from cache read, not written to cache)
+      regular_tokens = max(input_num - cache_read_tokens - cache_write_tokens, 0)
+
+      # Calculate costs (rates are per million tokens)
+      input_cost =
+        Float.round(
+          regular_tokens / 1_000_000 * input_rate +
+            cache_read_tokens / 1_000_000 * cache_read_rate +
+            cache_write_tokens / 1_000_000 * cache_write_rate,
+          6
+        )
+
+      output_cost = Float.round(output_num / 1_000_000 * output_rate, 6)
+      total_cost = Float.round(input_cost + output_cost, 6)
+
+      {:ok,
+       %{
+         input_cost: input_cost,
+         output_cost: output_cost,
+         total_cost: total_cost
+       }}
+    else
+      _ -> {:ok, nil}
+    end
+  end
+
+  def calculate(_usage, _cost_map), do: {:ok, nil}
+
+  @doc """
+  Adds cost breakdown fields to a usage map if model cost data is available.
+
+  This is a convenience function for streaming that mutates the usage map directly.
+  """
+  @spec add_cost_to_usage(map(), map() | nil) :: map()
+  def add_cost_to_usage(usage, nil), do: usage
+
+  def add_cost_to_usage(usage, cost_map) when is_map(cost_map) do
+    case calculate(usage, cost_map) do
+      {:ok, %{input_cost: input_cost, output_cost: output_cost, total_cost: total_cost}} ->
+        usage
+        |> Map.put(:input_cost, input_cost)
+        |> Map.put(:output_cost, output_cost)
+        |> Map.put(:total_cost, total_cost)
+
+      {:ok, nil} ->
+        usage
+    end
+  end
+
+  def add_cost_to_usage(usage, _), do: usage
+
+  # Safely clamps a value to a valid token count within bounds.
+  @spec clamp_tokens(any(), number()) :: integer()
+  defp clamp_tokens(value, max_allowed) do
+    case safe_to_number(value) do
+      {:ok, num} ->
+        num
+        |> max(0)
+        |> min(max(max_allowed, 0))
+
+      _ ->
+        0
+    end
+  end
+
+  @spec safe_to_number(any()) :: {:ok, number()} | :error
+  defp safe_to_number(value) when is_integer(value), do: {:ok, value}
+  defp safe_to_number(value) when is_float(value), do: {:ok, trunc(value)}
+  defp safe_to_number(_), do: :error
+end

--- a/test/req_llm/cost_test.exs
+++ b/test/req_llm/cost_test.exs
@@ -1,0 +1,145 @@
+defmodule ReqLLM.CostTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Cost
+
+  describe "calculate/2" do
+    test "returns nil for nil cost_map" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 0}
+      assert {:ok, nil} = Cost.calculate(usage, nil)
+    end
+
+    test "calculates basic cost without caching" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 0}
+      cost_map = %{input: 3.0, output: 15.0}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      # 1000 input at $3/M = $0.003, 500 output at $15/M = $0.0075
+      assert breakdown.input_cost == 0.003
+      assert breakdown.output_cost == 0.0075
+      assert breakdown.total_cost == Float.round(0.003 + 0.0075, 6)
+    end
+
+    test "applies cache_read pricing for cached tokens" do
+      usage = %{input: 1000, output: 500, cached_input: 800, cache_creation: 0}
+      cost_map = %{input: 3.0, output: 15.0, cache_read: 0.3}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      # 200 uncached at $3/M = $0.0006, 800 cached at $0.3/M = $0.00024
+      expected_input = Float.round((200 * 3.0 + 800 * 0.3) / 1_000_000, 6)
+      expected_output = Float.round(500 * 15.0 / 1_000_000, 6)
+
+      assert breakdown.input_cost == expected_input
+      assert breakdown.output_cost == expected_output
+    end
+
+    test "applies cache_write pricing for creation tokens" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 300}
+      cost_map = %{input: 3.0, output: 15.0, cache_write: 3.75}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      # 700 regular at $3/M, 300 cache_write at $3.75/M
+      expected_input = Float.round((700 * 3.0 + 300 * 3.75) / 1_000_000, 6)
+      expected_output = Float.round(500 * 15.0 / 1_000_000, 6)
+
+      assert breakdown.input_cost == expected_input
+      assert breakdown.output_cost == expected_output
+    end
+
+    test "handles mixed cache read and write tokens" do
+      usage = %{input: 1000, output: 200, cached_input: 600, cache_creation: 200}
+      cost_map = %{input: 3.0, output: 15.0, cache_read: 0.3, cache_write: 3.75}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      # 200 regular at $3/M, 600 cache_read at $0.3/M, 200 cache_write at $3.75/M
+      expected_input = Float.round((200 * 3.0 + 600 * 0.3 + 200 * 3.75) / 1_000_000, 6)
+      expected_output = Float.round(200 * 15.0 / 1_000_000, 6)
+
+      assert breakdown.input_cost == expected_input
+      assert breakdown.output_cost == expected_output
+    end
+
+    test "falls back to input rate when cache rates not specified" do
+      usage = %{input: 1000, output: 500, cached_input: 400, cache_creation: 200}
+      cost_map = %{input: 3.0, output: 15.0}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      # All tokens at input rate since no cache rates specified
+      expected_input = Float.round(1000 * 3.0 / 1_000_000, 6)
+      expected_output = Float.round(500 * 15.0 / 1_000_000, 6)
+
+      assert breakdown.input_cost == expected_input
+      assert breakdown.output_cost == expected_output
+    end
+
+    test "clamps cached tokens to not exceed input tokens" do
+      usage = %{input: 500, output: 200, cached_input: 800, cache_creation: 0}
+      cost_map = %{input: 3.0, output: 15.0, cache_read: 0.3}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      # cached_input clamped to 500 (all at cache rate, 0 regular)
+      expected_input = Float.round(500 * 0.3 / 1_000_000, 6)
+
+      assert breakdown.input_cost == expected_input
+    end
+
+    test "handles string keys in cost_map" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 0}
+      cost_map = %{"input" => 3.0, "output" => 15.0}
+
+      {:ok, breakdown} = Cost.calculate(usage, cost_map)
+
+      assert breakdown.input_cost == 0.003
+      assert breakdown.output_cost == 0.0075
+    end
+
+    test "returns nil when input_rate is missing" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 0}
+      cost_map = %{output: 15.0}
+
+      assert {:ok, nil} = Cost.calculate(usage, cost_map)
+    end
+
+    test "returns nil when output_rate is missing" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 0}
+      cost_map = %{input: 3.0}
+
+      assert {:ok, nil} = Cost.calculate(usage, cost_map)
+    end
+  end
+
+  describe "add_cost_to_usage/2" do
+    test "adds cost fields to usage map" do
+      usage = %{input: 1000, output: 500, cached_input: 0, cache_creation: 0}
+      cost_map = %{input: 3.0, output: 15.0}
+
+      result = Cost.add_cost_to_usage(usage, cost_map)
+
+      assert result.input_cost == 0.003
+      assert result.output_cost == 0.0075
+      assert result.total_cost == Float.round(0.003 + 0.0075, 6)
+      # Original fields preserved
+      assert result.input == 1000
+      assert result.output == 500
+    end
+
+    test "returns usage unchanged for nil cost_map" do
+      usage = %{input: 1000, output: 500}
+      assert Cost.add_cost_to_usage(usage, nil) == usage
+    end
+
+    test "returns usage unchanged when cost cannot be calculated" do
+      usage = %{input: 1000, output: 500}
+      # missing output rate
+      cost_map = %{input: 3.0}
+
+      assert Cost.add_cost_to_usage(usage, cost_map) == usage
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fix `cache_read_input_tokens` not being recognized (Anthropic/Azure/Vertex format)
- Fix `cacheReadInputTokens` not being recognized (AWS Bedrock format)
- Add extraction of `cache_creation_input_tokens` for cache write costs
- Add `cache_write` pricing support using LLMDB's cache_write rate
- Extract shared cost calculation logic into `ReqLLM.Cost` module
- Fix streaming mode to extract cache creation tokens

## Problem

The cost calculation in `ReqLLM.Step.Usage` had three bugs:

1. **Wrong field names**: `get_cached_input_tokens/1` looked for `cached_input`, `cached_tokens`, etc. but Anthropic returns `cache_read_input_tokens`
2. **Missing cache creation extraction**: `cache_creation_input_tokens` was completely ignored
3. **Missing cache write pricing**: No code used LLMDB's `cache_write` rate for cache creation tokens

| What Anthropic Returns      | What ReqLLM Looked For      | Result             |
|-----------------------------|-----------------------------|--------------------|
| cache_read_input_tokens     | cached_input, cached_tokens | Not found → 0      |
| cache_creation_input_tokens | (nothing)                   | Completely ignored |

## Solution

The cost calculation now correctly handles three token categories:
- Regular input tokens (at `input` rate)
- Cache read tokens (at `cache_read` rate, typically 10% of input)
- Cache write tokens (at `cache_write` rate, typically 125% of input)

Also refactored duplicate cost calculation logic from `usage.ex` and `stream_server.ex` into a shared `ReqLLM.Cost` module.

## Test plan

- [x] Added tests for Anthropic `cache_read_input_tokens` format
- [x] Added tests for AWS Bedrock `cacheReadInputTokens` format
- [x] Added 13 tests for `ReqLLM.Cost` module
- [x] All 1840 existing tests pass