### PR TITLE
docs: clarify custom provider registration and usage

### DIFF
--- a/lib/req_llm/providers.ex
+++ b/lib/req_llm/providers.ex
@@ -28,7 +28,21 @@ defmodule ReqLLM.Providers do
       end
 
     :persistent_term.put(@registry_key, registry)
+
+    load_custom_providers()
+
     :ok
+  end
+
+  defp load_custom_providers do
+    custom_providers = Application.get_env(:req_llm, :custom_providers, [])
+
+    Enum.each(custom_providers, fn module ->
+      case register(module) do
+        {:ok, _provider_id} -> :ok
+        {:error, _error} -> :ok
+      end
+    end)
   end
 
   def get(provider_id) when is_atom(provider_id) do
@@ -120,14 +134,14 @@ defmodule ReqLLM.Providers do
       get_provider_id(module)
     else
       {:error,
-       ReqLLM.Error.Invalid.exception(
+       ReqLLM.Error.Invalid.Provider.exception(
          message: "Module #{inspect(module)} does not implement ReqLLM.Provider behaviour"
        )}
     end
   rescue
     error ->
       {:error,
-       ReqLLM.Error.Invalid.exception(
+       ReqLLM.Error.Invalid.Provider.exception(
          message: "Failed to validate provider module #{inspect(module)}: #{inspect(error)}"
        )}
   end

--- a/test/req_llm/providers_test.exs
+++ b/test/req_llm/providers_test.exs
@@ -1,0 +1,37 @@
+defmodule ReqLLM.ProvidersTest do
+  use ExUnit.Case, async: true
+
+  describe "list/0" do
+    test "returns list of registered provider atoms" do
+      providers = ReqLLM.Providers.list()
+
+      assert is_list(providers)
+      assert :openai in providers
+      assert :anthropic in providers
+      assert :groq in providers
+    end
+  end
+
+  describe "get/1" do
+    test "returns provider module for valid provider" do
+      assert {:ok, ReqLLM.Providers.OpenAI} = ReqLLM.Providers.get(:openai)
+      assert {:ok, ReqLLM.Providers.Anthropic} = ReqLLM.Providers.get(:anthropic)
+    end
+
+    test "returns error for unknown provider" do
+      assert {:error, %ReqLLM.Error.Invalid.Provider{provider: :unknown_provider}} =
+               ReqLLM.Providers.get(:unknown_provider)
+    end
+  end
+
+  describe "register/1 and unregister/1" do
+    test "register returns error for non-Provider module" do
+      defmodule NotAProvider do
+        def hello, do: :world
+      end
+
+      assert {:error, %ReqLLM.Error.Invalid.Provider{}} =
+               ReqLLM.Providers.register(NotAProvider)
+    end
+  end
+end

--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -21,6 +21,27 @@ defmodule ReqLLMTest do
     end
   end
 
+  describe "model/1 with map-based specs (custom providers)" do
+    test "creates model from map with id and provider" do
+      assert {:ok, %LLMDB.Model{provider: :custom, id: "my-model"}} =
+               ReqLLM.model(%{id: "my-model", provider: :custom})
+    end
+
+    test "creates model from map with string keys" do
+      assert {:ok, %LLMDB.Model{provider: :acme, id: "acme-chat"}} =
+               ReqLLM.model(%{"id" => "acme-chat", "provider" => :acme})
+    end
+
+    test "passes through existing LLMDB.Model struct unchanged" do
+      model = LLMDB.Model.new!(%{id: "test-model", provider: :test})
+      assert {:ok, ^model} = ReqLLM.model(model)
+    end
+
+    test "returns error for map missing required fields" do
+      assert {:error, _} = ReqLLM.model(%{id: "no-provider"})
+    end
+  end
+
   describe "provider/1 top-level API" do
     test "returns provider module for valid provider" do
       assert {:ok, ReqLLM.Providers.Groq} = ReqLLM.provider(:groq)


### PR DESCRIPTION
## Problem
Users are confused about how to use custom providers. Documentation was unclear about:
- How to use providers not in LLMDB catalog
- Version requirements for mix tasks
- The relationship between provider registration and model resolution

Fixes #283 - "Custom providers don't work?"

## Root Causes
1. `mix mc` not found: User on ReqLLM 1.0, alias added in later versions
2. "Unknown provider 'acme'": `ReqLLM.model/1` delegated to LLMDB which only knows catalog providers

## Solution

### Code Changes
- **ReqLLM.model/1**: Added support for map-based model specs (`%{id: "model", provider: :custom}`) to bypass LLMDB catalog lookup
- **ReqLLM.Providers.initialize/0**: Now loads custom providers from `config :req_llm, :custom_providers` at startup
- **Error handling**: Fixed `validate_provider_module/1` to use correct Splode error type

### Documentation Updates
Updated `guides/adding_a_provider.md` with:
- Two registration options (config-based vs manual)
- How to use map-based model specs for custom providers
- Version note about `mix mc` availability
- Clear examples for the full workflow

### Tests
- Added tests for map-based model specs in `test/req_llm_test.exs`
- Added `test/req_llm/providers_test.exs` for provider registration

## Usage Example

```elixir
# config/config.exs
config :req_llm, :custom_providers, [MyApp.Providers.Acme]

# Using the custom provider
{:ok, model} = ReqLLM.model(%{id: "acme-chat-mini", provider: :acme})
{:ok, response} = ReqLLM.generate_text(model, "Hello!")
```