### PR TITLE
fix: remove impossible role == :tool checks

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -526,12 +526,8 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   # Regular message (user, assistant, system)
   defp encode_message(%Message{role: role, content: content}) do
-    # Converse API only accepts "user" or "assistant" roles
-    # Tool results must be wrapped in a "user" message
-    normalized_role = if role == :tool, do: :user, else: role
-
     %{
-      "role" => Atom.to_string(normalized_role),
+      "role" => Atom.to_string(role),
       "content" => encode_content(content)
     }
   end

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -150,10 +150,8 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   end
 
   defp encode_message(%ReqLLM.Message{role: role, content: content}) do
-    normalized_role = if role == :tool, do: :user, else: role
-
     %{
-      role: to_string(normalized_role),
+      role: to_string(role),
       content: encode_content(content)
     }
   end


### PR DESCRIPTION
Since tool roles are specifically pattern matched in an earlier function clause for both AmazonBedrock.Converse and Anthropic.Context, the catch-all clause will never receive a message with role == :tool. This removes the impossible check to fix compiler warnings in Elixir 1.20.


## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

