### PR TITLE
Fix object generation for alibaba providers (alibaba and alibaba_cn)

### DIFF
--- a/lib/req_llm/providers/alibaba.ex
+++ b/lib/req_llm/providers/alibaba.ex
@@ -63,6 +63,11 @@ defmodule ReqLLM.Providers.Alibaba do
   defdelegate translate_options(operation, model, opts), to: Shared
 
   @impl ReqLLM.Provider
+  def prepare_request(operation, model_spec, input, opts) do
+    Shared.prepare_request(__MODULE__, operation, model_spec, input, opts)
+  end
+
+  @impl ReqLLM.Provider
   defdelegate build_body(request), to: Shared
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/alibaba/shared.ex
+++ b/lib/req_llm/providers/alibaba/shared.ex
@@ -42,10 +42,15 @@ defmodule ReqLLM.Providers.Alibaba.Shared do
     incremental_output: [
       type: :boolean,
       doc: "Streaming: send incremental chunks only (no prior content)."
+    ],
+    response_format: [
+      type: :map,
+      doc: "The response_format object (e.g., type: json_schema)."
     ]
   ]
 
-  @dashscope_keys Keyword.keys(@provider_schema)
+  # Exclude 'response_format' here because it's not unique to DashScope but is instead a general provider option
+  @dashscope_keys Keyword.keys(@provider_schema) -- [:response_format]
 
   @doc """
   Returns the DashScope-specific provider schema.
@@ -60,7 +65,7 @@ defmodule ReqLLM.Providers.Alibaba.Shared do
   @doc """
   Returns the provider option keys that must be registered on requests.
   """
-  def supported_provider_options, do: @dashscope_keys ++ [:dashscope_parameters]
+  def supported_provider_options, do: @dashscope_keys ++ [:dashscope_parameters, :response_format]
 
   @doc """
   Translates provider-specific options into DashScope parameters.
@@ -86,6 +91,68 @@ defmodule ReqLLM.Providers.Alibaba.Shared do
       end
 
     {opts_with_dashscope, []}
+  end
+
+  @doc """
+  Overrides the default request preparation for :object operations to inject
+  the appropriate `response_format` for DashScope's native structured output (JSON output).
+  """
+  def prepare_request(provider_mod, operation, model_spec, prompt, opts) do
+    case operation do
+      :object ->
+        prepare_object_request(provider_mod, model_spec, prompt, opts)
+
+      _ ->
+        ReqLLM.Provider.Defaults.prepare_request(
+          provider_mod,
+          operation,
+          model_spec,
+          prompt,
+          opts
+        )
+    end
+  end
+
+  defp prepare_object_request(provider_mod, model_spec, prompt, opts) do
+    # Fetch schema and options
+    compiled_schema = Keyword.fetch!(opts, :compiled_schema)
+
+    # Build json schema from the provided schema struct
+    json_schema = ReqLLM.Schema.to_json(compiled_schema.schema)
+    final_schema = enforce_strict_schema_requirements(json_schema)
+
+    schema_name = Map.get(compiled_schema, :name, "output_schema")
+
+    # Construct response_format
+    response_format = %{
+      type: "json_schema",
+      json_schema: %{
+        name: schema_name,
+        schema: final_schema,
+        strict: true
+      }
+    }
+
+    # Inject 'response_format' into :provider_options so they are passed to the API.
+    opts_with_format =
+      opts
+      |> Keyword.update(
+        :provider_options,
+        [response_format: response_format],
+        fn existing ->
+          existing
+          |> Keyword.put(:response_format, response_format)
+        end
+      )
+      |> Keyword.put(:operation, :object)
+
+    # Note: Fully qualified call to Defaults
+    ReqLLM.Provider.Defaults.prepare_chat_request(
+      provider_mod,
+      model_spec,
+      prompt,
+      opts_with_format
+    )
   end
 
   @doc """
@@ -140,4 +207,16 @@ defmodule ReqLLM.Providers.Alibaba.Shared do
   defp encode_map_param(params) when is_map(params) do
     Map.new(params, fn {k, v} -> {to_string(k), v} end)
   end
+
+  defp enforce_strict_schema_requirements(
+         %{"type" => "object", "properties" => properties} = schema
+       ) do
+    all_property_names = Map.keys(properties)
+
+    schema
+    |> Map.put("required", all_property_names)
+    |> Map.put("additionalProperties", false)
+  end
+
+  defp enforce_strict_schema_requirements(schema), do: schema
 end

--- a/lib/req_llm/providers/alibaba_cn.ex
+++ b/lib/req_llm/providers/alibaba_cn.ex
@@ -40,6 +40,11 @@ defmodule ReqLLM.Providers.AlibabaCN do
   defdelegate translate_options(operation, model, opts), to: Shared
 
   @impl ReqLLM.Provider
+  def prepare_request(operation, model_spec, input, opts) do
+    Shared.prepare_request(__MODULE__, operation, model_spec, input, opts)
+  end
+
+  @impl ReqLLM.Provider
   defdelegate build_body(request), to: Shared
 
   @impl ReqLLM.Provider

--- a/test/providers/alibaba_cn_test.exs
+++ b/test/providers/alibaba_cn_test.exs
@@ -140,6 +140,32 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       assert decoded["enable_thinking"] == true
     end
 
+    test "prepare_request for :object includes response_format in final http request" do
+      model = model_fixture()
+
+      {:ok, compiled_schema} =
+        ReqLLM.Schema.compile(
+          name: [type: :string, required: true],
+          age: [type: :integer]
+        )
+
+      {:ok, request} =
+        AlibabaCN.prepare_request(:object, model, "Generate a person",
+          compiled_schema: Map.put(compiled_schema, :name, "person_schema")
+        )
+
+      encoded_request = AlibabaCN.encode_body(request)
+      decoded = Jason.decode!(encoded_request.body)
+
+      assert decoded["response_format"]["type"] == "json_schema"
+      assert decoded["response_format"]["json_schema"]["name"] == "person_schema"
+      assert decoded["response_format"]["json_schema"]["strict"] == true
+      assert decoded["response_format"]["json_schema"]["schema"]["additionalProperties"] == false
+
+      assert Enum.sort(decoded["response_format"]["json_schema"]["schema"]["required"]) ==
+               ["age", "name"]
+    end
+
     test "rejects unsupported operations" do
       model = model_fixture()
       prompt = "Hello world"

--- a/test/providers/alibaba_test.exs
+++ b/test/providers/alibaba_test.exs
@@ -140,6 +140,32 @@ defmodule ReqLLM.Providers.AlibabaTest do
       assert decoded["enable_thinking"] == true
     end
 
+    test "prepare_request for :object includes response_format in final http request" do
+      model = model_fixture()
+
+      {:ok, compiled_schema} =
+        ReqLLM.Schema.compile(
+          name: [type: :string, required: true],
+          age: [type: :integer]
+        )
+
+      {:ok, request} =
+        Alibaba.prepare_request(:object, model, "Generate a person",
+          compiled_schema: Map.put(compiled_schema, :name, "person_schema")
+        )
+
+      encoded_request = Alibaba.encode_body(request)
+      decoded = Jason.decode!(encoded_request.body)
+
+      assert decoded["response_format"]["type"] == "json_schema"
+      assert decoded["response_format"]["json_schema"]["name"] == "person_schema"
+      assert decoded["response_format"]["json_schema"]["strict"] == true
+      assert decoded["response_format"]["json_schema"]["schema"]["additionalProperties"] == false
+
+      assert Enum.sort(decoded["response_format"]["json_schema"]["schema"]["required"]) ==
+               ["age", "name"]
+    end
+
     test "rejects unsupported operations" do
       model = model_fixture()
       prompt = "Hello world"


### PR DESCRIPTION
## Description

This PR fixes the structured output handling for the Alibaba providers (alibaba and alibaba_cn).

According to the Alibaba documentation (https://www.alibabacloud.com/help/en/model-studio/qwen-structured-output), structured JSON output is natively supported via the `response_format` parameter. However, this capability is not supported by the default OpenAI-compatible API.

This change ensures the provider correctly enables and handles structured JSON output.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
