### PR TITLE
fix: normalize provider tool choice handling and harden tool call dec…

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1176,18 +1176,7 @@ defmodule ReqLLM.Provider.Defaults do
          "type" => "function",
          "function" => %{"name" => name, "arguments" => args_json}
        }) do
-    case Jason.decode(args_json || "{}") do
-      {:ok, args} ->
-        ReqLLM.StreamChunk.tool_call(name, args, %{id: id})
-
-      {:error, _} ->
-        %ReqLLM.StreamChunk{
-          type: :tool_call,
-          name: name,
-          arguments: %{},
-          metadata: %{id: id, raw_arguments: args_json}
-        }
-    end
+    build_openai_tool_call_chunk(name, args_json, %{id: id})
   end
 
   # Mistral API omits "type" field - add it and delegate
@@ -1235,10 +1224,7 @@ defmodule ReqLLM.Provider.Defaults do
          "function" => %{"name" => name, "arguments" => args_json}
        })
        when is_binary(name) do
-    case Jason.decode(args_json || "{}") do
-      {:ok, args} -> ReqLLM.StreamChunk.tool_call(name, args, %{id: id, index: index})
-      {:error, _} -> ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id, index: index})
-    end
+    build_openai_tool_call_chunk(name, args_json, %{id: id, index: index})
   end
 
   # Handle tool call delta with only name (arguments may come in later chunks)
@@ -1281,10 +1267,7 @@ defmodule ReqLLM.Provider.Defaults do
          "function" => %{"name" => name, "arguments" => args_json}
        })
        when is_binary(name) do
-    case Jason.decode(args_json || "{}") do
-      {:ok, args} -> ReqLLM.StreamChunk.tool_call(name, args, %{id: id})
-      {:error, _} -> ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id})
-    end
+    build_openai_tool_call_chunk(name, args_json, %{id: id})
   end
 
   # Handle malformed tool call deltas (some APIs send incomplete structures)
@@ -1297,6 +1280,38 @@ defmodule ReqLLM.Provider.Defaults do
   end
 
   defp decode_openai_tool_call_delta(_), do: nil
+
+  defp build_openai_tool_call_chunk(name, args_json, metadata) do
+    case Jason.decode(args_json || "{}") do
+      {:ok, decoded_args} ->
+        {arguments, extra_metadata} = normalize_tool_call_arguments(decoded_args, args_json)
+        ReqLLM.StreamChunk.tool_call(name, arguments, Map.merge(metadata, extra_metadata))
+
+      {:error, _reason} ->
+        ReqLLM.StreamChunk.tool_call(
+          name,
+          %{},
+          Map.merge(metadata, %{
+            invalid_arguments: true,
+            raw_arguments: args_json,
+            unparseable_arguments: true
+          })
+        )
+    end
+  end
+
+  defp normalize_tool_call_arguments(arguments, _raw_arguments) when is_map(arguments) do
+    {arguments, %{}}
+  end
+
+  defp normalize_tool_call_arguments(arguments, raw_arguments) do
+    {%{},
+     %{
+       invalid_arguments: true,
+       raw_arguments: raw_arguments,
+       decoded_arguments: arguments
+     }}
+  end
 
   defp build_openai_message_from_chunks(chunks) when is_list(chunks) do
     content_parts =
@@ -1336,9 +1351,21 @@ defmodule ReqLLM.Provider.Defaults do
          metadata: meta
        }) do
     args_json =
-      case Map.get(meta, :raw_arguments) do
-        raw when is_binary(raw) -> raw
-        _ -> if(is_binary(args), do: args, else: Jason.encode!(args))
+      cond do
+        Map.get(meta, :unparseable_arguments) && is_binary(Map.get(meta, :raw_arguments)) ->
+          Map.get(meta, :raw_arguments)
+
+        Map.get(meta, :invalid_arguments) ->
+          Jason.encode!(args)
+
+        is_binary(Map.get(meta, :raw_arguments)) ->
+          Map.get(meta, :raw_arguments)
+
+        is_binary(args) ->
+          args
+
+        true ->
+          Jason.encode!(args)
       end
 
     id = Map.get(meta, :id)

--- a/lib/req_llm/providers/amazon_bedrock/openai.ex
+++ b/lib/req_llm/providers/amazon_bedrock/openai.ex
@@ -10,6 +10,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAI do
 
   alias ReqLLM.Provider.Defaults
   alias ReqLLM.Providers.AmazonBedrock
+  alias ReqLLM.Providers.OpenAI.AdapterHelpers
 
   @doc """
   Returns whether this model family supports toolChoice in Bedrock Converse API.
@@ -37,7 +38,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAI do
       end
 
     # Get tools from context if available
-    tools = Map.get(context, :tools, [])
+    tools = opts[:tools] || Map.get(context, :tools, [])
 
     # Create a minimal request struct to use default OpenAI encoding
     temp_request =
@@ -55,7 +56,10 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAI do
         )
       )
 
-    body = Defaults.default_build_body(temp_request)
+    body =
+      temp_request
+      |> Defaults.default_build_body()
+      |> AdapterHelpers.translate_tool_choice_format()
 
     messages = body[:messages] || body["messages"]
 

--- a/lib/req_llm/providers/cerebras.ex
+++ b/lib/req_llm/providers/cerebras.ex
@@ -12,7 +12,8 @@ defmodule ReqLLM.Providers.Cerebras do
   - Streaming not supported with reasoning models in JSON mode or tool calling
   - `strict: true` is automatically added to tool schemas when the model supports it
   - Models that don't support `strict: true` (e.g., Qwen, ZAI GLM models) have it automatically excluded
-  - Only supports `tool_choice: "auto"` or `"none"`, not function-specific choices
+  - Supports OpenAI-style tool calling, including `tool_choice: "auto"`, `"none"`, `"required"`, and function-specific choice objects
+  - Supports `parallel_tool_calls` to control whether tools can be requested concurrently
 
   ## Unsupported OpenAI Features
 
@@ -20,8 +21,6 @@ defmodule ReqLLM.Providers.Cerebras do
   - `frequency_penalty`
   - `logit_bias`
   - `presence_penalty`
-  - `parallel_tool_calls`
-  - `service_tier`
 
   ## Configuration
 
@@ -33,6 +32,8 @@ defmodule ReqLLM.Providers.Cerebras do
     id: :cerebras,
     default_base_url: "https://api.cerebras.ai/v1",
     default_env_key: "CEREBRAS_API_KEY"
+
+  import ReqLLM.Provider.Utils, only: [maybe_put: 3]
 
   @provider_schema []
 
@@ -49,7 +50,7 @@ defmodule ReqLLM.Providers.Cerebras do
     ReqLLM.Provider.Defaults.default_build_body(request)
     |> translate_tool_choice_format()
     |> add_strict_to_tools(model)
-    |> normalize_tool_choice()
+    |> maybe_put(:parallel_tool_calls, request.options[:parallel_tool_calls])
     |> normalize_assistant_content()
   end
 
@@ -61,20 +62,29 @@ defmodule ReqLLM.Providers.Cerebras do
         true -> {nil, nil}
       end
 
-    type = tool_choice && (Map.get(tool_choice, :type) || Map.get(tool_choice, "type"))
-    name = tool_choice && (Map.get(tool_choice, :name) || Map.get(tool_choice, "name"))
+    case tool_choice do
+      map when is_map(map) ->
+        type = Map.get(tool_choice, :type) || Map.get(tool_choice, "type")
+        name = Map.get(tool_choice, :name) || Map.get(tool_choice, "name")
 
-    if type == "tool" && name do
-      replacement =
-        if is_map_key(tool_choice, :type) do
-          %{type: "function", function: %{name: name}}
+        if type == "tool" && name do
+          replacement =
+            if is_map_key(tool_choice, :type) do
+              %{type: "function", function: %{name: name}}
+            else
+              %{"type" => "function", "function" => %{"name" => name}}
+            end
+
+          Map.put(body, body_key, replacement)
         else
-          %{"type" => "function", "function" => %{"name" => name}}
+          body
         end
 
-      Map.put(body, body_key, replacement)
-    else
-      body
+      atom when not is_nil(atom) and is_atom(atom) ->
+        Map.put(body, body_key, to_string(atom))
+
+      _ ->
+        body
     end
   end
 
@@ -156,28 +166,6 @@ defmodule ReqLLM.Providers.Cerebras do
   end
 
   defp strip_constraints_recursive(value), do: value
-
-  defp normalize_tool_choice(%{"tool_choice" => %{} = tool_choice} = body) do
-    if tool_choice_type(tool_choice) == "function" do
-      Map.put(body, "tool_choice", "auto")
-    else
-      body
-    end
-  end
-
-  defp normalize_tool_choice(%{tool_choice: %{} = tool_choice} = body) do
-    if tool_choice_type(tool_choice) == "function" do
-      Map.put(body, :tool_choice, "auto")
-    else
-      body
-    end
-  end
-
-  defp normalize_tool_choice(body), do: body
-
-  defp tool_choice_type(tool_choice) do
-    Map.get(tool_choice, :type) || Map.get(tool_choice, "type")
-  end
 
   defp normalize_assistant_content(%{"messages" => messages} = body) when is_list(messages) do
     normalized_messages = Enum.map(messages, &normalize_assistant_message/1)

--- a/lib/req_llm/providers/google_vertex/openai_compat.ex
+++ b/lib/req_llm/providers/google_vertex/openai_compat.ex
@@ -16,6 +16,7 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompat do
   """
 
   alias ReqLLM.Provider.Defaults
+  alias ReqLLM.Providers.OpenAI.AdapterHelpers
 
   @doc """
   Formats a ReqLLM context into OpenAI Chat Completions request format.
@@ -34,7 +35,7 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompat do
       end
 
     # Get tools from context if available
-    tools = Map.get(context, :tools, [])
+    tools = opts[:tools] || Map.get(context, :tools, [])
 
     # Build OpenAI-compatible request body using Defaults helper
     temp_request =
@@ -52,7 +53,9 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompat do
         )
       )
 
-    Defaults.default_build_body(temp_request)
+    temp_request
+    |> Defaults.default_build_body()
+    |> AdapterHelpers.translate_tool_choice_format()
   end
 
   @doc """

--- a/lib/req_llm/providers/groq.ex
+++ b/lib/req_llm/providers/groq.ex
@@ -162,20 +162,29 @@ defmodule ReqLLM.Providers.Groq do
         true -> {nil, nil}
       end
 
-    type = tool_choice && (Map.get(tool_choice, :type) || Map.get(tool_choice, "type"))
-    name = tool_choice && (Map.get(tool_choice, :name) || Map.get(tool_choice, "name"))
+    case tool_choice do
+      map when is_map(map) ->
+        type = Map.get(tool_choice, :type) || Map.get(tool_choice, "type")
+        name = Map.get(tool_choice, :name) || Map.get(tool_choice, "name")
 
-    if type == "tool" && name do
-      replacement =
-        if is_map_key(tool_choice, :type) do
-          %{type: "function", function: %{name: name}}
+        if type == "tool" && name do
+          replacement =
+            if is_map_key(tool_choice, :type) do
+              %{type: "function", function: %{name: name}}
+            else
+              %{"type" => "function", "function" => %{"name" => name}}
+            end
+
+          Map.put(body, body_key, replacement)
         else
-          %{"type" => "function", "function" => %{"name" => name}}
+          body
         end
 
-      Map.put(body, body_key, replacement)
-    else
-      body
+      atom when not is_nil(atom) and is_atom(atom) ->
+        Map.put(body, body_key, to_string(atom))
+
+      _ ->
+        body
     end
   end
 

--- a/lib/req_llm/providers/zenmux.ex
+++ b/lib/req_llm/providers/zenmux.ex
@@ -226,20 +226,29 @@ defmodule ReqLLM.Providers.Zenmux do
         true -> {nil, nil}
       end
 
-    type = tool_choice && (Map.get(tool_choice, :type) || Map.get(tool_choice, "type"))
-    name = tool_choice && (Map.get(tool_choice, :name) || Map.get(tool_choice, "name"))
+    case tool_choice do
+      map when is_map(map) ->
+        type = Map.get(tool_choice, :type) || Map.get(tool_choice, "type")
+        name = Map.get(tool_choice, :name) || Map.get(tool_choice, "name")
 
-    if type == "tool" && name do
-      replacement =
-        if is_map_key(tool_choice, :type) do
-          %{type: "function", function: %{name: name}}
+        if type == "tool" && name do
+          replacement =
+            if is_map_key(tool_choice, :type) do
+              %{type: "function", function: %{name: name}}
+            else
+              %{"type" => "function", "function" => %{"name" => name}}
+            end
+
+          Map.put(body, body_key, replacement)
         else
-          %{"type" => "function", "function" => %{"name" => name}}
+          body
         end
 
-      Map.put(body, body_key, replacement)
-    else
-      body
+      atom when not is_nil(atom) and is_atom(atom) ->
+        Map.put(body, body_key, to_string(atom))
+
+      _ ->
+        body
     end
   end
 

--- a/test/providers/cerebras_test.exs
+++ b/test/providers/cerebras_test.exs
@@ -1,0 +1,110 @@
+defmodule ReqLLM.Providers.CerebrasTest do
+  @moduledoc """
+  Provider-level tests for Cerebras implementation.
+  """
+
+  use ReqLLM.ProviderCase, provider: ReqLLM.Providers.Cerebras
+
+  alias ReqLLM.Providers.Cerebras
+
+  describe "body encoding" do
+    test "encode_body preserves atom tool_choice values" do
+      {:ok, model} = ReqLLM.model("cerebras:gpt-oss-120b")
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "specific_tool",
+          description: "A specific tool",
+          parameter_schema: [
+            value: [type: :string, required: true, doc: "A value parameter"]
+          ],
+          callback: fn _ -> {:ok, "result"} end
+        )
+
+      for tool_choice <- [:auto, :none, :required] do
+        mock_request = %Req.Request{
+          options: [
+            context: context,
+            model: model.model,
+            stream: false,
+            tools: [tool],
+            tool_choice: tool_choice
+          ]
+        }
+
+        updated_request = Cerebras.encode_body(mock_request)
+        assert_no_duplicate_json_keys(updated_request.body)
+        decoded = Jason.decode!(updated_request.body)
+
+        assert is_list(decoded["tools"])
+        assert decoded["tool_choice"] == to_string(tool_choice)
+      end
+    end
+
+    test "encode_body preserves function-specific tool_choice" do
+      {:ok, model} = ReqLLM.model("cerebras:gpt-oss-120b")
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "specific_tool",
+          description: "A specific tool",
+          parameter_schema: [
+            value: [type: :string, required: true, doc: "A value parameter"]
+          ],
+          callback: fn _ -> {:ok, "result"} end
+        )
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          tools: [tool],
+          tool_choice: %{type: "function", function: %{name: "specific_tool"}}
+        ]
+      }
+
+      updated_request = Cerebras.encode_body(mock_request)
+      assert_no_duplicate_json_keys(updated_request.body)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["tool_choice"] == %{
+               "type" => "function",
+               "function" => %{"name" => "specific_tool"}
+             }
+    end
+
+    test "encode_body includes parallel_tool_calls when provided" do
+      {:ok, model} = ReqLLM.model("cerebras:gpt-oss-120b")
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "specific_tool",
+          description: "A specific tool",
+          parameter_schema: [
+            value: [type: :string, required: true, doc: "A value parameter"]
+          ],
+          callback: fn _ -> {:ok, "result"} end
+        )
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          tools: [tool],
+          parallel_tool_calls: false
+        ]
+      }
+
+      updated_request = Cerebras.encode_body(mock_request)
+      assert_no_duplicate_json_keys(updated_request.body)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["parallel_tool_calls"] == false
+    end
+  end
+end

--- a/test/providers/google_vertex_openai_compat_test.exs
+++ b/test/providers/google_vertex_openai_compat_test.exs
@@ -285,6 +285,30 @@ defmodule ReqLLM.Providers.GoogleVertex.OpenAICompatTest do
       assert body[:response_format] == %{type: "json_object"}
     end
 
+    test "translates ReqLLM tool_choice to OpenAI function format" do
+      context = context_fixture("What's the weather?")
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Get weather info",
+          parameter_schema: [location: [type: :string, required: true]],
+          callback: fn _ -> {:ok, %{}} end
+        )
+
+      opts = [
+        tools: [tool],
+        tool_choice: %{type: "tool", name: "get_weather"}
+      ]
+
+      body = OpenAICompat.format_request("zai-org/glm-4.7-maas", context, opts)
+
+      assert body[:tool_choice] == %{
+               type: "function",
+               function: %{name: "get_weather"}
+             }
+    end
+
     test "injects structured_output tool for :object operation" do
       context = context_fixture("Extract the name")
 

--- a/test/providers/groq_test.exs
+++ b/test/providers/groq_test.exs
@@ -217,6 +217,40 @@ defmodule ReqLLM.Providers.GroqTest do
              }
     end
 
+    test "encode_body preserves atom tool_choice values" do
+      {:ok, model} = ReqLLM.model("groq:llama-3.1-8b-instant")
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "specific_tool",
+          description: "A specific tool",
+          parameter_schema: [
+            value: [type: :string, required: true, doc: "A value parameter"]
+          ],
+          callback: fn _ -> {:ok, "result"} end
+        )
+
+      for tool_choice <- [:auto, :none, :required] do
+        mock_request = %Req.Request{
+          options: [
+            context: context,
+            model: model.model,
+            stream: false,
+            tools: [tool],
+            tool_choice: tool_choice
+          ]
+        }
+
+        updated_request = Groq.encode_body(mock_request)
+        assert_no_duplicate_json_keys(updated_request.body)
+        decoded = Jason.decode!(updated_request.body)
+
+        assert is_list(decoded["tools"])
+        assert decoded["tool_choice"] == to_string(tool_choice)
+      end
+    end
+
     test "encode_body with response_format" do
       {:ok, model} = ReqLLM.model("groq:llama-3.1-8b-instant")
       context = context_fixture()

--- a/test/providers/zenmux_test.exs
+++ b/test/providers/zenmux_test.exs
@@ -194,6 +194,40 @@ defmodule ReqLLM.Providers.ZenmuxTest do
                "function" => %{"name" => "my_tool"}
              }
     end
+
+    test "encode_body preserves atom tool_choice values" do
+      {:ok, model} = ReqLLM.model("zenmux:xiaomi/mimo-v2-flash")
+      context = context_fixture()
+
+      tool =
+        ReqLLM.Tool.new!(
+          name: "specific_tool",
+          description: "A specific tool",
+          parameter_schema: [
+            value: [type: :string, required: true, doc: "A value parameter"]
+          ],
+          callback: fn _ -> {:ok, "result"} end
+        )
+
+      for tool_choice <- [:auto, :none, :required] do
+        mock_request = %Req.Request{
+          options: [
+            context: context,
+            model: model.model,
+            stream: false,
+            tools: [tool],
+            tool_choice: tool_choice
+          ]
+        }
+
+        updated_request = Zenmux.encode_body(mock_request)
+        assert_no_duplicate_json_keys(updated_request.body)
+        decoded = Jason.decode!(updated_request.body)
+
+        assert is_list(decoded["tools"])
+        assert decoded["tool_choice"] == to_string(tool_choice)
+      end
+    end
   end
 
   describe "object generation" do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -548,6 +548,35 @@ defmodule ReqLLM.Provider.DefaultsTest do
       [chunk] = Defaults.default_decode_stream_event(invalid_json_event, model)
       assert chunk.type == :tool_call
       assert chunk.arguments == %{}
+      assert chunk.metadata.invalid_arguments
+    end
+
+    test "normalizes non-object tool arguments in streaming deltas", %{model: model} do
+      scalar_args_event = %{
+        data: %{
+          "choices" => [
+            %{
+              "delta" => %{
+                "tool_calls" => [
+                  %{
+                    "id" => "call_scalar",
+                    "type" => "function",
+                    "function" => %{"name" => "get_weather", "arguments" => ~s("Paris")}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+
+      [chunk] = Defaults.default_decode_stream_event(scalar_args_event, model)
+      assert chunk.type == :tool_call
+      assert chunk.arguments == %{}
+      assert chunk.metadata.id == "call_scalar"
+      assert chunk.metadata.invalid_arguments
+      assert chunk.metadata.raw_arguments == ~s("Paris")
+      assert chunk.metadata.decoded_arguments == "Paris"
     end
 
     test "decodes streaming tool calls without type field (Mistral format)", %{model: model} do
@@ -841,6 +870,52 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert %ReqLLM.Response{} = returned_resp.body
       assert returned_resp.body.model == "unknown_provider:model-1"
       assert returned_resp.body.finish_reason == :stop
+    end
+
+    test "normalizes non-object tool arguments in non-streaming responses" do
+      req =
+        Req.new()
+        |> Map.update!(:options, fn opts ->
+          Map.merge(opts, %{
+            operation: :chat,
+            model: "groq:llama-3.1-8b-instant",
+            context: %Context{messages: []}
+          })
+        end)
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "id" => "chatcmpl-tool-scalar",
+          "model" => "groq:llama-3.1-8b-instant",
+          "choices" => [
+            %{
+              "message" => %{
+                "role" => "assistant",
+                "tool_calls" => [
+                  %{
+                    "id" => "call_scalar",
+                    "type" => "function",
+                    "function" => %{
+                      "name" => "agent.build_workflow",
+                      "arguments" => ~s("draft")
+                    }
+                  }
+                ]
+              },
+              "finish_reason" => "tool_calls"
+            }
+          ],
+          "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2}
+        }
+      }
+
+      {_returned_req, returned_resp} = Defaults.default_decode_response({req, resp})
+      [tool_call] = returned_resp.body.message.tool_calls
+
+      assert Jason.decode!(tool_call.function.arguments) == %{}
+      assert returned_resp.body.finish_reason == :tool_calls
+      assert returned_resp.body.message.metadata == %{}
     end
   end
 end

--- a/test/req_llm/providers/amazon_bedrock/openai_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/openai_test.exs
@@ -87,6 +87,33 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAITest do
       assert tool["type"] == "function"
       assert tool["function"]["name"] == "get_weather"
     end
+
+    test "translates ReqLLM tool_choice to OpenAI function format" do
+      get_weather =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Get the current weather for a location",
+          parameter_schema: [
+            location: [type: :string, required: true, doc: "City name"]
+          ],
+          callback: fn _args -> {:ok, "sunny"} end
+        )
+
+      context = Context.new([Context.user("What's the weather?")])
+
+      formatted =
+        OpenAI.format_request(
+          "openai.gpt-oss-120b-1:0",
+          context,
+          tools: [get_weather],
+          tool_choice: %{type: "tool", name: "get_weather"}
+        )
+
+      assert formatted[:tool_choice] == %{
+               type: "function",
+               function: %{name: "get_weather"}
+             }
+    end
   end
 
   describe "parse_response/2" do


### PR DESCRIPTION
This PR tightens ReqLLM's tool-calling contract handling across OpenAI-compatible providers and hardens response decoding for malformed tool arguments.

The main changes are:

- Normalize `tool_choice` handling for OpenAI-compatible providers so ReqLLM inputs like `:auto`, `:none`, `:required`, and `%{type: "tool", name: ...}` are encoded consistently for provider APIs.
- Fix providers that were previously too narrow or inconsistent in this area:
  - `Cerebras`
  - `Groq`
  - `Zenmux`
  - `Google Vertex OpenAI-compatible`
  - `Amazon Bedrock OpenAI`
- Preserve OpenAI-style function-specific `tool_choice` objects for Cerebras instead of collapsing them back to `"auto"`.
- Pass through `parallel_tool_calls` for Cerebras.
- Harden default OpenAI-format response decoding so tool calls with invalid or non-object JSON arguments do not crash or produce bad decoded shapes.
- Preserve malformed raw JSON where needed so ReqLLM's existing structured-output JSON repair path still works.

This came out of a broader provider-contract pass rather than only fixing the original crash case. In particular, the PR addresses:
- atom `tool_choice` values flowing into OpenAI-compatible providers
- forced tool-choice encoding for providers expecting OpenAI's function object shape
- inconsistent wrapper behavior in OpenAI-compatible adapters that build request bodies through shared defaults
- response-side handling of malformed/scalar tool arguments

I also added regression coverage for these provider and decoding paths, including live manual verification against real Groq and Cerebras APIs in local IEx.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Breaking Changes

N/A.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Additional validation performed:
- Added/updated provider regression tests for Groq, Cerebras, Zenmux, Google Vertex OpenAI-compatible, Bedrock OpenAI, and default OpenAI-style decoding
- Manually tested tool-calling with:
  - `groq:llama-3.1-8b-instant`
  - `cerebras:gpt-oss-120b`

Observed live behavior:
- Groq correctly handled `tool_choice: :auto`
- Groq correctly handled forced `%{type: "tool", name: ...}`
- Cerebras correctly handled `tool_choice: :auto`
- Cerebras correctly handled forced `%{type: "function", function: %{name: ...}}`
- Both providers returned decoded ReqLLM tool calls with expected arguments and `finish_reason == :tool_calls`

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #597
