### PR TITLE
fix(bedrock): filter empty text blocks in Converse

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -557,8 +557,12 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   defp encode_content(content) when is_list(content) do
-    Enum.map(content, &encode_content_part/1)
+    content
+    |> Enum.map(&encode_content_part/1)
+    |> Enum.reject(&is_nil/1)
   end
+
+  defp encode_content_part(%ContentPart{type: :text, text: ""}), do: nil
 
   defp encode_content_part(%ContentPart{type: :text, text: text}) do
     %{"text" => text}

--- a/test/req_llm/integration/bedrock_empty_content_test.exs
+++ b/test/req_llm/integration/bedrock_empty_content_test.exs
@@ -1,0 +1,121 @@
+defmodule ReqLLM.Integration.BedrockEmptyContentTest do
+  @moduledoc """
+  Live integration tests to probe Bedrock's handling of empty/blank assistant
+  content in multi-turn tool-calling conversations.
+
+  Tests the Converse and native Anthropic encoding paths with a Message struct
+  containing an explicit empty-text ContentPart — the scenario that triggers
+  Bedrock 400 errors when the encoder doesn't filter it out.
+
+  Run with:
+
+      aws-vault exec bedrock-test -- env AWS_REGION=us-east-1 REQ_LLM_FIXTURES_MODE=record \
+        mix test test/req_llm/integration/bedrock_empty_content_test.exs --include integration
+  """
+
+  use ExUnit.Case, async: false
+
+  alias ReqLLM.{Context, Message, Message.ContentPart, ToolCall}
+
+  @moduletag :integration
+  @moduletag timeout: 120_000
+
+  @live_ready ReqLLM.Test.Env.fixtures_mode() == :record
+
+  if not @live_ready do
+    @moduletag skip: "Run with REQ_LLM_FIXTURES_MODE=record to hit live Bedrock APIs"
+  end
+
+  @bedrock_model "amazon-bedrock:anthropic.claude-haiku-4-5-20251001-v1:0"
+
+  setup_all do
+    LLMDB.load(allow: :all, custom: %{})
+    :ok
+  end
+
+  defp add_tool do
+    ReqLLM.Tool.new!(
+      name: "add",
+      description: "Add two numbers",
+      parameter_schema: %{
+        "type" => "object",
+        "properties" => %{
+          "a" => %{"type" => "number", "description" => "First number"},
+          "b" => %{"type" => "number", "description" => "Second number"}
+        },
+        "required" => ["a", "b"]
+      },
+      callback: fn %{"a" => a, "b" => b} -> {:ok, %{result: a + b}} end
+    )
+  end
+
+  # Build a context with an explicit %Message{} struct containing an empty-text
+  # ContentPart in the assistant message. This bypasses Context.assistant/2's
+  # to_parts normalization and hits the encoder directly.
+  defp context_with_explicit_empty_text_content_part do
+    tool_call = ToolCall.new("toolu_test_001", "add", ~s({"a": 2, "b": 3}))
+
+    Context.new([
+      %Message{role: :system, content: [ContentPart.text("You are a calculator.")]},
+      %Message{role: :user, content: [ContentPart.text("What is 2 + 3?")]},
+      %Message{role: :assistant, content: [ContentPart.text("")], tool_calls: [tool_call]},
+      %Message{
+        role: :tool,
+        content: [ContentPart.text("5")],
+        tool_call_id: "toolu_test_001",
+        name: "add"
+      },
+      %Message{role: :user, content: [ContentPart.text("Now what is 10 + 20?")]}
+    ])
+  end
+
+  describe "explicit empty-text ContentPart in assistant message" do
+    test "Converse API rejects empty text ContentBlock" do
+      context = context_with_explicit_empty_text_content_part()
+
+      result =
+        ReqLLM.generate_text(
+          @bedrock_model,
+          context,
+          tools: [add_tool()],
+          max_tokens: 200,
+          use_converse: true
+        )
+
+      case result do
+        {:ok, response} ->
+          assert %ReqLLM.Response{} = response
+
+        {:error, error} ->
+          flunk("""
+          Bedrock Converse API rejected empty text ContentPart:
+          #{inspect(error, pretty: true)}
+          """)
+      end
+    end
+
+    test "native Anthropic API handles empty text ContentPart" do
+      context = context_with_explicit_empty_text_content_part()
+
+      result =
+        ReqLLM.generate_text(
+          @bedrock_model,
+          context,
+          tools: [add_tool()],
+          max_tokens: 200,
+          use_converse: false
+        )
+
+      case result do
+        {:ok, response} ->
+          assert %ReqLLM.Response{} = response
+
+        {:error, error} ->
+          flunk("""
+          Bedrock Anthropic (native) rejected empty text ContentPart:
+          #{inspect(error, pretty: true)}
+          """)
+      end
+    end
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -86,6 +86,29 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
              }
     end
 
+    test "filters empty text ContentParts from assistant message with tool calls" do
+      tool_call = ReqLLM.ToolCall.new("call_123", "add", Jason.encode!(%{a: 2, b: 3}))
+
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: [ContentPart.text("What is 2+3?")]},
+          %Message{
+            role: :assistant,
+            content: [ContentPart.text("")],
+            tool_calls: [tool_call]
+          },
+          %Message{role: :tool, tool_call_id: "call_123", content: [ContentPart.text("5")]},
+          %Message{role: :user, content: [ContentPart.text("Thanks")]}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+      [_user, assistant_msg | _rest] = result["messages"]
+
+      # The empty text block should be filtered out, leaving only the toolUse block
+      assert [%{"toolUse" => _}] = assistant_msg["content"]
+    end
+
     test "formats request with content blocks" do
       context = %ReqLLM.Context{
         messages: [


### PR DESCRIPTION
## Description

Bedrock Converse API rejects `ContentBlock` with blank text field. Filter empty-text `ContentPart`s in `encode_content`, matching what the native Anthropic encoder already does.

Supersedes agentjido/jido_ai#215

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A
