### PR TITLE
feat(openrouter): add support for native JSON schema structured output

### DIFF
--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -347,10 +347,6 @@ defmodule ReqLLM.Providers.OpenRouterTest do
 
       {:ok, request} = OpenRouter.prepare_request(:object, model, context, opts)
 
-      # Verify no tools
-      refute Map.has_key?(request.options, :tools)
-
-      # Verify response_format has json_schema
       assert %{
                type: "json_schema",
                json_schema: %{
@@ -359,6 +355,42 @@ defmodule ReqLLM.Providers.OpenRouterTest do
                  schema: _
                }
              } = request.options[:response_format]
+
+      refute Map.has_key?(request.options, :tools)
+      refute Map.has_key?(request.options, :tool_choice)
+      assert request.options[:max_tokens] == 4096
+    end
+
+    test "prepare_request for :object with json_schema mode respects custom max_tokens" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      context = context_fixture()
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string])
+
+      opts = [
+        compiled_schema: schema,
+        max_tokens: 8192,
+        provider_options: [openrouter_structured_output_mode: :json_schema]
+      ]
+
+      {:ok, request} = OpenRouter.prepare_request(:object, model, context, opts)
+
+      assert request.options[:max_tokens] == 8192
+    end
+
+    test "prepare_request for :object with json_schema mode enforces minimum max_tokens" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      context = context_fixture()
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string])
+
+      opts = [
+        compiled_schema: schema,
+        max_tokens: 50,
+        provider_options: [openrouter_structured_output_mode: :json_schema]
+      ]
+
+      {:ok, request} = OpenRouter.prepare_request(:object, model, context, opts)
+
+      assert request.options[:max_tokens] == 200
     end
 
     test "prepare_request for :object falls back to tools when mode is not :json_schema" do
@@ -370,13 +402,15 @@ defmodule ReqLLM.Providers.OpenRouterTest do
 
       {:ok, request} = OpenRouter.prepare_request(:object, model, context, opts)
 
-      # Verify tools are used
       assert Map.has_key?(request.options, :tools)
 
       assert request.options[:tool_choice] == %{
                type: "function",
                function: %{name: "structured_output"}
              }
+
+      refute Map.has_key?(request.options, :response_format)
+      assert request.options[:max_tokens] == 4096
     end
 
     test "decode_response handles streaming responses" do


### PR DESCRIPTION
## Description

Implements openrouter_structured_output_mode provider option which is useful if tools are not supported by the endpoint.


## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Breaking Changes

None

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
