### PR TITLE
Fix: preserve inference profile prefix in Bedrock API URLs

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -330,7 +330,9 @@ defmodule ReqLLM do
   def model(spec) when is_binary(spec) do
     case LLMDB.model(spec) do
       {:ok, %LLMDB.Model{} = model} ->
-        normalize_model_result({:ok, model})
+        {:ok, model}
+        |> maybe_restore_inference_prefix(spec)
+        |> normalize_model_result()
 
       {:error, _reason} = error ->
         spec
@@ -391,6 +393,49 @@ defmodule ReqLLM do
     do: {:ok, normalize_model_metadata(model)}
 
   defp normalize_model_result(other), do: other
+
+  # Bedrock cross-region inference profile prefixes.
+  # These are stripped by LLMDB during catalog lookup but must be preserved
+  # in API URLs for models that only support inference profiles (not on-demand).
+  @bedrock_inference_prefixes ~w(us eu ap apac ca au jp us-gov global)
+
+  # When a Bedrock model is resolved from a spec like "amazon_bedrock:global.anthropic.claude-opus-4-6-v1",
+  # the LLMDB catalog lookup strips the inference profile prefix for matching.
+  # This function detects that specific case and restores the original prefixed
+  # model ID as provider_model_id so it's used in API URL construction.
+  #
+  # Scoped to Bedrock inference profile prefixes only — does NOT affect alias
+  # resolution for other providers (e.g., anthropic:claude-3-haiku resolving
+  # to claude-3-haiku-20240307 should NOT set provider_model_id).
+  defp maybe_restore_inference_prefix(
+         {:ok, %LLMDB.Model{provider: :amazon_bedrock} = model},
+         spec
+       )
+       when is_binary(spec) do
+    original_model_id = extract_model_id_from_spec(spec)
+
+    if original_model_id && has_inference_prefix?(original_model_id) do
+      {:ok, %{model | provider_model_id: original_model_id}}
+    else
+      {:ok, model}
+    end
+  end
+
+  defp maybe_restore_inference_prefix({:ok, %LLMDB.Model{}} = result, _spec), do: result
+
+  defp has_inference_prefix?(model_id) do
+    case String.split(model_id, ".", parts: 2) do
+      [prefix, _rest] -> prefix in @bedrock_inference_prefixes
+      _ -> false
+    end
+  end
+
+  defp extract_model_id_from_spec(spec) do
+    case String.split(spec, ":", parts: 2) do
+      [_provider, model_id] -> model_id
+      _ -> nil
+    end
+  end
 
   defp normalize_inline_model_result({:ok, %LLMDB.Model{} = model}, _attrs) do
     {:ok, normalize_model_metadata(model)}

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -354,7 +354,9 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     base_url = "https://bedrock-runtime.#{region}.amazonaws.com"
 
     # Use provider_model_id if set (for models requiring specific API format like inference profiles),
-    # otherwise fall back to canonical model ID
+    # otherwise fall back to canonical model ID.
+    # Note: provider_model_id is set by ReqLLM.model/1 to include inference profile prefixes
+    # (e.g., "global.anthropic.claude-opus-4-6-v1") when the original model spec had one.
     model_id = model.provider_model_id || model.id
 
     # Check if we should use Converse API

--- a/test/providers/amazon_bedrock_provider_test.exs
+++ b/test/providers/amazon_bedrock_provider_test.exs
@@ -567,6 +567,101 @@ defmodule ReqLLM.Providers.AmazonBedrockProviderTest do
       assert response.message.reasoning_details == nil
     end
   end
+
+  describe "inference profile prefix preservation" do
+    test "global prefix is preserved in URL when model spec includes it" do
+      {:ok, model} = ReqLLM.model("amazon_bedrock:global.anthropic.claude-opus-4-6-v1")
+      context = context_fixture()
+
+      opts = [
+        api_key: "test-api-key",
+        region: "us-east-1"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      # The URL path must include the "global." prefix
+      assert request.url.path == "/model/global.anthropic.claude-opus-4-6-v1/invoke"
+    end
+
+    test "us prefix is preserved in URL when model spec includes it" do
+      {:ok, model} =
+        ReqLLM.model("amazon_bedrock:us.anthropic.claude-opus-4-1-20250805-v1:0")
+
+      context = context_fixture()
+
+      opts = [
+        api_key: "test-api-key",
+        region: "us-east-1"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      # The URL path must include the "us." prefix
+      assert request.url.path ==
+               "/model/us.anthropic.claude-opus-4-1-20250805-v1:0/invoke"
+    end
+
+    test "model without prefix still works normally" do
+      {:ok, model} =
+        ReqLLM.model("amazon_bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      context = context_fixture()
+
+      opts = [
+        api_key: "test-api-key",
+        region: "us-east-1"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      # No prefix, so the path should use the base model ID
+      assert request.url.path ==
+               "/model/anthropic.claude-3-haiku-20240307-v1:0/invoke"
+    end
+
+    test "global prefix is preserved in streaming URL" do
+      {:ok, model} = ReqLLM.model("amazon_bedrock:global.anthropic.claude-opus-4-6-v1")
+      context = context_fixture()
+
+      opts = [
+        stream: true,
+        api_key: "test-api-key",
+        region: "us-east-1"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      # The streaming URL path must include the "global." prefix
+      assert request.url.path ==
+               "/model/global.anthropic.claude-opus-4-6-v1/invoke-with-response-stream"
+    end
+
+    test "provider_model_id is set to prefixed ID after model resolution" do
+      {:ok, model} = ReqLLM.model("amazon_bedrock:global.anthropic.claude-opus-4-6-v1")
+
+      # provider_model_id should contain the full prefixed model ID
+      assert model.provider_model_id == "global.anthropic.claude-opus-4-6-v1"
+    end
+
+    test "model without prefix has original provider_model_id" do
+      {:ok, model} =
+        ReqLLM.model("amazon_bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      # For models without prefix, provider_model_id should match the id
+      # (or be nil if LLMDB doesn't set it, but id should be the base)
+      effective_id = model.provider_model_id || model.id
+      assert effective_id == "anthropic.claude-3-haiku-20240307-v1:0"
+    end
+
+    test "non-Bedrock alias resolution does not set provider_model_id" do
+      # Alias like anthropic:claude-3-haiku resolves to claude-3-haiku-20240307
+      # provider_model_id should NOT be set to the alias — that would break API calls
+      {:ok, model} = ReqLLM.model("anthropic:claude-3-haiku")
+
+      refute model.provider_model_id == "claude-3-haiku"
+    end
+  end
 end
 
 # Test double for Finch


### PR DESCRIPTION
## Description

When using Bedrock models with inference profile prefixes (e.g., `global.`, `us.`, `eu.`), the prefix is stripped during LLMDB catalog lookup but never restored for API URL construction. Models like `global.anthropic.claude-opus-4-6-v1` that only support cross-region inference profiles (not on-demand access) fail with: "Invocation of model ID anthropic.claude-opus-4-6-v1 with on-demand throughput isn't supported."

This wasn't an issue with earlier llm_db versions (e.g., 2026.2.8) which preserved the prefix in the model struct. Starting with llm_db 2026.3.x, `normalize_model_id` strips inference profile prefixes for catalog matching but doesn't preserve the original prefixed ID anywhere on the returned model struct. See #579 for full history.

This fix adds `maybe_restore_inference_prefix/2` in `ReqLLM.model/1` which detects when a prefix was stripped during catalog lookup and restores it as `provider_model_id`. Since all Bedrock URL construction already uses `model.provider_model_id || model.id`, this fixes all code paths (non-streaming, streaming, embedding) without changing the provider code.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. Models without inference profile prefixes continue to work identically.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #579