### PR TITLE
docs: add JSONSpec as parameter_schema option

### DIFF
--- a/lib/req_llm/tool.ex
+++ b/lib/req_llm/tool.ex
@@ -161,6 +161,19 @@ defmodule ReqLLM.Tool do
         callback: {WeatherService, :get_weather}
       )
 
+      # Using Elixir typespec syntax via JSONSpec (https://hex.pm/packages/json_spec)
+      import JSONSpec
+
+      {:ok, tool} = ReqLLM.Tool.new(
+        name: "get_weather",
+        description: "Get current weather",
+        parameter_schema: schema(
+          %{required(:location) => String.t(), optional(:units) => :celsius | :fahrenheit},
+          doc: [location: "City name", units: "Temperature units"]
+        ),
+        callback: {WeatherService, :get_weather}
+      )
+
   """
   @spec new(tool_opts()) :: {:ok, t()} | {:error, term()}
   def new(opts) when is_list(opts) do


### PR DESCRIPTION
Add [JSONSpec](https://hex.pm/packages/json_spec) example to `Tool.new/1` docs — Elixir typespec syntax that compiles to JSON Schema maps.

## Type of Change

- [x] Documentation update

## Checklist

- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)