### PR TITLE
fix: support nested Google Vertex credentials

### DIFF
--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -551,18 +551,31 @@ defmodule ReqLLM.Providers.GoogleVertex do
   defp extract_gcp_credentials(opts) do
     gcp_keys = [:service_account_json, :access_token, :project_id, :region]
     {passed_creds, other_opts} = Keyword.split(opts, gcp_keys)
+    provider_opts = normalize_provider_opts(Keyword.get(other_opts, :provider_options, []))
 
     creds = %{
       service_account_json:
         passed_creds[:service_account_json] ||
+          provider_opts[:service_account_json] ||
           System.get_env("GOOGLE_APPLICATION_CREDENTIALS"),
-      project_id: passed_creds[:project_id] || System.get_env("GOOGLE_CLOUD_PROJECT"),
-      region: passed_creds[:region] || System.get_env("GOOGLE_CLOUD_REGION") || "global",
-      access_token: passed_creds[:access_token]
+      project_id:
+        passed_creds[:project_id] ||
+          provider_opts[:project_id] ||
+          System.get_env("GOOGLE_CLOUD_PROJECT"),
+      region:
+        passed_creds[:region] ||
+          provider_opts[:region] ||
+          System.get_env("GOOGLE_CLOUD_REGION") ||
+          "global",
+      access_token: passed_creds[:access_token] || provider_opts[:access_token]
     }
 
     {creds, other_opts}
   end
+
+  defp normalize_provider_opts(opts) when is_list(opts), do: opts
+  defp normalize_provider_opts(opts) when is_map(opts), do: Map.to_list(opts)
+  defp normalize_provider_opts(_), do: []
 
   # Validate GCP credentials
   defp validate_gcp_credentials!(creds) do

--- a/test/providers/google_vertex_embedding_test.exs
+++ b/test/providers/google_vertex_embedding_test.exs
@@ -109,6 +109,41 @@ defmodule ReqLLM.Providers.GoogleVertex.EmbeddingTest do
         GoogleVertex.prepare_request(:embedding, @model_spec, "Hello", access_token: "tok")
       end
     end
+
+    test "accepts credentials nested under provider_options" do
+      opts = [
+        provider_options: [
+          access_token: "nested-token",
+          project_id: "nested-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:embedding, @model_spec, "Hello", opts)
+      url = URI.to_string(request.url)
+
+      assert url =~ "projects/nested-project"
+      assert url =~ "locations/us-central1"
+    end
+
+    test "top-level credentials take precedence over provider_options" do
+      opts = [
+        access_token: "top-level-token",
+        project_id: "top-level-project",
+        region: "europe-west1",
+        provider_options: [
+          access_token: "nested-token",
+          project_id: "nested-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:embedding, @model_spec, "Hello", opts)
+      url = URI.to_string(request.url)
+
+      assert url =~ "projects/top-level-project"
+      assert url =~ "locations/europe-west1"
+    end
   end
 
   describe "decode_embedding_response/1" do

--- a/test/providers/google_vertex_openai_compat_test.exs
+++ b/test/providers/google_vertex_openai_compat_test.exs
@@ -66,6 +66,47 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompatTest do
       assert url =~ "projects/my-project"
       assert url =~ "locations/europe-west1"
     end
+
+    test "openai_compat model accepts credentials nested under provider_options" do
+      {:ok, model} = ReqLLM.model("google_vertex:zai-org/glm-4.7-maas")
+      context = context_fixture()
+
+      opts = [
+        provider_options: [
+          access_token: "nested-token",
+          project_id: "nested-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context, opts)
+      url = URI.to_string(request.url)
+
+      assert url =~ "projects/nested-project"
+      assert url =~ "locations/us-central1"
+    end
+
+    test "top-level credentials take precedence over provider_options" do
+      {:ok, model} = ReqLLM.model("google_vertex:zai-org/glm-4.7-maas")
+      context = context_fixture()
+
+      opts = [
+        access_token: "top-level-token",
+        project_id: "top-level-project",
+        region: "europe-west1",
+        provider_options: [
+          access_token: "nested-token",
+          project_id: "nested-project",
+          region: "us-central1"
+        ]
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context, opts)
+      url = URI.to_string(request.url)
+
+      assert url =~ "projects/top-level-project"
+      assert url =~ "locations/europe-west1"
+    end
   end
 
   describe "provider_options validation" do


### PR DESCRIPTION
## Summary
- read Google Vertex credentials from `provider_options` as well as top-level opts
- preserve top-level precedence when both are present
- cover both chat and embedding request paths with focused tests

Closes #481

## Testing
- mix test test/providers/google_vertex_openai_compat_test.exs test/providers/google_vertex_embedding_test.exs