### PR TITLE
fix: emit usage for Vertex embeddings

### DIFF
--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -223,7 +223,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
         |> Req.Request.merge_options(operation: :embedding, text: text)
         |> Req.Request.put_private(:gcp_credentials, gcp_creds)
         |> Req.Request.put_private(:model, model)
-        |> attach_embedding(gcp_creds)
+        |> attach_embedding(model, gcp_creds, other_opts)
 
       {:ok, request}
     end
@@ -323,12 +323,14 @@ defmodule ReqLLM.Providers.GoogleVertex do
     )
   end
 
-  defp attach_embedding(request, gcp_creds) do
+  defp attach_embedding(request, model, gcp_creds, opts) do
     request
     |> Req.Request.merge_options(finch: ReqLLM.Application.finch_name())
     |> ReqLLM.Step.Error.attach()
     |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Usage.attach(model)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_embedding_response/1)
+    |> ReqLLM.Step.Fixture.maybe_attach(model, opts)
     |> put_gcp_auth(gcp_creds)
   end
 
@@ -643,14 +645,36 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
   @impl ReqLLM.Provider
   def extract_usage(body, model) do
-    formatter = get_formatter(model)
+    case extract_embedding_usage(body) do
+      {:ok, _usage} = usage ->
+        usage
 
-    if function_exported?(formatter, :extract_usage, 2) do
-      formatter.extract_usage(body, model)
-    else
-      {:error, :no_usage_extractor}
+      :error ->
+        formatter = get_formatter(model)
+
+        if function_exported?(formatter, :extract_usage, 2) do
+          formatter.extract_usage(body, model)
+        else
+          {:error, :no_usage_extractor}
+        end
     end
   end
+
+  defp extract_embedding_usage(%{"predictions" => predictions}) when is_list(predictions) do
+    total_tokens =
+      predictions
+      |> Enum.map(&get_in(&1, ["embeddings", "statistics", "token_count"]))
+      |> Enum.filter(&is_integer/1)
+      |> Enum.sum()
+
+    if total_tokens > 0 do
+      {:ok, %{input_tokens: total_tokens, output_tokens: 0, total_tokens: total_tokens}}
+    else
+      :error
+    end
+  end
+
+  defp extract_embedding_usage(_), do: :error
 
   def pre_validate_options(operation, model, opts) do
     model_family = get_model_family(model)

--- a/test/providers/google_vertex_embedding_test.exs
+++ b/test/providers/google_vertex_embedding_test.exs
@@ -163,4 +163,22 @@ defmodule ReqLLM.Providers.GoogleVertex.EmbeddingTest do
       assert decoded.body == %{"error" => "bad request"}
     end
   end
+
+  describe "extract_usage/2 for embeddings" do
+    test "extracts token counts from prediction statistics" do
+      {:ok, model} = ReqLLM.model(@model_spec)
+
+      body = %{
+        "predictions" => [
+          %{"embeddings" => %{"statistics" => %{"token_count" => 2}}},
+          %{"embeddings" => %{"statistics" => %{"token_count" => 3}}}
+        ]
+      }
+
+      assert {:ok, usage} = GoogleVertex.extract_usage(body, model)
+      assert usage.input_tokens == 5
+      assert usage.output_tokens == 0
+      assert usage.total_tokens == 5
+    end
+  end
 end

--- a/test/req_llm/embedding_test.exs
+++ b/test/req_llm/embedding_test.exs
@@ -14,6 +14,24 @@ defmodule ReqLLM.EmbeddingTest do
 
   alias ReqLLM.Embedding
 
+  defp setup_telemetry do
+    test_pid = self()
+    ref = System.unique_integer([:positive])
+    handler_id = "embedding-usage-handler-#{ref}"
+
+    :telemetry.attach(
+      handler_id,
+      [:req_llm, :token_usage],
+      fn name, measurements, metadata, _ ->
+        send(test_pid, {:telemetry_event, name, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    :ok
+  end
+
   describe "supported_models/0" do
     test "returns list of available embedding models" do
       models = Embedding.supported_models()
@@ -103,6 +121,46 @@ defmodule ReqLLM.EmbeddingTest do
 
     test "rejects unsupported providers" do
       assert {:error, :unknown_provider} = Embedding.embed("unsupported:model", "Hello")
+    end
+  end
+
+  describe "embed/3 - Google Vertex usage metadata" do
+    setup do
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{
+          "predictions" => [
+            %{
+              "embeddings" => %{
+                "values" => [0.1, -0.2, 0.3],
+                "statistics" => %{"token_count" => 2}
+              }
+            }
+          ]
+        })
+      end)
+
+      setup_telemetry()
+    end
+
+    test "emits telemetry and returns usage for embeddings" do
+      {:ok, %{embedding: embedding, usage: usage}} =
+        Embedding.embed(
+          "google_vertex:gemini-embedding-001",
+          "Hello world",
+          access_token: "test-token",
+          project_id: "test-project",
+          region: "us-central1",
+          return_usage: true,
+          req_http_options: [plug: {Req.Test, __MODULE__}]
+        )
+
+      assert embedding == [0.1, -0.2, 0.3]
+      assert usage.input == 2
+
+      assert_receive {:telemetry_event, [:req_llm, :token_usage], measurements, metadata}
+      assert measurements.tokens.input == 2
+      assert metadata.model.provider == :google_vertex
+      assert metadata.model.id == "gemini-embedding-001"
     end
   end
 


### PR DESCRIPTION
## Summary
- attach usage and fixture steps for Google Vertex embedding requests
- extract embedding token counts from Vertex prediction statistics
- cover telemetry and `return_usage` through the top-level embedding API

Closes #482

## Testing
- mix test test/req_llm/embedding_test.exs test/providers/google_vertex_embedding_test.exs