### PR TITLE
fix: default GPT-4o models to OpenAI Responses API

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -383,7 +383,7 @@ defmodule ReqLLM do
 
     model_id = model.provider_model_id || model.id || model.model
 
-    if is_nil(protocol) and ReqLLM.Providers.OpenAI.AdapterHelpers.reasoning_model?(model_id) do
+    if is_nil(protocol) and ReqLLM.Providers.OpenAI.AdapterHelpers.responses_model?(model_id) do
       extra = model.extra || %{}
 
       updated_extra =

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -209,10 +209,10 @@ defmodule ReqLLM.Providers.OpenAI do
 
       _ ->
         # Fallback for newer OpenAI models whose wire metadata may lag behind.
-        # Reasoning/Codex families should use Responses API.
+        # GPT-4o and reasoning/Codex families should use Responses API.
         model_id = model.provider_model_id || model.id
 
-        if ReqLLM.Providers.OpenAI.AdapterHelpers.reasoning_model?(model_id) do
+        if ReqLLM.Providers.OpenAI.AdapterHelpers.responses_model?(model_id) do
           "responses"
         else
           nil

--- a/lib/req_llm/providers/openai/adapter_helpers.ex
+++ b/lib/req_llm/providers/openai/adapter_helpers.ex
@@ -133,6 +133,19 @@ defmodule ReqLLM.Providers.OpenAI.AdapterHelpers do
   end
 
   @doc """
+  Checks if a model ID should default to the Responses API.
+
+  This includes reasoning/codex families plus GPT-4o models, which support
+  Responses even when older metadata has not been updated yet.
+  """
+  @spec responses_model?(term()) :: boolean()
+  def responses_model?(model_id) when is_binary(model_id) do
+    reasoning_model?(model_id) || gpt4o_model?(model_id)
+  end
+
+  def responses_model?(_), do: false
+
+  @doc """
   Checks if a model ID corresponds to an OpenAI reasoning model.
 
   Reasoning models (o-series, gpt-4.1, gpt-5, codex) require special handling:
@@ -160,6 +173,12 @@ defmodule ReqLLM.Providers.OpenAI.AdapterHelpers do
   @spec gpt41_model?(term()) :: boolean()
   def gpt41_model?(<<"gpt-4.1", _::binary>>), do: true
   def gpt41_model?(_), do: false
+
+  @doc "Checks if model is a GPT-4o family model."
+  @spec gpt4o_model?(term()) :: boolean()
+  def gpt4o_model?(<<"gpt-4o", _::binary>>), do: true
+  def gpt4o_model?("chatgpt-4o-latest"), do: true
+  def gpt4o_model?(_), do: false
 
   @doc "Checks if model is a GPT-5 reasoning model (excludes gpt-5-chat-latest)."
   @spec gpt5_model?(term()) :: boolean()

--- a/test/parity/openai_chat_parity_test.exs
+++ b/test/parity/openai_chat_parity_test.exs
@@ -15,7 +15,7 @@ defmodule ReqLLM.Parity.OpenAIChatParityTest do
   @moduletag :integration
 
   # Use a model that uses the Chat API (not Responses API)
-  @model "openai:gpt-4o-mini"
+  @model "openai:gpt-4-turbo"
 
   describe "streaming vs non-streaming parity" do
     @describetag :integration

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -64,7 +64,7 @@ defmodule ReqLLM.Providers.OpenAITest do
 
   describe "request preparation & pipeline wiring" do
     test "prepare_request creates configured chat request" do
-      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      {:ok, model} = ReqLLM.model("openai:gpt-4-turbo")
       context = context_fixture()
       opts = [temperature: 0.7, max_tokens: 100]
 
@@ -72,6 +72,17 @@ defmodule ReqLLM.Providers.OpenAITest do
 
       assert %Req.Request{} = request
       assert request.url.path == "/chat/completions"
+      assert request.method == :post
+    end
+
+    test "prepare_request routes gpt-4o models to Responses API" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      context = context_fixture()
+
+      {:ok, request} = OpenAI.prepare_request(:chat, model, context, [])
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/responses"
       assert request.method == :post
     end
 
@@ -115,7 +126,7 @@ defmodule ReqLLM.Providers.OpenAITest do
     end
 
     test "prepare_request configures authentication and pipeline for chat" do
-      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      {:ok, model} = ReqLLM.model("openai:gpt-4-turbo")
       prompt = "Hello, world!"
       opts = [temperature: 0.5, max_tokens: 50]
 
@@ -215,7 +226,7 @@ defmodule ReqLLM.Providers.OpenAITest do
     end
 
     test "prepare_request uses longer timeout for reasoning models (Responses API)" do
-      {:ok, chat_model} = ReqLLM.model("openai:gpt-4o")
+      {:ok, chat_model} = ReqLLM.model("openai:gpt-4-turbo")
       {:ok, reasoning_model} = ReqLLM.model("openai:gpt-5")
       context = context_fixture()
 

--- a/test/req_llm/generation_test.exs
+++ b/test/req_llm/generation_test.exs
@@ -3,6 +3,8 @@ defmodule ReqLLM.GenerationTest do
 
   alias ReqLLM.{Context, Generation, Response, StreamResponse}
 
+  @chat_model "openai:gpt-4-turbo"
+
   defmodule CacheBackend do
     alias ReqLLM.Context
     alias ReqLLM.Message
@@ -85,7 +87,7 @@ defmodule ReqLLM.GenerationTest do
     Req.Test.stub(ReqLLM.GenerationTest, fn conn ->
       Req.Test.json(conn, %{
         "id" => "cmpl_test_123",
-        "model" => "gpt-4o-mini-2024-07-18",
+        "model" => "gpt-4-turbo",
         "choices" => [
           %{
             "message" => %{"role" => "assistant", "content" => "Hello! How can I help you today?"}
@@ -102,14 +104,14 @@ defmodule ReqLLM.GenerationTest do
     test "accepts string input format" do
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
         )
 
       assert %Response{} = response
       # Model might have version suffix
-      assert response.model =~ "gpt-4o-mini"
+      assert response.model =~ "gpt-4-turbo"
       assert is_binary(Response.text(response))
       assert String.length(Response.text(response)) > 0
     end
@@ -119,7 +121,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           context,
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
         )
@@ -135,7 +137,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           messages,
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
         )
@@ -146,7 +148,7 @@ defmodule ReqLLM.GenerationTest do
     test "handles system prompt option" do
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           system_prompt: "Be helpful",
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
@@ -163,7 +165,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, first_response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           cache: CacheBackend,
           cache_ttl: 600,
@@ -177,7 +179,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, cached_response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           cache: CacheBackend,
           cache_ttl: 600,
@@ -208,7 +210,7 @@ defmodule ReqLLM.GenerationTest do
         %{role: "invalid_role", content: "Hello"}
       ]
 
-      {:error, error} = Generation.generate_text("openai:gpt-4o-mini", messages)
+      {:error, error} = Generation.generate_text(@chat_model, messages)
 
       # Should get a Role error
       assert %ReqLLM.Error.Invalid.Role{} = error
@@ -218,7 +220,7 @@ defmodule ReqLLM.GenerationTest do
     test "returns validation error for invalid options" do
       {:error, error} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           temperature: "invalid"
         )
@@ -247,7 +249,7 @@ defmodule ReqLLM.GenerationTest do
     test "returns text on success" do
       result =
         Generation.generate_text!(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
         )
@@ -283,7 +285,7 @@ defmodule ReqLLM.GenerationTest do
     test "returns streaming response" do
       {:ok, response} =
         Generation.stream_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Tell me a story",
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationStreamTest}]
         )
@@ -297,7 +299,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, _response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Tell me a story",
           cache: CacheBackend,
           cache_options: [agent: cache_agent, namespace: "stream"],
@@ -310,7 +312,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.stream_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Tell me a story",
           cache: CacheBackend,
           cache_options: [agent: cache_agent, namespace: "stream"],
@@ -342,7 +344,7 @@ defmodule ReqLLM.GenerationTest do
       Req.Test.stub(ObjectHTTP, fn conn ->
         Req.Test.json(conn, %{
           "id" => "cmpl_object_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{
@@ -369,7 +371,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, first_response} =
         Generation.generate_object(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Return a person",
           schema,
           cache: CacheBackend,
@@ -383,7 +385,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, cached_response} =
         Generation.generate_object(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Return a person",
           schema,
           cache: CacheBackend,
@@ -405,7 +407,7 @@ defmodule ReqLLM.GenerationTest do
       Req.Test.stub(BrokenObjectHTTP, fn conn ->
         Req.Test.json(conn, %{
           "id" => "cmpl_object_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{
@@ -432,7 +434,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_object(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Return a person",
           schema,
           openai_structured_output_mode: :tool_strict,
@@ -446,7 +448,7 @@ defmodule ReqLLM.GenerationTest do
       Req.Test.stub(BrokenObjectHTTP, fn conn ->
         Req.Test.json(conn, %{
           "id" => "cmpl_object_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{
@@ -473,7 +475,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_object(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Return a person",
           schema,
           json_repair: false,
@@ -540,7 +542,7 @@ defmodule ReqLLM.GenerationTest do
     test "accepts generation options without errors" do
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           temperature: 0.8,
           max_tokens: 50,
@@ -554,7 +556,7 @@ defmodule ReqLLM.GenerationTest do
     test "handles provider-specific options" do
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           frequency_penalty: 0.1,
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
@@ -570,7 +572,7 @@ defmodule ReqLLM.GenerationTest do
       # Req's internal validation will raise an ArgumentError. This confirms the options are being passed
       # all the way to `Req.new/1` without making a real network request.
       assert_raise ArgumentError, ~r/got unsupported atom method :invalid_method/, fn ->
-        Generation.generate_text("openai:gpt-4o-mini", "Hello",
+        Generation.generate_text(@chat_model, "Hello",
           req_http_options: [method: :invalid_method]
         )
       end
@@ -589,7 +591,7 @@ defmodule ReqLLM.GenerationTest do
 
         Req.Test.json(conn, %{
           "id" => "cmpl_test_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{"role" => "assistant", "content" => "Response"}
@@ -601,7 +603,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           api_key: custom_key,
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTestAPIKey}]
@@ -621,7 +623,7 @@ defmodule ReqLLM.GenerationTest do
 
         Req.Test.json(conn, %{
           "id" => "cmpl_test_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{"role" => "assistant", "content" => "Response"}
@@ -633,7 +635,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           api_key: custom_key,
           provider_options: [auth_mode: :api_key, access_token: "stale-oauth-token"],
@@ -656,7 +658,7 @@ defmodule ReqLLM.GenerationTest do
 
         Req.Test.json(conn, %{
           "id" => "cmpl_test_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{"role" => "assistant", "content" => "Response"}
@@ -668,7 +670,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           provider_options: [auth_mode: :oauth, access_token: oauth_token],
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTestOAuthAccessToken}]
@@ -712,7 +714,7 @@ defmodule ReqLLM.GenerationTest do
 
         Req.Test.json(conn, %{
           "id" => "cmpl_test_123",
-          "model" => "gpt-4o-mini-2024-07-18",
+          "model" => "gpt-4-turbo",
           "choices" => [
             %{
               "message" => %{"role" => "assistant", "content" => "Response"}
@@ -724,7 +726,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.generate_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           provider_options: [auth_mode: :oauth, oauth_file: path],
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationTestOAuthFile}]
@@ -753,7 +755,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.stream_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           provider_options: [auth_mode: :oauth, access_token: oauth_token],
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationStreamTestOAuthAccessToken}]
@@ -784,7 +786,7 @@ defmodule ReqLLM.GenerationTest do
 
       {:ok, response} =
         Generation.stream_text(
-          "openai:gpt-4o-mini",
+          @chat_model,
           "Hello",
           api_key: custom_key,
           req_http_options: [plug: {Req.Test, ReqLLM.GenerationStreamTestAPIKey}]

--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -31,6 +31,12 @@ defmodule ReqLLMTest do
       assert get_in(model, [Access.key(:extra, %{}), :wire, :protocol]) == "openai_responses"
     end
 
+    test "normalizes gpt-4o model wire protocol to openai_responses when metadata lags" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+
+      assert get_in(model, [Access.key(:extra, %{}), :wire, :protocol]) == "openai_responses"
+    end
+
     test "resolves openai_codex string spec via openai catalog fallback" do
       assert {:ok,
               %LLMDB.Model{


### PR DESCRIPTION
## Summary
- treat GPT-4o models as Responses-capable by default when OpenAI wire metadata is missing or stale
- keep explicit `openai_chat` overrides intact while sharing the same fallback logic between model normalization and provider routing
- move the generic chat-fixture tests onto a true chat-completions model so the generation and provider suites keep covering the intended protocol paths

Closes #375

## Verification
- mix test test/req_llm_test.exs test/providers/openai_test.exs test/provider/openai_structured_output_test.exs test/provider/openai/responses_api_unit_test.exs test/req_llm/generation_test.exs
- mix quality
