### PR TITLE
fix(openai): retrieve structured output from tool call

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1220,35 +1220,50 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     {req, %{resp | body: merged_response}}
   end
 
-  # Extract and validate structured object from json_schema responses
   defp maybe_extract_object(req, text, tool_calls) do
-    case {req.options[:operation], text} do
-      {:object, text} when is_binary(text) and text != "" ->
+    case req.options[:operation] do
+      :object ->
         compiled_schema = req.options[:compiled_schema]
 
-        case ReqLLM.JSON.decode(text, req.options) do
+        case extract_object_payload(text, tool_calls, req.options) do
           {:ok, parsed_object} when is_map(parsed_object) ->
             case validate_object(parsed_object, compiled_schema) do
               {:ok, _} -> {parsed_object, %{}}
               {:error, reason} -> {nil, %{object_parse_error: reason}}
             end
 
-          {:error, _} ->
-            {nil, %{object_parse_error: :invalid_json}}
-
-          _ ->
+          {:ok, _} ->
             {nil, %{object_parse_error: :not_an_object}}
-        end
 
-      {:object, _} ->
-        # gpt-5 returns structured output as a tool call
-        case ReqLLM.ToolCall.find_args(tool_calls, "structured_output") do
-          nil -> {nil, %{}}
-          args -> {args, %{}}
+          {:error, reason} ->
+            {nil, %{object_parse_error: reason}}
+
+          :none ->
+            {nil, %{}}
         end
 
       _ ->
         nil
+    end
+  end
+
+  defp extract_object_payload(text, _tool_calls, opts) when is_binary(text) and text != "" do
+    case ReqLLM.JSON.decode(text, opts) do
+      {:ok, parsed_object} -> {:ok, parsed_object}
+      {:error, _} -> {:error, :invalid_json}
+    end
+  end
+
+  defp extract_object_payload(_text, tool_calls, opts) do
+    case Enum.find(tool_calls, &ReqLLM.ToolCall.matches_name?(&1, "structured_output")) do
+      nil ->
+        :none
+
+      tool_call ->
+        case ReqLLM.ToolCall.args_map(tool_call, opts) do
+          nil -> {:error, :invalid_json}
+          parsed_object -> {:ok, parsed_object}
+        end
     end
   end
 

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -815,6 +815,86 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
 
       assert %ReqLLM.Response{} = decoded_resp.body
       assert decoded_resp.body.object == %{"name" => "Alice"}
+      assert decoded_resp.body.provider_meta[:object_parse_error] == nil
+    end
+
+    test "validates structured output from tool calls against the compiled schema" do
+      schema = [name: [type: :string, required: true], age: [type: :integer, required: true]]
+      {:ok, compiled_schema} = ReqLLM.Schema.compile(schema)
+
+      response_body = %{
+        "id" => "resp_123",
+        "model" => "gpt-5.4",
+        "output" => [
+          %{
+            "type" => "function_call",
+            "call_id" => "call_abc",
+            "name" => "structured_output",
+            "arguments" => ~s({"name": "Alice"})
+          }
+        ],
+        "usage" => %{"input_tokens" => 10, "output_tokens" => 20}
+      }
+
+      req = %Req.Request{
+        method: :post,
+        url: URI.parse("https://api.openai.com/v1/responses"),
+        headers: %{},
+        body: {:json, %{}},
+        options: %{
+          id: "gpt-5",
+          operation: :object,
+          compiled_schema: compiled_schema
+        }
+      }
+
+      resp = %Req.Response{status: 200, headers: %{}, body: response_body}
+
+      {_req, decoded_resp} = ResponsesAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Response{} = decoded_resp.body
+      assert decoded_resp.body.object == nil
+      assert decoded_resp.body.provider_meta[:object_parse_error] == :validation_failed
+    end
+
+    test "respects json_repair option for structured output tool calls" do
+      schema = [name: [type: :string, required: true]]
+      {:ok, compiled_schema} = ReqLLM.Schema.compile(schema)
+
+      response_body = %{
+        "id" => "resp_123",
+        "model" => "gpt-5.4",
+        "output" => [
+          %{
+            "type" => "function_call",
+            "call_id" => "call_abc",
+            "name" => "structured_output",
+            "arguments" => ~s({"name":"Alice",})
+          }
+        ],
+        "usage" => %{"input_tokens" => 10, "output_tokens" => 20}
+      }
+
+      req = %Req.Request{
+        method: :post,
+        url: URI.parse("https://api.openai.com/v1/responses"),
+        headers: %{},
+        body: {:json, %{}},
+        options: %{
+          id: "gpt-5",
+          operation: :object,
+          compiled_schema: compiled_schema,
+          json_repair: false
+        }
+      }
+
+      resp = %Req.Response{status: 200, headers: %{}, body: response_body}
+
+      {_req, decoded_resp} = ResponsesAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Response{} = decoded_resp.body
+      assert decoded_resp.body.object == nil
+      assert decoded_resp.body.provider_meta[:object_parse_error] == :invalid_json
     end
   end
 


### PR DESCRIPTION
## Description

OpenAI GPT models like `gpt-5.4-mini` will return structured output as a tool call. This fix adds a branch in `maybe_extract_object/2` and passes `tool_calls` to retrieve output from the `structured_output` tool call.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

None yet
