### PR TITLE
feat: pass anthropic_beta through Bedrock to request body

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -172,6 +172,11 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       - `0` - first message, `1` - second, etc.
       """
     ],
+    anthropic_beta: [
+      type: {:list, :string},
+      doc:
+        "Beta feature flags for Anthropic models on Bedrock (e.g., [\"context-1m-2025-08-07\"])"
+    ],
     service_tier: [
       type: {:in, ["priority", "default", "flex"]},
       default: "default",

--- a/lib/req_llm/providers/amazon_bedrock/anthropic.ex
+++ b/lib/req_llm/providers/amazon_bedrock/anthropic.ex
@@ -71,6 +71,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
 
     body
     |> Map.put(:anthropic_version, "bedrock-2023-05-31")
+    |> maybe_add_anthropic_beta(opts)
     |> AdapterHelpers.maybe_add_param(:max_tokens, opts[:max_tokens] || default_max_tokens)
     |> AdapterHelpers.maybe_add_param(:temperature, opts[:temperature])
     |> AdapterHelpers.maybe_add_param(:top_p, opts[:top_p])
@@ -79,6 +80,16 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
     |> AdapterHelpers.maybe_add_thinking(opts)
     |> maybe_add_tools(opts)
     |> Anthropic.maybe_apply_prompt_caching(opts)
+  end
+
+  defp maybe_add_anthropic_beta(body, opts) do
+    case get_in(opts, [:provider_options, :anthropic_beta]) do
+      betas when is_list(betas) and betas != [] ->
+        Map.put(body, :anthropic_beta, betas)
+
+      _ ->
+        body
+    end
   end
 
   # Add tools from opts to request body (same as native Anthropic provider)


### PR DESCRIPTION
## Description

Add anthropic_beta to Bedrock's provider schema and Anthropic formatter so users can enable Bedrock-supported beta features (e.g., extended context windows, output limits) via the request body.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
