### PR TITLE
fix: support multiple system messages

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -541,11 +541,10 @@ defmodule ReqLLM.Context do
 
   # Validation and wrap/encode helpers
 
-  @doc "Validate context: ensures valid messages, at most one system message, and tool message constraints."
+  @doc "Validate context: ensures valid messages and tool message constraints."
   @spec validate(t()) :: {:ok, t()} | {:error, String.t()}
   def validate(%__MODULE__{messages: msgs} = context) do
-    with :ok <- validate_system_messages(msgs),
-         :ok <- validate_message_structure(msgs),
+    with :ok <- validate_message_structure(msgs),
          :ok <- validate_tool_messages(msgs) do
       {:ok, context}
     end
@@ -1020,16 +1019,6 @@ defmodule ReqLLM.Context do
   end
 
   defp maybe_add_system(context, _), do: context
-
-  defp validate_system_messages(messages) do
-    system_count = Enum.count(messages, &(&1.role == :system))
-
-    case system_count do
-      0 -> :ok
-      1 -> :ok
-      n -> {:error, "Context should have at most one system message, found #{n}"}
-    end
-  end
 
   defp validate_message_structure(messages) do
     Enum.reduce_while(messages, :ok, fn msg, :ok ->

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -332,18 +332,15 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     {system_messages, non_system_messages} =
       Enum.split_with(messages, fn %Message{role: role} -> role == :system end)
 
-    # Add system messages
     request =
-      case system_messages do
+      case encode_system_messages(system_messages) do
         [] ->
           request
 
-        [%Message{content: content} | _] ->
-          # Converse API accepts system as array of content blocks
-          Map.put(request, "system", encode_content_for_system(content))
+        encoded_system ->
+          Map.put(request, "system", encoded_system)
       end
 
-    # Add regular messages, dropping any that end up empty after ContentPart filtering
     encoded_messages =
       non_system_messages
       |> Enum.map(&encode_message/1)
@@ -352,6 +349,24 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
     Map.put(request, "messages", encoded_messages)
   end
+
+  defp encode_system_messages(messages) do
+    messages
+    |> Enum.map(&encode_system_message/1)
+    |> Enum.reject(&(&1 == []))
+    |> Enum.intersperse([%{"text" => "\n\n"}])
+    |> List.flatten()
+  end
+
+  defp encode_system_message(%Message{content: content}) when is_binary(content) do
+    encode_content_for_system(content)
+  end
+
+  defp encode_system_message(%Message{content: content}) when is_list(content) do
+    encode_content_for_system(content)
+  end
+
+  defp encode_system_message(_message), do: []
 
   defp merge_consecutive_tool_results(messages) do
     messages

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -58,13 +58,12 @@ defmodule ReqLLM.Providers.Anthropic.Context do
       Enum.split_with(messages, fn %ReqLLM.Message{role: role} -> role == :system end)
 
     request =
-      case system_messages do
-        [] ->
+      case encode_system_messages(system_messages) do
+        nil ->
           request
 
-        [%ReqLLM.Message{content: content} | _] ->
-          # Anthropic only accepts one system message at top level
-          Map.put(request, :system, encode_content(content))
+        encoded_system ->
+          Map.put(request, :system, encoded_system)
       end
 
     encoded_messages =
@@ -155,6 +154,35 @@ defmodule ReqLLM.Providers.Anthropic.Context do
       content: encode_content(content)
     }
   end
+
+  defp encode_system_messages(messages) do
+    messages
+    |> Enum.map(&encode_system_message/1)
+    |> Enum.reject(&(&1 == []))
+    |> Enum.intersperse([%{type: "text", text: "\n\n"}])
+    |> List.flatten()
+    |> normalize_system_content()
+  end
+
+  defp encode_system_message(%ReqLLM.Message{content: content}) when is_binary(content) do
+    if content == "" do
+      []
+    else
+      [%{type: "text", text: content}]
+    end
+  end
+
+  defp encode_system_message(%ReqLLM.Message{content: content}) when is_list(content) do
+    content
+    |> Enum.map(&encode_content_part/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp encode_system_message(_message), do: []
+
+  defp normalize_system_content([]), do: nil
+  defp normalize_system_content([%{type: "text", text: text}]), do: text
+  defp normalize_system_content(blocks), do: blocks
 
   # Simple text content
   defp encode_content(content) when is_binary(content), do: content

--- a/test/providers/alibaba_test.exs
+++ b/test/providers/alibaba_test.exs
@@ -591,19 +591,15 @@ defmodule ReqLLM.Providers.AlibabaTest do
   end
 
   describe "context validation" do
-    test "multiple system messages should fail" do
-      invalid_context =
+    test "multiple system messages are allowed" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
   end
 end

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -445,6 +445,27 @@ defmodule ReqLLM.Providers.AnthropicTest do
              end)
     end
 
+    test "encode_request combines multiple system messages" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.system("Talk like a pirate"),
+          ReqLLM.Context.user("Tell me about Elixir"),
+          ReqLLM.Context.system("Respond in verses")
+        ])
+
+      request = ReqLLM.Providers.Anthropic.Context.encode_request(context, model)
+
+      assert request[:system] == [
+               %{type: "text", text: "Talk like a pirate"},
+               %{type: "text", text: "\n\n"},
+               %{type: "text", text: "Respond in verses"}
+             ]
+
+      assert request[:messages] == [%{role: "user", content: "Tell me about Elixir"}]
+    end
+
     test "encode_body sanitizes OpenAI-style tool call IDs for Anthropic" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1228,20 +1228,15 @@ defmodule ReqLLM.Providers.GoogleTest do
   end
 
   describe "error handling & robustness" do
-    test "context validation" do
-      # Multiple system messages should fail
-      invalid_context =
+    test "context validation allows multiple system messages" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
   end
 

--- a/test/providers/groq_test.exs
+++ b/test/providers/groq_test.exs
@@ -539,20 +539,15 @@ defmodule ReqLLM.Providers.GroqTest do
   end
 
   describe "error handling & robustness" do
-    test "context validation" do
-      # Multiple system messages should fail
-      invalid_context =
+    test "context validation allows multiple system messages" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/Context should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
   end
 end

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -74,13 +74,14 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
   end
 
   describe "attach_stream/4" do
-    test "builds SSE request against codex backend with instructions" do
+    test "builds SSE request against codex backend with combined instructions" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
 
       context =
         ReqLLM.context([
           ReqLLM.Context.system("You are a mining analyst."),
-          ReqLLM.Context.user("Tell me about FMG")
+          ReqLLM.Context.user("Tell me about FMG"),
+          ReqLLM.Context.system("Use bullet points.")
         ])
 
       {:ok, request} =
@@ -104,7 +105,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
 
       body = Jason.decode!(request.body)
 
-      assert body["instructions"] == "You are a mining analyst."
+      assert body["instructions"] == "You are a mining analyst.\n\nUse bullet points."
       assert body["model"] == "gpt-5.3-codex-spark"
       assert body["store"] == false
       assert body["include"] == ["reasoning.encrypted_content"]

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -1029,20 +1029,15 @@ defmodule ReqLLM.Providers.OpenAITest do
   end
 
   describe "error handling & robustness" do
-    test "context validation" do
-      # Multiple system messages should fail
-      invalid_context =
+    test "context validation allows multiple system messages" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
 
     test "prepare_request rejects unsupported operations" do

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -784,20 +784,15 @@ defmodule ReqLLM.Providers.OpenRouterTest do
   end
 
   describe "error handling & robustness" do
-    test "context validation" do
-      # Multiple system messages should fail
-      invalid_context =
+    test "context validation allows multiple system messages" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
   end
 

--- a/test/providers/venice_test.exs
+++ b/test/providers/venice_test.exs
@@ -511,19 +511,15 @@ defmodule ReqLLM.Providers.VeniceTest do
   end
 
   describe "context validation" do
-    test "multiple system messages should fail" do
-      invalid_context =
+    test "multiple system messages are allowed" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
   end
 end

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -732,19 +732,15 @@ defmodule ReqLLM.Providers.XAITest do
   end
 
   describe "context validation" do
-    test "multiple system messages should fail" do
-      invalid_context =
+    test "multiple system messages are allowed" do
+      context =
         Context.new([
           Context.system("System 1"),
           Context.system("System 2"),
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error,
-                   ~r/should have at most one system message/,
-                   fn ->
-                     Context.validate!(invalid_context)
-                   end
+      assert ^context = Context.validate!(context)
     end
   end
 end

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -174,7 +174,7 @@ defmodule ReqLLM.ContextTest do
       assert {:ok, ^context} = Context.validate(context)
     end
 
-    test "validate/1 fails with multiple system messages" do
+    test "validate/1 allows multiple system messages" do
       context =
         Context.new([
           Context.system("First system"),
@@ -182,11 +182,10 @@ defmodule ReqLLM.ContextTest do
           Context.user("Hello")
         ])
 
-      assert {:error, "Context should have at most one system message, found 2"} =
-               Context.validate(context)
+      assert {:ok, ^context} = Context.validate(context)
     end
 
-    test "validate!/1 raises with invalid context" do
+    test "validate!/1 returns context with multiple system messages" do
       context =
         Context.new([
           Context.system("First system"),
@@ -194,9 +193,7 @@ defmodule ReqLLM.ContextTest do
           Context.user("Hello")
         ])
 
-      assert_raise ReqLLM.Error.Validation.Error, fn ->
-        Context.validate!(context)
-      end
+      assert ^context = Context.validate!(context)
     end
 
     test "validate/1 fails with invalid messages" do
@@ -439,10 +436,10 @@ defmodule ReqLLM.ContextTest do
       assert system_msg.role == :system
       assert user_msg.role == :user
 
-      # Fails with multiple system messages
+      # Keeps multiple system messages
       input = [Context.system("First system"), Context.system("Second system"), "User message"]
-      {:error, reason} = Context.normalize(input)
-      assert reason == "Context should have at most one system message, found 2"
+      {:ok, context3} = Context.normalize(input)
+      assert Enum.map(context3.messages, & &1.role) == [:system, :system, :user]
     end
 
     test "rejects invalid loose maps when convert_loose: false" do

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -34,6 +34,26 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
       assert result["messages"] == [%{"role" => "user", "content" => [%{"text" => "Hello"}]}]
     end
 
+    test "formats request with multiple system messages" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :system, content: "Talk like a pirate"},
+          %Message{role: :user, content: "Hello"},
+          %Message{role: :system, content: "Respond in verses"}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+
+      assert result["system"] == [
+               %{"text" => "Talk like a pirate"},
+               %{"text" => "\n\n"},
+               %{"text" => "Respond in verses"}
+             ]
+
+      assert result["messages"] == [%{"role" => "user", "content" => [%{"text" => "Hello"}]}]
+    end
+
     test "formats request with tools" do
       {:ok, tool} =
         ReqLLM.Tool.new(


### PR DESCRIPTION
## Summary
- allow contexts to validate and normalize with more than one system message
- combine multiple system messages for Anthropic-style top-level system fields and Bedrock Converse requests
- update provider tests to reflect the new supported behavior and cover Codex instruction folding

Closes #230