### PR TITLE
fix: allow max_retries to be 0 to disable retries

### DIFF
--- a/lib/req_llm/images.ex
+++ b/lib/req_llm/images.ex
@@ -76,9 +76,10 @@ defmodule ReqLLM.Images do
                    doc: "Timeout for receiving HTTP responses in milliseconds"
                  ],
                  max_retries: [
-                   type: :pos_integer,
+                   type: :non_neg_integer,
                    default: 3,
-                   doc: "Maximum number of retry attempts for transient network errors"
+                   doc:
+                     "Maximum number of retry attempts for transient network errors. Set to 0 to disable retries."
                  ],
                  on_unsupported: [
                    type: {:in, [:warn, :error, :ignore]},

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -164,10 +164,10 @@ defmodule ReqLLM.Provider.Options do
                                    "Timeout for receiving HTTP responses in milliseconds (defaults to global config)"
                                ],
                                max_retries: [
-                                 type: :pos_integer,
+                                 type: :non_neg_integer,
                                  default: 3,
                                  doc:
-                                   "Maximum number of retry attempts for transient network errors"
+                                   "Maximum number of retry attempts for transient network errors. Set to 0 to disable retries."
                                ]
                              )
 


### PR DESCRIPTION
## Description

Change max_retries type from `:pos_integer` to `:non_neg_integer` so users can set it to 0 to disable retry attempts for transient network errors.

The reason I'd like to disable automatic transient error retries is to have control over how timeouts are handled. Some generations can take 5+ minutes and I'm not sure Req's `put_aws_sig_v4` regenerates the signature on timeout retries, so eventually it hits a 403 with a signature error like this:

```elixir
%ReqLLM.Error.API.Response{reason: "Bedrock API error", response_body: %{"message" => "Signature expired: 20260226T031356Z is now earlier than 20260226T031459Z (20260226T031959Z - 5 min.)"}, status: 403
```

I'd rather have timeouts not be retried and instead rely on Oban retry limits. Req already supports `max_retries: 0`, so I think it makes sense to allow that.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
