### PR TITLE
feat: add service_tier to openai provider options

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -61,6 +61,11 @@ Passed via `:provider_options` keyword:
 - **Purpose**: Control reasoning effort (Responses API only)
 - **Example**: `reasoning_effort: :high`
 
+### `service_tier`
+- **Type**: `:auto` | `:default` | `:flex` | `:priority` | String
+- **Purpose**: Service tier for request prioritization
+- **Example**: `service_tier: :auto`
+
 ### `seed`
 - **Type**: Integer
 - **Purpose**: Set seed for reproducible outputs

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -151,6 +151,10 @@ defmodule ReqLLM.Providers.OpenAI do
       type: {:list, :any},
       doc:
         "Tool execution results for Responses API tool resume flow (list of %{call_id, output})"
+    ],
+    service_tier: [
+      type: {:or, [:atom, :string]},
+      doc: "Service tier for request prioritization ('auto', 'default', 'flex' or 'priority')"
     ]
   ]
 
@@ -291,7 +295,8 @@ defmodule ReqLLM.Providers.OpenAI do
             :provider_options,
             :api_mod,
             :max_completion_tokens,
-            :reasoning_effort
+            :reasoning_effort,
+            :service_tier
           ]
 
       timeout = get_timeout_for_model(api_mod, processed_opts)

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -116,6 +116,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
         |> add_token_limits(model_name, opts_map)
         |> add_stream_options(opts_map)
         |> add_reasoning_effort(opts_map)
+        |> add_service_tier(opts_map)
         |> add_response_format(opts_map)
         |> add_parallel_tool_calls(opts_map)
         |> translate_tool_choice_format()
@@ -198,6 +199,12 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
   defp add_reasoning_effort(body, request_options) do
     provider_opts = request_options[:provider_options] || []
     maybe_put(body, :reasoning_effort, provider_opts[:reasoning_effort])
+  end
+
+  defp add_service_tier(body, request_options) do
+    provider_opts = request_options[:provider_options] || []
+    service_tier = request_options[:service_tier] || provider_opts[:service_tier]
+    maybe_put(body, :service_tier, service_tier)
   end
 
   defp translate_tool_choice_format(body) do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -292,6 +292,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
     tool_choice = encode_tool_choice(opts_map[:tool_choice])
     reasoning = encode_reasoning_effort(opts_map[:reasoning_effort])
+    service_tier = opts_map[:service_tier] || provider_opts[:service_tier]
 
     text_format = encode_text_format(provider_opts[:response_format])
 
@@ -304,6 +305,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("reasoning", reasoning)
       |> maybe_put_string("tools", tools)
       |> maybe_put_string("tool_choice", tool_choice)
+      |> maybe_put_string("service_tier", service_tier)
       |> maybe_put_string("text", text_format)
 
     if previous_response_id do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -464,6 +464,42 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert decoded["input"] == "Hello, world!"
       assert decoded["dimensions"] == 512
     end
+
+    test "encode_body includes service_tier when provided" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          service_tier: "auto"
+        ]
+      }
+
+      updated_request = OpenAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["service_tier"] == "auto"
+    end
+
+    test "encode_body includes service_tier when provided as flex" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          service_tier: "flex"
+        ]
+      }
+
+      updated_request = OpenAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["service_tier"] == "flex"
+    end
   end
 
   describe "response decoding" do


### PR DESCRIPTION
## Description

Adds service_tier support for OpenAI provider

## Type of Change

 - [x] New feature (non-breaking change adding functionality)


## Testing

-  [x] Tests pass (`mix test`)
-  [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
