### PR TITLE
docs: add attachment support documentation and validation

### DIFF
--- a/guides/attachments.md
+++ b/guides/attachments.md
@@ -1,0 +1,146 @@
+# Attachments & Multi-Modal Content
+
+ReqLLM supports multi-modal content including images, PDFs, audio, and other file types. However, provider support varies significantly.
+
+## Attachment Support by Provider
+
+| Provider   | Images | PDFs | Audio | Video | Notes |
+|------------|--------|------|-------|-------|-------|
+| Anthropic  | ✅     | ✅   | ❌    | ❌    | Native PDF support via Documents API |
+| Google     | ✅     | ✅   | ✅    | ✅    | Extensive multi-modal via Gemini |
+| OpenAI     | ✅     | ❌   | ❌    | ❌    | Chat Completions API: images only |
+| OpenRouter | ✅     | ✅*  | ✅*   | ✅*   | Depends on underlying model |
+| xAI        | ✅     | ❌   | ❌    | ❌    | OpenAI-compatible: images only |
+| Groq       | ✅     | ❌   | ❌    | ❌    | OpenAI-compatible: images only |
+| Azure      | ✅     | ❌   | ❌    | ❌    | OpenAI-compatible: images only |
+
+\* OpenRouter support depends on the underlying model being called.
+
+## Using Attachments
+
+### Images
+
+All providers support image attachments:
+
+```elixir
+alias ReqLLM.Message.ContentPart
+
+# From URL
+context = ReqLLM.Context.new([
+  ReqLLM.Context.user([
+    ContentPart.text("What's in this image?"),
+    ContentPart.image_url("https://example.com/image.jpg")
+  ])
+])
+
+# From binary data
+image_data = File.read!("photo.png")
+context = ReqLLM.Context.new([
+  ReqLLM.Context.user([
+    ContentPart.text("Describe this image"),
+    ContentPart.image(image_data, "image/png")
+  ])
+])
+
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-haiku-4-5", context)
+```
+
+### PDFs (Anthropic, Google, OpenRouter)
+
+```elixir
+pdf_data = File.read!("document.pdf")
+
+context = ReqLLM.Context.new([
+  ReqLLM.Context.user([
+    ContentPart.text("Summarize this document"),
+    ContentPart.file(pdf_data, "document.pdf", "application/pdf")
+  ])
+])
+
+# Works with Anthropic
+{:ok, response} = ReqLLM.generate_text("anthropic:claude-sonnet-4", context)
+
+# Works with Google
+{:ok, response} = ReqLLM.generate_text("google:gemini-2.0-flash", context)
+
+# Works with OpenRouter (model-dependent)
+{:ok, response} = ReqLLM.generate_text("openrouter:anthropic/claude-3.5-sonnet", context)
+```
+
+### Audio (Google)
+
+```elixir
+audio_data = File.read!("recording.mp3")
+
+context = ReqLLM.Context.new([
+  ReqLLM.Context.user([
+    ContentPart.text("Transcribe this audio"),
+    ContentPart.file(audio_data, "recording.mp3", "audio/mpeg")
+  ])
+])
+
+{:ok, response} = ReqLLM.generate_text("google:gemini-2.0-flash", context)
+```
+
+## Error Handling
+
+When using unsupported attachment types, ReqLLM returns a clear error:
+
+```elixir
+pdf_data = File.read!("document.pdf")
+
+context = ReqLLM.Context.new([
+  ReqLLM.Context.user([
+    ContentPart.text("Summarize this"),
+    ContentPart.file(pdf_data, "doc.pdf", "application/pdf")
+  ])
+])
+
+# Returns error for OpenAI
+{:error, %ReqLLM.Error.Invalid.Capability{}} = 
+  ReqLLM.generate_text("openai:gpt-4o", context)
+
+# Error message explains the limitation and suggests alternatives
+```
+
+## Provider-Specific Notes
+
+### Anthropic
+
+Anthropic supports PDFs natively through their Documents API:
+- Maximum 100 pages per document
+- Maximum 32MB per document
+- Supports PDF text extraction and image analysis
+
+### Google (Gemini)
+
+Google Gemini has the most extensive multi-modal support:
+- Images: JPEG, PNG, GIF, WebP
+- Audio: MP3, WAV, FLAC, OGG
+- Video: MP4, MOV, WebM
+- Documents: PDF, plain text
+
+### OpenAI
+
+OpenAI Chat Completions API only supports images:
+- JPEG, PNG, GIF, WebP
+- Maximum 20MB per image
+- For document processing, consider using GPT-4o with extracted text
+
+### OpenRouter
+
+OpenRouter proxies to various providers, so attachment support depends on the underlying model:
+- Anthropic models: Full Anthropic attachment support
+- OpenAI models: Images only
+- Google models: Full Google attachment support
+
+## Choosing the Right Provider
+
+For document-heavy workloads:
+1. **Anthropic** - Best for PDF analysis with Claude models
+2. **Google** - Best for mixed media (images, audio, video, documents)
+3. **OpenRouter** - Good for flexibility, routing to the best model for the task
+
+For image-only workloads:
+- Any provider works well
+- Consider cost and latency for your use case

--- a/guides/core-concepts.md
+++ b/guides/core-concepts.md
@@ -75,10 +75,11 @@ Define tools once; invoke across providers with a unified call/result shape.
 
 Example:
 ```elixir
-tool = ReqLLM.Tool.new(
+{:ok, tool} = ReqLLM.Tool.new(
   name: "get_weather",
   description: "Gets weather by city",
-  schema: [city: [type: :string, required: true]]
+  parameter_schema: [city: [type: :string, required: true]],
+  callback: fn %{city: city} -> {:ok, "Weather in #{city}: sunny"} end
 )
 
 {:ok, response} =

--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -169,18 +169,20 @@ Defines callable functions (aka "tools" or "function calling") with validation.
 **Typical fields**:
 - `name`: string
 - `description`: string
-- `schema`: `NimbleOptions`-based schema for argument validation
+- `parameter_schema`: `NimbleOptions`-based schema for argument validation
+- `callback`: function or MFA tuple to execute the tool
 
 **Example**:
 ```elixir
-tool = ReqLLM.Tool.new(
+{:ok, tool} = ReqLLM.Tool.new(
   name: "get_weather",
   description: "Gets weather by city",
-  schema: [city: [type: :string, required: true]]
+  parameter_schema: [city: [type: :string, required: true]],
+  callback: fn %{city: city} -> {:ok, "Weather in #{city}: sunny"} end
 )
 
 # Execute locally (e.g., after a model issues a tool_call)
-{:ok, result} = ReqLLM.Tool.execute(tool, %{city: "NYC"})
+{:ok, result} = ReqLLM.Tool.execute(tool, %{"city" => "NYC"})
 ```
 
 **How this supports normalization**:
@@ -324,10 +326,11 @@ alias ReqLLM.Message.ContentPart
 
 {:ok, model} = ReqLLM.Model.from("anthropic:claude-haiku-4-5")
 
-tool = ReqLLM.Tool.new(
+{:ok, tool} = ReqLLM.Tool.new(
   name: "get_weather",
   description: "Gets weather by city",
-  schema: [city: [type: :string, required: true]]
+  parameter_schema: [city: [type: :string, required: true]],
+  callback: fn %{city: city} -> {:ok, "Weather in #{city}: sunny"} end
 )
 
 context = ReqLLM.Context.new([

--- a/guides/openai.md
+++ b/guides/openai.md
@@ -154,6 +154,21 @@ response.usage.cost
 
 See the [Image Generation Guide](image-generation.md) for more details.
 
+## Attachment Limitations
+
+OpenAI Chat Completions API only supports **image attachments**. Attempting to use PDFs, audio, or other file types will return an error with guidance on alternative providers.
+
+Supported image formats:
+- JPEG, PNG, GIF, WebP
+- Maximum 20MB per image
+
+For document processing (PDFs, etc.), use:
+- **Anthropic** - Native PDF support
+- **Google** - Supports PDF, audio, video
+- **OpenRouter** - Route to Anthropic/Google models
+
+See the [Attachments Guide](attachments.md) for details.
+
 ## Resources
 
 - [OpenAI API Documentation](https://platform.openai.com/docs/api-reference)

--- a/guides/xai.md
+++ b/guides/xai.md
@@ -122,6 +122,20 @@ response.usage.cost
 
 xAI may report usage in different units (`"call"` or `"source"`) depending on the response format.
 
+## Attachment Limitations
+
+xAI uses an OpenAI-compatible API and only supports **image attachments**. Attempting to use PDFs, audio, or other file types will return an error with guidance on alternative providers.
+
+Supported image formats:
+- JPEG, PNG, GIF, WebP
+
+For document processing (PDFs, etc.), use:
+- **Anthropic** - Native PDF support
+- **Google** - Supports PDF, audio, video
+- **OpenRouter** - Route to Anthropic/Google models
+
+See the [Attachments Guide](attachments.md) for details.
+
 ## Resources
 
 - [xAI API Documentation](https://docs.x.ai/)

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -710,18 +710,44 @@ defmodule ReqLLM.Provider.Defaults do
          media_type: media_type
        })
        when is_binary(data) do
-    # Encode file as image_url data URI (OpenAI format supports various media types this way)
-    base64 = Base.encode64(data)
+    if image_mime_type?(media_type) do
+      base64 = Base.encode64(data)
 
-    %{
-      type: "image_url",
-      image_url: %{
-        url: "data:#{media_type};base64,#{base64}"
+      %{
+        type: "image_url",
+        image_url: %{
+          url: "data:#{media_type};base64,#{base64}"
+        }
       }
-    }
+    else
+      raise ReqLLM.Error.Invalid.Capability.exception(
+              message:
+                "OpenAI Chat Completions API only supports image attachments (got: #{media_type}). " <>
+                  "For PDF, audio, and other file types, use Anthropic, Google, or OpenRouter with compatible models."
+            )
+    end
   end
 
   defp encode_openai_content_part(_), do: nil
+
+  @image_mime_types [
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/gif",
+    "image/webp"
+  ]
+
+  @doc """
+  Checks if a MIME type is a supported image type for OpenAI Chat Completions API.
+  """
+  @spec image_mime_type?(String.t()) :: boolean()
+  def image_mime_type?(media_type) when is_binary(media_type) do
+    normalized = String.downcase(media_type)
+    normalized in @image_mime_types or String.starts_with?(normalized, "image/")
+  end
+
+  def image_mime_type?(_), do: false
 
   @passthrough_metadata_keys [:cache_control, "cache_control"]
 

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -264,7 +264,14 @@ defmodule ReqLLM.Provider.Options do
       if provider_options == [] do
         translated_opts
       else
-        Keyword.put(translated_opts, :provider_options, provider_options)
+        translated_provider_opts =
+          Keyword.take(translated_opts, Keyword.keys(provider_options))
+
+        if translated_provider_opts == [] do
+          translated_opts
+        else
+          Keyword.put(translated_opts, :provider_options, translated_provider_opts)
+        end
       end
 
     final_opts = handle_warnings(final_opts, opts)

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -1151,4 +1151,120 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert Enum.any?(body["tools"], fn tool -> tool["type"] == "web_search" end)
     end
   end
+
+  describe "attachment MIME type validation" do
+    alias ReqLLM.Message.ContentPart
+
+    test "encode_body succeeds with image attachments" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("What's in this image?"),
+            ContentPart.file("fake image data", "photo.jpg", "image/jpeg")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = OpenAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [user_msg] = decoded["messages"]
+      assert is_list(user_msg["content"])
+      assert Enum.any?(user_msg["content"], fn part -> part["type"] == "image_url" end)
+    end
+
+    test "encode_body raises error for PDF attachments" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Summarize this document"),
+            ContentPart.file("fake pdf data", "document.pdf", "application/pdf")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      error =
+        assert_raise ReqLLM.Error.Invalid.Capability, fn ->
+          OpenAI.encode_body(mock_request)
+        end
+
+      assert error.message =~ "OpenAI Chat Completions API only supports image attachments"
+      assert error.message =~ "application/pdf"
+      assert error.message =~ "Anthropic"
+      assert error.message =~ "Google"
+    end
+
+    test "encode_body raises error for audio attachments" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Transcribe this audio"),
+            ContentPart.file("fake audio data", "recording.mp3", "audio/mpeg")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      error =
+        assert_raise ReqLLM.Error.Invalid.Capability, fn ->
+          OpenAI.encode_body(mock_request)
+        end
+
+      assert error.message =~ "only supports image attachments"
+      assert error.message =~ "audio/mpeg"
+    end
+
+    test "encode_body raises error for text file attachments" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Read this file"),
+            ContentPart.file("file contents", "data.txt", "text/plain")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      error =
+        assert_raise ReqLLM.Error.Invalid.Capability, fn ->
+          OpenAI.encode_body(mock_request)
+        end
+
+      assert error.message =~ "text/plain"
+    end
+  end
 end

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -684,4 +684,63 @@ defmodule ReqLLM.Providers.XAITest do
                    end
     end
   end
+
+  describe "attachment MIME type validation" do
+    alias ReqLLM.Message.ContentPart
+
+    test "encode_body succeeds with image attachments" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("What's in this image?"),
+            ContentPart.file("fake image data", "photo.png", "image/png")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = XAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [user_msg] = decoded["messages"]
+      assert is_list(user_msg["content"])
+      assert Enum.any?(user_msg["content"], fn part -> part["type"] == "image_url" end)
+    end
+
+    test "encode_body raises error for PDF attachments" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Summarize this document"),
+            ContentPart.file("fake pdf data", "document.pdf", "application/pdf")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      error =
+        assert_raise ReqLLM.Error.Invalid.Capability, fn ->
+          XAI.encode_body(mock_request)
+        end
+
+      assert error.message =~ "only supports image attachments"
+      assert error.message =~ "application/pdf"
+    end
+  end
 end

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -742,4 +742,38 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert length(response.message.tool_calls) == 1
     end
   end
+
+  describe "image_mime_type?/1" do
+    test "returns true for standard image MIME types" do
+      assert Defaults.image_mime_type?("image/jpeg") == true
+      assert Defaults.image_mime_type?("image/jpg") == true
+      assert Defaults.image_mime_type?("image/png") == true
+      assert Defaults.image_mime_type?("image/gif") == true
+      assert Defaults.image_mime_type?("image/webp") == true
+    end
+
+    test "returns true for any image/* MIME type" do
+      assert Defaults.image_mime_type?("image/bmp") == true
+      assert Defaults.image_mime_type?("image/tiff") == true
+      assert Defaults.image_mime_type?("image/svg+xml") == true
+    end
+
+    test "is case-insensitive" do
+      assert Defaults.image_mime_type?("IMAGE/JPEG") == true
+      assert Defaults.image_mime_type?("Image/PNG") == true
+    end
+
+    test "returns false for non-image MIME types" do
+      assert Defaults.image_mime_type?("application/pdf") == false
+      assert Defaults.image_mime_type?("audio/mpeg") == false
+      assert Defaults.image_mime_type?("video/mp4") == false
+      assert Defaults.image_mime_type?("text/plain") == false
+      assert Defaults.image_mime_type?("application/octet-stream") == false
+    end
+
+    test "returns false for nil or non-binary input" do
+      assert Defaults.image_mime_type?(nil) == false
+      assert Defaults.image_mime_type?(123) == false
+    end
+  end
 end

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -296,6 +296,115 @@ defmodule ReqLLM.Provider.OptionsTest do
     end
   end
 
+  defmodule ProviderOptionsTranslator do
+    @behaviour ReqLLM.Provider
+
+    def provider_id, do: :translator
+    def default_base_url, do: "https://api.translator.com"
+    def supported_provider_options, do: [:custom_option, :deprecated_option, :removable_option]
+
+    def provider_schema do
+      NimbleOptions.new!(
+        custom_option: [type: :string, doc: "Custom provider option"],
+        deprecated_option: [type: :string, doc: "Will be renamed to new_option"],
+        removable_option: [type: :string, doc: "Will be removed during translation"]
+      )
+    end
+
+    def translate_options(_operation, _model, opts) do
+      opts =
+        case Keyword.pop(opts, :deprecated_option) do
+          {nil, rest} -> rest
+          {value, rest} -> Keyword.put(rest, :new_option, "translated_" <> value)
+        end
+
+      opts =
+        case Keyword.pop(opts, :removable_option) do
+          {nil, rest} -> rest
+          {_value, rest} -> rest
+        end
+
+      opts =
+        case Keyword.get(opts, :custom_option) do
+          nil -> opts
+          value -> Keyword.put(opts, :custom_option, String.upcase(value))
+        end
+
+      {opts, []}
+    end
+
+    def attach(_request, _model, _opts), do: nil
+    def prepare_request(_operation, _model, _input, _opts), do: {:error, :not_implemented}
+    def encode_body(_request), do: nil
+    def decode_response(_response), do: nil
+  end
+
+  describe "Options.process/4 - translate_options preserves provider_options changes" do
+    test "translate_options can modify provider_options values" do
+      model = %LLMDB.Model{provider: :translator, id: "test-model"}
+
+      opts = [
+        temperature: 0.7,
+        provider_options: [custom_option: "lowercase"]
+      ]
+
+      assert {:ok, processed} = Options.process(ProviderOptionsTranslator, :chat, model, opts)
+      assert processed[:temperature] == 0.7
+      assert processed[:provider_options][:custom_option] == "LOWERCASE"
+    end
+
+    test "translate_options can remove provider_options keys" do
+      model = %LLMDB.Model{provider: :translator, id: "test-model"}
+
+      opts = [
+        temperature: 0.7,
+        provider_options: [removable_option: "will be removed", custom_option: "keep"]
+      ]
+
+      assert {:ok, processed} = Options.process(ProviderOptionsTranslator, :chat, model, opts)
+      assert processed[:temperature] == 0.7
+      refute Keyword.has_key?(processed[:provider_options], :removable_option)
+      assert processed[:provider_options][:custom_option] == "KEEP"
+    end
+
+    test "translate_options removes provider_options key when all options removed" do
+      model = %LLMDB.Model{provider: :translator, id: "test-model"}
+
+      opts = [
+        temperature: 0.7,
+        provider_options: [removable_option: "will be removed"]
+      ]
+
+      assert {:ok, processed} = Options.process(ProviderOptionsTranslator, :chat, model, opts)
+      assert processed[:temperature] == 0.7
+      refute Keyword.has_key?(processed, :provider_options)
+    end
+
+    test "empty provider_options still works normally" do
+      model = %LLMDB.Model{provider: :translator, id: "test-model"}
+      opts = [temperature: 0.7]
+
+      assert {:ok, processed} = Options.process(ProviderOptionsTranslator, :chat, model, opts)
+      assert processed[:temperature] == 0.7
+      refute Keyword.has_key?(processed, :provider_options)
+    end
+
+    test "standard options still work normally alongside provider_options" do
+      model = %LLMDB.Model{provider: :translator, id: "test-model"}
+
+      opts = [
+        temperature: 0.7,
+        max_tokens: 1000,
+        provider_options: [custom_option: "test"]
+      ]
+
+      assert {:ok, processed} = Options.process(ProviderOptionsTranslator, :chat, model, opts)
+      assert processed[:temperature] == 0.7
+      assert processed[:max_tokens] == 1000
+      assert processed[:provider_options][:custom_option] == "TEST"
+    end
+  end
+
   describe "Options.process/4 - provider translation" do
     test "applies provider-specific option translation" do
       model = %LLMDB.Model{provider: :mock, id: "o1-preview"}


### PR DESCRIPTION
## Summary

Fixes #317 - OpenAI, xAI don't encode non-image attachments properly

## Changes

### MIME Type Validation
- Added `image_mime_type?/1` function to `Provider.Defaults` to validate supported image MIME types
- Modified `encode_openai_content_part/1` for `:file` content parts to raise `ReqLLM.Error.Invalid.Capability` when a non-image file type is used
- Error message includes the unsupported MIME type and suggests alternative providers (Anthropic, Google, OpenRouter)

### Documentation
- Created `guides/attachments.md` with comprehensive documentation:
  - Attachment support table by provider (Images, PDFs, Audio, Video)
  - Code examples for images, PDFs, and audio
  - Error handling examples
  - Provider-specific notes
- Updated `guides/openai.md` with attachment limitations section
- Updated `guides/xai.md` with attachment limitations section

### Tests
- Added `image_mime_type?/1` unit tests in `defaults_test.exs`
- Added attachment MIME type validation tests in `openai_test.exs`:
  - Image attachments succeed
  - PDF attachments raise helpful error
  - Audio attachments raise helpful error
  - Text file attachments raise helpful error
- Added attachment MIME type validation tests in `xai_test.exs`

## Example Error Message

```
OpenAI Chat Completions API only supports image attachments (got: application/pdf). For PDF, audio, and other file types, use Anthropic, Google, or OpenRouter with compatible models.
```

## Testing

```bash
mix test test/req_llm/provider/defaults_test.exs test/providers/openai_test.exs test/providers/xai_test.exs
# 148 tests, 0 failures

mix quality
# done (passed successfully)
```