### PR TITLE
fix: Do not force strict tools for responses api

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -662,17 +662,23 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     end
   end
 
-  defp encode_tool_for_responses_api(%ReqLLM.Tool{} = tool) do
+  defp encode_tool_for_responses_api(%ReqLLM.Tool{strict: strict} = tool) do
     schema = ReqLLM.Tool.to_schema(tool)
     function_def = schema["function"]
-    params = normalize_parameters_for_strict(function_def["parameters"])
+
+    params =
+      if strict do
+        normalize_parameters_for_strict(function_def["parameters"])
+      else
+        normalize_parameters(function_def["parameters"])
+      end
 
     %{
       "type" => "function",
       "name" => function_def["name"],
       "description" => function_def["description"],
       "parameters" => params,
-      "strict" => true
+      "strict" => strict
     }
   end
 
@@ -729,6 +735,24 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       "type" => "object",
       "properties" => stringify_keys(properties),
       "required" => all_property_names,
+      "additionalProperties" => false
+    }
+  end
+
+  defp normalize_parameters(nil) do
+    %{
+      "type" => "object",
+      "properties" => %{},
+      "additionalProperties" => false
+    }
+  end
+
+  defp normalize_parameters(params) when is_map(params) do
+    properties = params[:properties] || params["properties"] || %{}
+
+    %{
+      "type" => "object",
+      "properties" => stringify_keys(properties),
       "additionalProperties" => false
     }
   end


### PR DESCRIPTION
## Description

Right now, strict tool schemas are enforced for open_ai responses api, it should be a user decision.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #398
