### PR TITLE
feat: add video_url multimodal support

### DIFF
--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -118,6 +118,8 @@ Typed content elements that compose a `Message`. Common variants:
 - `text/2`: `ContentPart.text("...", metadata)` with metadata map
 - `image_url/1`: `ContentPart.image_url("https://...")`
 - `image_url/2`: `ContentPart.image_url("https://...", metadata)` with metadata
+- `video_url/1`: `ContentPart.video_url("https://...")`
+- `video_url/2`: `ContentPart.video_url("https://...", metadata)` with metadata
 - `image/2`: `ContentPart.image(binary, "image/png")`
 - `image/3`: `ContentPart.image(binary, "image/png", metadata)` with metadata
 - `file/3`: `ContentPart.file(binary, "name.ext", "mime/type")`
@@ -129,7 +131,8 @@ Typed content elements that compose a `Message`. Common variants:
 ```elixir
 parts = [
   ContentPart.text("Analyze:"),
-  ContentPart.image_url("https://example.com/chart.png")
+  ContentPart.image_url("https://example.com/chart.png"),
+  ContentPart.video_url("https://example.com/demo.mp4")
 ]
 ```
 

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -980,12 +980,62 @@ defmodule ReqLLM.Context do
           []
         end
 
+      type when type in [:image_url, "image_url"] ->
+        build_url_content_part(part, :image_url)
+
+      type when type in [:video_url, "video_url"] ->
+        build_url_content_part(part, :video_url)
+
       _ ->
         []
     end
   end
 
   defp to_part_list(_part), do: []
+
+  defp build_url_content_part(part, type) do
+    url = extract_url_content(part, type)
+    media_type = extract_url_media_type(part, type)
+    metadata = Map.get(part, :metadata) || Map.get(part, "metadata") || %{}
+
+    if is_binary(url) and url != "" do
+      [
+        %ContentPart{
+          type: type,
+          url: url,
+          media_type: media_type,
+          metadata: metadata
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp extract_url_content(part, type) do
+    nested_key = nested_url_key(type)
+
+    Map.get(part, :url) ||
+      Map.get(part, "url") ||
+      get_in(part, [nested_key, :url]) ||
+      get_in(part, [nested_key, "url"]) ||
+      get_in(part, [Atom.to_string(nested_key), "url"]) ||
+      get_in(part, [Atom.to_string(nested_key), :url])
+  end
+
+  defp extract_url_media_type(part, type) do
+    nested_key = nested_url_key(type)
+
+    Map.get(part, :media_type) ||
+      Map.get(part, "media_type") ||
+      get_in(part, [nested_key, :media_type]) ||
+      get_in(part, [nested_key, "media_type"]) ||
+      get_in(part, [Atom.to_string(nested_key), "media_type"]) ||
+      get_in(part, [Atom.to_string(nested_key), :media_type])
+  end
+
+  defp nested_url_key(:image_url), do: :image_url
+  defp nested_url_key(:video_url), do: :video_url
 
   defp convert_loose_role_list_content(role, content, metadata, reasoning_details) do
     case role do

--- a/lib/req_llm/message/content_part.ex
+++ b/lib/req_llm/message/content_part.ex
@@ -5,6 +5,7 @@ defmodule ReqLLM.Message.ContentPart do
   Supports multiple content types:
   - `:text` - Plain text content
   - `:image_url` - Image from URL
+  - `:video_url` - Video from URL
   - `:image` - Image from binary data
   - `:file` - File attachment
   - `:thinking` - Chain-of-thought thinking content
@@ -15,7 +16,7 @@ defmodule ReqLLM.Message.ContentPart do
   """
 
   @schema Zoi.struct(__MODULE__, %{
-            type: Zoi.enum([:text, :image_url, :image, :file, :thinking]),
+            type: Zoi.enum([:text, :image_url, :video_url, :image, :file, :thinking]),
             text: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             url: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             data: Zoi.any() |> Zoi.nullable() |> Zoi.default(nil),
@@ -55,6 +56,12 @@ defmodule ReqLLM.Message.ContentPart do
   @spec image_url(String.t(), map()) :: t()
   def image_url(url, metadata), do: %__MODULE__{type: :image_url, url: url, metadata: metadata}
 
+  @spec video_url(String.t()) :: t()
+  def video_url(url), do: %__MODULE__{type: :video_url, url: url}
+
+  @spec video_url(String.t(), map()) :: t()
+  def video_url(url, metadata), do: %__MODULE__{type: :video_url, url: url, metadata: metadata}
+
   @spec image(binary(), String.t()) :: t()
   def image(data, media_type \\ "image/png"),
     do: %__MODULE__{type: :image, data: data, media_type: media_type}
@@ -74,6 +81,7 @@ defmodule ReqLLM.Message.ContentPart do
           :text -> inspect_text(part.text, opts)
           :thinking -> inspect_text(part.text, opts)
           :image_url -> "url: #{part.url}"
+          :video_url -> "url: #{part.url}"
           :image -> "#{part.media_type} (#{byte_size(part.data)} bytes)"
           :file -> "#{part.media_type} (#{byte_size(part.data || <<>>)} bytes)"
         end

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -920,6 +920,12 @@ defmodule ReqLLM.Provider.Defaults do
     |> merge_content_metadata(metadata)
   end
 
+  defp encode_openai_content_part(%ReqLLM.Message.ContentPart{type: :video_url}) do
+    raise ReqLLM.Error.Invalid.Parameter.exception(
+            parameter: "Video URLs are not supported for this provider."
+          )
+  end
+
   defp encode_openai_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
          data: data,

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -842,17 +842,7 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp encode_image_body(request) do
-    {system_instruction, contents} =
-      case request.options[:context] do
-        %ReqLLM.Context{} = ctx ->
-          model_name = request.options[:model]
-          encoded = ReqLLM.Provider.Defaults.encode_context_to_openai_format(ctx, model_name)
-          messages = encoded[:messages] || encoded["messages"] || []
-          split_messages_for_gemini(messages)
-
-        _ ->
-          split_messages_for_gemini(request.options[:messages] || [])
-      end
+    {system_instruction, contents} = google_messages_from_request(request)
 
     # Note: We intentionally keep the role field in contents.
     # Experiments show that including "role": "user" improves multi-image
@@ -931,18 +921,7 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp encode_chat_body(request) do
-    {system_instruction, contents} =
-      case request.options[:context] do
-        %ReqLLM.Context{} = ctx ->
-          model_name = request.options[:model]
-          # Convert OpenAI-style context to Gemini format
-          encoded = ReqLLM.Provider.Defaults.encode_context_to_openai_format(ctx, model_name)
-          messages = encoded[:messages] || encoded["messages"] || []
-          split_messages_for_gemini(messages)
-
-        _ ->
-          split_messages_for_gemini(request.options[:messages] || [])
-      end
+    {system_instruction, contents} = google_messages_from_request(request)
 
     tool_config = build_google_tool_config(request.options[:tool_choice])
 
@@ -1016,17 +995,7 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp encode_object_body(request) do
-    {system_instruction, contents} =
-      case request.options[:context] do
-        %ReqLLM.Context{} = ctx ->
-          model_name = request.options[:model]
-          encoded = ReqLLM.Provider.Defaults.encode_context_to_openai_format(ctx, model_name)
-          messages = encoded[:messages] || encoded["messages"] || []
-          split_messages_for_gemini(messages)
-
-        _ ->
-          split_messages_for_gemini(request.options[:messages] || [])
-      end
+    {system_instruction, contents} = google_messages_from_request(request)
 
     compiled_schema =
       case request.options do
@@ -2093,42 +2062,103 @@ defmodule ReqLLM.Providers.Google do
     end)
   end
 
+  defp google_messages_from_request(request) do
+    case request.options[:context] do
+      %ReqLLM.Context{} = ctx ->
+        model_name = request.options[:model]
+
+        encoded =
+          ctx
+          |> normalize_video_url_context()
+          |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
+
+        messages = encoded[:messages] || encoded["messages"] || []
+        split_messages_for_gemini(messages)
+
+      _ ->
+        (request.options[:messages] || [])
+        |> List.wrap()
+        |> Enum.map(&normalize_video_url_message/1)
+        |> split_messages_for_gemini()
+    end
+  end
+
+  defp normalize_video_url_context(%ReqLLM.Context{messages: messages} = context) do
+    %{context | messages: Enum.map(messages, &normalize_video_url_message/1)}
+  end
+
+  defp normalize_video_url_message(%ReqLLM.Message{content: content} = message)
+       when is_list(content) do
+    %{message | content: Enum.map(content, &normalize_video_url_part/1)}
+  end
+
+  defp normalize_video_url_message(%{content: content} = message) when is_list(content) do
+    Map.put(message, :content, Enum.map(content, &normalize_video_url_part/1))
+  end
+
+  defp normalize_video_url_message(message), do: message
+
+  defp normalize_video_url_part(%ReqLLM.Message.ContentPart{type: :video_url} = part) do
+    %{part | type: :image_url}
+  end
+
+  defp normalize_video_url_part(%{type: :video_url} = part) do
+    %{part | type: :image_url}
+  end
+
+  defp normalize_video_url_part(%{type: "video_url", video_url: video_url} = part) do
+    part
+    |> Map.delete(:video_url)
+    |> Map.put(:type, "image_url")
+    |> Map.put(:image_url, video_url)
+  end
+
+  defp normalize_video_url_part(%{"type" => "video_url", "video_url" => video_url} = part) do
+    part
+    |> Map.delete("video_url")
+    |> Map.put("type", "image_url")
+    |> Map.put("image_url", video_url)
+  end
+
+  defp normalize_video_url_part(part), do: part
+
   # Handle OpenAI-format image_url (from Provider.Defaults.encode_openai_content_part)
   defp convert_content_part(%{type: "image_url", image_url: %{url: url}} = part)
        when is_binary(url) do
-    cond do
-      # Data URI format: data:mime/type;base64,<data>
-      String.starts_with?(url, "data:") ->
-        case String.split(url, ",", parts: 2) do
-          [header, base64_data] ->
-            mime_type =
-              case Regex.run(~r/data:([^;]+)/, header) do
-                [_, type] -> type
-                _ -> "image/jpeg"
-              end
+    convert_url_content_part(part, url, "image/jpeg")
+  end
 
-            %{
-              inline_data: %{
-                mime_type: mime_type,
-                data: base64_data
-              }
-            }
+  defp convert_content_part(%{"type" => "image_url", "image_url" => %{"url" => url}} = part)
+       when is_binary(url) do
+    convert_url_content_part(part, url, "image/jpeg")
+  end
 
-          _ ->
-            %{text: "[Malformed data URI]"}
-        end
+  defp convert_content_part(%{type: "video_url", video_url: %{url: url}} = part)
+       when is_binary(url) do
+    convert_url_content_part(part, url, "video/mp4")
+  end
 
-      # HTTP/HTTPS URL: use fileData.fileUri (Google-native URL support)
-      String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
-        build_file_data(part, url)
+  defp convert_content_part(%{"type" => "video_url", "video_url" => %{"url" => url}} = part)
+       when is_binary(url) do
+    convert_url_content_part(part, url, "video/mp4")
+  end
 
-      # GCS URI: gs://bucket/path
-      String.starts_with?(url, "gs://") ->
-        build_file_data(part, url)
+  defp convert_content_part(%ReqLLM.Message.ContentPart{type: :image_url, url: url} = part)
+       when is_binary(url) do
+    convert_url_content_part(part, url, "image/jpeg")
+  end
 
-      true ->
-        %{text: "[Unsupported URL scheme: #{String.slice(url, 0, 20)}...]"}
-    end
+  defp convert_content_part(%ReqLLM.Message.ContentPart{type: :video_url, url: url} = part)
+       when is_binary(url) do
+    convert_url_content_part(part, url, "video/mp4")
+  end
+
+  defp convert_content_part(%{type: :image_url, url: url} = part) when is_binary(url) do
+    convert_url_content_part(part, url, "image/jpeg")
+  end
+
+  defp convert_content_part(%{type: :video_url, url: url} = part) when is_binary(url) do
+    convert_url_content_part(part, url, "video/mp4")
   end
 
   # Most specific patterns first (file, image, etc.) - for ContentPart structs
@@ -2155,6 +2185,39 @@ defmodule ReqLLM.Providers.Google do
 
   defp convert_content_part(part), do: %{text: to_string(part)}
 
+  defp convert_url_content_part(part, url, default_mime_type) do
+    cond do
+      String.starts_with?(url, "data:") ->
+        case String.split(url, ",", parts: 2) do
+          [header, base64_data] ->
+            mime_type =
+              case Regex.run(~r/data:([^;]+)/, header) do
+                [_, type] -> type
+                _ -> default_mime_type
+              end
+
+            %{
+              inline_data: %{
+                mime_type: mime_type,
+                data: base64_data
+              }
+            }
+
+          _ ->
+            %{text: "[Malformed data URI]"}
+        end
+
+      String.starts_with?(url, "http://") or String.starts_with?(url, "https://") ->
+        build_file_data(part, url)
+
+      String.starts_with?(url, "gs://") ->
+        build_file_data(part, url)
+
+      true ->
+        %{text: "[Unsupported URL scheme: #{String.slice(url, 0, 20)}...]"}
+    end
+  end
+
   # Builds a fileData map, omitting mimeType when it cannot be reliably inferred.
   # YouTube and other extensionless URLs need mimeType omitted so Gemini can infer it.
   defp build_file_data(part, url) do
@@ -2176,7 +2239,12 @@ defmodule ReqLLM.Providers.Google do
   defp get_mime_type_from_part(part, url) do
     # Try metadata first (if passed through from ContentPart)
     case part do
+      %{media_type: type} when is_binary(type) and type != "" -> type
+      %{"media_type" => type} when is_binary(type) and type != "" -> type
       %{image_url: %{media_type: type}} when is_binary(type) and type != "" -> type
+      %{"image_url" => %{"media_type" => type}} when is_binary(type) and type != "" -> type
+      %{video_url: %{media_type: type}} when is_binary(type) and type != "" -> type
+      %{"video_url" => %{"media_type" => type}} when is_binary(type) and type != "" -> type
       _ -> infer_mime_type_from_url(url)
     end
   end

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1351,6 +1351,37 @@ defmodule ReqLLM.Providers.GoogleTest do
   end
 
   describe "image_url file URI support" do
+    test "encode_body converts HTTPS video_url to fileData format" do
+      url = "https://example.com/video.mp4"
+
+      video_url_part = ReqLLM.Message.ContentPart.video_url(url)
+
+      message = %ReqLLM.Message{
+        role: :user,
+        content: [video_url_part]
+      }
+
+      context = %ReqLLM.Context{messages: [message]}
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          id: "gemini-1.5-flash",
+          stream: false
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [user_msg] = decoded["contents"]
+      [part] = user_msg["parts"]
+
+      assert Map.has_key?(part, "fileData")
+      assert part["fileData"]["fileUri"] == url
+      assert part["fileData"]["mimeType"] == "video/mp4"
+    end
+
     test "encode_body converts HTTPS image_url to fileData format" do
       url = "https://example.com/images/photo.jpg"
 

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -832,5 +832,29 @@ defmodule ReqLLM.ContextTest do
       assert length(msg.tool_calls) == 2
       assert Enum.map(msg.tool_calls, & &1.id) == ["call_1", "call_2"]
     end
+
+    test "normalizes video_url content maps" do
+      input = [
+        %{
+          role: "user",
+          content: [
+            %{"type" => "text", "text" => "What is happening in this video?"},
+            %{
+              "type" => "video_url",
+              "video_url" => %{"url" => "https://example.com/video.mp4"}
+            }
+          ]
+        }
+      ]
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      [msg] = context.messages
+
+      assert [
+               %ContentPart{type: :text, text: "What is happening in this video?"},
+               %ContentPart{type: :video_url, url: "https://example.com/video.mp4"}
+             ] = msg.content
+    end
   end
 end

--- a/test/req_llm/message/content_part_test.exs
+++ b/test/req_llm/message/content_part_test.exs
@@ -54,6 +54,25 @@ defmodule ReqLLM.Message.ContentPartTest do
     end
   end
 
+  describe "video_url/1 and video_url/2" do
+    test "creates video URL content part" do
+      url = "https://example.com/video.mp4"
+      part = ContentPart.video_url(url)
+
+      assert %ContentPart{type: :video_url, url: ^url} = part
+      assert part.data == nil
+      assert part.media_type == nil
+    end
+
+    test "creates video URL with metadata" do
+      url = "https://example.com/video.mp4"
+      metadata = %{source: "user"}
+      part = ContentPart.video_url(url, metadata)
+
+      assert %ContentPart{type: :video_url, url: ^url, metadata: ^metadata} = part
+    end
+  end
+
   describe "image/2 and image/3" do
     setup do
       %{
@@ -128,7 +147,7 @@ defmodule ReqLLM.Message.ContentPartTest do
     end
 
     test "accepts valid content types" do
-      valid_types = [:text, :image_url, :image, :file, :thinking]
+      valid_types = [:text, :image_url, :video_url, :image, :file, :thinking]
 
       for type <- valid_types do
         part = struct!(ContentPart, %{type: type})
@@ -203,6 +222,15 @@ defmodule ReqLLM.Message.ContentPartTest do
       assert output =~ "url: https://example.com/pic.jpg"
     end
 
+    test "inspects video_url content part" do
+      part = ContentPart.video_url("https://example.com/video.mp4")
+      output = inspect(part)
+
+      assert output =~ "#ContentPart<"
+      assert output =~ "video_url"
+      assert output =~ "url: https://example.com/video.mp4"
+    end
+
     test "inspects image content part" do
       data = <<1, 2, 3, 4, 5>>
       part = ContentPart.image(data, "image/jpeg")
@@ -244,6 +272,7 @@ defmodule ReqLLM.Message.ContentPartTest do
         ContentPart.text("hello"),
         ContentPart.thinking("thinking"),
         ContentPart.image_url("https://example.com/pic.jpg"),
+        ContentPart.video_url("https://example.com/video.mp4"),
         ContentPart.image(<<1, 2, 3>>, "image/png"),
         ContentPart.file("data", "file.txt", "text/plain")
       ]

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -348,6 +348,22 @@ defmodule ReqLLM.Provider.DefaultsTest do
       [encoded_message] = result.messages
       assert encoded_message.content == ""
     end
+
+    test "raises for video_url content parts on unsupported providers" do
+      message = %Message{
+        role: :user,
+        content: [ContentPart.video_url("https://example.com/video.mp4")]
+      }
+
+      context = %Context{messages: [message]}
+
+      error =
+        assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+          Defaults.encode_context_to_openai_format(context, "gpt-4")
+        end
+
+      assert error.parameter =~ "Video URLs are not supported for this provider"
+    end
   end
 
   describe "decode_response_body_openai_format/2" do


### PR DESCRIPTION
## Summary
- add a first-class `ContentPart.video_url/1,2` API and normalize raw `video_url` message maps
- support `video_url` URLs on Google Gemini by translating them to Gemini `fileData` inputs
- raise a clear unsupported-provider error on the default OpenAI-style encoding path and document the new content part

## Testing
- mix test test/req_llm/message/content_part_test.exs test/req_llm/context_test.exs test/req_llm/provider/defaults_test.exs test/providers/google_test.exs
- mix compile --warnings-as-errors
- mix quality

Refs #259