### PR TITLE
fix: Add api_key to internal keys

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -343,6 +343,7 @@ defmodule ReqLLM.Provider.Defaults do
   @spec filter_req_opts(keyword()) :: keyword()
   def filter_req_opts(opts) do
     internal_keys = [
+      :api_key,
       :on_unsupported,
       :context,
       :text,


### PR DESCRIPTION
## Description

This can be safely dropped, it bonks the Google API Client

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #275
