### PR TITLE
feat(openai): add explicit Ollama auth marker

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -39,7 +39,8 @@ defmodule ReqLLM do
         ReqLLM.model!(%{
           provider: :openai,
           id: "gpt-6-mini",
-          base_url: "http://localhost:8000/v1"
+          base_url: "http://localhost:8000/v1",
+          extra: %{openai_compatible_backend: :ollama}
         })
 
       ReqLLM.generate_text(model, messages)

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -192,6 +192,11 @@ defmodule ReqLLM.Providers.OpenAI do
       doc:
         "Streaming transport for Responses models. Use :websocket for OpenAI WebSocket mode; SSE remains the default."
     ],
+    openai_compatible_backend: [
+      type: {:or, [{:in, [:ollama]}, {:in, ["ollama"]}]},
+      doc:
+        "Explicit OpenAI-compatible backend marker. Set to :ollama to allow missing API keys for unauthenticated local deployments."
+    ],
     tool_outputs: [
       type: {:list, :any},
       doc:
@@ -439,7 +444,7 @@ defmodule ReqLLM.Providers.OpenAI do
         |> maybe_add_transcription_part(:language, language)
         |> maybe_add_transcription_provider_parts(provider_options)
 
-      api_key = ReqLLM.Keys.get!(model, opts)
+      credential = resolve_request_credential!(model, opts)
 
       request =
         Req.new(
@@ -449,11 +454,10 @@ defmodule ReqLLM.Providers.OpenAI do
             base_url: Keyword.get(opts, :base_url, base_url()),
             receive_timeout: timeout,
             pool_timeout: timeout,
-            form_multipart: form_parts,
-            auth: {:bearer, api_key}
-          ] ++ http_opts
+            form_multipart: form_parts
+          ] ++ auth_req_options(credential) ++ http_opts
         )
-        |> Req.Request.put_header("authorization", "Bearer #{api_key}")
+        |> maybe_put_authorization_header(credential)
         |> ReqLLM.Step.Retry.attach()
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
@@ -649,19 +653,19 @@ defmodule ReqLLM.Providers.OpenAI do
       raise ReqLLM.Error.Invalid.Provider.exception(provider: model.provider)
     end
 
-    credential = ReqLLM.Auth.resolve!(model, user_opts)
+    credential = resolve_request_credential!(model, user_opts)
     extra_option_keys = ReqLLM.Provider.Defaults.extra_option_keys(__MODULE__)
 
     request
     |> Req.Request.put_header("content-type", "application/json")
-    |> Req.Request.put_header("authorization", "Bearer #{credential.token}")
+    |> maybe_put_authorization_header(credential)
     |> Req.Request.register_options(extra_option_keys)
     |> Req.Request.merge_options(
       [
         finch: ReqLLM.Application.finch_name(),
-        model: model.provider_model_id || model.id,
-        auth: {:bearer, credential.token}
+        model: model.provider_model_id || model.id
       ] ++
+        auth_req_options(credential) ++
         user_opts
     )
     |> ReqLLM.Step.Retry.attach()
@@ -713,6 +717,29 @@ defmodule ReqLLM.Providers.OpenAI do
       _ -> :http
     end
   end
+
+  @doc false
+  def resolve_request_credential!(%LLMDB.Model{} = model, opts) do
+    case ReqLLM.Auth.resolve(model, opts) do
+      {:ok, credential} ->
+        credential
+
+      {:error, message} ->
+        if allow_missing_api_key?(model, opts) and missing_api_key_error?(message) do
+          :none
+        else
+          raise ReqLLM.Error.Invalid.Parameter.exception(parameter: message)
+        end
+    end
+  end
+
+  @doc false
+  def auth_header_list(:none), do: []
+  def auth_header_list(credential), do: [{"Authorization", "Bearer " <> credential.token}]
+
+  @doc false
+  def auth_req_options(:none), do: []
+  def auth_req_options(credential), do: [auth: {:bearer, credential.token}]
 
   @doc """
   Custom body encoding that delegates to the selected API module.
@@ -862,6 +889,61 @@ defmodule ReqLLM.Providers.OpenAI do
 
   defp maybe_add_transcription_part(parts, _key, nil), do: parts
   defp maybe_add_transcription_part(parts, key, value), do: parts ++ [{key, to_string(value)}]
+
+  defp maybe_put_authorization_header(request, :none), do: request
+
+  defp maybe_put_authorization_header(request, credential) do
+    Req.Request.put_header(request, "authorization", "Bearer #{credential.token}")
+  end
+
+  defp allow_missing_api_key?(%LLMDB.Model{} = model, opts) do
+    auth_mode(opts) == :api_key and openai_compatible_backend(model, opts) == :ollama
+  end
+
+  defp auth_mode(opts) do
+    case option_value(opts, :auth_mode) || provider_option_value(opts, :auth_mode) || :api_key do
+      :oauth -> :oauth
+      "oauth" -> :oauth
+      _ -> :api_key
+    end
+  end
+
+  defp openai_compatible_backend(%LLMDB.Model{extra: extra}, opts) do
+    normalize_backend(
+      provider_option_value(opts, :openai_compatible_backend) ||
+        map_option_value(extra, :openai_compatible_backend)
+    )
+  end
+
+  defp normalize_backend(:ollama), do: :ollama
+  defp normalize_backend("ollama"), do: :ollama
+  defp normalize_backend(_), do: nil
+
+  defp missing_api_key_error?(message) when is_binary(message) do
+    String.contains?(
+      message,
+      ":api_key option, config :req_llm, openai_api_key, or OPENAI_API_KEY env var"
+    )
+  end
+
+  defp option_value(opts, key) when is_list(opts), do: Keyword.get(opts, key)
+  defp option_value(opts, key) when is_map(opts), do: map_option_value(opts, key)
+
+  defp provider_option_value(opts, key) do
+    opts
+    |> option_value(:provider_options)
+    |> map_or_keyword_value(key)
+  end
+
+  defp map_option_value(opts, key) when is_map(opts) do
+    Map.get(opts, key) || Map.get(opts, Atom.to_string(key))
+  end
+
+  defp map_option_value(_opts, _key), do: nil
+
+  defp map_or_keyword_value(opts, key) when is_list(opts), do: Keyword.get(opts, key)
+  defp map_or_keyword_value(opts, key) when is_map(opts), do: map_option_value(opts, key)
+  defp map_or_keyword_value(_opts, _key), do: nil
 
   defp maybe_add_transcription_provider_parts(parts, opts) when is_list(opts) do
     Enum.reduce(opts, parts, fn

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -78,12 +78,10 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
   # ========================================================================
 
   defp build_request_headers(model, opts) do
-    credential = ReqLLM.Auth.resolve!(model, opts)
-
-    [
-      {"Authorization", "Bearer " <> credential.token},
-      {"Content-Type", "application/json"}
-    ]
+    ReqLLM.Providers.OpenAI.auth_header_list(
+      ReqLLM.Providers.OpenAI.resolve_request_credential!(model, opts)
+    ) ++
+      [{"Content-Type", "application/json"}]
   end
 
   defp build_request_body(context, model_name, opts, operation \\ :chat) do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -482,12 +482,10 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   # ========================================================================
 
   defp build_request_headers(model, opts) do
-    credential = ReqLLM.Auth.resolve!(model, opts)
-
-    [
-      {"Authorization", "Bearer " <> credential.token},
-      {"Content-Type", "application/json"}
-    ]
+    ReqLLM.Providers.OpenAI.auth_header_list(
+      ReqLLM.Providers.OpenAI.resolve_request_credential!(model, opts)
+    ) ++
+      [{"Content-Type", "application/json"}]
   end
 
   defp build_request_url(opts) do

--- a/lib/req_llm/providers/openai/web_socket.ex
+++ b/lib/req_llm/providers/openai/web_socket.ex
@@ -5,12 +5,12 @@ defmodule ReqLLM.Providers.OpenAI.WebSocket do
 
   @spec headers(LLMDB.Model.t(), keyword()) :: [{String.t(), String.t()}]
   def headers(%LLMDB.Model{} = model, opts) do
-    credential = ReqLLM.Auth.resolve!(model, opts)
     custom_headers = ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options])
 
-    [
-      {"Authorization", "Bearer " <> credential.token}
-    ] ++ custom_headers
+    ReqLLM.Providers.OpenAI.auth_header_list(
+      ReqLLM.Providers.OpenAI.resolve_request_credential!(model, opts)
+    ) ++
+      custom_headers
   end
 
   @spec responses_url(LLMDB.Model.t(), keyword()) :: String.t()

--- a/test/req_llm/openai_compatible_backend_test.exs
+++ b/test/req_llm/openai_compatible_backend_test.exs
@@ -1,0 +1,125 @@
+defmodule ReqLLM.OpenAICompatibleBackendTest do
+  use ExUnit.Case, async: false
+
+  alias ReqLLM.Context
+  alias ReqLLM.Generation
+  alias ReqLLM.Provider.Options
+  alias ReqLLM.Response
+  alias ReqLLM.Transcription
+
+  setup do
+    env_key = System.get_env("OPENAI_API_KEY")
+    app_key = Application.get_env(:req_llm, :openai_api_key)
+
+    System.delete_env("OPENAI_API_KEY")
+    Application.delete_env(:req_llm, :openai_api_key)
+
+    on_exit(fn ->
+      restore_system_env("OPENAI_API_KEY", env_key)
+      restore_application_env(:openai_api_key, app_key)
+    end)
+
+    :ok
+  end
+
+  test "generate_text allows explicit Ollama models without OPENAI_API_KEY" do
+    Req.Test.stub(ReqLLM.OpenAICompatibleBackendGenerateTextTest, fn conn ->
+      assert conn.request_path == "/v1/chat/completions"
+      assert Plug.Conn.get_req_header(conn, "authorization") == []
+
+      Req.Test.json(conn, %{
+        "id" => "chatcmpl_test_123",
+        "model" => "llama3",
+        "choices" => [
+          %{
+            "message" => %{"role" => "assistant", "content" => "Ollama says hi"}
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 4, "completion_tokens" => 4, "total_tokens" => 8}
+      })
+    end)
+
+    assert {:ok, response} =
+             Generation.generate_text(
+               ollama_model(extra: %{openai_compatible_backend: :ollama}),
+               "Hello",
+               req_http_options: [
+                 plug: {Req.Test, ReqLLM.OpenAICompatibleBackendGenerateTextTest}
+               ]
+             )
+
+    assert Response.text(response) == "Ollama says hi"
+  end
+
+  test "streaming request builders omit auth for explicit Ollama provider options" do
+    model = ReqLLM.model!(ollama_model())
+    context = Context.new([Context.user("Hello")])
+
+    opts =
+      Options.process!(
+        ReqLLM.Providers.OpenAI,
+        :chat,
+        model,
+        provider_options: [openai_compatible_backend: :ollama]
+      )
+
+    assert {:ok, finch_request} =
+             ReqLLM.Providers.OpenAI.ChatAPI.attach_stream(model, context, opts, nil)
+
+    refute Enum.any?(finch_request.headers, fn {name, _value} ->
+             String.downcase(name) == "authorization"
+           end)
+
+    assert finch_request.path == "/v1/chat/completions"
+  end
+
+  test "transcribe allows explicit Ollama provider options without OPENAI_API_KEY" do
+    Req.Test.stub(ReqLLM.OpenAICompatibleBackendTranscriptionTest, fn conn ->
+      assert conn.request_path == "/v1/audio/transcriptions"
+      assert Plug.Conn.get_req_header(conn, "authorization") == []
+
+      Req.Test.json(conn, %{
+        "text" => "Hello from Ollama",
+        "language" => "en"
+      })
+    end)
+
+    assert {:ok, result} =
+             Transcription.transcribe(
+               ollama_model(id: "whisper-1"),
+               {:binary, "fake audio", "audio/mpeg"},
+               provider_options: [openai_compatible_backend: :ollama],
+               req_http_options: [
+                 plug: {Req.Test, ReqLLM.OpenAICompatibleBackendTranscriptionTest}
+               ]
+             )
+
+    assert result.text == "Hello from Ollama"
+    assert result.language == "en"
+  end
+
+  test "unmarked OpenAI-compatible models still require authentication" do
+    assert_raise ReqLLM.Error.Invalid.Parameter, ~r/OPENAI_API_KEY/, fn ->
+      Generation.generate_text(ollama_model(), "Hello")
+    end
+  end
+
+  defp ollama_model(attrs \\ []) do
+    attrs = Enum.into(attrs, %{})
+
+    Map.merge(
+      %{
+        provider: :openai,
+        id: "llama3",
+        base_url: "http://localhost:11434/v1"
+      },
+      attrs
+    )
+  end
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
+
+  defp restore_application_env(key, nil), do: Application.delete_env(:req_llm, key)
+  defp restore_application_env(key, value), do: Application.put_env(:req_llm, key, value)
+end


### PR DESCRIPTION
## Summary
- add an explicit `openai_compatible_backend: :ollama` marker for OpenAI-compatible backends via `provider_options` or `model.extra`
- omit bearer auth only for explicitly marked Ollama requests when no OpenAI API key is configured, while preserving the default auth requirement and existing OAuth behavior
- cover the new behavior across text generation, streaming request building, and transcription, and update the inline localhost OpenAI example to show the explicit marker

## Validation
- `mix test test/req_llm/generation_test.exs test/req_llm/transcription_test.exs test/req_llm/base_url_streaming_test.exs test/req_llm/openai_websocket_test.exs test/req_llm/openai_compatible_backend_test.exs test/provider/openai`
- `mix quality`

Fixes #583