### PR TITLE
feat: add reasoning_cost to cost breakdown

### DIFF
--- a/lib/req_llm/step/usage.ex
+++ b/lib/req_llm/step/usage.ex
@@ -64,6 +64,7 @@ defmodule ReqLLM.Step.Usage do
           Map.merge(meta, %{
             input_cost: cost_breakdown.input_cost,
             output_cost: cost_breakdown.output_cost,
+            reasoning_cost: cost_breakdown.reasoning_cost,
             total_cost: cost_breakdown.total_cost
           })
         else

--- a/lib/req_llm/usage/cost.ex
+++ b/lib/req_llm/usage/cost.ex
@@ -35,6 +35,7 @@ defmodule ReqLLM.Usage.Cost do
            %{
              input_cost: cost.input_cost,
              output_cost: cost.output_cost,
+             reasoning_cost: cost.reasoning_cost,
              total_cost: cost.total,
              cost: cost
            }}
@@ -57,6 +58,7 @@ defmodule ReqLLM.Usage.Cost do
       |> Map.put(:cost, cost_breakdown.cost)
       |> Map.put(:input_cost, cost_breakdown.input_cost)
       |> Map.put(:output_cost, cost_breakdown.output_cost)
+      |> Map.put(:reasoning_cost, cost_breakdown.reasoning_cost)
 
     if Keyword.get(opts, :preserve_total_cost, false) do
       Map.put_new(usage, :total_cost, cost_breakdown.total_cost)


### PR DESCRIPTION
Closes #198

## Summary
Adds `reasoning_cost` as a separate field in the cost breakdown, allowing users to see how much they're spending on reasoning tokens.

## Changes
- **lib/req_llm/billing.ex**: Add `reasoning_cost` calculation via `token_reasoning_item?/1` filter and include it in the returned cost map
- **lib/req_llm/usage/cost.ex**: Expose `reasoning_cost` in breakdown and merge it into usage
- **lib/req_llm/step/usage.ex**: Include `reasoning_cost` in telemetry events
- **test/req_llm/billing_test.exs**: Add tests for reasoning cost calculation

## How It Works
- Models with `token.reasoning` pricing components (xAI grok-3-mini, Azure, Google Gemini 2.5, OpenRouter models) now have their reasoning token costs tracked separately
- `reasoning_cost` is included in `output_cost` (for backwards compatibility) but also exposed independently
- For models without separate reasoning pricing, `reasoning_cost` is 0

## Testing
```bash
mix test  # 2035 tests, 0 failures
mix quality  # passes
```