### PR TITLE
fix(anthropic): handle malformed tool arguments gracefully

### DIFF
--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -267,7 +267,13 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     %{type: "tool_use", id: id, name: name, input: decode_tool_arguments(args)}
   end
 
-  defp decode_tool_arguments(args) when is_binary(args), do: Jason.decode!(args)
+  defp decode_tool_arguments(args) when is_binary(args) do
+    case ReqLLM.JSON.decode(args) do
+      {:ok, map} -> map
+      {:error, _} -> %{}
+    end
+  end
+
   defp decode_tool_arguments(args) when is_map(args), do: args
   defp decode_tool_arguments(nil), do: %{}
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -518,6 +518,43 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert tool_result_block["tool_use_id"] == "functions_add_0"
     end
 
+    test "encode_body handles tool calls with empty string arguments" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user("Take a screenshot"),
+          ReqLLM.Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "call_1",
+                type: "function",
+                function: %{name: "take_screenshot", arguments: ""}
+              }
+            ]
+          ),
+          ReqLLM.Context.tool_result("call_1", "screenshot.png")
+        ])
+
+      mock_request = %Req.Request{
+        options: [context: context, model: model.model, stream: false]
+      }
+
+      updated_request = Anthropic.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+      messages = decoded["messages"]
+
+      tool_use_block =
+        messages
+        |> Enum.find(&(&1["role"] == "assistant"))
+        |> Map.fetch!("content")
+        |> Enum.find(&(&1["type"] == "tool_use"))
+
+      assert tool_use_block["id"] == "call_1"
+      assert tool_use_block["name"] == "take_screenshot"
+      assert tool_use_block["input"] == %{}
+    end
+
     test "encode_body rejects contexts ending with unresolved tool calls" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 


### PR DESCRIPTION
## Problem

`decode_tool_arguments/1` in the Anthropic context encoder uses `Jason.decode!/1`, which raises when the LLM sends an empty string `""` as tool arguments. This happens with parameter-free tools (e.g. `take_screenshot()`) where some models send `""` instead of `"{}"` or `null`.

## Fix

Replace `Jason.decode!/1` with `ReqLLM.JSON.decode/1` (already used elsewhere in the codebase, e.g. `ToolCall.parse_arguments/2`) so malformed or empty arguments fall back to `%{}` instead of crashing.

```elixir
# before
defp decode_tool_arguments(args) when is_binary(args), do: Jason.decode!(args)

# after
defp decode_tool_arguments(args) when is_binary(args) do
  case ReqLLM.JSON.decode(args) do
    {:ok, map} -> map
    {:error, _} -> %{}
  end
end
```

## Test

Added a test case that encodes a conversation history containing a `ToolCall` with `arguments: ""` and asserts the encoded `input` is `%{}`.