### PR TITLE
feat(openai): add `store` provider option for ZDR orgs, allow PDFs for Responses API models

### DIFF
--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -177,6 +177,12 @@ defmodule ReqLLM.Providers.OpenAI do
       type: :string,
       doc: "Previous response ID for Responses API tool resume flow"
     ],
+    store: [
+      type: :boolean,
+      doc:
+        "Whether to store responses for multi-turn chaining via previous_response_id. " <>
+          "Set to false for Zero Data Retention (ZDR) organizations."
+    ],
     openai_stream_transport: [
       type: {:in, [:sse, :websocket]},
       default: :sse,

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -868,7 +868,6 @@ defmodule ReqLLM.Providers.OpenAI do
     end
   end
 
-
   defp maybe_add_transcription_part(parts, _key, nil), do: parts
   defp maybe_add_transcription_part(parts, key, value), do: parts ++ [{key, to_string(value)}]
 

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -868,7 +868,6 @@ defmodule ReqLLM.Providers.OpenAI do
     end
   end
 
-  defp validate_responses_api_attachments(_), do: :ok
 
   defp maybe_add_transcription_part(parts, _key, nil), do: parts
   defp maybe_add_transcription_part(parts, key, value), do: parts ++ [{key, to_string(value)}]

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -112,6 +112,9 @@ defmodule ReqLLM.Providers.OpenAI do
     default_base_url: "https://api.openai.com/v1",
     default_env_key: "OPENAI_API_KEY"
 
+  # The Responses API supports richer file types than the Chat Completions API.
+  @responses_api_mimes ~w(image/jpeg image/png image/gif image/webp application/pdf)
+
   @provider_schema [
     access_token: [
       type: :string,
@@ -344,7 +347,7 @@ defmodule ReqLLM.Providers.OpenAI do
   def prepare_request(:chat, model_spec, prompt, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, context} <- ReqLLM.Context.normalize(prompt, opts),
-         :ok <- validate_attachments(context),
+         :ok <- validate_attachments(context, model),
          opts_with_context = Keyword.put(opts, :context, context),
          http_opts = Keyword.get(opts, :req_http_options, []),
          {:ok, processed_opts} <-
@@ -825,15 +828,47 @@ defmodule ReqLLM.Providers.OpenAI do
 
   defp enforce_strict_schema_requirements(schema), do: schema
 
-  defp validate_attachments(context) do
-    case ReqLLM.Provider.Defaults.validate_image_only_attachments(context) do
-      :ok ->
-        :ok
+  defp validate_attachments(context, model) do
+    case select_api_mod(model) do
+      ReqLLM.Providers.OpenAI.ResponsesAPI ->
+        validate_responses_api_attachments(context)
 
-      {:error, message} ->
-        {:error, ReqLLM.Error.Invalid.Parameter.exception(parameter: message)}
+      _ ->
+        case ReqLLM.Provider.Defaults.validate_image_only_attachments(context) do
+          :ok ->
+            :ok
+
+          {:error, message} ->
+            {:error, ReqLLM.Error.Invalid.Parameter.exception(parameter: message)}
+        end
     end
   end
+
+  defp validate_responses_api_attachments(%ReqLLM.Context{messages: messages}) do
+    unsupported =
+      messages
+      |> Enum.flat_map(fn msg -> msg.content || [] end)
+      |> Enum.filter(fn part ->
+        part.type == :file and part.media_type not in @responses_api_mimes
+      end)
+
+    case unsupported do
+      [] ->
+        :ok
+
+      parts ->
+        mimes = parts |> Enum.map(& &1.media_type) |> Enum.uniq() |> Enum.join(", ")
+
+        {:error,
+         ReqLLM.Error.Invalid.Parameter.exception(
+           parameter:
+             "OpenAI Responses API supports image and PDF attachments. " <>
+               "Found unsupported file types: #{mimes}."
+         )}
+    end
+  end
+
+  defp validate_responses_api_attachments(_), do: :ok
 
   defp maybe_add_transcription_part(parts, _key, nil), do: parts
   defp maybe_add_transcription_part(parts, key, value), do: parts ++ [{key, to_string(value)}]

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -502,9 +502,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     opts_map = if is_map(opts), do: opts, else: Map.new(opts)
     provider_opts = opts_map[:provider_options] || []
 
+    store = Keyword.get(provider_opts, :store, true)
+
     previous_response_id =
-      provider_opts[:previous_response_id] ||
-        extract_previous_response_id_from_context(context)
+      if store != false do
+        provider_opts[:previous_response_id] ||
+          extract_previous_response_id_from_context(context)
+      end
 
     {input, _tool_messages, reasoning_items} =
       Enum.reduce(context.messages, {[], [], []}, fn msg, {input_acc, tool_acc, reasoning_acc} ->
@@ -620,10 +624,17 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("service_tier", service_tier)
       |> maybe_put_string("text", text_format)
 
-    if previous_response_id do
-      body
-      |> Map.put("previous_response_id", previous_response_id)
-      |> Map.put("store", true)
+    body =
+      if previous_response_id do
+        body
+        |> Map.put("previous_response_id", previous_response_id)
+        |> Map.put("store", true)
+      else
+        body
+      end
+
+    if store == false do
+      Map.put(body, "store", false)
     else
       body
     end

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1282,6 +1282,66 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              end)
     end
 
+    test "store: false suppresses previous_response_id and sets store to false" do
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
+        metadata: %{response_id: "resp_prev_123"}
+      }
+
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
+      request = build_request(context: context, provider_options: [store: false])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+    end
+
+    test "store: true (default) preserves previous_response_id behavior" do
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
+        metadata: %{response_id: "resp_prev_456"}
+      }
+
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
+      request = build_request(context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      assert body["previous_response_id"] == "resp_prev_456"
+      assert body["store"] == true
+    end
+
+    test "store: false without prior response_id omits both fields" do
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Hello"}]
+      }
+
+      context = %ReqLLM.Context{messages: [user_msg]}
+      request = build_request(context: context, provider_options: [store: false])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+    end
+
     test "skips non-OpenAI reasoning details with warning" do
       import ExUnit.CaptureLog
 

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -1255,8 +1255,9 @@ defmodule ReqLLM.Providers.OpenAITest do
       end
     end
 
-    test "rejects PDF attachments with clear error" do
-      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+    test "Chat API rejects PDF attachments with clear error" do
+      # Force a Chat API model by using an inline spec without Responses API routing
+      {:ok, model} = ReqLLM.model(%{provider: :openai, id: "gpt-3.5-turbo"})
 
       pdf_part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "doc.pdf", "application/pdf")
       message = %ReqLLM.Message{role: :user, content: [pdf_part]}
@@ -1267,7 +1268,6 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert %ReqLLM.Error.Invalid.Parameter{} = error
       assert error.parameter =~ "only supports image attachments"
       assert error.parameter =~ "application/pdf"
-      assert error.parameter =~ "Anthropic or Google"
     end
 
     test "rejects text file attachments" do
@@ -1292,6 +1292,39 @@ defmodule ReqLLM.Providers.OpenAITest do
       context = %ReqLLM.Context{messages: [message]}
 
       {:ok, _request} = OpenAI.prepare_request(:chat, model, context, [])
+    end
+
+    test "Responses API accepts PDF attachments" do
+      {:ok, model} = ReqLLM.model("openai:gpt-5")
+
+      pdf_part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "doc.pdf", "application/pdf")
+      message = %ReqLLM.Message{role: :user, content: [pdf_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      assert {:ok, _request} = OpenAI.prepare_request(:chat, model, context, [])
+    end
+
+    test "Responses API accepts image attachments" do
+      {:ok, model} = ReqLLM.model("openai:gpt-5")
+
+      image_part = ReqLLM.Message.ContentPart.file(<<1, 2, 3>>, "photo.jpg", "image/jpeg")
+      message = %ReqLLM.Message{role: :user, content: [image_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      assert {:ok, _request} = OpenAI.prepare_request(:chat, model, context, [])
+    end
+
+    test "Responses API rejects unsupported file types" do
+      {:ok, model} = ReqLLM.model("openai:gpt-5")
+
+      text_part = ReqLLM.Message.ContentPart.file("content", "file.txt", "text/plain")
+      message = %ReqLLM.Message{role: :user, content: [text_part]}
+      context = %ReqLLM.Context{messages: [message]}
+
+      {:error, error} = OpenAI.prepare_request(:chat, model, context, [])
+
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+      assert error.parameter =~ "text/plain"
     end
   end
 


### PR DESCRIPTION
## Description

Two fixes for OpenAI Responses API usage:

### 1. `store` provider option for Zero Data Retention orgs

Organizations with ZDR enabled cannot use `previous_response_id` because OpenAI does not persist responses, causing 400 errors on multi-turn conversations.

Adds a `store` provider option (default: `true`) that, when set to `false`:
- Skips extracting `previous_response_id` from conversation context
- Sends `"store": false` in the request body

```elixir
ReqLLM.generate_text("openai:gpt-4o", context,
  provider_options: [store: false]
)
```

### 2. Allow PDF attachments for Responses API models

The attachment validation rejected all non-image files unconditionally, but the Responses API supports PDFs via `input_file` encoding (which the encoder already handles correctly). The Chat Completions API remains image-only.

Makes validation model aware so each path validates against its own supported types:
- **Responses API**: images + PDFs
- **Chat API**: images only (unchanged)

Fixes #317.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None — default behavior is unchanged for both changes.

## Testing

- [x] Tests pass (`mix test` — 2754 tests, 0 failures)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Fixes #317