### PR TITLE
feat: extend Context.normalize to handle tool_calls and tool result messages

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -747,6 +747,23 @@ defmodule ReqLLM.Context do
     end
   end
 
+  defp convert_loose_map(%{role: :assistant, tool_calls: tool_calls} = msg)
+       when is_list(tool_calls) do
+    content = Map.get(msg, :content, "") || ""
+    {:ok, assistant(content, tool_calls: tool_calls)}
+  end
+
+  defp convert_loose_map(%{role: :tool, tool_call_id: id, content: content} = msg)
+       when is_binary(id) and is_binary(content) do
+    name = Map.get(msg, :name)
+
+    if name do
+      {:ok, tool_result(id, name, content)}
+    else
+      {:ok, tool_result(id, content)}
+    end
+  end
+
   defp convert_loose_map(%{role: role, content: content})
        when is_atom(role) and is_binary(content) do
     {:ok, text(role, content)}


### PR DESCRIPTION
## Summary

Extends `Context.normalize/2` with `convert_loose: true` to support:

1. **Assistant messages with tool_calls**:
   ```elixir
   %{role: :assistant, content: "", tool_calls: [%{id: "call_123", name: "get_weather", arguments: %{location: "SF"}}]}
   ```

2. **Tool result messages**:
   ```elixir
   %{role: :tool, tool_call_id: "call_123", name: "get_weather", content: "{\"temp\": 72}"}
   ```

## Motivation

This allows consumers (like Jido's ReAct strategy) to use `Context.normalize/2` directly instead of maintaining ~30 lines of custom conversion logic.

## Changes

- Added `convert_loose_map/1` clause for assistant messages with `tool_calls` key
- Added `convert_loose_map/1` clause for tool result messages (`:tool` role with `tool_call_id`)
- Placed new clauses before general role/content clauses for correct pattern matching
- Added 7 comprehensive tests covering various tool message scenarios

## Testing

- All existing tests pass
- Quality checks pass (format, dialyzer, credo)
- New test describe block: `normalize/2 with tool messages`

Closes #312