### PR TITLE
fix: prevent Inspect.ReqLLM.Context crash on Logger depth truncation

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -636,24 +636,14 @@ defmodule ReqLLM.Context do
   end
 
   defimpl Inspect do
-    def inspect(%{messages: msgs}, opts) do
+    def inspect(%{messages: msgs}, opts) when is_list(msgs) do
       msg_count = length(msgs)
 
       if msg_count <= 2 do
         role_previews =
           msgs
           |> Enum.map_join(", ", fn msg ->
-            content_preview =
-              case List.first(msg.content) do
-                %{text: text} when is_binary(text) ->
-                  trimmed = String.slice(text, 0, 40)
-                  if String.length(text) > 40, do: trimmed <> "...", else: trimmed
-
-                _ ->
-                  ""
-              end
-
-            "#{msg.role}:\"#{content_preview}\""
+            "#{msg.role}:\"#{content_preview(msg, 40)}\""
           end)
 
         Inspect.Algebra.concat([
@@ -668,17 +658,7 @@ defmodule ReqLLM.Context do
           msgs
           |> Enum.with_index()
           |> Enum.map(fn {msg, idx} ->
-            content_preview =
-              case List.first(msg.content) do
-                %{text: text} when is_binary(text) ->
-                  trimmed = String.slice(text, 0, 60)
-                  if String.length(text) > 60, do: trimmed <> "...", else: trimmed
-
-                _ ->
-                  ""
-              end
-
-            "  [#{idx}] #{msg.role}: \"#{content_preview}\""
+            "  [#{idx}] #{msg.role}: \"#{content_preview(msg, 60)}\""
           end)
 
         Inspect.Algebra.concat([
@@ -690,6 +670,20 @@ defmodule ReqLLM.Context do
           Inspect.Algebra.line(),
           ">"
         ])
+      end
+    end
+
+    def inspect(_context, _opts) do
+      Inspect.Algebra.concat(["#Context<", "(truncated)", ">"])
+    end
+
+    defp content_preview(msg, max_len) do
+      with content when is_list(content) <- msg.content,
+           %{text: text} when is_binary(text) <- List.first(content) do
+        trimmed = String.slice(text, 0, max_len)
+        if String.length(text) > max_len, do: trimmed <> "...", else: trimmed
+      else
+        _ -> ""
       end
     end
   end

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -321,6 +321,23 @@ defmodule ReqLLM.ContextTest do
       inspected = inspect(context)
       assert inspected == "#Context<1 msgs: system:\"Only system\">"
     end
+
+    test "handles truncated messages field (depth truncation)" do
+      # Simulate Logger depth truncation replacing the messages list with a metadata map
+      context = %Context{messages: %{size: 1, type: :list, __truncated_depth__: 4}}
+
+      inspected = inspect(context)
+      assert inspected == "#Context<(truncated)>"
+    end
+
+    test "handles truncated msg.content field (depth truncation)" do
+      # Simulate depth truncation replacing content list with a metadata map
+      msg = %ReqLLM.Message{role: :user, content: %{size: 1, type: :list, __truncated_depth__: 5}}
+      context = %Context{messages: [msg]}
+
+      inspected = inspect(context)
+      assert inspected == "#Context<1 msgs: user:\"\">"
+    end
   end
 
   describe "normalize/2" do


### PR DESCRIPTION
## Motivation

When Elixir's Logger or `IO.inspect` truncates a `ReqLLM.Context` struct at depth, the `Inspect` protocol implementation crashes with a `FunctionClauseError`. This happens because `length(msgs)` and `List.first(msg.content)` assume their arguments are always lists, but depth-truncated structs replace nested data with metadata maps like `%{size: 1, type: :list, __truncated_depth__: 4}`. The crash pollutes logs with large `Inspect.Error` stacktraces instead of useful context summaries.

## Use cases

- **Logger output**: When a `Context` struct is logged at a restricted depth (e.g. `Logger.info(inspect(context, depth: 2))`), the inspect implementation should degrade gracefully instead of crashing.
- **IO.inspect debugging**: Developers using `IO.inspect/2` with custom `:depth` options should see a `#Context<(truncated)>` placeholder rather than an `Inspect.Error` stacktrace.
- **Production logging**: Large contexts with many messages or deep content structures are more likely to trigger depth truncation in production Logger configurations.

## Requirements

- `inspect/2` must not crash when `messages` is not a list (depth-truncated to a map).
- `inspect/2` must not crash when `msg.content` is not a list (depth-truncated to a map).
- Existing inspect behavior for normal (non-truncated) contexts must be preserved.

## Proposed Solution

1. **Guard `inspect/2` on `is_list(msgs)`** — Split into two clauses: one with `when is_list(msgs)` for normal operation, and a fallback that returns `#Context<(truncated)>`.
2. **Extract `content_preview/2` helper** — Replaces duplicated inline `case List.first(msg.content)` logic with a `with`-based helper that safely handles non-list `content` fields by returning an empty string.
3. **Added tests** — Two new test cases in the `"Inspect protocol"` describe block covering both truncation scenarios.