### PR TITLE
fix: route Vertex AI MaaS models to endpoints/openapi/chat/completions

### DIFF
--- a/lib/req_llm/providers/google_vertex/openai_compat.ex
+++ b/lib/req_llm/providers/google_vertex/openai_compat.ex
@@ -3,15 +3,16 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompat do
   OpenAI-compatible model family support for Google Vertex AI.
 
   Handles third-party MaaS (Model-as-a-Service) models on Vertex AI that use
-  the OpenAI Chat Completions API format through the rawPredict endpoint.
+  the OpenAI Chat Completions API format.
 
   Currently supports:
   - GLM models (zai-org/glm-4.7-maas)
   - OpenAI OSS models (openai/gpt-oss-120b-maas, openai/gpt-oss-20b-maas)
   - Other future MaaS models using OpenAI-compatible format
 
-  These models are accessed via Vertex AI's rawPredict/streamRawPredict endpoints
-  and use standard OpenAI Chat Completions request/response format.
+  These models are accessed via Vertex AI's `endpoints/openapi/chat/completions`
+  endpoint and use standard OpenAI Chat Completions request/response format.
+  The model ID (e.g., `zai-org/glm-4.7-maas`) is included in the request body.
   """
 
   alias ReqLLM.Provider.Defaults


### PR DESCRIPTION
## Summary

- Fixes endpoint routing for OpenAI-compatible MaaS models (GLM, GPT-OSS) on Vertex AI
- Routes to `endpoints/openapi/chat/completions` instead of `publishers/{org}/models/{model}:rawPredict`
- Model ID is passed in the request body, not the URL path
- Removes the now-unnecessary `extract_publisher_and_model/1` helper

## Context

PR #422 added OpenAI-compatible model family support but routed requests to the wrong Vertex AI endpoint. MaaS models using the OpenAI Chat Completions format should use the `endpoints/openapi/chat/completions` endpoint, with streaming controlled via `stream: true` in the request body rather than a separate `streamRawPredict` URL.

## Test plan

- [x] New endpoint routing tests verify correct path for sync and streaming requests
- [x] Negative assertions confirm old `publishers/` and `rawPredict` patterns are not present
- [x] Project ID and region correctly interpolated in URL path
- [x] All existing Claude and Gemini tests pass (no regressions)
- [x] Full test suite passes (2216 tests, 0 failures)