### PR TITLE
fix: only add cache_control to last tool in Anthropic prompt caching

### DIFF
--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -588,16 +588,16 @@ defmodule ReqLLM.Providers.Anthropic do
   defp maybe_cache_tools(body, cache_meta) do
     case Map.get(body, :tools) do
       tools when is_list(tools) and tools != [] ->
-        updated_tools =
-          Enum.map(tools, fn tool ->
-            if Map.has_key?(tool, :cache_control) or Map.has_key?(tool, "cache_control") do
-              tool
-            else
-              Map.put(tool, :cache_control, cache_meta)
-            end
-          end)
+        {init, [last]} = Enum.split(tools, -1)
 
-        Map.put(body, :tools, updated_tools)
+        updated_last =
+          if Map.has_key?(last, :cache_control) or Map.has_key?(last, "cache_control") do
+            last
+          else
+            Map.put(last, :cache_control, cache_meta)
+          end
+
+        Map.put(body, :tools, init ++ [updated_last])
 
       _ ->
         body


### PR DESCRIPTION
## Summary

- `maybe_cache_tools/2` was adding `cache_control: %{type: "ephemeral"}` to **every** tool definition via `Enum.map`, exceeding Anthropic's 4 `cache_control` breakpoint limit with 3+ tools
- Since Anthropic's caching is prefix-based, only the **last** tool needs a breakpoint — it caches all preceding tools in the prefix
- Changed to use `Enum.split(tools, -1)` to only annotate the last tool

### Before (5 tools + system + message = 7 breakpoints)
```
tool_a: cache_control ← redundant
tool_b: cache_control ← redundant
tool_c: cache_control ← redundant
tool_d: cache_control ← redundant
tool_e: cache_control
system: cache_control
message: cache_control
Total: 7 (exceeds limit of 4)
```

### After (last tool + system + message = 3 breakpoints)
```
tool_a:
tool_b:
tool_c:
tool_d:
tool_e: cache_control
system: cache_control
message: cache_control
Total: 3 (within limit of 4)
```

## Test plan

- [x] Added test with 5 tools verifying only the last gets `cache_control`
- [x] All 31 existing prompt cache tests pass unchanged

Fixes #452