### PR TITLE
fix: Support json schema usage for gemini 3.1

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1155,10 +1155,9 @@ defmodule ReqLLM.Providers.Google do
     |> maybe_put(:safetySettings, request.options[:google_safety_settings])
   end
 
-  # TODO: remove this check when gemini 2 is deprecated?
   defp json_schema_supported?(model_name) when is_binary(model_name) do
     String.starts_with?(model_name, "gemini-2.5-") or model_name == "gemini-2.5" or
-      String.contains?(model_name, "gemini-3") or model_name == "gemini-3"
+      String.starts_with?(model_name, "gemini-3")
   end
 
   defp json_schema_supported?(_), do: false

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1191,6 +1191,33 @@ defmodule ReqLLM.Providers.GoogleTest do
       refute Map.has_key?(decoded["generationConfig"], "responseSchema")
     end
 
+    test "encode_object_body uses responseJsonSchema for Gemini 3.1" do
+      context = context_fixture()
+
+      {:ok, schema} =
+        ReqLLM.Schema.compile(
+          name: [type: :string, required: true],
+          age: [type: :pos_integer]
+        )
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: "gemini-3.1-pro-preview",
+          operation: :object,
+          compiled_schema: schema
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      response_json_schema = decoded["generationConfig"]["responseJsonSchema"]
+      assert response_json_schema["type"] == "object"
+      assert Map.has_key?(response_json_schema, "properties")
+      refute Map.has_key?(decoded["generationConfig"], "responseSchema")
+    end
+
     test "prepare_request creates configured embedding request" do
       {:ok, model} = ReqLLM.model("google:gemini-embedding-001")
       text = "Hello, world!"


### PR DESCRIPTION
## Description

Gemini 3 pro will be deprecated on Vertex Ai from March 26th 

This PR updates loosens the check for json schema to support both gemini-3 and gemini-3.1-pro
Also considering that gemini 2.0 is scheduled to be [deprecated in June](https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models) , maybe once it's deprecated this check won't be needed anymore so add a `#TODO` comment  to remove it later

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
