### PR TITLE
Avoid injecting max_tokens when max_completion_tokens is already set

### DIFF
--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -487,7 +487,9 @@ defmodule ReqLLM.Provider.Options do
 
   defp maybe_extract_max_tokens(%LLMDB.Model{} = model, opts) do
     cond do
-      Keyword.has_key?(opts, :max_tokens) ->
+      Keyword.has_key?(opts, :max_tokens) or
+        Keyword.has_key?(opts, :max_completion_tokens) or
+          provider_option_present?(opts, :max_completion_tokens) ->
         opts
 
       is_map(model.limits) and is_integer(model.limits[:output]) and model.limits[:output] > 0 ->
@@ -496,6 +498,12 @@ defmodule ReqLLM.Provider.Options do
       true ->
         opts
     end
+  end
+
+  defp provider_option_present?(opts, key) do
+    opts
+    |> Keyword.get(:provider_options, [])
+    |> Keyword.has_key?(key)
   end
 
   defp maybe_extract_model_base_url(opts, %LLMDB.Model{} = model) do

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -1,7 +1,10 @@
 defmodule ReqLLM.Provider.OptionsTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias ReqLLM.Provider.Options
+  alias ReqLLM.Providers.OpenAI
 
   # Mock provider for testing - implements minimal Provider behavior
   defmodule MockProvider do
@@ -265,6 +268,24 @@ defmodule ReqLLM.Provider.OptionsTest do
       # max_tokens: 0 should NOT be extracted
       refute Keyword.has_key?(processed, :max_tokens)
       assert processed[:temperature] == 0.5
+    end
+
+    test "does not synthesize max_tokens when max_completion_tokens is already provided" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4.1-mini")
+
+      log =
+        capture_log(fn ->
+          assert {:ok, processed} =
+                   Options.process(OpenAI, :object, model,
+                     max_completion_tokens: 123,
+                     operation: :object
+                   )
+
+          assert processed[:max_completion_tokens] == 123
+          refute Keyword.has_key?(processed, :max_tokens)
+        end)
+
+      refute log =~ "Renamed :max_tokens to :max_completion_tokens"
     end
   end
 


### PR DESCRIPTION
## Summary
- stop model-limit extraction from adding `:max_tokens` when `:max_completion_tokens` is already present
- cover the reasoning-model object-generation case in `Options.process/4`
- prevent the OpenAI rename warning from being triggered by library-internal defaults

## Why
For OpenAI Responses/reasoning models, callers can already provide `max_completion_tokens`. `ReqLLM.Provider.Options` was still auto-injecting `max_tokens` from model limits during object option processing, which then triggered the OpenAI translation path and logged:

`Renamed :max_tokens to :max_completion_tokens for reasoning models`

This patch keeps the existing extraction behavior for normal models, but avoids synthesizing the legacy token key when the completion-token key is already present.

## Verification
- `mix test test/req_llm/provider/options_test.exs`
- `mix test test/provider/openai_structured_output_test.exs`