### PR TITLE
fix: ReqLLM embed should use embedding schema, not generation

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -433,7 +433,9 @@ defmodule ReqLLM.Provider.Defaults do
         :stop,
         :user,
         :reasoning_effort,
-        :reasoning_token_budget
+        :reasoning_token_budget,
+        :dimensions,
+        :encoding_format
       ] ++ provider_mod.supported_provider_options()
 
     {api_key, extra_option_keys}

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -295,6 +295,7 @@ defmodule ReqLLM.Provider.Options do
   end
 
   defp base_schema_for_operation(:image), do: ReqLLM.Images.schema()
+  defp base_schema_for_operation(:embedding), do: ReqLLM.Embedding.schema()
   defp base_schema_for_operation(_operation), do: @generation_options_schema
 
   @doc """
@@ -473,6 +474,7 @@ defmodule ReqLLM.Provider.Options do
   end
 
   defp maybe_extract_model_options(:image, _model, opts), do: opts
+  defp maybe_extract_model_options(:embedding, _model, opts), do: opts
 
   defp maybe_extract_model_options(_operation, model, opts),
     do: extract_model_options(model, opts)

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -553,7 +553,9 @@ defmodule ReqLLM.Providers.Google do
         :reasoning_effort,
         :reasoning_token_budget,
         :stream,
-        :provider_options
+        :provider_options,
+        :dimensions,
+        :encoding_format
       ] ++
         __MODULE__.supported_provider_options()
 


### PR DESCRIPTION
## Description

Wrong parameter schema being used for the ReqLLM.embed operation

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #445
