### PR TITLE
Guard decoded tool call arguments with is_map

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1002,8 +1002,11 @@ defmodule ReqLLM.Provider.Defaults do
        })
        when is_binary(name) do
     case Jason.decode(args_json || "{}") do
-      {:ok, args} -> ReqLLM.StreamChunk.tool_call(name, args, %{id: id, index: index})
-      {:error, _} -> ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id, index: index})
+      {:ok, args} when is_map(args) ->
+        ReqLLM.StreamChunk.tool_call(name, args, %{id: id, index: index})
+
+      _ ->
+        ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id, index: index})
     end
   end
 
@@ -1048,8 +1051,11 @@ defmodule ReqLLM.Provider.Defaults do
        })
        when is_binary(name) do
     case Jason.decode(args_json || "{}") do
-      {:ok, args} -> ReqLLM.StreamChunk.tool_call(name, args, %{id: id})
-      {:error, _} -> ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id})
+      {:ok, args} when is_map(args) ->
+        ReqLLM.StreamChunk.tool_call(name, args, %{id: id})
+
+      _ ->
+        ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id})
     end
   end
 


### PR DESCRIPTION
## Summary

- Add `when is_map(args)` guard to `Jason.decode` success branches in `decode_openai_tool_call_delta/1`
- Prevents `FunctionClauseError` in `StreamChunk.tool_call/3` when providers send non-object JSON in streaming tool call argument deltas

## Problem

Some LLM providers (e.g. Kimi K2.5 via OpenRouter) send malformed streaming tool call deltas where the `arguments` field is a JSON string literal (e.g. `", "`) rather than a JSON object. `Jason.decode` succeeds on these values, but the result is a string, not a map. Passing it to `StreamChunk.tool_call/3` triggers a `FunctionClauseError` due to the `is_map(arguments)` guard on that function.

## Fix

Add `when is_map(args)` to the `{:ok, args}` branch of both `Jason.decode` call sites in `decode_openai_tool_call_delta`. Non-map decoded values now fall through to the catch-all which substitutes an empty map `%{}`.

