### PR TITLE
fix: expose stream keepalive callbacks

### DIFF
--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -120,8 +120,7 @@ defmodule ReqLLM.Providers.Anthropic.Response do
         end
 
       %{"type" => "ping"} ->
-        # Keep-alive ping, no content
-        []
+        [ReqLLM.StreamChunk.meta(%{keepalive?: true, provider_event: :ping})]
 
       _ ->
         []

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -312,7 +312,7 @@ defmodule ReqLLM.StreamResponse do
   end
 
   @doc """
-  Process a stream with real-time callbacks for content and thinking.
+  Process a stream with real-time callbacks for chunk activity and visible output.
 
   Unlike `to_response/1`, this function processes the stream incrementally and invokes
   callbacks as chunks arrive, enabling real-time streaming to UIs or other consumers.
@@ -323,6 +323,13 @@ defmodule ReqLLM.StreamResponse do
 
     * `stream_response` - The StreamResponse struct to process
     * `opts` - Keyword list of options:
+      * `:on_chunk` - Callback invoked immediately for every chunk that reaches
+                      `process_stream/2`, including metadata-only chunks.
+                      Receives the full `StreamChunk` struct.
+                      Signature: `(StreamChunk.t() -> any())`
+      * `:on_meta` - Callback invoked immediately for each `:meta` chunk.
+                     Receives the full `StreamChunk` struct.
+                     Signature: `(StreamChunk.t() -> any())`
       * `:on_result` - Callback invoked immediately for each `:content` chunk.
                        Signature: `(String.t() -> any())`
       * `:on_thinking` - Callback invoked immediately for each `:thinking` chunk.
@@ -369,6 +376,7 @@ defmodule ReqLLM.StreamResponse do
 
   ## Implementation Notes
 
+  - Raw chunk callbacks fire immediately as chunks arrive, including metadata/keepalive chunks
   - Content and thinking callbacks fire immediately as chunks arrive (real-time streaming)
   - Tool calls are reconstructed from stream chunks and available in the returned Response
   - The stream is consumed exactly once (no double-consumption bugs)
@@ -405,28 +413,35 @@ defmodule ReqLLM.StreamResponse do
   # Process stream chunks, invoking callbacks and collecting chunks
   defp process_stream_with_callbacks(stream, callbacks) do
     Enum.map(stream, fn chunk ->
-      # Invoke callbacks for real-time streaming
-      case chunk.type do
-        :content ->
-          if callbacks.on_result && chunk.text, do: callbacks.on_result.(chunk.text)
-
-        :thinking ->
-          if callbacks.on_thinking && chunk.text, do: callbacks.on_thinking.(chunk.text)
-
-        :tool_call ->
-          if callbacks.on_tool_call, do: callbacks.on_tool_call.(chunk)
-
-        _ ->
-          :ok
-      end
-
+      invoke_callbacks(chunk, callbacks)
       chunk
     end)
+  end
+
+  defp invoke_callbacks(chunk, callbacks) do
+    if callbacks.on_chunk, do: callbacks.on_chunk.(chunk)
+    if callbacks.on_meta && chunk.type == :meta, do: callbacks.on_meta.(chunk)
+
+    case chunk.type do
+      :content ->
+        if callbacks.on_result && chunk.text, do: callbacks.on_result.(chunk.text)
+
+      :thinking ->
+        if callbacks.on_thinking && chunk.text, do: callbacks.on_thinking.(chunk.text)
+
+      :tool_call ->
+        if callbacks.on_tool_call, do: callbacks.on_tool_call.(chunk)
+
+      _ ->
+        :ok
+    end
   end
 
   # Extract callbacks from options
   defp extract_callbacks(opts) do
     %{
+      on_chunk: Keyword.get(opts, :on_chunk),
+      on_meta: Keyword.get(opts, :on_meta),
       on_result: Keyword.get(opts, :on_result),
       on_thinking: Keyword.get(opts, :on_thinking),
       on_tool_call: Keyword.get(opts, :on_tool_call)

--- a/test/provider/azure/streaming_test.exs
+++ b/test/provider/azure/streaming_test.exs
@@ -188,7 +188,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
       assert Azure.decode_stream_event(event, model) == []
     end
 
-    test "Claude: ping event returns empty list" do
+    test "Claude: ping event returns keepalive meta chunk" do
       model = %LLMDB.Model{
         id: "claude-3-5-sonnet-20241022",
         provider: :azure,
@@ -197,7 +197,10 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
 
       event = %{data: %{"type" => "ping"}}
 
-      assert Azure.decode_stream_event(event, model) == []
+      assert [%ReqLLM.StreamChunk{} = chunk] = Azure.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata[:keepalive?] == true
+      assert chunk.metadata[:provider_event] == :ping
     end
 
     test "Claude: unknown event type returns empty list" do

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -499,6 +499,18 @@ defmodule ReqLLM.Providers.AnthropicTest do
     end
   end
 
+  describe "streaming response decoding" do
+    test "decode_stream_event returns keepalive meta chunk for ping events" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      event = %{data: %{"type" => "ping"}}
+
+      assert [%ReqLLM.StreamChunk{} = chunk] = Anthropic.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata[:keepalive?] == true
+      assert chunk.metadata[:provider_event] == :ping
+    end
+  end
+
   describe "option translation" do
     test "translate_options converts stop to stop_sequences" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")

--- a/test/req_llm/stream_response_test.exs
+++ b/test/req_llm/stream_response_test.exs
@@ -707,6 +707,65 @@ defmodule ReqLLM.StreamResponseTest do
       assert length(Response.tool_calls(response)) == 2
     end
 
+    test "calls on_chunk callback for every chunk including meta chunks" do
+      chunks = [
+        StreamChunk.text("Hello"),
+        StreamChunk.thinking("Let me think"),
+        StreamChunk.tool_call("search", %{}, %{id: "call-1", index: 0}),
+        StreamChunk.meta(%{tool_call_args: %{index: 0, fragment: ~s({"q":"test"})}})
+      ]
+
+      stream_response = create_stream_response(stream: chunks)
+      parent = self()
+
+      {:ok, response} =
+        StreamResponse.process_stream(stream_response,
+          on_chunk: fn chunk -> send(parent, {:chunk, chunk}) end
+        )
+
+      assert_receive {:chunk, %StreamChunk{type: :content, text: "Hello"}}
+      assert_receive {:chunk, %StreamChunk{type: :thinking, text: "Let me think"}}
+      assert_receive {:chunk, %StreamChunk{type: :tool_call, name: "search"}}
+
+      assert_receive {:chunk,
+                      %StreamChunk{
+                        type: :meta,
+                        metadata: %{tool_call_args: %{index: 0, fragment: "{\"q\":\"test\"}"}}
+                      }}
+
+      assert Response.text(response) == "Hello"
+      assert length(Response.tool_calls(response)) == 1
+    end
+
+    test "calls on_meta callback only for meta chunks" do
+      chunks = [
+        StreamChunk.text("Hello"),
+        StreamChunk.meta(%{usage: %{input_tokens: 1}}),
+        StreamChunk.thinking("Thinking"),
+        StreamChunk.meta(%{keepalive?: true, provider_event: :ping})
+      ]
+
+      stream_response = create_stream_response(stream: chunks)
+      parent = self()
+
+      {:ok, response} =
+        StreamResponse.process_stream(stream_response,
+          on_meta: fn chunk -> send(parent, {:meta, chunk}) end
+        )
+
+      assert_receive {:meta, %StreamChunk{type: :meta, metadata: %{usage: %{input_tokens: 1}}}}
+
+      assert_receive {:meta,
+                      %StreamChunk{
+                        type: :meta,
+                        metadata: %{keepalive?: true, provider_event: :ping}
+                      }}
+
+      refute_received {:meta, %StreamChunk{type: :content}}
+      refute_received {:meta, %StreamChunk{type: :thinking}}
+      assert Response.text(response) == "Hello"
+    end
+
     test "on_tool_call callback not invoked when not provided" do
       chunks = [
         StreamChunk.tool_call("test_tool", %{arg: "value"}, %{id: "call-1", index: 0})


### PR DESCRIPTION
## Summary
- add `on_chunk` and `on_meta` callbacks to `ReqLLM.StreamResponse.process_stream/2`
- surface Anthropic `ping` frames as keepalive meta chunks instead of dropping them
- add callback and provider coverage for meta/tool-arg keepalive behavior

## Testing
- `mix test test/req_llm/stream_response_test.exs test/providers/anthropic_test.exs test/provider/azure/streaming_test.exs`

Closes #493.
Upstream context: agentjido/jido_ai#195.