### PR TITLE
fix(bedrock): update inference profile prefixes

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -825,9 +825,13 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     end
   end
 
+  # Cross-region inference profile prefixes.
+  # See: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+  @region_prefixes ["us", "eu", "ap", "apac", "ca", "au", "jp", "us-gov", "global"]
+
   defp strip_region_prefix(model_id) do
     case String.split(model_id, ".", parts: 2) do
-      [region, rest] when region in ["us", "eu", "ap", "ca", "global"] -> rest
+      [region, rest] when region in @region_prefixes -> rest
       _ -> model_id
     end
   end
@@ -1021,15 +1025,12 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   def normalize_model_id(model_id) when is_binary(model_id) do
     # Strip region prefixes from inference profile IDs for metadata lookup
     # (e.g., "us.anthropic.claude-3-sonnet" -> "anthropic.claude-3-sonnet")
-    # (e.g., "global.anthropic.claude-sonnet-4-5" -> "anthropic.claude-sonnet-4-5")
+    # (e.g., "au.anthropic.claude-sonnet-4-5" -> "anthropic.claude-sonnet-4-5")
     #
     # Note: This is ONLY for metadata lookup. The preserve_inference_profile? callback
     # controls whether the prefix is kept in API requests (see prepare_request/4).
     case String.split(model_id, ".", parts: 3) do
-      # Pattern: region.provider.rest where region is known
-      [possible_region, _provider, _rest]
-      when possible_region in ["us", "eu", "ap", "ca", "global"] ->
-        # Strip region prefix for metadata lookup
+      [possible_region, _provider, _rest] when possible_region in @region_prefixes ->
         [_region, rest] = String.split(model_id, ".", parts: 2)
         rest
 


### PR DESCRIPTION
## Description

I was attempting to use req_llm with caching enabled and noticed some unexpected behaviour. It was falling back to the converse API due to the inference profile I was using (`au.anthropic.claude-sonnet-4-5-20250929-v1:0`). This PR adds `au` and some other missing inference profile prefixes to the logic that strips/normalizes the model id for amazon bedrock.

Fix identified/fixed by claude code (opus 4.6):

> ⏺ Here's the chain that caused the fallback:

>   1. get_model_family("au.anthropic.claude-sonnet-4-5-...") calls strip_region_prefix (line 926)
>   2. Old strip_region_prefix didn't have "au" in its list, so it returned "au.anthropic.claude-sonnet-4-5-..." unchanged
>   3. @model_families lookup (line 930) checked if the normalized ID starts with "anthropic." — but it started with "au.", so no match → found_family = nil
>   4. Fallback prefix extraction (line 937) split on . → got "au" as the family
>   5. Back in determine_use_converse, get_formatter_module("au") found no entry in @model_families → returned the Converse module as fallback
>   6. is_fallback_to_converse (line 1152) was true → returned true at line 1177

I went with the current approach of only stripping a list of known inference profile prefixes.

Setting `use_converse: false` doesn't fix the issue:

> To summarize the error: even with use_converse: false, the Hex version of req_llm (without the au prefix fix) still uses the Converse formatter to build the request body because get_model_family("au.anthropic...") returns "au" → no matching formatter → falls back to Converse formatter. So the endpoint is /invoke but the body is Converse-formatted — causing the "type: Field required" error.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)


Related PR on llm_db: https://github.com/agentjido/llm_db/pull/130