### PR TITLE
fix: break Azure Anthropic xref cycle

### DIFF
--- a/lib/req_llm/providers/azure/anthropic.ex
+++ b/lib/req_llm/providers/azure/anthropic.ex
@@ -128,11 +128,9 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
       end
 
     context =
-      ReqLLM.ToolCallIdCompat.apply_context(
-        ReqLLM.Providers.Azure,
-        operation || :chat,
-        %{id: model_id, provider_model_id: model_id, provider: :azure},
+      ReqLLM.ToolCallIdCompat.apply_context_with_policy(
         context,
+        tool_call_id_policy(),
         opts
       )
 
@@ -186,6 +184,14 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
   end
 
   defp tool_to_anthropic_format(%{name: _, description: _, input_schema: _} = stub), do: stub
+
+  defp tool_call_id_policy do
+    %{
+      mode: :sanitize,
+      invalid_chars_regex: ~r/[^A-Za-z0-9_-]/,
+      enforce_turn_boundary: true
+    }
+  end
 
   @doc """
   Parses Anthropic response from Azure into ReqLLM format.


### PR DESCRIPTION
## Summary
- stop `Azure.Anthropic` from calling back into the parent Azure provider just to resolve tool-call ID policy
- apply the Claude-specific tool-call ID compatibility policy directly inside the Azure Anthropic formatter
- remove the compile-connected Azure/Azure.Anthropic cycle from `mix xref`

## Verification
- mix test test/provider/azure/tools_test.exs
- mix xref graph --format cycles --label compile-connected
- mix xref graph --format stats --label compile-connected
- mix test
- mix quality