### PR TITLE
feat: repair lightly malformed structured JSON

### DIFF
--- a/lib/req_llm/json.ex
+++ b/lib/req_llm/json.ex
@@ -1,0 +1,129 @@
+defmodule ReqLLM.JSON do
+  @moduledoc false
+
+  @spec decode(term(), keyword()) :: {:ok, term()} | {:error, term()}
+  def decode(json, opts \\ [])
+
+  def decode(json, opts) when is_binary(json) do
+    case Jason.decode(json) do
+      {:ok, _parsed} = ok ->
+        ok
+
+      {:error, error} ->
+        if json_repair_enabled?(opts) do
+          repaired = repair(json)
+
+          if repaired == json do
+            {:error, error}
+          else
+            Jason.decode(repaired)
+          end
+        else
+          {:error, error}
+        end
+    end
+  end
+
+  def decode(_json, _opts), do: {:error, :invalid_json}
+
+  defp json_repair_enabled?(opts) when is_list(opts), do: Keyword.get(opts, :json_repair, true)
+  defp json_repair_enabled?(opts) when is_map(opts), do: Map.get(opts, :json_repair, true)
+  defp json_repair_enabled?(_opts), do: true
+
+  defp repair(json) do
+    json
+    |> strip_bom()
+    |> normalize_quotes()
+    |> strip_code_fences()
+    |> extract_json_payload()
+    |> remove_trailing_commas()
+    |> close_unbalanced_delimiters()
+  end
+
+  defp strip_bom(<<239, 187, 191, rest::binary>>), do: rest
+  defp strip_bom(json), do: json
+
+  defp normalize_quotes(json) do
+    json
+    |> String.replace(["\u201c", "\u201d"], "\"")
+    |> String.replace(["\u2018", "\u2019"], "'")
+  end
+
+  defp strip_code_fences(json) do
+    case Regex.run(~r/\A```(?:json)?\s*(.*?)\s*```\z/s, String.trim(json),
+           capture: :all_but_first
+         ) do
+      [inner] -> inner
+      _ -> json
+    end
+  end
+
+  defp extract_json_payload(json) do
+    trimmed = String.trim(json)
+
+    case first_json_boundary(trimmed) do
+      nil ->
+        trimmed
+
+      {start_index, _opening, closing} ->
+        candidate = String.slice(trimmed, start_index..-1//1)
+
+        case last_grapheme_index(candidate, closing) do
+          nil -> candidate
+          end_index -> String.slice(candidate, 0, end_index + 1)
+        end
+    end
+  end
+
+  defp first_json_boundary(json) do
+    json
+    |> String.graphemes()
+    |> Enum.with_index()
+    |> Enum.find_value(fn
+      {"{", index} -> {index, "{", "}"}
+      {"[", index} -> {index, "[", "]"}
+      _ -> nil
+    end)
+  end
+
+  defp last_grapheme_index(json, target) do
+    json
+    |> String.graphemes()
+    |> Enum.with_index()
+    |> Enum.reduce(nil, fn
+      {^target, index}, _acc -> index
+      _, acc -> acc
+    end)
+  end
+
+  defp remove_trailing_commas(json) do
+    Regex.replace(~r/,\s*([}\]])/, json, "\\1")
+  end
+
+  defp close_unbalanced_delimiters(json) do
+    {stack, _in_string?, _escaped?} =
+      json
+      |> String.graphemes()
+      |> Enum.reduce({[], false, false}, &track_delimiters/2)
+
+    closing =
+      stack
+      |> Enum.map(fn
+        "{" -> "}"
+        "[" -> "]"
+      end)
+      |> Enum.join("")
+
+    json <> closing
+  end
+
+  defp track_delimiters("\\", {stack, true, false}), do: {stack, true, true}
+  defp track_delimiters(_char, {stack, true, true}), do: {stack, true, false}
+  defp track_delimiters("\"", {stack, true, false}), do: {stack, false, false}
+  defp track_delimiters("\"", {stack, false, false}), do: {stack, true, false}
+  defp track_delimiters("{", {stack, false, false}), do: {["{" | stack], false, false}
+  defp track_delimiters("[", {stack, false, false}), do: {["[" | stack], false, false}
+  defp track_delimiters("}", {["{" | rest], false, false}), do: {rest, false, false}
+  defp track_delimiters("]", {["[" | rest], false, false}), do: {rest, false, false}
+  defp track_delimiters(_char, state), do: state
+end

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -628,6 +628,7 @@ defmodule ReqLLM.Provider.Defaults do
       :stream,
       :frequency_penalty,
       :system_prompt,
+      :json_repair,
       :top_p,
       :presence_penalty,
       :seed,
@@ -1170,8 +1171,16 @@ defmodule ReqLLM.Provider.Defaults do
          "function" => %{"name" => name, "arguments" => args_json}
        }) do
     case Jason.decode(args_json || "{}") do
-      {:ok, args} -> ReqLLM.StreamChunk.tool_call(name, args, %{id: id})
-      {:error, _} -> nil
+      {:ok, args} ->
+        ReqLLM.StreamChunk.tool_call(name, args, %{id: id})
+
+      {:error, _} ->
+        %ReqLLM.StreamChunk{
+          type: :tool_call,
+          name: name,
+          arguments: %{},
+          metadata: %{id: id, raw_arguments: args_json}
+        }
     end
   end
 
@@ -1320,7 +1329,12 @@ defmodule ReqLLM.Provider.Defaults do
          arguments: args,
          metadata: meta
        }) do
-    args_json = if is_binary(args), do: args, else: Jason.encode!(args)
+    args_json =
+      case Map.get(meta, :raw_arguments) do
+        raw when is_binary(raw) -> raw
+        _ -> if(is_binary(args), do: args, else: Jason.encode!(args))
+      end
+
     id = Map.get(meta, :id)
     ReqLLM.ToolCall.new(id, name, args_json)
   end
@@ -1643,19 +1657,19 @@ defmodule ReqLLM.Provider.Defaults do
     extracted_object =
       case response_format do
         %{type: "json_schema"} ->
-          extract_from_json_schema_content(response)
+          extract_from_json_schema_content(response, req.options)
 
         %{"type" => "json_schema"} ->
-          extract_from_json_schema_content(response)
+          extract_from_json_schema_content(response, req.options)
 
         _ ->
-          extract_from_tool_calls(response)
+          extract_from_tool_calls(response, req.options)
       end
 
     %{response | object: extracted_object}
   end
 
-  defp extract_from_json_schema_content(response) do
+  defp extract_from_json_schema_content(response, opts) do
     %ReqLLM.Message{content: content_parts} = response.message
 
     text_content =
@@ -1670,17 +1684,17 @@ defmodule ReqLLM.Provider.Defaults do
         nil
 
       json_string ->
-        case Jason.decode(json_string) do
+        case ReqLLM.JSON.decode(json_string, opts) do
           {:ok, parsed_object} -> parsed_object
           {:error, _} -> nil
         end
     end
   end
 
-  defp extract_from_tool_calls(response) do
+  defp extract_from_tool_calls(response, opts) do
     response
     |> ReqLLM.Response.tool_calls()
-    |> ReqLLM.ToolCall.find_args("structured_output")
+    |> ReqLLM.ToolCall.find_args("structured_output", opts)
   end
 
   defp merge_response_with_context(req, response) do

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -119,6 +119,12 @@ defmodule ReqLLM.Provider.Options do
                                  default: [],
                                  doc: "Options passed through to ReqLLM.Cache callbacks"
                                ],
+                               json_repair: [
+                                 type: :boolean,
+                                 default: true,
+                                 doc:
+                                   "Attempt light JSON repair for structured outputs before failing decode"
+                               ],
 
                                # Canonical reasoning controls
                                reasoning_effort: [

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -219,7 +219,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     # For :object operation, extract structured output from tool call
     final_response =
       if opts[:operation] == :object do
-        extract_and_set_object(response)
+        extract_and_set_object(response, opts)
       else
         response
       end
@@ -228,11 +228,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   # Extract structured output from tool call (same logic as native Anthropic provider)
-  defp extract_and_set_object(response) do
+  defp extract_and_set_object(response, opts) do
     extracted_object =
       response
       |> ReqLLM.Response.tool_calls()
-      |> ReqLLM.ToolCall.find_args("structured_output")
+      |> ReqLLM.ToolCall.find_args("structured_output", opts)
 
     %{response | object: extracted_object}
   end

--- a/lib/req_llm/providers/amazon_bedrock/openai.ex
+++ b/lib/req_llm/providers/amazon_bedrock/openai.ex
@@ -153,7 +153,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAI do
       # For :object operation, extract structured output from tool call
       final_response =
         if opts[:operation] == :object do
-          extract_and_set_object(response)
+          extract_and_set_object(response, opts)
         else
           response
         end
@@ -166,11 +166,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAI do
   end
 
   # Extract structured output from tool call (same logic as native Anthropic provider)
-  defp extract_and_set_object(response) do
+  defp extract_and_set_object(response, opts) do
     extracted_object =
       response
       |> ReqLLM.Response.tool_calls()
-      |> ReqLLM.ToolCall.find_args("structured_output")
+      |> ReqLLM.ToolCall.find_args("structured_output", opts)
 
     %{response | object: extracted_object}
   end

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1296,20 +1296,20 @@ defmodule ReqLLM.Providers.Anthropic do
 
             case text_content do
               %ReqLLM.Message.ContentPart{text: text} ->
-                case Jason.decode(text) do
+                case ReqLLM.JSON.decode(text, opts) do
                   {:ok, json} -> json
-                  _ -> find_structured_output(response)
+                  _ -> find_structured_output(response, opts)
                 end
 
               _ ->
-                find_structured_output(response)
+                find_structured_output(response, opts)
             end
 
           _ ->
-            find_structured_output(response)
+            find_structured_output(response, opts)
         end
       else
-        find_structured_output(response)
+        find_structured_output(response, opts)
       end
 
     %{response | object: extracted_object}
@@ -1337,10 +1337,10 @@ defmodule ReqLLM.Providers.Anthropic do
     provider_opts[:output_format]
   end
 
-  defp find_structured_output(response) do
+  defp find_structured_output(response, opts) do
     response
     |> ReqLLM.Response.tool_calls()
-    |> ReqLLM.ToolCall.find_args("structured_output")
+    |> ReqLLM.ToolCall.find_args("structured_output", opts)
   end
 
   defp merge_response_with_context(req, response) do

--- a/lib/req_llm/providers/azure/openai.ex
+++ b/lib/req_llm/providers/azure/openai.ex
@@ -272,7 +272,7 @@ defmodule ReqLLM.Providers.Azure.OpenAI do
 
     final_response =
       if operation == :object do
-        extract_and_set_object(merged_response)
+        extract_and_set_object(merged_response, opts)
       else
         merged_response
       end
@@ -280,11 +280,11 @@ defmodule ReqLLM.Providers.Azure.OpenAI do
     {:ok, final_response}
   end
 
-  defp extract_and_set_object(response) do
+  defp extract_and_set_object(response, opts) do
     extracted_object =
       response
       |> ReqLLM.Response.tool_calls()
-      |> ReqLLM.ToolCall.find_args("structured_output")
+      |> ReqLLM.ToolCall.find_args("structured_output", opts)
 
     %{response | object: extracted_object}
   end

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -546,6 +546,7 @@ defmodule ReqLLM.Providers.Google do
         :aspect_ratio,
         :output_format,
         :response_format,
+        :json_repair,
         :quality,
         :style,
         :negative_prompt,
@@ -1200,7 +1201,7 @@ defmodule ReqLLM.Providers.Google do
               ReqLLM.Provider.Defaults.decode_response_body_openai_format(openai_format, model)
 
             response_with_object =
-              case ReqLLM.Response.unwrap_object(response) do
+              case ReqLLM.Response.unwrap_object(response, req.options) do
                 {:ok, object} -> %{response | object: object}
                 {:error, _} -> response
               end

--- a/lib/req_llm/providers/google_vertex/openai_compat.ex
+++ b/lib/req_llm/providers/google_vertex/openai_compat.ex
@@ -87,7 +87,7 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompat do
     # For :object operation, extract structured output from tool call
     final_response =
       if opts[:operation] == :object do
-        extract_and_set_object(merged_response)
+        extract_and_set_object(merged_response, opts)
       else
         merged_response
       end
@@ -114,11 +114,11 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompat do
   end
 
   # Extract structured output from tool call for :object operations
-  defp extract_and_set_object(response) do
+  defp extract_and_set_object(response, opts) do
     extracted_object =
       response
       |> ReqLLM.Response.tool_calls()
-      |> ReqLLM.ToolCall.find_args("structured_output")
+      |> ReqLLM.ToolCall.find_args("structured_output", opts)
 
     %{response | object: extracted_object}
   end

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1185,7 +1185,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       {:object, text} when is_binary(text) and text != "" ->
         compiled_schema = req.options[:compiled_schema]
 
-        case Jason.decode(text) do
+        case ReqLLM.JSON.decode(text, req.options) do
           {:ok, parsed_object} when is_map(parsed_object) ->
             case validate_object(parsed_object, compiled_schema) do
               {:ok, _} -> {parsed_object, %{}}

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -1157,7 +1157,7 @@ defmodule ReqLLM.Providers.XAI do
         final_response =
           case operation do
             :object ->
-              extract_and_set_object(response)
+              extract_and_set_object(response, req.options)
 
             _ ->
               response
@@ -1177,42 +1177,42 @@ defmodule ReqLLM.Providers.XAI do
     end
   end
 
-  defp extract_and_set_object(response) do
+  defp extract_and_set_object(response, opts) do
     extracted_object =
       case ReqLLM.Response.tool_calls(response) do
         [] ->
-          extract_from_content(response)
+          extract_from_content(response, opts)
 
         tool_calls ->
-          ReqLLM.ToolCall.find_args(tool_calls, "structured_output")
+          ReqLLM.ToolCall.find_args(tool_calls, "structured_output", opts)
       end
 
     %{response | object: extracted_object}
   end
 
-  defp extract_from_content(response) do
+  defp extract_from_content(response, opts) do
     %ReqLLM.Message{content: content_parts} = response.message
 
     content_parts
     |> Enum.find_value(fn
       %ReqLLM.Message.ContentPart{type: :text, text: text} when is_binary(text) ->
-        parse_json_defensively(text)
+        parse_json_defensively(text, opts)
 
       _ ->
         nil
     end)
   end
 
-  @dialyzer {:nowarn_function, parse_json_defensively: 1}
-  @spec parse_json_defensively(term()) :: map() | nil
-  defp parse_json_defensively(text) when is_binary(text) do
-    case Jason.decode(text) do
+  @dialyzer {:nowarn_function, parse_json_defensively: 2}
+  @spec parse_json_defensively(term(), keyword()) :: map() | nil
+  defp parse_json_defensively(text, opts) when is_binary(text) do
+    case ReqLLM.JSON.decode(text, opts) do
       {:ok, parsed_object} when is_map(parsed_object) -> parsed_object
       _ -> nil
     end
   end
 
-  defp parse_json_defensively(_), do: nil
+  defp parse_json_defensively(_, _opts), do: nil
 
   defp merge_response_with_context(req, response) do
     context = req.options[:context] || %ReqLLM.Context{messages: []}

--- a/lib/req_llm/providers/zai.ex
+++ b/lib/req_llm/providers/zai.ex
@@ -221,19 +221,19 @@ defmodule ReqLLM.Providers.Zai do
     extracted_object =
       case response_format do
         %{type: "json_schema"} ->
-          extract_from_json_schema_content(response)
+          extract_from_json_schema_content(response, req.options)
 
         %{"type" => "json_schema"} ->
-          extract_from_json_schema_content(response)
+          extract_from_json_schema_content(response, req.options)
 
         _ ->
-          extract_from_tool_calls(response)
+          extract_from_tool_calls(response, req.options)
       end
 
     %{response | object: extracted_object}
   end
 
-  defp extract_from_json_schema_content(response) do
+  defp extract_from_json_schema_content(response, opts) do
     %ReqLLM.Message{content: content_parts} = response.message
 
     text_content =
@@ -248,18 +248,18 @@ defmodule ReqLLM.Providers.Zai do
         nil
 
       json_string ->
-        case Jason.decode(json_string) do
+        case ReqLLM.JSON.decode(json_string, opts) do
           {:ok, parsed_object} -> parsed_object
           {:error, _} -> nil
         end
     end
   end
 
-  defp extract_from_tool_calls(response) do
+  defp extract_from_tool_calls(response, opts) do
     case response.message do
       %ReqLLM.Message{tool_calls: [%ReqLLM.ToolCall{function: %{arguments: args_json}} | _]}
       when is_binary(args_json) ->
-        case Jason.decode(args_json) do
+        case ReqLLM.JSON.decode(args_json, opts) do
           {:ok, args} -> args
           {:error, _} -> nil
         end

--- a/lib/req_llm/providers/zai_coder.ex
+++ b/lib/req_llm/providers/zai_coder.ex
@@ -222,19 +222,19 @@ defmodule ReqLLM.Providers.ZaiCoder do
     extracted_object =
       case response_format do
         %{type: "json_schema"} ->
-          extract_from_json_schema_content(response)
+          extract_from_json_schema_content(response, req.options)
 
         %{"type" => "json_schema"} ->
-          extract_from_json_schema_content(response)
+          extract_from_json_schema_content(response, req.options)
 
         _ ->
-          extract_from_tool_calls(response)
+          extract_from_tool_calls(response, req.options)
       end
 
     %{response | object: extracted_object}
   end
 
-  defp extract_from_json_schema_content(response) do
+  defp extract_from_json_schema_content(response, opts) do
     %ReqLLM.Message{content: content_parts} = response.message
 
     text_content =
@@ -249,18 +249,18 @@ defmodule ReqLLM.Providers.ZaiCoder do
         nil
 
       json_string ->
-        case Jason.decode(json_string) do
+        case ReqLLM.JSON.decode(json_string, opts) do
           {:ok, parsed_object} -> parsed_object
           {:error, _} -> nil
         end
     end
   end
 
-  defp extract_from_tool_calls(response) do
+  defp extract_from_tool_calls(response, opts) do
     case response.message do
       %ReqLLM.Message{tool_calls: [%ReqLLM.ToolCall{function: %{arguments: args_json}} | _]}
       when is_binary(args_json) ->
-        case Jason.decode(args_json) do
+        case ReqLLM.JSON.decode(args_json, opts) do
           {:ok, args} -> args
           {:error, _} -> nil
         end

--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -548,16 +548,18 @@ defmodule ReqLLM.Response do
       #=> {:ok, %{"name" => "John", "age" => 30}}
 
   """
-  @spec unwrap_object(t()) :: {:ok, map()} | {:error, term()}
-  def unwrap_object(%__MODULE__{object: object}) when not is_nil(object) do
+  @spec unwrap_object(t(), keyword()) :: {:ok, map() | list()} | {:error, term()}
+  def unwrap_object(response, opts \\ [])
+
+  def unwrap_object(%__MODULE__{object: object}, _opts) when not is_nil(object) do
     {:ok, object}
   end
 
-  def unwrap_object(%__MODULE__{message: nil}) do
+  def unwrap_object(%__MODULE__{message: nil}, _opts) do
     {:error, %ReqLLM.Error.API.Response{reason: "No message in response"}}
   end
 
-  def unwrap_object(%__MODULE__{message: %Message{content: content}}) do
+  def unwrap_object(%__MODULE__{message: %Message{content: content}}, opts) do
     text_content =
       content
       |> Enum.filter(&(&1.type == :text))
@@ -572,7 +574,7 @@ defmodule ReqLLM.Response do
         {:ok, tool_call_content.input}
 
       text_content != "" ->
-        case Jason.decode(text_content) do
+        case ReqLLM.JSON.decode(text_content, opts) do
           {:ok, object} when is_map(object) ->
             {:ok, object}
 

--- a/lib/req_llm/tool_call.ex
+++ b/lib/req_llm/tool_call.ex
@@ -96,9 +96,9 @@ defmodule ReqLLM.ToolCall do
   Extract and decode the arguments as a map from a ToolCall.
   Returns nil if decoding fails.
   """
-  @spec args_map(t()) :: map() | nil
-  def args_map(%__MODULE__{function: %{arguments: json}}) do
-    case Jason.decode(json) do
+  @spec args_map(t(), keyword()) :: map() | nil
+  def args_map(%__MODULE__{function: %{arguments: json}}, opts \\ []) do
+    case ReqLLM.JSON.decode(json, opts) do
       {:ok, map} -> map
       {:error, _} -> nil
     end
@@ -120,12 +120,12 @@ defmodule ReqLLM.ToolCall do
       iex> ToolCall.to_map(tc)
       %{id: "call_456", name: "get_time", arguments: %{}}
   """
-  @spec to_map(t()) :: %{id: String.t(), name: String.t(), arguments: map()}
-  def to_map(%__MODULE__{id: id, function: %{name: name}} = tc) do
+  @spec to_map(t(), keyword()) :: %{id: String.t(), name: String.t(), arguments: map()}
+  def to_map(%__MODULE__{id: id, function: %{name: name}} = tc, opts \\ []) do
     %{
       id: id,
       name: name,
-      arguments: args_map(tc) || %{}
+      arguments: args_map(tc, opts) || %{}
     }
   end
 
@@ -144,26 +144,28 @@ defmodule ReqLLM.ToolCall do
       iex> ToolCall.from_map(tc)
       %{id: "call_456", name: "get_time", arguments: %{}}
   """
-  @spec from_map(t() | map()) :: %{id: String.t(), name: String.t(), arguments: map()}
-  def from_map(%__MODULE__{} = tc), do: to_map(tc)
+  @spec from_map(t() | map(), keyword()) :: %{id: String.t(), name: String.t(), arguments: map()}
+  def from_map(tool_call, opts \\ [])
 
-  def from_map(map) when is_map(map) do
+  def from_map(%__MODULE__{} = tc, opts), do: to_map(tc, opts)
+
+  def from_map(map, opts) when is_map(map) do
     %{
       id: map[:id] || map["id"] || generate_id(),
       name: map[:name] || map["name"],
-      arguments: parse_arguments(map[:arguments] || map["arguments"] || %{})
+      arguments: parse_arguments(map[:arguments] || map["arguments"] || %{}, opts)
     }
   end
 
-  defp parse_arguments(args) when is_binary(args) do
-    case Jason.decode(args) do
+  defp parse_arguments(args, opts) when is_binary(args) do
+    case ReqLLM.JSON.decode(args, opts) do
       {:ok, parsed} -> parsed
       {:error, _} -> %{}
     end
   end
 
-  defp parse_arguments(args) when is_map(args), do: args
-  defp parse_arguments(_), do: %{}
+  defp parse_arguments(args, _opts) when is_map(args), do: args
+  defp parse_arguments(_, _opts), do: %{}
 
   @doc """
   Check if a ToolCall matches the given function name.
@@ -175,13 +177,13 @@ defmodule ReqLLM.ToolCall do
   Find the first tool call matching the given name and return its decoded arguments.
   Returns nil if no match found or if arguments cannot be decoded.
   """
-  @spec find_args([t()], String.t()) :: map() | nil
-  def find_args(tool_calls, name) do
+  @spec find_args([t()], String.t(), keyword()) :: map() | nil
+  def find_args(tool_calls, name, opts \\ []) do
     tool_calls
     |> Enum.find(&matches_name?(&1, name))
     |> case do
       nil -> nil
-      call -> args_map(call)
+      call -> args_map(call, opts)
     end
   end
 

--- a/test/req_llm/generation_test.exs
+++ b/test/req_llm/generation_test.exs
@@ -77,6 +77,9 @@ defmodule ReqLLM.GenerationTest do
   defmodule ObjectHTTP do
   end
 
+  defmodule BrokenObjectHTTP do
+  end
+
   setup do
     # Stub HTTP responses for testing
     Req.Test.stub(ReqLLM.GenerationTest, fn conn ->
@@ -381,6 +384,91 @@ defmodule ReqLLM.GenerationTest do
     end
   end
 
+  describe "generate_object/4 JSON repair" do
+    test "repairs slightly broken structured output arguments by default" do
+      Req.Test.stub(BrokenObjectHTTP, fn conn ->
+        Req.Test.json(conn, %{
+          "id" => "cmpl_object_123",
+          "model" => "gpt-4o-mini-2024-07-18",
+          "choices" => [
+            %{
+              "message" => %{
+                "role" => "assistant",
+                "tool_calls" => [
+                  %{
+                    "id" => "call_123",
+                    "type" => "function",
+                    "function" => %{
+                      "name" => "structured_output",
+                      "arguments" => ~s({"name":"Ada",})
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ],
+          "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 4, "total_tokens" => 14}
+        })
+      end)
+
+      schema = [name: [type: :string, required: true]]
+
+      {:ok, response} =
+        Generation.generate_object(
+          "openai:gpt-4o-mini",
+          "Return a person",
+          schema,
+          openai_structured_output_mode: :tool_strict,
+          req_http_options: [plug: {Req.Test, BrokenObjectHTTP}]
+        )
+
+      assert response.object == %{"name" => "Ada"}
+    end
+
+    test "allows JSON repair to be disabled" do
+      Req.Test.stub(BrokenObjectHTTP, fn conn ->
+        Req.Test.json(conn, %{
+          "id" => "cmpl_object_123",
+          "model" => "gpt-4o-mini-2024-07-18",
+          "choices" => [
+            %{
+              "message" => %{
+                "role" => "assistant",
+                "tool_calls" => [
+                  %{
+                    "id" => "call_123",
+                    "type" => "function",
+                    "function" => %{
+                      "name" => "structured_output",
+                      "arguments" => ~s({"name":"Ada",})
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ],
+          "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 4, "total_tokens" => 14}
+        })
+      end)
+
+      schema = [name: [type: :string, required: true]]
+
+      {:ok, response} =
+        Generation.generate_object(
+          "openai:gpt-4o-mini",
+          "Return a person",
+          schema,
+          json_repair: false,
+          openai_structured_output_mode: :tool_strict,
+          req_http_options: [plug: {Req.Test, BrokenObjectHTTP}]
+        )
+
+      assert response.object == nil
+    end
+  end
+
   describe "option validation and translation" do
     test "validates base schema options" do
       schema = Generation.schema()
@@ -408,6 +496,15 @@ defmodule ReqLLM.GenerationTest do
       assert Keyword.has_key?(schema.schema, :cache_key)
       assert Keyword.has_key?(schema.schema, :cache_ttl)
       assert Keyword.has_key?(schema.schema, :cache_options)
+    end
+
+    test "includes json_repair option in schema" do
+      schema = Generation.schema()
+      json_repair_spec = Keyword.get(schema.schema, :json_repair)
+
+      assert json_repair_spec != nil
+      assert json_repair_spec[:type] == :boolean
+      assert json_repair_spec[:default] == true
     end
 
     test "provider schema composition works" do

--- a/test/req_llm/response_test.exs
+++ b/test/req_llm/response_test.exs
@@ -396,6 +396,26 @@ defmodule ReqLLM.ResponseTest do
     end
   end
 
+  describe "unwrap_object/2" do
+    test "repairs lightly malformed JSON content by default" do
+      content = [%ContentPart{type: :text, text: "```json\n{\"name\":\"Ada\",}\n```"}]
+      message = %Message{role: :assistant, content: content, metadata: %{}}
+      response = create_response(message: message)
+
+      assert Response.unwrap_object(response) == {:ok, %{"name" => "Ada"}}
+    end
+
+    test "allows JSON repair to be disabled" do
+      content = [%ContentPart{type: :text, text: "```json\n{\"name\":\"Ada\",}\n```"}]
+      message = %Message{role: :assistant, content: content, metadata: %{}}
+      response = create_response(message: message)
+
+      assert {:error,
+              %ReqLLM.Error.API.Response{reason: "Failed to parse JSON from text content"}} =
+               Response.unwrap_object(response, json_repair: false)
+    end
+  end
+
   describe "classify/1" do
     test "classifies text-only responses as :final_answer" do
       content = [

--- a/test/req_llm/tool_call_test.exs
+++ b/test/req_llm/tool_call_test.exs
@@ -103,6 +103,18 @@ defmodule ReqLLM.ToolCallTest do
                "unit" => "celsius"
              }
     end
+
+    test "repairs lightly malformed JSON by default" do
+      tool_call = ToolCall.new("call_123", "structured_output", ~s({"name":"Ada",}))
+
+      assert ToolCall.args_map(tool_call) == %{"name" => "Ada"}
+    end
+
+    test "allows JSON repair to be disabled" do
+      tool_call = ToolCall.new("call_123", "structured_output", ~s({"name":"Ada",}))
+
+      assert ToolCall.args_map(tool_call, json_repair: false) == nil
+    end
   end
 
   describe "matches_name?/2" do
@@ -174,6 +186,13 @@ defmodule ReqLLM.ToolCallTest do
       result = ToolCall.find_args(tool_calls, "structured_output")
 
       assert result == %{"name" => "John", "age" => 30}
+    end
+
+    test "respects JSON repair options" do
+      tool_calls = [ToolCall.new("call_1", "structured_output", ~s({"name":"Ada",}))]
+
+      assert ToolCall.find_args(tool_calls, "structured_output") == %{"name" => "Ada"}
+      assert ToolCall.find_args(tool_calls, "structured_output", json_repair: false) == nil
     end
   end
 


### PR DESCRIPTION
## Summary
- add a shared JSON decoder that attempts light repair for fenced, trailing-comma, and slightly truncated structured outputs
- apply the repair path across structured-output extraction flows while preserving a `json_repair: false` opt-out
- add end-to-end and helper coverage for repaired and strict-fail behavior

## Testing
- mix test test/req_llm/generation_test.exs test/req_llm/response_test.exs test/req_llm/tool_call_test.exs test/provider/openai_structured_output_test.exs test/provider/openai/responses_api_unit_test.exs test/providers/openai_test.exs test/providers/anthropic_test.exs test/providers/google_test.exs test/providers/google_vertex_openai_compat_test.exs test/providers/xai_test.exs test/providers/zai_test.exs test/provider/azure/openai_test.exs

Closes #196