### PR TITLE
fix: support image content in Bedrock tool results

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock/anthropic.ex
+++ b/lib/req_llm/providers/amazon_bedrock/anthropic.ex
@@ -117,7 +117,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
 
         case Keyword.get(opts, :tool_choice) do
           nil -> body
-          choice -> Map.put(body, :tool_choice, choice)
+          choice -> Map.put(body, :tool_choice, Anthropic.normalize_tool_choice(choice))
         end
     end
   end

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -529,7 +529,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
         %{
           "toolResult" => %{
             "toolUseId" => id,
-            "content" => [%{"text" => extract_tool_result_text(msg)}]
+            "content" => encode_tool_result_content(msg)
           }
         }
       ]
@@ -628,6 +628,16 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   defp extract_text_content(_), do: ""
+
+  defp encode_tool_result_content(%Message{content: content})
+       when is_list(content) and content != [] do
+    Enum.map(content, &encode_content_part/1)
+  end
+
+  defp encode_tool_result_content(%Message{} = msg) do
+    text = extract_tool_result_text(msg)
+    [%{"text" => text}]
+  end
 
   defp extract_tool_result_text(%Message{content: content} = msg) do
     text = extract_text_content(content)

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -835,18 +835,16 @@ defmodule ReqLLM.Providers.Anthropic do
     end
   end
 
-  # Normalize tool_choice to Anthropic's expected format
-  # Anthropic expects: %{type: "auto"}, %{type: "any"}, or %{type: "tool", name: "..."}
-  defp normalize_tool_choice(:auto), do: %{type: "auto"}
-  defp normalize_tool_choice(:required), do: %{type: "any"}
-  defp normalize_tool_choice(:none), do: %{type: "none"}
-  defp normalize_tool_choice("auto"), do: %{type: "auto"}
-  defp normalize_tool_choice("required"), do: %{type: "any"}
-  defp normalize_tool_choice("none"), do: %{type: "none"}
-  defp normalize_tool_choice({:tool, name}) when is_binary(name), do: %{type: "tool", name: name}
-
-  defp normalize_tool_choice(%{type: _} = choice), do: choice
-  defp normalize_tool_choice(%{"type" => _} = choice), do: choice
+  @doc false
+  def normalize_tool_choice(:auto), do: %{type: "auto"}
+  def normalize_tool_choice(:required), do: %{type: "any"}
+  def normalize_tool_choice(:none), do: %{type: "none"}
+  def normalize_tool_choice("auto"), do: %{type: "auto"}
+  def normalize_tool_choice("required"), do: %{type: "any"}
+  def normalize_tool_choice("none"), do: %{type: "none"}
+  def normalize_tool_choice({:tool, name}) when is_binary(name), do: %{type: "tool", name: name}
+  def normalize_tool_choice(%{type: _} = choice), do: choice
+  def normalize_tool_choice(%{"type" => _} = choice), do: choice
 
   defp get_option(options, key, default \\ nil)
 

--- a/test/req_llm/providers/amazon_bedrock/anthropic_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/anthropic_test.exs
@@ -173,6 +173,116 @@ defmodule ReqLLM.Providers.AmazonBedrock.AnthropicTest do
     end
   end
 
+  describe "format_request/3 tool_choice normalization" do
+    test "normalizes atom :auto to Anthropic map format" do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "bash",
+          description: "Run bash",
+          parameter_schema: [command: [type: :string, required: true]],
+          callback: fn _ -> {:ok, "ok"} end
+        )
+
+      context = Context.new([Context.user("hello")])
+
+      body =
+        Anthropic.format_request("test-model", context, tools: [tool], tool_choice: :auto)
+
+      assert body[:tool_choice] == %{type: "auto"}
+    end
+
+    test "normalizes atom :required to Anthropic any format" do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "bash",
+          description: "Run bash",
+          parameter_schema: [command: [type: :string, required: true]],
+          callback: fn _ -> {:ok, "ok"} end
+        )
+
+      context = Context.new([Context.user("hello")])
+
+      body =
+        Anthropic.format_request("test-model", context, tools: [tool], tool_choice: :required)
+
+      assert body[:tool_choice] == %{type: "any"}
+    end
+
+    test "passes through map tool_choice unchanged" do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "bash",
+          description: "Run bash",
+          parameter_schema: [command: [type: :string, required: true]],
+          callback: fn _ -> {:ok, "ok"} end
+        )
+
+      context = Context.new([Context.user("hello")])
+      choice = %{type: "tool", name: "bash"}
+
+      body =
+        Anthropic.format_request("test-model", context, tools: [tool], tool_choice: choice)
+
+      assert body[:tool_choice] == %{type: "tool", name: "bash"}
+    end
+
+    test "omits tool_choice when not specified" do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "bash",
+          description: "Run bash",
+          parameter_schema: [command: [type: :string, required: true]],
+          callback: fn _ -> {:ok, "ok"} end
+        )
+
+      context = Context.new([Context.user("hello")])
+
+      body = Anthropic.format_request("test-model", context, tools: [tool])
+
+      refute Map.has_key?(body, :tool_choice)
+    end
+  end
+
+  describe "format_request/3 tool result with image" do
+    test "image content parts flow through to native Anthropic encoding" do
+      tool_call = ReqLLM.ToolCall.new("call_1", "bash", ~s({"command":"view-image /test.jpg"}))
+
+      context =
+        Context.new([
+          Context.user("What's in this image?"),
+          Context.assistant("", tool_calls: [tool_call]),
+          Context.tool_result("call_1", [
+            ReqLLM.Message.ContentPart.text("Image loaded"),
+            ReqLLM.Message.ContentPart.image(<<0xFF, 0xD8>>, "image/jpeg")
+          ])
+        ])
+
+      body = Anthropic.format_request("test-model", context, [])
+
+      # Find the tool result message
+      tool_msg =
+        Enum.find(body[:messages], fn msg ->
+          case msg do
+            %{content: [%{type: "tool_result"} | _]} -> true
+            _ -> false
+          end
+        end)
+
+      assert tool_msg
+      [%{type: "tool_result", content: content}] = tool_msg[:content]
+
+      assert is_list(content)
+      assert length(content) == 2
+
+      [text_block, image_block] = content
+      assert text_block == %{type: "text", text: "Image loaded"}
+      assert image_block[:type] == "image"
+      assert image_block[:source][:type] == "base64"
+      assert image_block[:source][:media_type] == "image/jpeg"
+      assert image_block[:source][:data] == Base.encode64(<<0xFF, 0xD8>>)
+    end
+  end
+
   describe "parse_response/2" do
     test "parses basic Anthropic response" do
       response_body = %{

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -219,6 +219,70 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
              ]
     end
 
+    test "formats tool_result with image content part" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{
+            role: :tool,
+            tool_call_id: "call_img",
+            content: [
+              ContentPart.text("Image loaded: 768x1024"),
+              ContentPart.image(<<0xFF, 0xD8, 0xFF>>, "image/jpeg")
+            ]
+          }
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+
+      tool_result_content =
+        get_in(result, [
+          "messages",
+          Access.at(0),
+          "content",
+          Access.at(0),
+          "toolResult",
+          "content"
+        ])
+
+      assert length(tool_result_content) == 2
+
+      assert Enum.at(tool_result_content, 0) == %{"text" => "Image loaded: 768x1024"}
+
+      image_block = Enum.at(tool_result_content, 1)
+      assert image_block["image"]["format"] == "jpeg"
+      assert image_block["image"]["source"]["bytes"] == Base.encode64(<<0xFF, 0xD8, 0xFF>>)
+    end
+
+    test "formats tool_result with image-only content" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{
+            role: :tool,
+            tool_call_id: "call_img2",
+            content: [
+              ContentPart.image(<<0xFF, 0xD8>>, "image/jpeg")
+            ]
+          }
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+
+      tool_result_content =
+        get_in(result, [
+          "messages",
+          Access.at(0),
+          "content",
+          Access.at(0),
+          "toolResult",
+          "content"
+        ])
+
+      assert length(tool_result_content) == 1
+      assert Enum.at(tool_result_content, 0)["image"]["format"] == "jpeg"
+    end
+
     test "merges consecutive tool results into single user message" do
       tool_call_1 = ReqLLM.ToolCall.new("call_1", "get_weather", ~s({"location":"Paris"}))
       tool_call_2 = ReqLLM.ToolCall.new("call_2", "get_weather", ~s({"location":"London"}))


### PR DESCRIPTION
## Description

Support image content in Bedrock tool results.

Converse API: encode all content parts (text + image) in `tool_result` blocks instead of hardcoding text-only. Fixes multimodal tool results being silently reduced to text.

Native API: normalize `tool_choice` through `Anthropic.normalize_tool_choice` to fix HTTP 400 when atoms like `:auto` were sent as-is.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (not necessary)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A
