### PR TITLE
fix: GoogleVertex extract_gcp_credentials from provider_options

### DIFF
--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -547,18 +547,44 @@ defmodule ReqLLM.Providers.GoogleVertex do
     {gcp_creds, other_opts, model_family, formatter}
   end
 
-  # Extract GCP credentials from options
+  # Extract GCP credentials from options.
+  # Credentials can be passed at the top level or inside :provider_options.
+  # Top-level values take precedence over :provider_options values.
   defp extract_gcp_credentials(opts) do
     gcp_keys = [:service_account_json, :access_token, :project_id, :region]
-    {passed_creds, other_opts} = Keyword.split(opts, gcp_keys)
+
+    # Extract from top-level opts
+    {top_creds, other_opts} = Keyword.split(opts, gcp_keys)
+
+    # Also extract from provider_options (users may pass credentials there per docs)
+    {provider_creds, remaining_provider_opts} =
+      case Keyword.get(other_opts, :provider_options) do
+        po when is_list(po) and po != [] ->
+          {extracted, rest} = Keyword.split(po, gcp_keys)
+          {extracted, rest}
+
+        _ ->
+          {[], nil}
+      end
+
+    # Update provider_options if we extracted credentials from it
+    other_opts =
+      case remaining_provider_opts do
+        nil -> other_opts
+        [] -> Keyword.delete(other_opts, :provider_options)
+        rest -> Keyword.put(other_opts, :provider_options, rest)
+      end
+
+    # Merge: top-level takes precedence over provider_options
+    merged = Keyword.merge(provider_creds, top_creds)
 
     creds = %{
       service_account_json:
-        passed_creds[:service_account_json] ||
+        merged[:service_account_json] ||
           System.get_env("GOOGLE_APPLICATION_CREDENTIALS"),
-      project_id: passed_creds[:project_id] || System.get_env("GOOGLE_CLOUD_PROJECT"),
-      region: passed_creds[:region] || System.get_env("GOOGLE_CLOUD_REGION") || "global",
-      access_token: passed_creds[:access_token]
+      project_id: merged[:project_id] || System.get_env("GOOGLE_CLOUD_PROJECT"),
+      region: merged[:region] || System.get_env("GOOGLE_CLOUD_REGION") || "global",
+      access_token: merged[:access_token]
     }
 
     {creds, other_opts}

--- a/test/providers/google_vertex_embedding_test.exs
+++ b/test/providers/google_vertex_embedding_test.exs
@@ -109,6 +109,44 @@ defmodule ReqLLM.Providers.GoogleVertex.EmbeddingTest do
         GoogleVertex.prepare_request(:embedding, @model_spec, "Hello", access_token: "tok")
       end
     end
+
+    test "accepts credentials inside provider_options" do
+      opts = [
+        provider_options: [
+          access_token: "test-token",
+          project_id: "test-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(:embedding, @model_spec, "Hello world", opts)
+
+      url = URI.to_string(request.url)
+      assert url =~ "us-central1-aiplatform.googleapis.com"
+      assert url =~ "projects/test-project"
+    end
+
+    test "top-level credentials take precedence over provider_options" do
+      opts = [
+        access_token: "top-level-token",
+        project_id: "top-project",
+        region: "eu-west1",
+        provider_options: [
+          access_token: "nested-token",
+          project_id: "nested-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(:embedding, @model_spec, "Hello", opts)
+
+      url = URI.to_string(request.url)
+      # Top-level should win
+      assert url =~ "eu-west1-aiplatform.googleapis.com"
+      assert url =~ "projects/top-project"
+    end
   end
 
   describe "decode_embedding_response/1" do

--- a/test/providers/google_vertex_openai_compat_test.exs
+++ b/test/providers/google_vertex_openai_compat_test.exs
@@ -125,6 +125,49 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompatTest do
     end
   end
 
+  describe "credentials in provider_options" do
+    test "accepts credentials inside provider_options for chat" do
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+      context = context_fixture()
+
+      opts = [
+        provider_options: [
+          access_token: "fake-token",
+          project_id: "test-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context, opts)
+      url = URI.to_string(request.url)
+
+      assert url =~ "us-central1-aiplatform.googleapis.com"
+      assert url =~ "projects/test-project"
+    end
+
+    test "top-level credentials take precedence over provider_options for chat" do
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+      context = context_fixture()
+
+      opts = [
+        access_token: "top-token",
+        project_id: "top-project",
+        region: "eu-west4",
+        provider_options: [
+          access_token: "nested-token",
+          project_id: "nested-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context, opts)
+      url = URI.to_string(request.url)
+
+      assert url =~ "eu-west4-aiplatform.googleapis.com"
+      assert url =~ "projects/top-project"
+    end
+  end
+
   describe "model family resolution" do
     test "GLM model resolves to openai_compat formatter via extra.family" do
       {:ok, model} = ReqLLM.model("google_vertex:zai-org/glm-4.7-maas")


### PR DESCRIPTION
## Description

`extract_gcp_credentials/1` only looked at top-level opts for `access_token`, `service_account_json`, `project_id`, and `region`. When users passed these inside `provider_options:` (as the docs and error messages suggest), the function found nothing and `validate_gcp_credentials!` raised. Now checks both top-level and `provider_options`, with top-level taking precedence.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #481