### PR TITLE
fix: honor Google image output format

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -825,6 +825,7 @@ defmodule ReqLLM.Providers.Google do
     generation_config =
       %{}
       |> maybe_put_google_aspect_ratio(request.options[:aspect_ratio])
+      |> maybe_put_google_output_format(request.options[:output_format])
       |> maybe_put(:candidateCount, image_candidate_count(request.options))
 
     generation_config = if generation_config != %{}, do: generation_config
@@ -863,6 +864,33 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp maybe_put_google_aspect_ratio(config, _), do: config
+
+  defp maybe_put_google_output_format(config, nil), do: config
+
+  defp maybe_put_google_output_format(config, format) do
+    case google_image_output_mime_type(format) do
+      nil ->
+        config
+
+      mime_type ->
+        Map.put(
+          config,
+          "imageConfig",
+          Map.put(Map.get(config, "imageConfig", %{}), "outputMimeType", mime_type)
+        )
+    end
+  end
+
+  defp google_image_output_mime_type(:png), do: "image/png"
+  defp google_image_output_mime_type(:jpeg), do: "image/jpeg"
+  defp google_image_output_mime_type(:webp), do: "image/webp"
+  defp google_image_output_mime_type("png"), do: "image/png"
+  defp google_image_output_mime_type("jpeg"), do: "image/jpeg"
+  defp google_image_output_mime_type("webp"), do: "image/webp"
+  defp google_image_output_mime_type("image/png"), do: "image/png"
+  defp google_image_output_mime_type("image/jpeg"), do: "image/jpeg"
+  defp google_image_output_mime_type("image/webp"), do: "image/webp"
+  defp google_image_output_mime_type(_), do: nil
 
   defp parse_size(size) when is_binary(size) do
     case String.split(size, "x") do

--- a/test/providers/google_images_test.exs
+++ b/test/providers/google_images_test.exs
@@ -38,7 +38,7 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
 
     assert get_in(body, ["generationConfig", "responseModalities"]) == nil
     assert get_in(body, ["generationConfig", "imageConfig", "aspectRatio"]) == "1:1"
-    assert get_in(body, ["generationConfig", "imageConfig", "mimeType"]) == nil
+    assert get_in(body, ["generationConfig", "imageConfig", "outputMimeType"]) == "image/png"
     assert get_in(body, ["generationConfig", "candidateCount"]) == 2
 
     assert get_in(body, ["contents", Access.at(0), "parts", Access.at(0), "text"]) ==
@@ -84,6 +84,34 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
     body = Jason.decode!(encoded.body)
 
     assert is_nil(body["generationConfig"])
+  end
+
+  test "encode_body/1 maps alternate image output formats" do
+    context = %Context{
+      messages: [
+        %ReqLLM.Message{role: :user, content: "A cat in space"}
+      ]
+    }
+
+    request =
+      Req.new(url: "/models/gemini-2.0-flash-exp-image-generation:generateContent")
+      |> Req.Request.register_options([
+        :operation,
+        :model,
+        :output_format,
+        :context
+      ])
+      |> Req.Request.merge_options(
+        operation: :image,
+        model: "gemini-2.0-flash-exp-image-generation",
+        output_format: :webp,
+        context: context
+      )
+
+    encoded = Google.encode_body(request)
+    body = Jason.decode!(encoded.body)
+
+    assert get_in(body, ["generationConfig", "imageConfig", "outputMimeType"]) == "image/webp"
   end
 
   test "decode_response/1 converts inlineData to ContentPart.image" do


### PR DESCRIPTION
## Summary
- serialize Google image `output_format` into `generationConfig.imageConfig.outputMimeType`
- cover the Google image request body for png and webp output formats

Closes #402

## Testing
- mix test test/providers/google_images_test.exs