### PR TITLE
fix(schema): preserve doc option in nested {:map, opts} fields

### DIFF
--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -457,7 +457,7 @@ defmodule ReqLLM.Schema do
           properties =
             Map.new(opts, fn {prop_name, prop_opts} ->
               prop_type = Keyword.fetch!(prop_opts, :type)
-              {to_string(prop_name), nimble_type_to_json_schema(prop_type, [])}
+              {to_string(prop_name), nimble_type_to_json_schema(prop_type, prop_opts)}
             end)
 
           map_schema = %{

--- a/test/req_llm/schema_test.exs
+++ b/test/req_llm/schema_test.exs
@@ -80,6 +80,33 @@ defmodule ReqLLM.SchemaTest do
       assert result["properties"]["tags"]["items"]["required"] == ["title"]
     end
 
+    test "preserves doc option in nested map properties" do
+      result_schema =
+        {:map,
+         [
+           label: [type: :string, required: true, doc: "Canonical name"],
+           count: [type: :integer, doc: "Item count"]
+         ]}
+
+      schema = [
+        concepts: [
+          type: {:list, result_schema},
+          required: true,
+          doc: "List of concepts"
+        ]
+      ]
+
+      result = Schema.to_json(schema)
+
+      assert result["properties"]["concepts"]["description"] == "List of concepts"
+
+      assert result["properties"]["concepts"]["items"]["properties"]["label"]["description"] ==
+               "Canonical name"
+
+      assert result["properties"]["concepts"]["items"]["properties"]["count"]["description"] ==
+               "Item count"
+    end
+
     test "handles schema without required fields" do
       schema = [name: [type: :string, doc: "User name"], age: [type: :integer]]
 


### PR DESCRIPTION
## Summary

Fixes #521 - The `doc:` option was being lost for nested `{:map, opts}` fields in `Schema.to_json/1`.

## Problem

`nimble_type_to_json_schema/2` at line 460 was passing `[]` instead of `prop_opts` when converting nested map properties. This dropped `doc:` (and any other opts) from nested properties — they never got a `"description"` field in the resulting JSON Schema.

## Fix

Changed `[]` to `prop_opts` at line 460:

```elixir
# Before:
{to_string(prop_name), nimble_type_to_json_schema(prop_type, [])}

# After:
{to_string(prop_name), nimble_type_to_json_schema(prop_type, prop_opts)}
```

## Test

Added test verifying that nested map properties preserve their `doc:` options and generate correct `"description"` fields in JSON Schema.

## Checklist

- [x] Tests pass (`mix test`)
- [x] Code formatted (`mix format`)
- [x] Credo passes (`mix credo --strict`)
- [x] Dialyzer passes (`mix dialyzer`)