### PR TITLE
fix(google): strip atom-keyed forbidden schema fields

### DIFF
--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -654,10 +654,12 @@ defmodule ReqLLM.Schema do
       }
 
   """
+  @google_forbidden_schema_keys ["$schema", "additionalProperties"]
+
   @spec to_google_format(ReqLLM.Tool.t()) :: map()
   def to_google_format(%ReqLLM.Tool{} = tool) do
     json_schema = to_json(tool.parameter_schema)
-    parameters = deep_delete_keys(json_schema, ["$schema", "additionalProperties"])
+    parameters = deep_delete_keys(json_schema, @google_forbidden_schema_keys)
 
     %{
       "name" => tool.name,
@@ -958,10 +960,10 @@ defmodule ReqLLM.Schema do
   defp format_jsv_error(%{"error" => error}), do: error
   defp format_jsv_error(error), do: inspect(error)
 
-  @spec deep_delete_keys(term(), [String.t()]) :: term()
+  @spec deep_delete_keys(term(), [String.t() | atom()]) :: term()
   defp deep_delete_keys(map, keys) when is_map(map) do
     map
-    |> Map.drop(keys)
+    |> Map.drop(key_variants(keys))
     |> Map.new(fn {k, v} -> {k, deep_delete_keys(v, keys)} end)
   end
 
@@ -969,4 +971,8 @@ defmodule ReqLLM.Schema do
     do: Enum.map(list, &deep_delete_keys(&1, keys))
 
   defp deep_delete_keys(value, _keys), do: value
+
+  defp key_variants(keys) when is_list(keys), do: Enum.flat_map(keys, &key_variants/1)
+  defp key_variants(key) when is_binary(key), do: [key, String.to_atom(key)]
+  defp key_variants(key) when is_atom(key), do: [key, Atom.to_string(key)]
 end

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -201,6 +201,63 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert is_list(tool_def["functionDeclarations"])
     end
 
+    test "encode_body strips atom-keyed forbidden fields from tool schemas" do
+      {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "register_company",
+          description: "Register company",
+          parameter_schema: %{
+            :type => :object,
+            :required => [:company],
+            :properties => %{
+              :company => %{
+                :type => :object,
+                :required => [:name, :address],
+                :properties => %{
+                  :name => %{type: :string},
+                  :address => %{
+                    :type => :object,
+                    :required => [:city],
+                    :properties => %{city: %{type: :string}},
+                    :additionalProperties => false
+                  }
+                },
+                :additionalProperties => false
+              }
+            },
+            :additionalProperties => false,
+            :"$schema" => "https://json-schema.org/draft/2020-12/schema"
+          },
+          callback: fn _ -> {:ok, %{}} end
+        )
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          tools: [tool],
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+      [tool_def] = decoded["tools"]
+      [function_def] = tool_def["functionDeclarations"]
+      parameters = function_def["parameters"]
+      company = parameters["properties"]["company"]
+      address = company["properties"]["address"]
+
+      refute Map.has_key?(parameters, "$schema")
+      refute Map.has_key?(parameters, "additionalProperties")
+      refute Map.has_key?(company, "additionalProperties")
+      refute Map.has_key?(address, "additionalProperties")
+    end
+
     test "encode_body with empty tools list and tool_choice omits toolConfig" do
       {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
       context = context_fixture()

--- a/test/req_llm/schema_test.exs
+++ b/test/req_llm/schema_test.exs
@@ -442,6 +442,48 @@ defmodule ReqLLM.SchemaTest do
       assert result["parameters"]["required"] == ["tags"]
     end
 
+    test "to_google_format/1 strips atom-keyed forbidden fields recursively" do
+      atom_keyed_schema = %{
+        :type => :object,
+        :required => [:company],
+        :properties => %{
+          :company => %{
+            :type => :object,
+            :required => [:name, :address],
+            :properties => %{
+              :name => %{type: :string},
+              :address => %{
+                :type => :object,
+                :required => [:city],
+                :properties => %{city: %{type: :string}},
+                :additionalProperties => false
+              }
+            },
+            :additionalProperties => false
+          }
+        },
+        :additionalProperties => false,
+        :"$schema" => "https://json-schema.org/draft/2020-12/schema"
+      }
+
+      tool = %Tool{
+        name: "register_company",
+        description: "Register company",
+        parameter_schema: atom_keyed_schema,
+        callback: fn _ -> {:ok, %{}} end
+      }
+
+      result = Schema.to_google_format(tool)
+      parameters = result["parameters"]
+      company = parameters[:properties][:company]
+      address = company[:properties][:address]
+
+      refute Map.has_key?(parameters, :"$schema")
+      refute Map.has_key?(parameters, :additionalProperties)
+      refute Map.has_key?(company, :additionalProperties)
+      refute Map.has_key?(address, :additionalProperties)
+    end
+
     test "format consistency across providers", %{basic_tool: tool} do
       anthropic = Schema.to_anthropic_format(tool)
       openai = Schema.to_openai_format(tool)


### PR DESCRIPTION
## Summary
- strip Google-forbidden schema keys in both atom and string forms when formatting tool schemas
- add a schema-level regression for atom-keyed `$schema` and `additionalProperties`
- add a provider-level regression to verify the encoded Google request body is clean

## Testing
- mix test test/req_llm/schema_test.exs test/providers/google_test.exs