### PR TITLE
fix: validate image-only attachments for OpenAI/xAI

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -8,6 +8,11 @@ Access GPT models including standard chat models and reasoning models (o1, o3, G
 OPENAI_API_KEY=sk-...
 ```
 
+## Attachments
+
+OpenAI Chat Completions API only supports image attachments (JPEG, PNG, GIF, WebP).
+For document support (PDFs, etc.), use Anthropic or Google providers.
+
 ## Dual API Architecture
 
 OpenAI provider automatically routes between two APIs based on model metadata:

--- a/guides/xai.md
+++ b/guides/xai.md
@@ -8,6 +8,11 @@ Access Grok models with real-time web search and reasoning capabilities.
 XAI_API_KEY=xai-...
 ```
 
+## Attachments
+
+xAI Chat Completions API only supports image attachments (JPEG, PNG, GIF, WebP).
+For document support (PDFs, etc.), use Anthropic or Google providers.
+
 ## Provider Options
 
 Passed via `:provider_options` keyword:

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -191,6 +191,7 @@ defmodule ReqLLM.Providers.XAI do
   defp prepare_chat_request(model_spec, prompt, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, context} <- ReqLLM.Context.normalize(prompt, opts),
+         :ok <- validate_attachments(context),
          opts_with_context = Keyword.put(opts, :context, context),
          http_opts = Keyword.get(opts, :req_http_options, []),
          {:ok, processed_opts} <-
@@ -1114,4 +1115,14 @@ defmodule ReqLLM.Providers.XAI do
   end
 
   defp maybe_add_additional_properties(schema, false), do: schema
+
+  defp validate_attachments(context) do
+    case ReqLLM.Provider.Defaults.validate_image_only_attachments(context) do
+      :ok ->
+        :ok
+
+      {:error, message} ->
+        {:error, ReqLLM.Error.Invalid.Parameter.exception(parameter: message)}
+    end
+  end
 end

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -668,6 +668,69 @@ defmodule ReqLLM.Providers.XAITest do
     end
   end
 
+  describe "attachment validation" do
+    test "accepts image attachments" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      image_part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "image.png", "image/png")
+      message = %ReqLLM.Message{role: :user, content: [image_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      {:ok, _request} = XAI.prepare_request(:chat, model, context, [])
+    end
+
+    test "accepts jpeg, gif, and webp attachments" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      for mime <- ~w(image/jpeg image/gif image/webp) do
+        part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "image", mime)
+        message = %ReqLLM.Message{role: :user, content: [part]}
+        context = %ReqLLM.Context{messages: [message]}
+
+        assert {:ok, _request} = XAI.prepare_request(:chat, model, context, [])
+      end
+    end
+
+    test "rejects PDF attachments with clear error" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      pdf_part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "doc.pdf", "application/pdf")
+      message = %ReqLLM.Message{role: :user, content: [pdf_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      {:error, error} = XAI.prepare_request(:chat, model, context, [])
+
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+      assert error.parameter =~ "only supports image attachments"
+      assert error.parameter =~ "application/pdf"
+      assert error.parameter =~ "Anthropic or Google"
+    end
+
+    test "rejects text file attachments" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      text_part = ReqLLM.Message.ContentPart.file("content", "file.txt", "text/plain")
+      message = %ReqLLM.Message{role: :user, content: [text_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      {:error, error} = XAI.prepare_request(:chat, model, context, [])
+
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+      assert error.parameter =~ "text/plain"
+    end
+
+    test "allows mixed text and image content" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      text_part = ReqLLM.Message.ContentPart.text("Describe this image")
+      image_part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "image.png", "image/png")
+      message = %ReqLLM.Message{role: :user, content: [text_part, image_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      {:ok, _request} = XAI.prepare_request(:chat, model, context, [])
+    end
+  end
+
   describe "context validation" do
     test "multiple system messages should fail" do
       invalid_context =


### PR DESCRIPTION
## Problem
OpenAI and xAI only support image attachments via their Chat Completions API. Non-image files (PDFs, etc.) fail with cryptic API errors.

## Solution
- Add upfront validation in OpenAI and xAI providers to detect non-image file attachments
- Return clear, actionable error messages suggesting Anthropic or Google for document support
- Document attachment support matrix in provider guides

## Changes
- `lib/req_llm/provider/defaults.ex`: Add `validate_image_only_attachments/1` helper
- `lib/req_llm/providers/openai.ex`: Validate attachments in `prepare_request(:chat, ...)`
- `lib/req_llm/providers/xai.ex`: Validate attachments in `prepare_chat_request/3`
- `guides/openai.md`: Document attachment limitations
- `guides/xai.md`: Document attachment limitations
- Tests for both providers verifying image acceptance and clear error messages for non-images

Closes #317