### PR TITLE
fix: clean up StreamServer processes after streaming completes

### DIFF
--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -84,8 +84,12 @@ defmodule ReqLLM.StreamServer do
     status: :init,
     consumer_refs: MapSet.new(),
     metadata: %{},
+    stream_requested?: false,
     metadata_delivered?: false,
     halt_delivered?: false,
+    completion_cleanup_after: 30_000,
+    completion_cleanup_timer: nil,
+    completion_cleanup_token: nil,
     high_watermark: 500,
     headers: [],
     http_status: nil,
@@ -131,6 +135,12 @@ defmodule ReqLLM.StreamServer do
       model: model,
       provider_state: provider_state,
       fixture_path: Keyword.get(opts, :fixture_path),
+      completion_cleanup_after:
+        Keyword.get(
+          opts,
+          :completion_cleanup_after,
+          Application.get_env(:req_llm, :stream_completion_cleanup_after, 30_000)
+        ),
       high_watermark: Keyword.get(opts, :high_watermark, 500)
     }
 
@@ -352,15 +362,16 @@ defmodule ReqLLM.StreamServer do
   def handle_call({:http_event, event}, _from, state) do
     {:reply, reply, new_state} = process_http_event(event, state)
 
-    if ready_to_stop?(new_state) do
-      {:stop, :normal, reply, new_state}
-    else
-      {:reply, reply, new_state}
+    case finalize_lifecycle(new_state) do
+      {:stop, final_state} -> {:stop, :normal, reply, final_state}
+      {:continue, final_state} -> {:reply, reply, final_state}
     end
   end
 
   @impl GenServer
   def handle_call({:next, _timeout}, from, state) do
+    state = cancel_completion_cleanup(%{state | stream_requested?: true})
+
     case dequeue_chunk(state) do
       {:ok, chunk, new_state} ->
         {:reply, {:ok, chunk}, new_state}
@@ -370,10 +381,9 @@ defmodule ReqLLM.StreamServer do
           :done ->
             halted_state = %{new_state | halt_delivered?: true}
 
-            if ready_to_stop?(halted_state) do
-              {:stop, :normal, :halt, halted_state}
-            else
-              {:reply, :halt, halted_state}
+            case finalize_lifecycle(halted_state) do
+              {:stop, final_state} -> {:stop, :normal, :halt, final_state}
+              {:continue, final_state} -> {:reply, :halt, final_state}
             end
 
           {:error, reason} ->
@@ -464,10 +474,9 @@ defmodule ReqLLM.StreamServer do
   def handle_call(:await_metadata, _from, %{status: :done} = state) do
     new_state = %{state | metadata_delivered?: true}
 
-    if ready_to_stop?(new_state) do
-      {:stop, :normal, {:ok, new_state.metadata}, new_state}
-    else
-      {:reply, {:ok, new_state.metadata}, new_state}
+    case finalize_lifecycle(new_state) do
+      {:stop, final_state} -> {:stop, :normal, {:ok, final_state.metadata}, final_state}
+      {:continue, final_state} -> {:reply, {:ok, final_state.metadata}, final_state}
     end
   end
 
@@ -496,7 +505,11 @@ defmodule ReqLLM.StreamServer do
       end
 
     new_state = reply_to_waiting_callers(new_state)
-    {:noreply, new_state}
+
+    case finalize_lifecycle(new_state) do
+      {:stop, final_state} -> {:stop, :normal, final_state}
+      {:continue, final_state} -> {:noreply, final_state}
+    end
   end
 
   @impl GenServer
@@ -513,11 +526,33 @@ defmodule ReqLLM.StreamServer do
       end
 
     new_state = reply_to_waiting_callers(new_state)
-    {:noreply, new_state}
+
+    case finalize_lifecycle(new_state) do
+      {:stop, final_state} -> {:stop, :normal, final_state}
+      {:continue, final_state} -> {:noreply, final_state}
+    end
   end
 
   @impl GenServer
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info(
+        {:completion_cleanup, token},
+        %{completion_cleanup_token: token} = state
+      ) do
+    new_state = %{state | completion_cleanup_timer: nil, completion_cleanup_token: nil}
+
+    case should_schedule_completion_cleanup?(new_state) do
+      true -> {:stop, :normal, new_state}
+      false -> {:noreply, new_state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:completion_cleanup, _ref}, state) do
     {:noreply, state}
   end
 
@@ -937,12 +972,49 @@ defmodule ReqLLM.StreamServer do
       Process.exit(state.http_task, :cancelled)
     end
 
-    state
+    cancel_completion_cleanup(state)
   end
 
   defp ready_to_stop?(state) do
     state.status == :done and state.metadata_delivered? and state.halt_delivered? and
       :queue.is_empty(state.queue)
+  end
+
+  defp finalize_lifecycle(state) do
+    cond do
+      ready_to_stop?(state) ->
+        {:stop, cancel_completion_cleanup(state)}
+
+      should_schedule_completion_cleanup?(state) ->
+        {:continue, ensure_completion_cleanup_timer(state)}
+
+      true ->
+        {:continue, cancel_completion_cleanup(state)}
+    end
+  end
+
+  defp should_schedule_completion_cleanup?(state) do
+    state.status == :done and state.metadata_delivered? and not state.stream_requested? and
+      not state.halt_delivered? and is_integer(state.completion_cleanup_after) and
+      state.completion_cleanup_after >= 0
+  end
+
+  defp ensure_completion_cleanup_timer(%{completion_cleanup_timer: nil} = state) do
+    token = make_ref()
+
+    timer =
+      Process.send_after(self(), {:completion_cleanup, token}, state.completion_cleanup_after)
+
+    %{state | completion_cleanup_timer: timer, completion_cleanup_token: token}
+  end
+
+  defp ensure_completion_cleanup_timer(state), do: state
+
+  defp cancel_completion_cleanup(%{completion_cleanup_timer: nil} = state), do: state
+
+  defp cancel_completion_cleanup(%{completion_cleanup_timer: ref} = state) do
+    Process.cancel_timer(ref)
+    %{state | completion_cleanup_timer: nil, completion_cleanup_token: nil}
   end
 
   defp build_http_error(status, chunk) do

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -148,6 +148,12 @@ defmodule ReqLLM.Streaming do
       provider_mod: provider_mod,
       model: model,
       fixture_path: maybe_capture_fixture(model, opts),
+      completion_cleanup_after:
+        Keyword.get(
+          opts,
+          :completion_cleanup_after,
+          Application.get_env(:req_llm, :stream_completion_cleanup_after, 30_000)
+        ),
       high_watermark: Keyword.get(opts, :high_watermark, 500)
     ]
 

--- a/test/req_llm/integration/streaming_orchestration_test.exs
+++ b/test/req_llm/integration/streaming_orchestration_test.exs
@@ -155,6 +155,51 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
       assert StreamResponse.finish_reason(stream_response) == :stop
     end
 
+    test "metadata-only access cleans up completed streams after the idle timeout" do
+      {:ok, model} = ReqLLM.model("openrouter:google/gemini-3-flash-preview")
+      before_pids = MapSet.new(Process.list())
+
+      {:ok, stream_response} =
+        Streaming.start_stream(
+          ReqLLM.Providers.OpenRouter,
+          model,
+          Context.new("Hello"),
+          fixture: "streaming",
+          completion_cleanup_after: 20
+        )
+
+      stream_server_pid = await_stream_server(before_pids, model.id)
+
+      assert is_pid(stream_server_pid)
+      assert StreamResponse.finish_reason(stream_response) == :stop
+      assert wait_until(fn -> not Process.alive?(stream_server_pid) end)
+    end
+
+    test "metadata access before streaming still allows consumption before idle cleanup" do
+      {:ok, model} = ReqLLM.model("openrouter:google/gemini-3-flash-preview")
+      before_pids = MapSet.new(Process.list())
+
+      {:ok, stream_response} =
+        Streaming.start_stream(
+          ReqLLM.Providers.OpenRouter,
+          model,
+          Context.new("Hello"),
+          fixture: "streaming",
+          completion_cleanup_after: 1_000
+        )
+
+      stream_server_pid = await_stream_server(before_pids, model.id)
+
+      assert is_pid(stream_server_pid)
+      assert StreamResponse.finish_reason(stream_response) == :stop
+      assert Process.alive?(stream_server_pid)
+
+      text = StreamResponse.text(stream_response)
+
+      assert byte_size(text) > 0
+      assert wait_until(fn -> not Process.alive?(stream_server_pid) end)
+    end
+
     test "partially consumed streams cancel their StreamServer" do
       {:ok, model} = ReqLLM.model("openrouter:google/gemini-3-flash-preview")
       before_pids = MapSet.new(Process.list())

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -81,5 +81,22 @@ defmodule ReqLLM.StreamServer.MetadataTest do
 
       StreamServer.cancel(server)
     end
+
+    test "stops after normal HTTP task completion once halt and metadata are delivered" do
+      server = start_server()
+      task = Task.async(fn -> Process.sleep(20) end)
+
+      StreamServer.attach_http_task(server, task.pid)
+
+      next_task = Task.async(fn -> StreamServer.next(server, 200) end)
+      metadata_task = Task.async(fn -> StreamServer.await_metadata(server, 200) end)
+
+      assert :halt = Task.await(next_task)
+      assert {:ok, metadata} = Task.await(metadata_task)
+      assert metadata.finish_reason == :incomplete
+
+      assert_receive {:EXIT, ^server, :normal}, 200
+      refute Process.alive?(server)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- stop StreamServer once both the stream halt and metadata have been delivered
- cancel unfinished streams from the Stream.resource cleanup callback
- add fixture-backed regressions for full consumption and partial cancellation

Closes #492.

## Testing
- mix test test/req_llm/stream_server test/req_llm/integration/streaming_orchestration_test.exs --include integration
- mix test test/req_llm/stream_response_test.exs