### PR TITLE
fix(bedrock): drop empty messages in Converse encoder

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -343,10 +343,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
           Map.put(request, "system", encode_content_for_system(content))
       end
 
-    # Add regular messages
+    # Add regular messages, dropping any that end up empty after ContentPart filtering
     encoded_messages =
       non_system_messages
       |> Enum.map(&encode_message/1)
+      |> Enum.reject(&is_nil/1)
       |> merge_consecutive_tool_results()
 
     Map.put(request, "messages", encoded_messages)
@@ -536,12 +537,13 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     }
   end
 
-  # Regular message (user, assistant, system)
+  # Regular message (user, assistant, system) — returns nil if content is
+  # empty after filtering, so the caller can reject it like empty ContentParts.
   defp encode_message(%Message{role: role, content: content}) do
-    %{
-      "role" => Atom.to_string(role),
-      "content" => encode_content(content)
-    }
+    case encode_content(content) do
+      [] -> nil
+      encoded -> %{"role" => Atom.to_string(role), "content" => encoded}
+    end
   end
 
   defp encode_content_for_system(content) when is_binary(content) do

--- a/test/req_llm/integration/bedrock_empty_content_test.exs
+++ b/test/req_llm/integration/bedrock_empty_content_test.exs
@@ -1,11 +1,14 @@
 defmodule ReqLLM.Integration.BedrockEmptyContentTest do
   @moduledoc """
-  Live integration tests to probe Bedrock's handling of empty/blank assistant
+  Live integration tests to probe Bedrock's handling of empty assistant
   content in multi-turn tool-calling conversations.
 
-  Tests the Converse and native Anthropic encoding paths with a Message struct
-  containing an explicit empty-text ContentPart — the scenario that triggers
-  Bedrock 400 errors when the encoder doesn't filter it out.
+  Tests both encoding paths (Converse and native Anthropic) with:
+    1. Assistant message with tool_calls + empty text ContentPart
+    2. Standalone assistant message with only an empty text ContentPart (no tool_calls)
+
+  The encoder must filter the empty ContentPart in case 1 and drop the
+  entire message in case 2.
 
   Run with:
 
@@ -49,10 +52,13 @@ defmodule ReqLLM.Integration.BedrockEmptyContentTest do
     )
   end
 
-  # Build a context with an explicit %Message{} struct containing an empty-text
-  # ContentPart in the assistant message. This bypasses Context.assistant/2's
-  # to_parts normalization and hits the encoder directly.
-  defp context_with_explicit_empty_text_content_part do
+  # Build a context that matches the production scenario: an agent does a tool
+  # call (empty text + tool_calls), gets the result, then produces an empty
+  # response (empty text, no tool_calls). Context.text/3 wraps "" as
+  # [ContentPart.text("")] — the encoder must handle both cases:
+  #   1. assistant + tool_calls + [ContentPart.text("")] → filter the empty part
+  #   2. assistant + no tool_calls + [ContentPart.text("")] → drop the message
+  defp context_with_empty_assistant_after_tool_call do
     tool_call = ToolCall.new("toolu_test_001", "add", ~s({"a": 2, "b": 3}))
 
     Context.new([
@@ -65,13 +71,16 @@ defmodule ReqLLM.Integration.BedrockEmptyContentTest do
         tool_call_id: "toolu_test_001",
         name: "add"
       },
+      # Empty assistant response (e.g. after no_response_needed tool) —
+      # ContentPart.text("") is what Context.text/3 produces for empty strings
+      %Message{role: :assistant, content: [ContentPart.text("")]},
       %Message{role: :user, content: [ContentPart.text("Now what is 10 + 20?")]}
     ])
   end
 
-  describe "explicit empty-text ContentPart in assistant message" do
-    test "Converse API rejects empty text ContentBlock" do
-      context = context_with_explicit_empty_text_content_part()
+  describe "empty text in assistant messages after tool calls" do
+    test "Converse API" do
+      context = context_with_empty_assistant_after_tool_call()
 
       result =
         ReqLLM.generate_text(
@@ -88,14 +97,14 @@ defmodule ReqLLM.Integration.BedrockEmptyContentTest do
 
         {:error, error} ->
           flunk("""
-          Bedrock Converse API rejected empty text ContentPart:
+          Bedrock Converse API rejected empty assistant content:
           #{inspect(error, pretty: true)}
           """)
       end
     end
 
-    test "native Anthropic API handles empty text ContentPart" do
-      context = context_with_explicit_empty_text_content_part()
+    test "native Anthropic API" do
+      context = context_with_empty_assistant_after_tool_call()
 
       result =
         ReqLLM.generate_text(
@@ -112,7 +121,7 @@ defmodule ReqLLM.Integration.BedrockEmptyContentTest do
 
         {:error, error} ->
           flunk("""
-          Bedrock Anthropic (native) rejected empty text ContentPart:
+          Bedrock native Anthropic API rejected empty assistant content:
           #{inspect(error, pretty: true)}
           """)
       end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -86,6 +86,29 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
              }
     end
 
+    test "drops assistant message with only empty text and no tool calls" do
+      # Production scenario: after a tool call round-trip, the agent produces an
+      # empty response. Context.text/3 wraps "" as [ContentPart.text("")].
+      # The encoder must filter the empty ContentPart AND drop the now-empty message.
+      tool_call = ReqLLM.ToolCall.new("call_123", "add", Jason.encode!(%{a: 2, b: 3}))
+
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: [ContentPart.text("What is 2+3?")]},
+          %Message{role: :assistant, content: [ContentPart.text("")], tool_calls: [tool_call]},
+          %Message{role: :tool, tool_call_id: "call_123", content: [ContentPart.text("5")]},
+          %Message{role: :assistant, content: [ContentPart.text("")]},
+          %Message{role: :user, content: [ContentPart.text("Thanks")]}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+      roles = Enum.map(result["messages"], & &1["role"])
+
+      # The empty assistant message should be dropped
+      assert roles == ["user", "assistant", "user", "user"]
+    end
+
     test "filters empty text ContentParts from assistant message with tool calls" do
       tool_call = ReqLLM.ToolCall.new("call_123", "add", Jason.encode!(%{a: 2, b: 3}))
 


### PR DESCRIPTION
Sorry, the previous change (#534) was incomplete... I thought I had tested it but evidently not.

## Description

After `ContentPart` filtering removes blank text parts, a message can end up with an empty content array. Bedrock rejects these with HTTP 400. Return nil from `encode_message` when content is empty, matching the existing nil-rejection pattern.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A
