### PR TITLE
fix: increase default timeout for DeepSeek and MAI-DS models on Azure

### DIFF
--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -1147,6 +1147,7 @@ defmodule ReqLLM.Providers.Azure do
       model_family == "claude" && (has_thinking || reasoning_effort) -> 180_000
       model_family in ["o1", "o3", "o4"] && reasoning_effort -> 180_000
       model_family in ["o1", "o3", "o4"] -> 120_000
+      model_family in ["deepseek", "mai-ds"] -> 120_000
       AdapterHelpers.gpt5_model?(model_id) -> 120_000
       true -> 30_000
     end

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -899,6 +899,52 @@ defmodule ReqLLM.Providers.AzureTest do
 
       assert request.options[:receive_timeout] == 90_000
     end
+
+    test "uses extended timeout for DeepSeek models" do
+      {:ok, model} = ReqLLM.model("azure:deepseek-r1")
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          base_url: "https://my-resource.services.ai.azure.com/models",
+          deployment: "deepseek-r1"
+        )
+
+      assert request.options[:receive_timeout] == 120_000
+    end
+
+    test "uses extended timeout for mai-ds models" do
+      {:ok, model} = ReqLLM.model("azure:mai-ds-r1")
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          base_url: "https://my-resource.services.ai.azure.com/models",
+          deployment: "mai-ds-r1"
+        )
+
+      assert request.options[:receive_timeout] == 120_000
+    end
+
+    test "custom timeout overrides default for DeepSeek models" do
+      {:ok, model} = ReqLLM.model("azure:deepseek-r1")
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          base_url: "https://my-resource.services.ai.azure.com/models",
+          deployment: "deepseek-r1",
+          receive_timeout: 60_000
+        )
+
+      assert request.options[:receive_timeout] == 60_000
+    end
   end
 
   describe "authentication edge cases" do


### PR DESCRIPTION
## Summary

- DeepSeek (`deepseek-r1`, `deepseek-v3-*`) and MAI-DS (`mai-ds-r1`) model families fall through to the 30-second catch-all in `default_timeout_for_model/2`, causing premature timeouts for reasoning models like `deepseek-r1`
- Adds a `model_family in ["deepseek", "mai-ds"] -> 120_000` clause, matching the timeout used by o-series reasoning models
- Adds tests for DeepSeek default timeout, MAI-DS default timeout, and user-specified timeout override

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test test/provider/azure/azure_test.exs --only "describe:timeout configuration"` — all 7 timeout tests pass
- [x] `mix test` — full suite passes (2223 tests, 0 failures)