### PR TITLE
docs: clarify structured tool result content

### DIFF
--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -191,6 +191,11 @@ Defines callable functions (aka "tools" or "function calling") with validation.
 **How this supports normalization**:
 - One tool definition is used across providers that support function/tool calling.
 - Tool calls/results appear in `ContentPart` and `StreamChunk` the same way for all providers.
+- Structured tool results should be represented in the content body as JSON when
+  they carry model-visible semantics like `%{ok: true, result: ...}` or
+  `%{ok: false, error: ...}`. Message metadata can preserve the original native
+  output for adapters and local consumers, but it should not be the only source
+  of meaning for follow-up model turns.
 
 ## 6) ReqLLM.StreamChunk
 

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -423,8 +423,19 @@ defmodule ReqLLM.Context do
   @doc """
   Build a tool result message.
 
-  Non-text outputs are stored in metadata to allow provider-specific structured
-  encoding.
+  The model-visible contract lives in the message content. When `output` is a
+  non-text value, ReqLLM encodes it into a JSON text content part and also
+  preserves the original value in metadata for provider adapters and local
+  tooling.
+
+  Prefer putting canonical success/failure semantics in the content body, for
+  example:
+
+      %{ok: true, result: %{temp_f: 72}}
+      %{ok: false, error: %{type: :timeout, message: "Tool timed out"}}
+
+  Metadata is supplementary and should not be the only place a model-facing tool
+  result is represented.
   """
   @spec tool_result_message(String.t() | nil, String.t(), term(), map()) :: Message.t()
   def tool_result_message(tool_name, tool_call_id, output, meta \\ %{}) do

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -809,6 +809,53 @@ defmodule ReqLLM.ContextTest do
       assert msg.metadata[:tool_output] == %{ok: true}
     end
 
+    test "encodes structured tool result output into content and preserves metadata" do
+      msg =
+        Context.tool_result_message(
+          "get_weather",
+          "call_structured",
+          %{ok: false, error: %{type: "timeout", message: "tool timed out"}},
+          %{request_id: "req_123", origin: :worker_runtime}
+        )
+
+      assert msg.role == :tool
+      assert msg.name == "get_weather"
+      assert msg.tool_call_id == "call_structured"
+      assert [%ContentPart{type: :text, text: encoded}] = msg.content
+
+      assert Jason.decode!(encoded) == %{
+               "ok" => false,
+               "error" => %{"type" => "timeout", "message" => "tool timed out"}
+             }
+
+      assert msg.metadata[:request_id] == "req_123"
+      assert msg.metadata[:origin] == :worker_runtime
+
+      assert msg.metadata[:tool_output] == %{
+               ok: false,
+               error: %{type: "timeout", message: "tool timed out"}
+             }
+    end
+
+    test "preserves explicit tool result content when structured output metadata is also present" do
+      msg =
+        Context.tool_result(
+          "call_explicit",
+          "calculator",
+          %ReqLLM.ToolResult{
+            content: [ContentPart.text(~s({"ok": true, "result": {"sum": 3}}))],
+            output: %{ok: true, result: %{sum: 3}},
+            metadata: %{request_id: "req_explicit"}
+          }
+        )
+
+      assert [%ContentPart{type: :text, text: ~s({"ok": true, "result": {"sum": 3}})}] =
+               msg.content
+
+      assert msg.metadata[:request_id] == "req_explicit"
+      assert msg.metadata[:tool_output] == %{ok: true, result: %{sum: 3}}
+    end
+
     test "normalizes full tool conversation flow" do
       input = [
         %{role: :user, content: "What's the weather in SF?"},


### PR DESCRIPTION
## Summary
- document the structured JSON contract for tool result content
- clarify that metadata is supplementary and model-visible semantics live in content
- add focused tests around context/tool result message handling

Companion to agentjido/jido_ai#222.

## Verification
- mix test test/req_llm/context_test.exs test/provider/openai/responses_api_unit_test.exs test/provider/azure/tools_test.exs