### PR TITLE
fix(openai): validate nested object schemas with string keys

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1214,12 +1214,12 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
         {:ok, object}
 
       %{compiled: compiled} when not is_nil(compiled) ->
-        # Convert string keys to atoms for validation
+        # Convert string keys to atoms for validation (recursively for nested maps)
         keyword_data =
           object
           |> Enum.map(fn {k, v} ->
             key = if is_binary(k), do: String.to_existing_atom(k), else: k
-            {key, v}
+            {key, deep_atomize_keys(v)}
           end)
 
         case NimbleOptions.validate(keyword_data, compiled) do
@@ -1237,6 +1237,16 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   defp validate_object(object, nil), do: {:ok, object}
+
+  defp deep_atomize_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} ->
+      key = if is_binary(k), do: String.to_existing_atom(k), else: k
+      {key, deep_atomize_keys(v)}
+    end)
+  end
+
+  defp deep_atomize_keys(list) when is_list(list), do: Enum.map(list, &deep_atomize_keys/1)
+  defp deep_atomize_keys(value), do: value
 
   defp aggregate_output_segments(body, segments) do
     texts = [

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -703,6 +703,67 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert Enum.at(resp.body.context.messages, 0).role == :user
       assert Enum.at(resp.body.context.messages, 1).role == :assistant
     end
+
+    test "validates nested schemas with string keys converted to atoms" do
+      result_schema =
+        {:map,
+         [
+           id: [type: :pos_integer, required: true],
+           reasoning: [type: :string, required: true],
+           tags: [type: {:list, {:in, ~w[IT transport]}}, required: true]
+         ]}
+
+      schema = [
+        results: [type: {:list, result_schema}, required: true]
+      ]
+
+      {:ok, compiled_schema} = ReqLLM.Schema.compile(schema)
+
+      response_body = %{
+        "id" => "resp_123",
+        "model" => "gpt-5",
+        "output_text" =>
+          ~s({"results": [{"id": 1, "reasoning": "Transport job", "tags": ["transport"]}]}),
+        "usage" => %{"input_tokens" => 10, "output_tokens" => 20}
+      }
+
+      msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Tag these jobs"}]
+      }
+
+      context = %ReqLLM.Context{messages: [msg]}
+
+      req = %Req.Request{
+        method: :post,
+        url: URI.parse("https://api.openai.com/v1/responses"),
+        headers: %{},
+        body: {:json, %{}},
+        options: %{
+          id: "gpt-5",
+          context: context,
+          operation: :object,
+          compiled_schema: compiled_schema
+        }
+      }
+
+      resp = %Req.Response{
+        status: 200,
+        headers: %{},
+        body: response_body
+      }
+
+      {_req, decoded_resp} = ResponsesAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Response{} = decoded_resp.body
+      assert decoded_resp.body.object != nil
+
+      assert decoded_resp.body.object["results"] == [
+               %{"id" => 1, "reasoning" => "Transport job", "tags" => ["transport"]}
+             ]
+
+      assert decoded_resp.body.provider_meta[:object_parse_error] == nil
+    end
   end
 
   describe "decode_stream_event/2" do


### PR DESCRIPTION
## Summary

Fixes #526 - `Response.object` returns `nil` for nested schemas with OpenAI Responses API.

## Problem

In `ReqLLM.Providers.OpenAI.ResponsesAPI.validate_object/2`, string-to-atom key conversion was only applied at the top level. After conversion, top-level keys were atoms, but nested maps retained string keys. `NimbleOptions.validate/2` then rejected the nested maps because it expected atom keys.

Example:
```elixir
schema = [
  results: [type: {:list, {:map, [
    id: [type: :pos_integer, required: true],
    reasoning: [type: :string, required: true],
    tags: [type: {:list, {:in, ~w[IT transport]}}, required: true]
  ]}}, required: true]
]
```

The JSON response `{"results": [{"id": 1, "reasoning": "...", "tags": ["transport"]}]}` would decode successfully but validation would fail because nested maps still had string keys.

## Fix

Added `deep_atomize_keys/1` helper function that recursively converts string keys to atoms throughout the entire data structure:

```elixir
defp deep_atomize_keys(map) when is_map(map) do
  Map.new(map, fn {k, v} ->
    key = if is_binary(k), do: String.to_existing_atom(k), else: k
    {key, deep_atomize_keys(v)}
  end)
end

defp deep_atomize_keys(list) when is_list(list), do: Enum.map(list, &deep_atomize_keys/1)
defp deep_atomize_keys(value), do: value
```

Applied this in `validate_object/2` to recursively convert all string keys before validation.

## Test

Added comprehensive test that:
1. Creates a nested schema with lists containing maps
2. Mocks a ResponsesAPI response with nested JSON
3. Verifies the response object is correctly parsed and validated
4. Confirms `provider_meta[:object_parse_error]` is nil

## Checklist

- [x] Tests pass (`mix test`)
- [x] Code formatted (`mix format`)
- [x] Credo passes (`mix credo --strict`)
- [x] Dialyzer passes (`mix dialyzer`)