### PR TITLE
fix: stream usage loses message_start token counts when message_delta arrives

### DIFF
--- a/lib/req_llm/response/stream.ex
+++ b/lib/req_llm/response/stream.ex
@@ -112,7 +112,7 @@ defmodule ReqLLM.Response.Stream do
   defp handle_finish_reason(_meta, acc), do: acc
 
   defp handle_usage(%{usage: usage}, acc) when is_map(usage) do
-    merged = Map.merge(acc.usage || %{}, usage)
+    merged = ReqLLM.Usage.merge(acc.usage || %{}, usage)
     %{acc | usage: merged}
   end
 
@@ -229,7 +229,7 @@ defmodule ReqLLM.Response.Stream do
       usage =
         Map.get(chunk.metadata || %{}, :usage) || Map.get(chunk.metadata || %{}, "usage") || %{}
 
-      Map.merge(acc || %{}, usage)
+      ReqLLM.Usage.merge(acc || %{}, usage)
     end)
   end
 end

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -652,7 +652,10 @@ defmodule ReqLLM.StreamServer do
               meta_with_usage =
                 if usage do
                   normalized_usage = normalize_streaming_usage(usage, state.model)
-                  Map.update(metadata, :usage, normalized_usage, &Map.merge(&1, normalized_usage))
+
+                  Map.update(metadata, :usage, normalized_usage, fn existing ->
+                    ReqLLM.Usage.merge(existing, normalized_usage)
+                  end)
                 else
                   metadata
                 end

--- a/test/req_llm/providers/amazon_bedrock/anthropic_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/anthropic_test.exs
@@ -311,7 +311,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.AnthropicTest do
       assert stream_chunk.type == :meta
       # When usage is present, the usage chunk is returned first
       # The finish_reason chunk comes after but we only return the first
-      assert stream_chunk.metadata[:usage]["output_tokens"] == 42
+      assert stream_chunk.metadata[:usage][:output_tokens] == 42
     end
 
     test "parses content block start" do

--- a/test/req_llm/usage_helpers_test.exs
+++ b/test/req_llm/usage_helpers_test.exs
@@ -67,6 +67,63 @@ defmodule ReqLLM.UsageHelpersTest do
                output: 0
              }
     end
+
+    test "merge takes max of numeric fields" do
+      message_start = %{input_tokens: 1500, output_tokens: 1, total_tokens: 1501}
+      message_delta = %{input_tokens: 0, output_tokens: 393, total_tokens: 393}
+
+      merged = ReqLLM.Usage.merge(message_start, message_delta)
+
+      assert merged.input_tokens == 1500
+      assert merged.output_tokens == 393
+      assert merged.total_tokens == 1893
+    end
+
+    test "merge handles cumulative usage from later events" do
+      message_start = %{input_tokens: 2679, output_tokens: 3, total_tokens: 2682}
+      message_delta = %{input_tokens: 10682, output_tokens: 510, total_tokens: 11192}
+
+      merged = ReqLLM.Usage.merge(message_start, message_delta)
+
+      assert merged.input_tokens == 10682
+      assert merged.output_tokens == 510
+      assert merged.total_tokens == 11192
+    end
+
+    test "merge preserves non-zero values when later event has zeros" do
+      message_start = %{
+        input_tokens: 1500,
+        output_tokens: 0,
+        total_tokens: 1500,
+        cached_tokens: 0,
+        cache_creation_tokens: 12000
+      }
+
+      message_delta = %{
+        input_tokens: 0,
+        output_tokens: 393,
+        total_tokens: 393,
+        cached_tokens: 0,
+        cache_creation_tokens: 0
+      }
+
+      merged = ReqLLM.Usage.merge(message_start, message_delta)
+
+      assert merged.input_tokens == 1500
+      assert merged.output_tokens == 393
+      assert merged.total_tokens == 1893
+      assert merged.cache_creation_tokens == 12000
+    end
+
+    test "merge adds keys only present in incoming map" do
+      existing = %{input_tokens: 10}
+      incoming = %{input_tokens: 0, output_tokens: 5}
+
+      merged = ReqLLM.Usage.merge(existing, incoming)
+
+      assert merged.input_tokens == 10
+      assert merged.output_tokens == 5
+    end
   end
 
   describe "ReqLLM.Pricing" do


### PR DESCRIPTION
## Description

When streaming with the Anthropic provider, the final usage reported in StreamResponse has input_tokens, cache_creation_input_tokens, and cache_read_input_tokens all set to 0, even though the API correctly reports them.

Root Cause

There are two compounding issues in the streaming usage tracking:

1. message_delta usage is not passed through parse_usage in Anthropic.Response

In lib/req_llm/providers/anthropic/response.ex, the message_start event correctly calls parse_usage(usage_data) (line 86), which normalizes string-keyed Anthropic usage into atom-keyed maps. However, the message_delta event (line 110) passes the raw string-keyed usage map directly:

```elixir
# message_start — correctly parsed:
usage = parse_usage(usage_data)
[ReqLLM.StreamChunk.meta(%{usage: usage})]

# message_delta — raw string keys, NOT parsed:
usage = Map.get(data, "usage", %{})
# ...
usage_chunk = ReqLLM.StreamChunk.meta(%{usage: usage})
```

2. Map.merge in StreamServer overwrites message_start values with message_delta zeros

In lib/req_llm/stream_server.ex (around line 655), when a :meta chunk arrives with usage, the accumulated usage is updated with:

Map.update(metadata, :usage, normalized_usage, &Map.merge(&1, normalized_usage))

The Anthropic API sends usage across two events:
- message_start contains: input_tokens, cache_creation_input_tokens, cache_read_input_tokens (but output_tokens: 0)
- message_delta contains: output_tokens (but input_tokens: 0 and no cache fields)

After normalization, both events produce maps with all the same keys. The Map.merge/2 from message_delta overwrites the message_start values — replacing real input_tokens, cache_creation_input_tokens, etc. with 0.

Example

Anthropic streams:

message_start:  {"input_tokens": 1500, "output_tokens": 0, "cache_creation_input_tokens": 12000, "cache_read_input_tokens": 0}
message_delta:  {"output_tokens": 393}

After parse_usage + normalize, message_start produces:
%{input_tokens: 1500, output_tokens: 0, cache_creation_tokens: 12000, cached_tokens: 0, ...}

After normalize, message_delta produces (note: parse_usage is not called, but normalize still runs):
%{input_tokens: 0, output_tokens: 393, cache_creation_tokens: 0, cached_tokens: 0, ...}

Map.merge/2 keeps the last value, so the final usage is:
%{input_tokens: 0, output_tokens: 393, cache_creation_tokens: 0, cached_tokens: 0, ...}

All the message_start values are lost.

Affected Providers

- Anthropic (direct API)
- Amazon Bedrock Anthropic (delegates to Anthropic.Response.decode_stream_event)

Note: I've only tested this on AWS Bedrock Anthropic.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
