### PR TITLE
feat: add video URL message support

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -980,12 +980,61 @@ defmodule ReqLLM.Context do
           []
         end
 
+      type when type in [:image_url, "image_url"] ->
+        case url_content_part(part, :image_url) do
+          {:ok, url_part} -> [url_part]
+          :error -> []
+        end
+
+      type when type in [:video_url, "video_url"] ->
+        case url_content_part(part, :video_url) do
+          {:ok, url_part} -> [url_part]
+          :error -> []
+        end
+
       _ ->
         []
     end
   end
 
   defp to_part_list(_part), do: []
+
+  defp url_content_part(part, kind) do
+    metadata = Map.get(part, :metadata) || Map.get(part, "metadata") || %{}
+
+    nested =
+      Map.get(part, kind) ||
+        Map.get(part, Atom.to_string(kind))
+
+    url =
+      Map.get(part, :url) ||
+        Map.get(part, "url") ||
+        if(is_map(nested), do: Map.get(nested, :url) || Map.get(nested, "url"))
+
+    media_type =
+      Map.get(part, :media_type) ||
+        Map.get(part, "media_type") ||
+        if(is_map(nested), do: Map.get(nested, :media_type) || Map.get(nested, "media_type"))
+
+    if is_binary(url) and url != "" do
+      content_part =
+        case kind do
+          :image_url -> ContentPart.image_url(url, metadata)
+          :video_url -> ContentPart.video_url(url, metadata)
+        end
+
+      {:ok, maybe_put_url_media_type(content_part, media_type)}
+    else
+      :error
+    end
+  end
+
+  defp maybe_put_url_media_type(%ContentPart{} = part, media_type)
+       when is_binary(media_type) and media_type != "" do
+    %{part | media_type: media_type}
+  end
+
+  defp maybe_put_url_media_type(%ContentPart{} = part, _media_type), do: part
 
   defp convert_loose_role_list_content(role, content, metadata, reasoning_details) do
     case role do

--- a/lib/req_llm/message/content_part.ex
+++ b/lib/req_llm/message/content_part.ex
@@ -5,6 +5,7 @@ defmodule ReqLLM.Message.ContentPart do
   Supports multiple content types:
   - `:text` - Plain text content
   - `:image_url` - Image from URL
+  - `:video_url` - Video from URL
   - `:image` - Image from binary data
   - `:file` - File attachment
   - `:thinking` - Chain-of-thought thinking content
@@ -15,7 +16,7 @@ defmodule ReqLLM.Message.ContentPart do
   """
 
   @schema Zoi.struct(__MODULE__, %{
-            type: Zoi.enum([:text, :image_url, :image, :file, :thinking]),
+            type: Zoi.enum([:text, :image_url, :video_url, :image, :file, :thinking]),
             text: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             url: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             data: Zoi.any() |> Zoi.nullable() |> Zoi.default(nil),
@@ -55,6 +56,12 @@ defmodule ReqLLM.Message.ContentPart do
   @spec image_url(String.t(), map()) :: t()
   def image_url(url, metadata), do: %__MODULE__{type: :image_url, url: url, metadata: metadata}
 
+  @spec video_url(String.t()) :: t()
+  def video_url(url), do: %__MODULE__{type: :video_url, url: url}
+
+  @spec video_url(String.t(), map()) :: t()
+  def video_url(url, metadata), do: %__MODULE__{type: :video_url, url: url, metadata: metadata}
+
   @spec image(binary(), String.t()) :: t()
   def image(data, media_type \\ "image/png"),
     do: %__MODULE__{type: :image, data: data, media_type: media_type}
@@ -74,6 +81,7 @@ defmodule ReqLLM.Message.ContentPart do
           :text -> inspect_text(part.text, opts)
           :thinking -> inspect_text(part.text, opts)
           :image_url -> "url: #{part.url}"
+          :video_url -> "url: #{part.url}"
           :image -> "#{part.media_type} (#{byte_size(part.data)} bytes)"
           :file -> "#{part.media_type} (#{byte_size(part.data || <<>>)} bytes)"
         end

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -920,6 +920,12 @@ defmodule ReqLLM.Provider.Defaults do
     |> merge_content_metadata(metadata)
   end
 
+  defp encode_openai_content_part(%ReqLLM.Message.ContentPart{type: :video_url}) do
+    raise ReqLLM.Error.Invalid.Message.exception(
+            reason: "Video URLs are not supported for this provider."
+          )
+  end
+
   defp encode_openai_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
          data: data,

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -846,7 +846,12 @@ defmodule ReqLLM.Providers.Google do
       case request.options[:context] do
         %ReqLLM.Context{} = ctx ->
           model_name = request.options[:model]
-          encoded = ReqLLM.Provider.Defaults.encode_context_to_openai_format(ctx, model_name)
+
+          encoded =
+            ctx
+            |> normalize_context_video_urls()
+            |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
+
           messages = encoded[:messages] || encoded["messages"] || []
           split_messages_for_gemini(messages)
 
@@ -936,7 +941,11 @@ defmodule ReqLLM.Providers.Google do
         %ReqLLM.Context{} = ctx ->
           model_name = request.options[:model]
           # Convert OpenAI-style context to Gemini format
-          encoded = ReqLLM.Provider.Defaults.encode_context_to_openai_format(ctx, model_name)
+          encoded =
+            ctx
+            |> normalize_context_video_urls()
+            |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
+
           messages = encoded[:messages] || encoded["messages"] || []
           split_messages_for_gemini(messages)
 
@@ -1020,7 +1029,12 @@ defmodule ReqLLM.Providers.Google do
       case request.options[:context] do
         %ReqLLM.Context{} = ctx ->
           model_name = request.options[:model]
-          encoded = ReqLLM.Provider.Defaults.encode_context_to_openai_format(ctx, model_name)
+
+          encoded =
+            ctx
+            |> normalize_context_video_urls()
+            |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
+
           messages = encoded[:messages] || encoded["messages"] || []
           split_messages_for_gemini(messages)
 
@@ -2093,41 +2107,59 @@ defmodule ReqLLM.Providers.Google do
     end)
   end
 
-  # Handle OpenAI-format image_url (from Provider.Defaults.encode_openai_content_part)
-  defp convert_content_part(%{type: "image_url", image_url: %{url: url}} = part)
-       when is_binary(url) do
-    cond do
-      # Data URI format: data:mime/type;base64,<data>
-      String.starts_with?(url, "data:") ->
-        case String.split(url, ",", parts: 2) do
-          [header, base64_data] ->
-            mime_type =
-              case Regex.run(~r/data:([^;]+)/, header) do
-                [_, type] -> type
-                _ -> "image/jpeg"
-              end
+  defp normalize_context_video_urls(%ReqLLM.Context{messages: messages} = context) do
+    %{
+      context
+      | messages: Enum.map(messages, &normalize_message_video_urls/1)
+    }
+  end
 
-            %{
-              inline_data: %{
-                mime_type: mime_type,
-                data: base64_data
-              }
-            }
+  defp normalize_message_video_urls(%ReqLLM.Message{content: content} = message)
+       when is_list(content) do
+    %{
+      message
+      | content: Enum.map(content, &normalize_content_part_video_url/1)
+    }
+  end
 
-          _ ->
-            %{text: "[Malformed data URI]"}
-        end
+  defp normalize_message_video_urls(message), do: message
 
-      # HTTP/HTTPS URL: use fileData.fileUri (Google-native URL support)
-      String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
-        build_file_data(part, url)
+  defp normalize_content_part_video_url(%ReqLLM.Message.ContentPart{
+         type: :video_url,
+         url: url,
+         media_type: media_type,
+         metadata: metadata
+       }) do
+    part = ReqLLM.Message.ContentPart.image_url(url, metadata)
 
-      # GCS URI: gs://bucket/path
-      String.starts_with?(url, "gs://") ->
-        build_file_data(part, url)
+    if is_binary(media_type) and media_type != "" do
+      %{part | media_type: media_type}
+    else
+      part
+    end
+  end
 
-      true ->
-        %{text: "[Unsupported URL scheme: #{String.slice(url, 0, 20)}...]"}
+  defp normalize_content_part_video_url(part), do: part
+
+  defp convert_content_part(%{type: type} = part)
+       when type in ["image_url", "video_url", :image_url, :video_url] do
+    case content_part_url(part) do
+      url when is_binary(url) ->
+        convert_url_content_part(part, url)
+
+      _ ->
+        %{text: to_string(part)}
+    end
+  end
+
+  defp convert_content_part(%{"type" => type} = part)
+       when type in ["image_url", "video_url"] do
+    case content_part_url(part) do
+      url when is_binary(url) ->
+        convert_url_content_part(part, url)
+
+      _ ->
+        %{text: to_string(part)}
     end
   end
 
@@ -2155,6 +2187,39 @@ defmodule ReqLLM.Providers.Google do
 
   defp convert_content_part(part), do: %{text: to_string(part)}
 
+  defp convert_url_content_part(part, url) do
+    cond do
+      String.starts_with?(url, "data:") ->
+        case String.split(url, ",", parts: 2) do
+          [header, base64_data] ->
+            mime_type =
+              case Regex.run(~r/data:([^;]+)/, header) do
+                [_, type] -> type
+                _ -> "image/jpeg"
+              end
+
+            %{
+              inline_data: %{
+                mime_type: mime_type,
+                data: base64_data
+              }
+            }
+
+          _ ->
+            %{text: "[Malformed data URI]"}
+        end
+
+      String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
+        build_file_data(part, url)
+
+      String.starts_with?(url, "gs://") ->
+        build_file_data(part, url)
+
+      true ->
+        %{text: "[Unsupported URL scheme: #{String.slice(url, 0, 20)}...]"}
+    end
+  end
+
   # Builds a fileData map, omitting mimeType when it cannot be reliably inferred.
   # YouTube and other extensionless URLs need mimeType omitted so Gemini can infer it.
   defp build_file_data(part, url) do
@@ -2176,10 +2241,26 @@ defmodule ReqLLM.Providers.Google do
   defp get_mime_type_from_part(part, url) do
     # Try metadata first (if passed through from ContentPart)
     case part do
+      %{media_type: type} when is_binary(type) and type != "" -> type
+      %{"media_type" => type} when is_binary(type) and type != "" -> type
       %{image_url: %{media_type: type}} when is_binary(type) and type != "" -> type
+      %{"image_url" => %{"media_type" => type}} when is_binary(type) and type != "" -> type
+      %{video_url: %{media_type: type}} when is_binary(type) and type != "" -> type
+      %{"video_url" => %{"media_type" => type}} when is_binary(type) and type != "" -> type
       _ -> infer_mime_type_from_url(url)
     end
   end
+
+  defp content_part_url(part) do
+    Map.get(part, :url) ||
+      Map.get(part, "url") ||
+      nested_url(Map.get(part, :image_url) || Map.get(part, "image_url")) ||
+      nested_url(Map.get(part, :video_url) || Map.get(part, "video_url"))
+  end
+
+  defp nested_url(%{url: url}) when is_binary(url), do: url
+  defp nested_url(%{"url" => url}) when is_binary(url), do: url
+  defp nested_url(_), do: nil
 
   defp infer_mime_type_from_url(url) do
     # Strip query params and get extension

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1413,6 +1413,36 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert part["fileData"]["mimeType"] == "image/png"
     end
 
+    test "encode_body converts OpenAI-format video_url to fileData format" do
+      url = "https://example.com/videos/clip.mp4"
+
+      mock_request = %Req.Request{
+        options: [
+          messages: [
+            %{
+              "role" => "user",
+              "content" => [
+                %{"type" => "text", "text" => "What happens in this video?"},
+                %{"type" => "video_url", "video_url" => %{"url" => url}}
+              ]
+            }
+          ],
+          id: "gemini-1.5-flash",
+          stream: false
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [user_msg] = decoded["contents"]
+      [_text_part, part] = user_msg["parts"]
+
+      assert Map.has_key?(part, "fileData")
+      assert part["fileData"]["fileUri"] == url
+      assert part["fileData"]["mimeType"] == "video/mp4"
+    end
+
     test "encode_body converts GCS URI to fileData format" do
       url = "gs://my-bucket/path/to/document.pdf"
 

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -509,6 +509,32 @@ defmodule ReqLLM.ContextTest do
              ] = content
     end
 
+    test "accepts JSON-decoded user loose maps with video_url content" do
+      input = %{
+        "role" => "user",
+        "content" => [
+          %{"type" => "text", "text" => "What happens in this video?"},
+          %{
+            "type" => "video_url",
+            "video_url" => %{"url" => "https://example.com/clip.mp4", "media_type" => "video/mp4"}
+          }
+        ]
+      }
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      assert [%Message{role: :user, content: content}] = context.messages
+
+      assert [
+               %ContentPart{type: :text, text: "What happens in this video?"},
+               %ContentPart{
+                 type: :video_url,
+                 url: "https://example.com/clip.mp4",
+                 media_type: "video/mp4"
+               }
+             ] = content
+    end
+
     test "rejects invalid input types" do
       {:error, reason} = Context.normalize(:invalid, validate: false)
       assert reason == :invalid_prompt

--- a/test/req_llm/message/content_part_test.exs
+++ b/test/req_llm/message/content_part_test.exs
@@ -54,6 +54,25 @@ defmodule ReqLLM.Message.ContentPartTest do
     end
   end
 
+  describe "video_url/1 and video_url/2" do
+    test "creates video URL content part" do
+      url = "https://example.com/video.mp4"
+      part = ContentPart.video_url(url)
+
+      assert %ContentPart{type: :video_url, url: ^url} = part
+      assert part.data == nil
+      assert part.media_type == nil
+    end
+
+    test "creates video URL with metadata" do
+      url = "https://example.com/video.mp4"
+      metadata = %{cache_control: %{type: "ephemeral"}}
+      part = ContentPart.video_url(url, metadata)
+
+      assert %ContentPart{type: :video_url, url: ^url, metadata: ^metadata} = part
+    end
+  end
+
   describe "image/2 and image/3" do
     setup do
       %{
@@ -128,7 +147,7 @@ defmodule ReqLLM.Message.ContentPartTest do
     end
 
     test "accepts valid content types" do
-      valid_types = [:text, :image_url, :image, :file, :thinking]
+      valid_types = [:text, :image_url, :video_url, :image, :file, :thinking]
 
       for type <- valid_types do
         part = struct!(ContentPart, %{type: type})
@@ -203,6 +222,15 @@ defmodule ReqLLM.Message.ContentPartTest do
       assert output =~ "url: https://example.com/pic.jpg"
     end
 
+    test "inspects video_url content part" do
+      part = ContentPart.video_url("https://example.com/clip.mp4")
+      output = inspect(part)
+
+      assert output =~ "#ContentPart<"
+      assert output =~ "video_url"
+      assert output =~ "url: https://example.com/clip.mp4"
+    end
+
     test "inspects image content part" do
       data = <<1, 2, 3, 4, 5>>
       part = ContentPart.image(data, "image/jpeg")
@@ -244,6 +272,7 @@ defmodule ReqLLM.Message.ContentPartTest do
         ContentPart.text("hello"),
         ContentPart.thinking("thinking"),
         ContentPart.image_url("https://example.com/pic.jpg"),
+        ContentPart.video_url("https://example.com/clip.mp4"),
         ContentPart.image(<<1, 2, 3>>, "image/png"),
         ContentPart.file("data", "file.txt", "text/plain")
       ]

--- a/test/req_llm/message_test.exs
+++ b/test/req_llm/message_test.exs
@@ -272,6 +272,7 @@ defmodule ReqLLM.MessageTest do
       content_types = [
         ContentPart.text("text"),
         ContentPart.image_url("http://example.com/img.jpg"),
+        ContentPart.video_url("http://example.com/clip.mp4"),
         ContentPart.image(<<1, 2, 3>>, "image/png"),
         ContentPart.file("data", "file.txt", "text/plain"),
         ContentPart.thinking("thinking")
@@ -280,7 +281,7 @@ defmodule ReqLLM.MessageTest do
       message = %Message{role: :user, content: content_types}
       output = inspect(message)
 
-      assert output =~ "text,image_url,image,file,thinking"
+      assert output =~ "text,image_url,video_url,image,file,thinking"
     end
   end
 

--- a/test/req_llm/messaging_test.exs
+++ b/test/req_llm/messaging_test.exs
@@ -12,6 +12,9 @@ defmodule ReqLLM.MessagingTest do
       assert %ContentPart{type: :image_url, url: "http://ex.com/img.jpg"} =
                ContentPart.image_url("http://ex.com/img.jpg")
 
+      assert %ContentPart{type: :video_url, url: "http://ex.com/video.mp4"} =
+               ContentPart.video_url("http://ex.com/video.mp4")
+
       data = <<1, 2, 3>>
 
       assert %ContentPart{type: :image, data: ^data, media_type: "image/png"} =

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -189,6 +189,19 @@ defmodule ReqLLM.Provider.DefaultsTest do
              }
     end
 
+    test "raises for unsupported video_url content parts" do
+      video_url_part = ContentPart.video_url("https://example.com/clip.mp4")
+
+      message = %Message{role: :user, content: [video_url_part]}
+      context = %Context{messages: [message]}
+
+      assert_raise ReqLLM.Error.Invalid.Message,
+                   ~r/Video URLs are not supported for this provider/,
+                   fn ->
+                     Defaults.encode_context_to_openai_format(context, "gpt-4")
+                   end
+    end
+
     test "mixed content with cache_control on different types" do
       text_cached = ContentPart.text("Cached text", %{cache_control: %{type: "ephemeral"}})
 


### PR DESCRIPTION
## Summary
- add a first-class `video_url` message content part and normalize OpenAI-style raw message maps into it
- let Gemini-compatible providers map `video_url` inputs to native `fileData.fileUri` requests while unsupported providers fail fast with a clear capability error
- add focused tests for content-part construction, context normalization, provider fallback errors, and Gemini request encoding

Closes #259

## Verification
- mix test test/req_llm/message/content_part_test.exs test/req_llm/context_test.exs test/req_llm/provider/defaults_test.exs test/providers/google_test.exs test/req_llm/message_test.exs test/req_llm/messaging_test.exs
- mix quality
