### PR TITLE
feat: add google_url_context provider option

### DIFF
--- a/guides/google.md
+++ b/guides/google.md
@@ -27,6 +27,12 @@ Passed via `:provider_options` keyword:
 - **Example**: `provider_options: [google_grounding: %{enable: true}]`
 - **Cost tracking**: Usage tracked in `response.usage.tool_usage.web_search` with `unit: "query"`
 
+### `google_url_context`
+- **Type**: `boolean` | `map`
+- **Purpose**: Enable URL context grounding - allows model to fetch and use content from specific URLs
+- **Example**: `provider_options: [google_url_context: true]`
+- **Note**: Requires v1beta (default)
+
 ### `google_thinking_budget`
 - **Type**: Non-negative integer
 - **Purpose**: Control thinking tokens for Gemini 2.5 models


### PR DESCRIPTION
## Problem
Google Gemini API supports `url_context` tool for grounding responses with web content, but ReqLLM didn't expose this.

## Solution
Added `google_url_context` provider option that includes the `url_context` tool in requests.

## Usage
```elixir
ReqLLM.generate_text(model, prompt,
  provider_options: [google_url_context: true]
)
```

Can also pass a map with options:
```elixir
ReqLLM.generate_text(model, prompt,
  provider_options: [google_url_context: %{some_option: "value"}]
)
```

Can be combined with `google_grounding` and user-defined tools.

Closes #226