### PR TITLE
fix: remove unsupported outputMimeType and add response_modalities fo…

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -18,7 +18,7 @@ defmodule ReqLLM.Providers.Google do
   - `cached_content` - Reference to cached content for 90% cost savings (see Context Caching below)
   - `dimensions` - Number of dimensions for embedding vectors
   - `task_type` - Task type for embeddings (e.g., RETRIEVAL_QUERY)
-  - `response_modalities` - Control output modalities for image generation (e.g., ["Image"] for image-only)
+  - `response_modalities` - Control output modalities for image generation (e.g., ["IMAGE"] for image-only)
 
   See `provider_schema/0` for the complete Google-specific schema and
   `ReqLLM.Provider.Options` for inherited OpenAI parameters.
@@ -133,9 +133,9 @@ defmodule ReqLLM.Providers.Google do
         "Use x-goog-api-key header for authentication instead of URL query parameter. Required for OpenAI-compatible API proxies."
     ],
     response_modalities: [
-      type: {:list, :string},
+      type: {:list, {:in, ["TEXT", "IMAGE"]}},
       doc:
-        "Control output modalities for image generation. List of \"Text\" and/or \"Image\". Default is [\"Text\", \"Image\"]. Use [\"Image\"] for image-only responses."
+        "Control output modalities for image generation. List of \"TEXT\" and/or \"IMAGE\". Default is [\"TEXT\", \"IMAGE\"]. Use [\"IMAGE\"] for image-only responses."
     ]
   ]
 
@@ -679,6 +679,7 @@ defmodule ReqLLM.Providers.Google do
     {provider_opts, rest} = Keyword.pop(opts, :provider_options, [])
 
     {effort, provider_opts} = Keyword.pop(provider_opts, :reasoning_effort)
+    provider_opts = normalize_response_modalities(provider_opts)
 
     provider_opts =
       case effort do
@@ -702,6 +703,31 @@ defmodule ReqLLM.Providers.Google do
 
     {Keyword.put(rest, :provider_options, provider_opts), []}
   end
+
+  defp normalize_response_modalities(provider_opts) do
+    case Keyword.fetch(provider_opts, :response_modalities) do
+      {:ok, modalities} when is_list(modalities) ->
+        normalized = Enum.map(modalities, &normalize_response_modality/1)
+        Keyword.put(provider_opts, :response_modalities, normalized)
+
+      _ ->
+        provider_opts
+    end
+  end
+
+  defp normalize_response_modality(modality) when is_atom(modality) do
+    modality
+    |> Atom.to_string()
+    |> normalize_response_modality()
+  end
+
+  defp normalize_response_modality(modality) when is_binary(modality) do
+    modality
+    |> String.trim()
+    |> String.upcase()
+  end
+
+  defp normalize_response_modality(modality), do: modality
 
   defp translate_reasoning_effort_to_budget(:none, _model), do: 0
   defp translate_reasoning_effort_to_budget(:minimal, _model), do: 2_048

--- a/test/providers/google_images_test.exs
+++ b/test/providers/google_images_test.exs
@@ -85,60 +85,40 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
     assert is_nil(body["generationConfig"])
   end
 
-  test "encode_body/1 includes responseModalities when specified" do
-    context = %Context{
-      messages: [
-        %ReqLLM.Message{role: :user, content: "Generate an image"}
-      ]
-    }
+  test "prepare_request/4 normalizes image response modalities to Gemini enums" do
+    {:ok, model} = ReqLLM.model("google:gemini-2.5-flash-image")
 
-    request =
-      Req.new(url: "/models/gemini-2.5-flash-image:generateContent")
-      |> Req.Request.register_options([
-        :operation,
-        :model,
-        :context,
-        :response_modalities
-      ])
-      |> Req.Request.merge_options(
-        operation: :image,
-        model: "gemini-2.5-flash-image",
-        context: context,
+    {:ok, request} =
+      Google.prepare_request(
+        :image,
+        model,
+        "Generate an image",
         response_modalities: ["Image"]
       )
 
     encoded = Google.encode_body(request)
     body = Jason.decode!(encoded.body)
 
-    assert get_in(body, ["generationConfig", "responseModalities"]) == ["Image"]
+    assert request.options[:response_modalities] == ["IMAGE"]
+    assert get_in(body, ["generationConfig", "responseModalities"]) == ["IMAGE"]
   end
 
-  test "encode_body/1 handles multiple response modalities" do
-    context = %Context{
-      messages: [
-        %ReqLLM.Message{role: :user, content: "Describe and draw something"}
-      ]
-    }
+  test "prepare_request/4 normalizes multiple image response modalities" do
+    {:ok, model} = ReqLLM.model("google:gemini-2.5-flash-image")
 
-    request =
-      Req.new(url: "/models/gemini-2.5-flash-image:generateContent")
-      |> Req.Request.register_options([
-        :operation,
-        :model,
-        :context,
-        :response_modalities
-      ])
-      |> Req.Request.merge_options(
-        operation: :image,
-        model: "gemini-2.5-flash-image",
-        context: context,
+    {:ok, request} =
+      Google.prepare_request(
+        :image,
+        model,
+        "Describe and draw something",
         response_modalities: ["Text", "Image"]
       )
 
     encoded = Google.encode_body(request)
     body = Jason.decode!(encoded.body)
 
-    assert get_in(body, ["generationConfig", "responseModalities"]) == ["Text", "Image"]
+    assert request.options[:response_modalities] == ["TEXT", "IMAGE"]
+    assert get_in(body, ["generationConfig", "responseModalities"]) == ["TEXT", "IMAGE"]
   end
 
   test "decode_response/1 converts inlineData to ContentPart.image" do


### PR DESCRIPTION
## Description

The image generation with gemini is failing. Gemini does not support output format. [Ref](https://ai.google.dev/gemini-api/docs/image-generation#other-modes)
I removed the code and implemented the response_modalities
I am not sure if it was ever supported by gemini or if it's something adapted from open ai.

```
ReqLLM.generate_image(
          "google:gemini-2.5-flash-image",
          "A futuristic cityscape with flying cars and neon lights",
          aspect_ratio: "3:4")
** (MatchError) no match of right hand side value:

    {:error,
     %ReqLLM.Error.API.Request{
       reason: "Provider response error (400): Google API error: Invalid JSON payload received. Unknown name \"outputMimeType\" at 'generation_config.image_config': Cannot find field.",
       status: 400,
       response_body: %{
         "error" => %{
           "code" => 400,
           "details" => [
             %{
               "@type" => "type.googleapis.com/google.rpc.BadRequest",
               "fieldViolations" => [
                 %{
                   "description" => "Invalid JSON payload received. Unknown name \"outputMimeType\" at 'generation_config.image_config': Cannot find field.",
                   "field" => "generation_config.image_config"
                 }
               ]
             }
           ],
           "message" => "Invalid JSON payload received. Unknown name \"outputMimeType\" at 'generation_config.image_config': Cannot find field.",
           "status" => "INVALID_ARGUMENT"
         }
       }
```

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)