### PR TITLE
fix: remove broken Discussions link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Documentation
     url: https://github.com/agentjido/req_llm/blob/main/README.md
     about: Check the documentation for usage examples
-  - name: Discussions
-    url: https://github.com/agentjido/req_llm/discussions
-    about: Ask questions and discuss ideas


### PR DESCRIPTION
Removes the broken Discussions contact link from issue template config since GitHub Discussions is not enabled.

Closes #288