### PR TITLE
feat: list models available for configured providers

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -80,7 +80,17 @@ defmodule ReqLLM do
       provider.generate_text(model, messages, opts)
   """
 
-  alias ReqLLM.{Embedding, Generation, Images, OCR, Schema, Speech, Tool, Transcription}
+  alias ReqLLM.{
+    Availability,
+    Embedding,
+    Generation,
+    Images,
+    OCR,
+    Schema,
+    Speech,
+    Tool,
+    Transcription
+  }
 
   @typedoc """
   Model input accepted by ReqLLM public APIs.
@@ -323,6 +333,35 @@ defmodule ReqLLM do
       {:error, error} -> raise error
     end
   end
+
+  @doc """
+  Returns catalog model specs for providers that are currently configured.
+
+  This is intended for building model selectors or narrowing choices to providers
+  that have usable credentials in the current environment or application config.
+
+  The result is filtered by provider availability first, then by the supplied
+  LLMDB query options.
+
+  ## Options
+
+    * `:scope` - Restrict results to a specific provider, or use `:all` (default)
+    * `:prefer` - Preferred provider ordering, forwarded to `LLMDB.Query.candidates/1`
+    * `:require` - Required capability filters, forwarded to `LLMDB.Query.candidates/1`
+    * `:forbid` - Forbidden capability filters, forwarded to `LLMDB.Query.candidates/1`
+    * `:provider_options` - Optional auth-related provider settings for scoped discovery
+
+  ## Examples
+
+      ReqLLM.available_models()
+      #=> ["openai:gpt-4o", "anthropic:claude-3-5-sonnet-20240620", ...]
+
+      ReqLLM.available_models(scope: :openai, require: [embeddings: true])
+      #=> ["openai:text-embedding-3-small", "openai:text-embedding-3-large", ...]
+
+  """
+  @spec available_models(keyword()) :: [String.t()]
+  defdelegate available_models(opts \\ []), to: Availability
 
   defp normalize_model_result({:ok, %LLMDB.Model{} = model}),
     do: {:ok, normalize_model_metadata(model)}

--- a/lib/req_llm/availability.ex
+++ b/lib/req_llm/availability.ex
@@ -1,0 +1,166 @@
+defmodule ReqLLM.Availability do
+  @moduledoc false
+
+  @query_opts [:scope, :prefer, :require, :forbid]
+
+  @azure_api_key_env_vars [
+    "AZURE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_ANTHROPIC_API_KEY",
+    "AZURE_DEEPSEEK_API_KEY",
+    "AZURE_MAI_API_KEY"
+  ]
+
+  @azure_base_url_env_vars [
+    "AZURE_BASE_URL",
+    "AZURE_OPENAI_BASE_URL",
+    "AZURE_ANTHROPIC_BASE_URL",
+    "AZURE_DEEPSEEK_BASE_URL",
+    "AZURE_MAI_BASE_URL"
+  ]
+
+  @spec available_models(keyword()) :: [String.t()]
+  def available_models(opts \\ []) do
+    configured_providers = configured_providers(opts) |> MapSet.new()
+
+    opts
+    |> Keyword.take(@query_opts)
+    |> LLMDB.Query.candidates()
+    |> Enum.filter(fn {provider, _model_id} -> MapSet.member?(configured_providers, provider) end)
+    |> Enum.map(&LLMDB.format/1)
+  end
+
+  defp configured_providers(opts) do
+    opts
+    |> providers_to_check()
+    |> Enum.filter(&configured_provider?(&1, opts))
+  end
+
+  defp providers_to_check(opts) do
+    case Keyword.get(opts, :scope, :all) do
+      :all -> ReqLLM.Providers.list()
+      provider when is_atom(provider) -> [provider]
+      _ -> []
+    end
+  end
+
+  defp configured_provider?(:amazon_bedrock, opts), do: amazon_bedrock_configured?(opts)
+  defp configured_provider?(:azure, opts), do: azure_configured?(opts)
+  defp configured_provider?(:google_vertex, opts), do: google_vertex_configured?(opts)
+  defp configured_provider?(provider, opts), do: auth_resolvable?(provider, opts)
+
+  defp auth_resolvable?(provider, opts) do
+    provider
+    |> put_default_auth_mode(opts)
+    |> then(&match?({:ok, _credential}, ReqLLM.Auth.resolve(provider, &1)))
+  end
+
+  defp put_default_auth_mode(provider, opts) do
+    with {:ok, provider_module} <- ReqLLM.provider(provider),
+         true <- function_exported?(provider_module, :provider_schema, 0),
+         schema when is_list(schema) <- provider_module.provider_schema().schema,
+         auth_mode_schema when is_list(auth_mode_schema) <- Keyword.get(schema, :auth_mode),
+         auth_mode when not is_nil(auth_mode) <- Keyword.get(auth_mode_schema, :default),
+         false <- provider_option_present?(opts, :auth_mode) do
+      put_provider_option(opts, :auth_mode, auth_mode)
+    else
+      _ -> opts
+    end
+  end
+
+  defp amazon_bedrock_configured?(opts) do
+    api_key =
+      option_value(opts, :api_key) ||
+        System.get_env("AWS_BEARER_TOKEN_BEDROCK")
+
+    access_key_id =
+      option_value(opts, :access_key_id) ||
+        System.get_env("AWS_ACCESS_KEY_ID")
+
+    secret_access_key =
+      option_value(opts, :secret_access_key) ||
+        System.get_env("AWS_SECRET_ACCESS_KEY")
+
+    present?(api_key) or (present?(access_key_id) and present?(secret_access_key))
+  end
+
+  defp azure_configured?(opts) do
+    api_key =
+      option_value(opts, :api_key) ||
+        Application.get_env(:req_llm, :azure_api_key) ||
+        first_present_env(@azure_api_key_env_vars)
+
+    base_url =
+      option_value(opts, :base_url) ||
+        Application.get_env(:req_llm, :azure, []) |> Keyword.get(:base_url) ||
+        first_present_env(@azure_base_url_env_vars)
+
+    present?(api_key) and present?(base_url)
+  end
+
+  defp google_vertex_configured?(opts) do
+    service_account_json =
+      option_value(opts, :service_account_json) ||
+        System.get_env("GOOGLE_APPLICATION_CREDENTIALS")
+
+    access_token = option_value(opts, :access_token)
+    project_id = option_value(opts, :project_id) || System.get_env("GOOGLE_CLOUD_PROJECT")
+
+    present?(project_id) and (present?(service_account_json) or present?(access_token))
+  end
+
+  defp first_present_env(vars) do
+    Enum.find_value(vars, &present_env/1)
+  end
+
+  defp present_env(var) do
+    case System.get_env(var) do
+      value when is_binary(value) and value != "" -> value
+      _ -> nil
+    end
+  end
+
+  defp option_value(opts, key) do
+    Keyword.get(opts, key) || provider_option_value(opts, key)
+  end
+
+  defp provider_option_value(opts, key) do
+    case Keyword.get(opts, :provider_options, []) do
+      provider_opts when is_list(provider_opts) ->
+        Keyword.get(provider_opts, key)
+
+      provider_opts when is_map(provider_opts) ->
+        Map.get(provider_opts, key) || Map.get(provider_opts, Atom.to_string(key))
+
+      _ ->
+        nil
+    end
+  end
+
+  defp provider_option_present?(opts, key) do
+    case Keyword.get(opts, :provider_options, []) do
+      provider_opts when is_list(provider_opts) ->
+        Keyword.has_key?(provider_opts, key)
+
+      provider_opts when is_map(provider_opts) ->
+        Map.has_key?(provider_opts, key) || Map.has_key?(provider_opts, Atom.to_string(key))
+
+      _ ->
+        false
+    end
+  end
+
+  defp put_provider_option(opts, key, value) do
+    provider_opts =
+      case Keyword.get(opts, :provider_options, []) do
+        existing when is_list(existing) -> Keyword.put_new(existing, key, value)
+        existing when is_map(existing) -> Map.put_new(existing, key, value)
+        _ -> [{key, value}]
+      end
+
+    Keyword.put(opts, :provider_options, provider_opts)
+  end
+
+  defp present?(value) when is_binary(value), do: value != ""
+  defp present?(value), do: not is_nil(value)
+end

--- a/test/req_llm/availability_test.exs
+++ b/test/req_llm/availability_test.exs
@@ -1,0 +1,137 @@
+defmodule ReqLLM.AvailabilityTest do
+  use ExUnit.Case, async: false
+
+  @env_vars [
+    "ANTHROPIC_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_SECRET_ACCESS_KEY",
+    "AZURE_API_KEY",
+    "AZURE_BASE_URL",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_BASE_URL",
+    "CEREBRAS_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "GROQ_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "VENICE_API_KEY",
+    "XAI_API_KEY",
+    "ZAI_API_KEY",
+    "ZENMUX_API_KEY"
+  ]
+
+  @app_keys [
+    :anthropic_api_key,
+    :azure_api_key,
+    :cerebras_api_key,
+    :deepseek_api_key,
+    :elevenlabs_api_key,
+    :google_api_key,
+    :groq_api_key,
+    :openai_api_key,
+    :openrouter_api_key,
+    :venice_api_key,
+    :xai_api_key,
+    :zai_api_key,
+    :zenmux_api_key
+  ]
+
+  setup do
+    env_snapshot = Map.new(@env_vars, &{&1, System.get_env(&1)})
+    app_snapshot = Map.new(@app_keys, &{&1, Application.get_env(:req_llm, &1)})
+    azure_snapshot = Application.get_env(:req_llm, :azure)
+
+    Enum.each(@env_vars, &System.delete_env/1)
+    Enum.each(@app_keys, &Application.delete_env(:req_llm, &1))
+    Application.delete_env(:req_llm, :azure)
+
+    on_exit(fn ->
+      Enum.each(env_snapshot, fn
+        {var, nil} -> System.delete_env(var)
+        {var, value} -> System.put_env(var, value)
+      end)
+
+      Enum.each(app_snapshot, fn
+        {key, nil} -> Application.delete_env(:req_llm, key)
+        {key, value} -> Application.put_env(:req_llm, key, value)
+      end)
+
+      restore_application_env(:azure, azure_snapshot)
+    end)
+
+    :ok
+  end
+
+  describe "available_models/1" do
+    test "returns models only for configured providers" do
+      System.put_env("OPENAI_API_KEY", "openai-test-key")
+      System.put_env("ANTHROPIC_API_KEY", "anthropic-test-key")
+
+      models = ReqLLM.available_models()
+
+      assert "openai:gpt-4o" in models
+      assert "anthropic:claude-3-haiku-20240307" in models
+      refute Enum.any?(models, &String.starts_with?(&1, "groq:"))
+    end
+
+    test "forwards capability filters to model selection" do
+      System.put_env("OPENAI_API_KEY", "openai-test-key")
+
+      models = ReqLLM.available_models(scope: :openai, require: [embeddings: true])
+
+      assert "openai:text-embedding-3-small" in models
+      refute "openai:gpt-4o" in models
+    end
+
+    test "accepts oauth provider options for scoped discovery" do
+      models =
+        ReqLLM.available_models(
+          scope: :openai,
+          provider_options: [auth_mode: :oauth, access_token: "oauth-access-token"]
+        )
+
+      assert "openai:gpt-4o" in models
+    end
+
+    test "requires project configuration for google vertex discovery" do
+      System.put_env("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/service-account.json")
+
+      assert ReqLLM.available_models(scope: :google_vertex) == []
+
+      System.put_env("GOOGLE_CLOUD_PROJECT", "test-project")
+
+      models = ReqLLM.available_models(scope: :google_vertex)
+
+      assert Enum.any?(models, &String.starts_with?(&1, "google_vertex:"))
+    end
+
+    test "detects Bedrock bearer token credentials" do
+      System.put_env("AWS_BEARER_TOKEN_BEDROCK", "bedrock-token")
+
+      models = ReqLLM.available_models(scope: :amazon_bedrock)
+
+      assert Enum.any?(models, &String.starts_with?(&1, "amazon_bedrock:"))
+    end
+
+    test "requires both azure key and base url" do
+      System.put_env("AZURE_OPENAI_API_KEY", "azure-test-key")
+
+      assert ReqLLM.available_models(scope: :azure) == []
+
+      System.put_env("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+
+      models = ReqLLM.available_models(scope: :azure)
+
+      assert Enum.any?(models, &String.starts_with?(&1, "azure:"))
+    end
+  end
+
+  defp restore_application_env(key, nil), do: Application.delete_env(:req_llm, key)
+  defp restore_application_env(key, value), do: Application.put_env(:req_llm, key, value)
+end


### PR DESCRIPTION
## Summary
- add a new `ReqLLM.available_models/1` API for model-selector discovery
- filter catalog results to providers with usable credentials in the current setup
- cover standard API-key flows plus Azure, Bedrock, Google Vertex, and oauth-scoped discovery in tests

Closes #213