### PR TITLE
feat: Allow redaction of message content when inspecting Context struct

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -23,6 +23,9 @@ config :req_llm,
   # Telemetry
   telemetry: [payloads: :none],      # Request payload policy (:none or :raw)
 
+  # Privacy
+  redact_context: false,             # Hide message contents in inspect output
+
   # Debugging
   debug: false                       # Enable verbose logging
 ```
@@ -277,6 +280,28 @@ Or via environment variable:
 
 ```bash
 REQ_LLM_DEBUG=1 mix test
+```
+
+## Context Redaction
+
+Hide message contents when a `Context` struct is inspected, preventing sensitive prompts or responses from leaking into logs:
+
+```elixir
+config :req_llm, redact_context: true
+```
+
+When enabled, `inspect/2` shows only the message count:
+
+```elixir
+inspect(context)
+#=> "#Context<4 messages [REDACTED]>"
+```
+
+When disabled (the default), the full message preview is shown as normal:
+
+```elixir
+inspect(context)
+#=> "#Context<2 msgs: system:\"You are a helpful assistant\", user:\"Hello\">"
 ```
 
 ## Example: Production Configuration

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -17,6 +17,15 @@ defmodule ReqLLM.Context do
       ])
 
       Context.validate!(context)
+
+  ## Redacting context on inspect
+
+  Set `config :req_llm, redact_context: true` to hide message contents
+  from `inspect/2` output. When enabled, only the message count is shown:
+
+      #Context<4 messages [REDACTED]>
+
+  This prevents sensitive prompts from leaking into logs or crash reports.
   """
 
   alias ReqLLM.Message
@@ -649,42 +658,58 @@ defmodule ReqLLM.Context do
     def inspect(%{messages: msgs}, opts) when is_list(msgs) do
       msg_count = length(msgs)
 
-      if msg_count <= 2 do
-        role_previews =
-          msgs
-          |> Enum.map_join(", ", fn msg ->
-            "#{msg.role}:\"#{content_preview(msg, 40)}\""
-          end)
-
+      if redact_context?() do
         Inspect.Algebra.concat([
           "#Context<",
           Inspect.Algebra.to_doc(msg_count, opts),
-          " msgs: ",
-          role_previews,
-          ">"
+          " messages [REDACTED]>"
         ])
       else
-        msg_docs =
-          msgs
-          |> Enum.with_index()
-          |> Enum.map(fn {msg, idx} ->
-            "  [#{idx}] #{msg.role}: \"#{content_preview(msg, 60)}\""
-          end)
-
-        Inspect.Algebra.concat([
-          "#Context<",
-          Inspect.Algebra.to_doc(msg_count, opts),
-          " messages:",
-          Inspect.Algebra.line(),
-          Inspect.Algebra.concat(Enum.intersperse(msg_docs, Inspect.Algebra.line())),
-          Inspect.Algebra.line(),
-          ">"
-        ])
+        format_messages(msgs, msg_count, opts)
       end
     end
 
     def inspect(_context, _opts) do
       Inspect.Algebra.concat(["#Context<", "(truncated)", ">"])
+    end
+
+    defp format_messages(msgs, msg_count, opts) when msg_count <= 2 do
+      role_previews =
+        msgs
+        |> Enum.map_join(", ", fn msg ->
+          "#{msg.role}:\"#{content_preview(msg, 40)}\""
+        end)
+
+      Inspect.Algebra.concat([
+        "#Context<",
+        Inspect.Algebra.to_doc(msg_count, opts),
+        " msgs: ",
+        role_previews,
+        ">"
+      ])
+    end
+
+    defp format_messages(msgs, msg_count, opts) do
+      msg_docs =
+        msgs
+        |> Enum.with_index()
+        |> Enum.map(fn {msg, idx} ->
+          "  [#{idx}] #{msg.role}: \"#{content_preview(msg, 60)}\""
+        end)
+
+      Inspect.Algebra.concat([
+        "#Context<",
+        Inspect.Algebra.to_doc(msg_count, opts),
+        " messages:",
+        Inspect.Algebra.line(),
+        Inspect.Algebra.concat(Enum.intersperse(msg_docs, Inspect.Algebra.line())),
+        Inspect.Algebra.line(),
+        ">"
+      ])
+    end
+
+    defp redact_context? do
+      Application.get_env(:req_llm, :redact_context, false)
     end
 
     defp content_preview(msg, max_len) do

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -469,6 +469,48 @@ defmodule ReqLLM.ContextTest do
       inspected = inspect(context)
       assert inspected == "#Context<1 msgs: user:\"\">"
     end
+
+    test "redacts content when :redact_context config is true" do
+      Application.put_env(:req_llm, :redact_context, true)
+
+      context =
+        Context.new([
+          Context.system("Secret system prompt"),
+          Context.user("Secret user message")
+        ])
+
+      inspected = inspect(context)
+      assert inspected == "#Context<2 messages [REDACTED]>"
+    after
+      Application.delete_env(:req_llm, :redact_context)
+    end
+
+    test "redacts content for long contexts when :redact_context config is true" do
+      Application.put_env(:req_llm, :redact_context, true)
+
+      context =
+        Context.new([
+          Context.system("Secret"),
+          Context.user("Hello"),
+          Context.assistant("Hi"),
+          Context.user("More secrets")
+        ])
+
+      inspected = inspect(context)
+      assert inspected == "#Context<4 messages [REDACTED]>"
+    after
+      Application.delete_env(:req_llm, :redact_context)
+    end
+
+    test "redacts empty context when :redact_context config is true" do
+      Application.put_env(:req_llm, :redact_context, true)
+
+      context = Context.new()
+      inspected = inspect(context)
+      assert inspected == "#Context<0 messages [REDACTED]>"
+    after
+      Application.delete_env(:req_llm, :redact_context)
+    end
   end
 
   describe "normalize/2" do


### PR DESCRIPTION
## Description

Adds a global config key to redact the inspect output of Context structs. This prevents sensitive prompts from leaking into logs or crash reports.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues
