### PR TITLE
fix: merge consecutive same-role entries in Gemini message encoding

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1822,74 +1822,97 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp convert_messages_to_gemini(messages) do
-    Enum.map(messages, fn message ->
-      raw_role =
-        case message do
-          %{role: role} -> role
-          %{"role" => role} -> role
-          _ -> "user"
-        end
+    messages
+    |> Enum.map(&convert_single_message_to_gemini/1)
+    |> merge_consecutive_roles()
+  end
 
-      role =
-        case raw_role do
-          :user -> "user"
-          "user" -> "user"
-          :assistant -> "model"
-          "assistant" -> "model"
-          :tool -> "user"
-          "tool" -> "user"
-          :system -> "user"
-          "system" -> "user"
-          other when is_binary(other) -> other
-          other -> to_string(other)
-        end
+  defp convert_single_message_to_gemini(message) do
+    raw_role =
+      case message do
+        %{role: role} -> role
+        %{"role" => role} -> role
+        _ -> "user"
+      end
 
-      raw_content =
-        case message do
-          %{content: content} -> content
-          %{"content" => content} -> content
-          _ -> ""
-        end
+    role =
+      case raw_role do
+        :user -> "user"
+        "user" -> "user"
+        :assistant -> "model"
+        "assistant" -> "model"
+        :tool -> "user"
+        "tool" -> "user"
+        :system -> "user"
+        "system" -> "user"
+        other when is_binary(other) -> other
+        other -> to_string(other)
+      end
 
-      thought_parts = encode_reasoning_details_for_gemini(message)
+    raw_content =
+      case message do
+        %{content: content} -> content
+        %{"content" => content} -> content
+        _ -> ""
+      end
 
-      content_parts =
-        case raw_content do
-          content when is_binary(content) -> [%{text: content}]
-          parts when is_list(parts) -> Enum.map(parts, &convert_content_part/1)
-        end
+    thought_parts = encode_reasoning_details_for_gemini(message)
 
-      tool_call_parts =
-        case message do
-          %{"tool_calls" => tool_calls} when is_list(tool_calls) ->
-            Enum.map(tool_calls, &convert_tool_call_to_function_call/1)
+    content_parts =
+      case raw_content do
+        content when is_binary(content) -> [%{text: content}]
+        parts when is_list(parts) -> Enum.map(parts, &convert_content_part/1)
+      end
 
-          %{tool_calls: tool_calls} when is_list(tool_calls) ->
-            Enum.map(tool_calls, &convert_tool_call_to_function_call/1)
+    tool_call_parts =
+      case message do
+        %{"tool_calls" => tool_calls} when is_list(tool_calls) ->
+          Enum.map(tool_calls, &convert_tool_call_to_function_call/1)
 
-          _ ->
-            []
-        end
+        %{tool_calls: tool_calls} when is_list(tool_calls) ->
+          Enum.map(tool_calls, &convert_tool_call_to_function_call/1)
 
-      tool_result_parts =
-        case message do
-          %{tool_call_id: _call_id, role: "tool"} ->
-            [build_tool_result_part(message, raw_content)]
+        _ ->
+          []
+      end
 
-          %{"tool_call_id" => _call_id, "role" => "tool"} ->
-            [build_tool_result_part(message, raw_content)]
+    tool_result_parts =
+      case message do
+        %{tool_call_id: _call_id, role: "tool"} ->
+          [build_tool_result_part(message, raw_content)]
 
-          %{tool_call_id: _call_id, role: :tool} ->
-            [build_tool_result_part(message, raw_content)]
+        %{"tool_call_id" => _call_id, "role" => "tool"} ->
+          [build_tool_result_part(message, raw_content)]
 
-          _ ->
-            []
-        end
+        %{tool_call_id: _call_id, role: :tool} ->
+          [build_tool_result_part(message, raw_content)]
 
-      parts = thought_parts ++ content_parts ++ tool_call_parts ++ tool_result_parts
+        _ ->
+          []
+      end
 
-      %{role: role, parts: parts}
-    end)
+    parts = thought_parts ++ content_parts ++ tool_call_parts ++ tool_result_parts
+
+    %{role: role, parts: parts}
+  end
+
+  # Gemini requires that consecutive messages with the same role are merged
+  # into a single entry. This is critical for parallel tool calls: N separate
+  # tool result messages (all mapped to role "user") must become one entry
+  # with N functionResponse parts.
+  defp merge_consecutive_roles([]), do: []
+
+  defp merge_consecutive_roles([first | rest]) do
+    {merged, last} =
+      Enum.reduce(rest, {[], first}, fn
+        %{role: role, parts: parts}, {acc, %{role: role} = current} ->
+          {acc, %{current | parts: current.parts ++ parts}}
+
+        entry, {acc, current} ->
+          {acc ++ [current], entry}
+      end)
+
+    merged ++ [last]
   end
 
   defp encode_reasoning_details_for_gemini(message) do

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1925,4 +1925,86 @@ defmodule ReqLLM.Providers.GoogleTest do
       Enum.any?(headers, fn {n, v} -> n == name and v == value end)
     end
   end
+
+  describe "consecutive role merging for parallel tool results" do
+    test "encode_body merges multiple tool results into a single user entry" do
+      {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
+
+      context =
+        Context.new([
+          Context.user("What's the weather in SF and NYC?"),
+          Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "call_1",
+                type: "function",
+                function: %{name: "get_weather", arguments: ~s({"location":"SF"})}
+              },
+              %ReqLLM.ToolCall{
+                id: "call_2",
+                type: "function",
+                function: %{name: "get_weather", arguments: ~s({"location":"NYC"})}
+              }
+            ]
+          ),
+          Context.tool_result("call_1", "get_weather", "72F sunny"),
+          Context.tool_result("call_2", "get_weather", "58F cloudy")
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+      contents = decoded["contents"]
+
+      tool_result_entries =
+        Enum.filter(contents, fn entry ->
+          Enum.any?(entry["parts"], &Map.has_key?(&1, "functionResponse"))
+        end)
+
+      assert length(tool_result_entries) == 1,
+             "Expected tool results merged into 1 entry, got #{length(tool_result_entries)}"
+
+      [merged] = tool_result_entries
+      fn_parts = Enum.filter(merged["parts"], &Map.has_key?(&1, "functionResponse"))
+      assert length(fn_parts) == 2
+
+      names = Enum.map(fn_parts, & &1["functionResponse"]["name"])
+      assert "get_weather" in names
+    end
+
+    test "encode_body preserves non-consecutive same-role entries separately" do
+      {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
+
+      context =
+        Context.new([
+          Context.user("Hello"),
+          Context.assistant("Hi there!"),
+          Context.user("How are you?")
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+      contents = decoded["contents"]
+
+      user_entries = Enum.filter(contents, &(&1["role"] == "user"))
+      assert length(user_entries) == 2
+    end
+  end
 end


### PR DESCRIPTION
## Description

The Gemini API requires that consecutive messages with the same role are merged into a single entry with concatenated `parts`. This affects both `:google` and `:google_vertex` providers.

When an LLM makes N parallel tool calls, each tool result is a separate message with role `:tool` (mapped to `"user"` in Gemini format). Without merging, N separate `"user"` entries are sent, but the API expects exactly one entry with N `functionResponse` parts matching the N `functionCall` parts. The API rejects with _"number of functionResponse parts must equal number of functionCall parts"_.

Extracted `convert_single_message_to_gemini/1` from the existing `convert_messages_to_gemini/1` and added a `merge_consecutive_roles/1` post-processing step that concatenates parts from adjacent same-role entries.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A