### PR TITLE
feat: add response_format to Vertex AI provider schema for OpenAI-compat MaaS models

### DIFF
--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -159,6 +159,11 @@ defmodule ReqLLM.Providers.GoogleVertex do
       type: :string,
       doc:
         "Task type for embedding (e.g., RETRIEVAL_QUERY, RETRIEVAL_DOCUMENT, SEMANTIC_SIMILARITY)"
+    ],
+    response_format: [
+      type: :map,
+      doc:
+        "Response format constraint (e.g., %{type: \"json_object\"}) for OpenAI-compatible MaaS models"
     ]
   ]
 
@@ -653,16 +658,32 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
     case model_family do
       "claude" ->
+        opts = warn_and_strip_response_format(opts, "Claude")
         # Delegate to Anthropic provider for Anthropic-specific option handling
         ReqLLM.Providers.Anthropic.translate_options(operation, model, opts)
 
       "gemini" ->
+        opts = warn_and_strip_response_format(opts, "Gemini")
         # Delegate to Google provider for Gemini-specific option handling
         ReqLLM.Providers.Google.translate_options(operation, model, opts)
 
       _ ->
-        # Other model families: no translation needed yet
+        # Other model families (openai_compat): no translation needed
         {opts, []}
+    end
+  end
+
+  # Called from translate_options where opts are already flattened (no :provider_options key)
+  defp warn_and_strip_response_format(opts, family_name) do
+    if opts[:response_format] do
+      Logger.warning(
+        "response_format is not supported for #{family_name} models on Vertex AI. " <>
+          "Use generate_object/4 with a schema instead. Ignoring response_format."
+      )
+
+      Keyword.delete(opts, :response_format)
+    else
+      opts
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds `response_format` to the GoogleVertex `@provider_schema` so NimbleOptions validation accepts it via `provider_options`
- For OpenAI-compatible MaaS models (GLM, GPT-OSS, etc.), `response_format` flows through to the request body as expected
- For Claude and Gemini models, logs a warning and strips the option since those families use different mechanisms for structured output

## Test plan
- [x] `response_format` accepted and present in request body for openai_compat models
- [x] `response_format` warned and stripped for Claude models on Vertex
- [x] `response_format` warned and stripped for Gemini models on Vertex
- [x] Unit test for `format_request` with `response_format` via `provider_options`
- [x] Full test suite passes (2281 tests, 0 failures)