### PR TITLE
fix: exclude embedding return_usage from provider transport options

### DIFF
--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -295,7 +295,13 @@ defmodule ReqLLM.Provider.Options do
   end
 
   defp base_schema_for_operation(:image), do: ReqLLM.Images.schema()
-  defp base_schema_for_operation(:embedding), do: ReqLLM.Embedding.schema()
+
+  defp base_schema_for_operation(:embedding) do
+    embedding_schema = ReqLLM.Embedding.schema()
+    embedding_keys = Keyword.delete(embedding_schema.schema, :return_usage)
+    NimbleOptions.new!(embedding_keys)
+  end
+
   defp base_schema_for_operation(_operation), do: @generation_options_schema
 
   @doc """

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -642,6 +642,14 @@ defmodule ReqLLM.Provider.OptionsTest do
       assert processed[:encoding_format] == "float"
     end
 
+    test "does not include return_usage in processed embedding transport options" do
+      model = %LLMDB.Model{provider: :simple, id: "embedding-model"}
+      opts = [dimensions: 512, encoding_format: "float"]
+
+      assert {:ok, processed} = Options.process(SimpleProvider, :embedding, model, opts)
+      refute Keyword.has_key?(processed, :return_usage)
+    end
+
     test "rejects generation-specific options for :embedding operations" do
       model = %LLMDB.Model{provider: :simple, id: "embedding-model"}
       opts = [temperature: 0.7]


### PR DESCRIPTION
## Summary
- exclude  from embedding schema used by provider option processing
- keep  as a high-level  concern only
- add regression test to ensure processed embedding transport opts never include 

## Why
CI on  fails with  from  in embedding provider request paths.

## Validation
- Running ExUnit with seed: 195034, max_cases: 20
Excluding tags: [:coverage, :integration]

.............................................................................................................................................................................................................................................................................................................................................................
Finished in 0.5 seconds (0.5s async, 0.04s sync)
349 tests, 0 failures
- Running ExUnit with seed: 790361, max_cases: 20
Excluding tags: [:coverage, :integration]

..........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................***...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................********.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 3.7 seconds (3.6s async, 0.1s sync)
2201 tests, 0 failures, 11 skipped (116 excluded)
