### PR TITLE
feat: add OpenRouter usage and plugins options

### DIFF
--- a/guides/openrouter.md
+++ b/guides/openrouter.md
@@ -84,6 +84,18 @@ Passed via `:provider_options` keyword:
 - **Purpose**: Number of top log probabilities to return
 - **Example**: `provider_options: [openrouter_top_logprobs: 5]`
 
+### Usage & Plugins
+
+#### `openrouter_usage`
+- **Type**: Map
+- **Purpose**: Configure usage reporting
+- **Example**: `provider_options: [openrouter_usage: %{include: true}]`
+
+#### `openrouter_plugins`
+- **Type**: List of maps
+- **Purpose**: Enable OpenRouter plugins (e.g., web search)
+- **Example**: `provider_options: [openrouter_plugins: [%{id: "web"}]]`
+
 ### App Attribution
 
 #### `app_referer`

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -19,6 +19,8 @@ defmodule ReqLLM.Providers.OpenRouter do
   - `openrouter_min_p` - Minimum probability threshold for sampling
   - `openrouter_top_a` - Top-a sampling parameter
   - `openrouter_structured_output_mode` - Enables `:json_schema` structured output (when tool calls are not supported)
+  - `openrouter_usage` - Usage options (e.g., `%{include: true}`)
+  - `openrouter_plugins` - Array of plugins (e.g., `[%{id: "web"}]`)
   - `app_referer` - HTTP-Referer header for app identification
   - `app_title` - X-Title header for app title in rankings
 
@@ -99,6 +101,14 @@ defmodule ReqLLM.Providers.OpenRouter do
       type: {:in, [:json_schema]},
       doc:
         "Structured output mode. Only :json_schema is supported, which enables JSON schema support instead of using tools. Useful when tool calls are not supported by the endpoint."
+    ],
+    openrouter_usage: [
+      type: :map,
+      doc: "OpenRouter usage options. Example: %{include: true}"
+    ],
+    openrouter_plugins: [
+      type: {:list, :map},
+      doc: "OpenRouter plugins. Example: [%{id: \"web\"}]"
     ]
   ]
 
@@ -295,6 +305,8 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> maybe_put(:top_a, request.options[:openrouter_top_a])
     |> maybe_put(:top_logprobs, request.options[:openrouter_top_logprobs])
     |> maybe_put(:reasoning_effort, request.options[:reasoning_effort])
+    |> maybe_put(:usage, request.options[:openrouter_usage])
+    |> maybe_put(:plugins, request.options[:openrouter_plugins])
     |> add_openrouter_specific_options(request.options)
     |> add_stream_options(request.options)
   end

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -237,6 +237,63 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       assert decoded["stream_options"] == %{"include_usage" => true}
     end
 
+    test "encode_body with openrouter_usage option" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          openrouter_usage: %{include: true}
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["usage"] == %{"include" => true}
+    end
+
+    test "encode_body with openrouter_plugins option" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          openrouter_plugins: [%{id: "web"}]
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["plugins"] == [%{"id" => "web"}]
+    end
+
+    test "encode_body with multiple openrouter_plugins" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          openrouter_plugins: [%{id: "web"}, %{id: "code"}]
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["plugins"] == [%{"id" => "web"}, %{"id" => "code"}]
+    end
+
     test "encode_body with response_format" do
       {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
       context = context_fixture()


### PR DESCRIPTION
## Problem
OpenRouter supports additional request options for usage reporting and plugins that weren't exposed.

## Solution
Added two provider options:
- `openrouter_usage`: Configure usage reporting (e.g., `%{include: true}`)
- `openrouter_plugins`: Enable OpenRouter plugins (e.g., `[%{id: "web"}]`)

## Changes
- Added schema entries in `lib/req_llm/providers/openrouter.ex`
- Added body encoding in `build_body/1`
- Updated documentation in `guides/openrouter.md`
- Added tests in `test/providers/openrouter_test.exs`

Closes #229