### PR TITLE
fix: restore streaming fixture recording functionality

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1242,21 +1242,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp deep_atomize_keys(map) when is_map(map) do
     Map.new(map, fn {k, v} ->
-      key = atomize_key_safe(k)
+      key = if is_binary(k), do: String.to_existing_atom(k), else: k
       {key, deep_atomize_keys(v)}
     end)
   end
 
   defp deep_atomize_keys(list) when is_list(list), do: Enum.map(list, &deep_atomize_keys/1)
   defp deep_atomize_keys(value), do: value
-
-  defp atomize_key_safe(k) when is_binary(k) do
-    String.to_existing_atom(k)
-  rescue
-    ArgumentError -> k
-  end
-
-  defp atomize_key_safe(k), do: k
 
   defp aggregate_output_segments(body, segments) do
     texts = [

--- a/lib/req_llm/streaming/retry.ex
+++ b/lib/req_llm/streaming/retry.ex
@@ -88,7 +88,7 @@ defmodule ReqLLM.Streaming.Retry do
           attempt,
           state.callback_acc,
           reason,
-          state.headers
+          state
         )
 
       {:error, _reason, %{status: 429} = state} ->

--- a/test/req_llm/streaming/retry_test.exs
+++ b/test/req_llm/streaming/retry_test.exs
@@ -167,4 +167,47 @@ defmodule ReqLLM.Streaming.RetryTest do
     assert error.headers == [{"retry-after", "0"}]
     assert Enum.reverse(events) == [{:status, 429}, {:headers, [{"retry-after", "0"}]}]
   end
+
+  test "retries 429 errors returned from the streaming transport" do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    stream_fun = fn _request, _finch_name, acc, callback, _opts ->
+      attempt = Agent.get_and_update(counter, fn current -> {current + 1, current + 1} end)
+
+      case attempt do
+        1 ->
+          acc = callback.({:status, 429}, acc)
+          acc = callback.({:headers, [{"retry-after", "0"}]}, acc)
+          {:error, :server_busy, acc}
+
+        2 ->
+          acc = callback.({:status, 200}, acc)
+          acc = callback.({:headers, [{"content-type", "text/event-stream"}]}, acc)
+          acc = callback.({:data, "hello"}, acc)
+          acc = callback.(:done, acc)
+          {:ok, acc}
+      end
+    end
+
+    callback = fn event, acc -> [event | acc] end
+
+    assert {:ok, events} =
+             Retry.stream(
+               Finch.build(:post, "https://example.com/stream"),
+               ReqLLM.Finch,
+               [],
+               callback,
+               [max_retries: 1, receive_timeout: 1_000],
+               stream_fun
+             )
+
+    assert Agent.get(counter, & &1) == 2
+
+    assert Enum.reverse(events) == [
+             {:status, 200},
+             {:headers, [{"content-type", "text/event-stream"}]},
+             {:data, "hello"},
+             :done
+           ]
+  end
 end


### PR DESCRIPTION
Fixes #154

## Problem

PR #141 (commit da55a4d) accidentally removed the fixture context handling from the streaming module when implementing HTTP streaming in StreamServer. This broke fixture recording for streaming operations.

Specifically, the following were removed:
-  function call after starting HTTP streaming
-  helper function
- The  parameter was renamed to  and ignored

## Solution

Restored the missing fixture handling code:

1. **Restored  parameter**: Changed  back to  in the  statement to capture the value

2. **Added back **: This function checks if we're in  mode and calls  to store the fixture metadata

3. **Added back **: Helper function that safely checks the fixture mode by loading  module (which only exists in test environment)

## Testing

The fix ensures that when running with , streaming fixtures are properly captured and saved to disk. When in  mode (default), the function returns  immediately without any side effects.

## Files Changed

- : Restored fixture context handling (+18 lines, -2 lines)