### PR TITLE
💅 : add DeepSeek guide to Providers section

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -106,6 +106,7 @@ defmodule ReqLLM.MixProject do
             "guides/ollama.md",
             "guides/amazon_bedrock.md",
             "guides/cerebras.md",
+            "guides/deepseek.md",
             "guides/meta.md",
             "guides/zenmux.md",
             "guides/zai.md",


### PR DESCRIPTION
## Description

Very small doc fix. DeepSeek wasn't in the providers section, so it was showing up in the top level in docs:

<img width="560" height="280" alt="Screenshot 2026-03-31 at 15 12 19" src="https://github.com/user-attachments/assets/67c7fd15-fd92-46e7-b8e0-faad0145c045" />


## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [X] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [X] My commits follow conventional commit format
- [X] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
