### PR TITLE
Fix to_parts/1 to handle list content from reasoning model turns

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -721,12 +721,7 @@ defmodule ReqLLM.Context do
   end
 
   defp to_parts(list) when is_list(list) do
-    Enum.flat_map(list, fn
-      %ContentPart{} = part -> [part]
-      %{type: :thinking, thinking: text} when is_binary(text) and text != "" -> [ContentPart.thinking(text)]
-      %{type: :text, text: text} when is_binary(text) and text != "" -> [ContentPart.text(text)]
-      _ -> []
-    end)
+    Enum.flat_map(list, &to_part_list/1)
   end
 
   defp normalize_tool_calls(nil), do: nil
@@ -885,10 +880,31 @@ defmodule ReqLLM.Context do
   end
 
   defp convert_loose_map(%{role: role, content: content} = msg)
+       when is_atom(role) and is_list(content) do
+    {:ok,
+     %Message{
+       role: role,
+       content: to_parts(content),
+       metadata: Map.get(msg, :metadata, %{})
+     }
+     |> maybe_put_reasoning_details(Map.get(msg, :reasoning_details))}
+  end
+
+  defp convert_loose_map(%{role: role, content: content} = msg)
        when is_atom(role) and is_binary(content) do
     {:ok,
      text(role, content, Map.get(msg, :metadata, %{}))
      |> maybe_put_reasoning_details(Map.get(msg, :reasoning_details))}
+  end
+
+  defp convert_loose_map(%{role: role, content: content} = msg)
+       when is_binary(role) and is_list(content) do
+    convert_loose_role_list_content(
+      role,
+      content,
+      Map.get(msg, :metadata, %{}),
+      Map.get(msg, :reasoning_details)
+    )
   end
 
   defp convert_loose_map(%{role: role, content: content} = msg)
@@ -913,6 +929,16 @@ defmodule ReqLLM.Context do
   end
 
   defp convert_loose_map(%{"role" => role, "content" => content} = msg)
+       when is_binary(role) and is_list(content) do
+    convert_loose_role_list_content(
+      role,
+      content,
+      Map.get(msg, "metadata", %{}),
+      Map.get(msg, "reasoning_details")
+    )
+  end
+
+  defp convert_loose_map(%{"role" => role, "content" => content} = msg)
        when is_binary(role) and is_binary(content) do
     metadata = Map.get(msg, "metadata", %{})
     reasoning_details = Map.get(msg, "reasoning_details")
@@ -934,6 +960,57 @@ defmodule ReqLLM.Context do
   end
 
   defp convert_loose_map(_map), do: {:error, :invalid_loose_map}
+
+  defp to_part_list(%ContentPart{} = part), do: [part]
+
+  defp to_part_list(part) when is_map(part) do
+    case Map.get(part, :type) || Map.get(part, "type") do
+      type when type in [:text, "text"] ->
+        text = Map.get(part, :text) || Map.get(part, "text")
+
+        if is_binary(text) and text != "" do
+          [ContentPart.text(text)]
+        else
+          []
+        end
+
+      type when type in [:thinking, "thinking"] ->
+        text =
+          Map.get(part, :text) ||
+            Map.get(part, "text") ||
+            Map.get(part, :thinking) ||
+            Map.get(part, "thinking")
+
+        if is_binary(text) and text != "" do
+          [ContentPart.thinking(text)]
+        else
+          []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp to_part_list(_part), do: []
+
+  defp convert_loose_role_list_content(role, content, metadata, reasoning_details) do
+    case role do
+      "user" ->
+        {:ok, %Message{role: :user, content: to_parts(content), metadata: metadata}}
+
+      "assistant" ->
+        {:ok,
+         %Message{role: :assistant, content: to_parts(content), metadata: metadata}
+         |> maybe_put_reasoning_details(reasoning_details)}
+
+      "system" ->
+        {:ok, %Message{role: :system, content: to_parts(content), metadata: metadata}}
+
+      _ ->
+        {:error, ReqLLM.Error.Invalid.Role.exception(role: role)}
+    end
+  end
 
   defp maybe_add_system(context, nil), do: context
 

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -457,6 +457,44 @@ defmodule ReqLLM.ContextTest do
       assert [%ContentPart{type: :text, text: "Hi there!"}] = assistant_msg.content
     end
 
+    test "accepts assistant loose maps with content part lists" do
+      input = %{
+        role: :assistant,
+        content: [
+          ContentPart.thinking("internal"),
+          ContentPart.text("hello")
+        ]
+      }
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      assert [%Message{role: :assistant, content: content}] = context.messages
+
+      assert [
+               %ContentPart{type: :thinking, text: "internal"},
+               %ContentPart{type: :text, text: "hello"}
+             ] = content
+    end
+
+    test "accepts JSON-decoded assistant loose maps with list content" do
+      input = %{
+        "role" => "assistant",
+        "content" => [
+          %{"type" => "thinking", "text" => "internal"},
+          %{"type" => "text", "text" => "answer"}
+        ]
+      }
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      assert [%Message{role: :assistant, content: content}] = context.messages
+
+      assert [
+               %ContentPart{type: :thinking, text: "internal"},
+               %ContentPart{type: :text, text: "answer"}
+             ] = content
+    end
+
     test "rejects invalid input types" do
       {:error, reason} = Context.normalize(:invalid, validate: false)
       assert reason == :invalid_prompt


### PR DESCRIPTION
Fixes #523.

## Problem

`to_parts/1` in `Context` only has a clause for binary strings. When a reasoning model emits thinking content during a streamed tool-call turn, `jido_ai` stores the assistant message content as a plain-map list:

```elixir
[%{type: :thinking, thinking: "..."}, %{type: :text, text: "..."}]
```

On the next ReAct iteration, `Context.normalize/2` calls `to_parts/1` on this list while converting the replayed assistant message. No clause matches, raising a raw `:function_clause` error that surfaces as a failed request.

## Fix

Add a `to_parts/1` clause for lists that maps each item to its `ContentPart` equivalent:

```elixir
defp to_parts(list) when is_list(list) do
  Enum.flat_map(list, fn
    %ContentPart{} = part -> [part]
    %{type: :thinking, thinking: text} when is_binary(text) and text != "" -> [ContentPart.thinking(text)]
    %{type: :text, text: text} when is_binary(text) and text != "" -> [ContentPart.text(text)]
    _ -> []
  end)
end
```

This is consistent with the stated design invariant that `Message.content` is always a list of `ContentPart` structs — `to_parts/1` is the conversion point, and it should handle all the input shapes that the rest of the library can produce.