### PR TITLE
fix: ReqLLM.Response.object returns string keys

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -50,7 +50,7 @@ schema = [
 ]
 {:ok, response} = ReqLLM.generate_object("anthropic:claude-haiku-4-5", "Generate a person", schema)
 object = ReqLLM.Response.object(response)
-# object => %{name: "John Doe", age: 30}
+# object => %{"name" => "John Doe", "age" => 30}
 ```
 
 ## Full Response with Usage


### PR DESCRIPTION


## Description

Fixes the example in the docs, which was incorrectly showing that response objects would have atom keys

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N / A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

