### PR TITLE
feat(schema): apply property ordering at wire encoding for non-Google providers

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -670,7 +670,10 @@ defmodule ReqLLM.Provider.Defaults do
   """
   @spec encode_body_from_map(Req.Request.t(), map()) :: Req.Request.t()
   def encode_body_from_map(request, body) do
-    encoded_body = Jason.encode!(body)
+    encoded_body =
+      body
+      |> ReqLLM.Schema.apply_property_ordering()
+      |> Jason.encode!()
 
     request
     |> Req.Request.put_header("content-type", "application/json")

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -451,7 +451,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     request_with_body =
       updated_request
       |> Req.Request.put_header("content-type", "application/json")
-      |> Map.put(:body, Jason.encode!(model_body))
+      |> Map.put(:body, model_body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!())
 
     request_with_body
     |> Step.Error.attach()
@@ -507,7 +507,10 @@ defmodule ReqLLM.Providers.AmazonBedrock do
           )
           |> Req.Request.put_header("content-type", "application/json")
           |> Req.Request.put_private(:req_llm_model, model)
-          |> Map.put(:body, Jason.encode!(model_body))
+          |> Map.put(
+            :body,
+            model_body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+          )
 
         updated_request
         |> Step.Error.attach()
@@ -592,7 +595,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         body
       end
 
-    json_body = Jason.encode!(body)
+    json_body = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
 
     # Ensure json_body is binary
     if !is_binary(json_body) do

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -347,7 +347,7 @@ defmodule ReqLLM.Providers.Anthropic do
     context = ReqLLM.ToolCallIdCompat.apply_context(__MODULE__, operation, model, context, opts)
 
     body = build_request_body(context, model_name, opts)
-    json_body = Jason.encode!(body)
+    json_body = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
 
     %{request | body: json_body}
   end
@@ -537,7 +537,8 @@ defmodule ReqLLM.Providers.Anthropic do
     body = build_request_body(context, get_api_model_id(model), translated_opts ++ [stream: true])
     url = build_request_url(translated_opts)
 
-    finch_request = Finch.build(:post, url, all_headers, Jason.encode!(body))
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    finch_request = Finch.build(:post, url, all_headers, encoded)
     {:ok, finch_request}
   rescue
     error ->

--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -714,7 +714,8 @@ defmodule ReqLLM.Providers.Azure do
       )
       |> maybe_add_model_for_foundry(deployment, base_url)
 
-    finch_request = Finch.build(:post, url, headers, Jason.encode!(body))
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    finch_request = Finch.build(:post, url, headers, encoded)
     {:ok, finch_request}
   rescue
     error ->

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -144,7 +144,8 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
     body = build_request_body(context, model.id, cleaned_opts)
     url = build_request_url(cleaned_opts)
 
-    {:ok, Finch.build(:post, url, headers, Jason.encode!(body))}
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    {:ok, Finch.build(:post, url, headers, encoded)}
   rescue
     error ->
       {:error,

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -81,7 +81,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   @impl true
   def encode_body(request) do
     body = build_body(request)
-    Map.put(request, :body, Jason.encode!(body))
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    Map.put(request, :body, encoded)
   end
 
   def build_body(request) do
@@ -737,7 +738,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     body = build_request_body(context, model.id, cleaned_opts, nil)
     url = build_request_url(cleaned_opts)
 
-    {:ok, Finch.build(:post, url, headers, Jason.encode!(body))}
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    {:ok, Finch.build(:post, url, headers, encoded)}
   rescue
     error ->
       {:error,
@@ -1077,12 +1079,15 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp normalize_parameters(params) when is_map(params) do
     properties = params[:properties] || params["properties"] || %{}
+    ordering = params[:propertyOrdering] || params["propertyOrdering"]
 
-    %{
+    result = %{
       "type" => "object",
       "properties" => stringify_keys(properties),
       "additionalProperties" => false
     }
+
+    if ordering, do: Map.put(result, "propertyOrdering", ordering), else: result
   end
 
   defp stringify_keys(map) when is_map(map) do

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -205,7 +205,8 @@ defmodule ReqLLM.Providers.OpenAICodex do
     context = request.options[:context] || %ReqLLM.Context{messages: []}
     model_name = request.options[:model] || request.options[:id]
     body = build_codex_body(context, model_name, request.options, request)
-    Map.put(request, :body, Jason.encode!(body))
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    Map.put(request, :body, encoded)
   end
 
   @impl ReqLLM.Provider
@@ -265,7 +266,8 @@ defmodule ReqLLM.Providers.OpenAICodex do
       {"openai-beta", "responses=experimental"}
     ]
 
-    {:ok, Finch.build(:post, url, headers, Jason.encode!(body))}
+    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+    {:ok, Finch.build(:post, url, headers, encoded)}
   rescue
     error ->
       {:error,

--- a/lib/req_llm/providers/zai.ex
+++ b/lib/req_llm/providers/zai.ex
@@ -147,7 +147,7 @@ defmodule ReqLLM.Providers.Zai do
       end
 
     try do
-      encoded_body = Jason.encode!(body)
+      encoded_body = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
 
       request
       |> Req.Request.put_header("content-type", "application/json")

--- a/lib/req_llm/providers/zai_coder.ex
+++ b/lib/req_llm/providers/zai_coder.ex
@@ -148,7 +148,7 @@ defmodule ReqLLM.Providers.ZaiCoder do
       end
 
     try do
-      encoded_body = Jason.encode!(body)
+      encoded_body = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
 
       request
       |> Req.Request.put_header("content-type", "application/json")

--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -976,6 +976,51 @@ defmodule ReqLLM.Schema do
   defp maybe_put_nonempty(map, _key, []), do: map
   defp maybe_put_nonempty(map, key, value), do: Map.put(map, key, value)
 
+  @doc """
+  Converts `"properties"` maps to `Jason.OrderedObject` using `"propertyOrdering"`,
+  then strips the `"propertyOrdering"` annotation.
+
+  This is intended to be called right before `Jason.encode!` so that the JSON
+  wire format has property keys in the declared order. Providers like OpenAI use
+  JSON key order (not a separate annotation) to determine structured output field
+  ordering.
+
+  Google providers should **not** call this — they read `propertyOrdering` natively.
+  """
+  @spec apply_property_ordering(term()) :: term()
+  def apply_property_ordering(data) when is_map(data) and not is_struct(data) do
+    # First, recurse into all values
+    processed = Map.new(data, fn {k, v} -> {k, apply_property_ordering(v)} end)
+
+    case {Map.get(processed, "properties"), Map.get(processed, "propertyOrdering")} do
+      {props, ordering} when is_map(props) and is_list(ordering) and ordering != [] ->
+        ordered_keys = ordering
+        remaining_keys = Map.keys(props) -- ordered_keys
+
+        ordered_values =
+          Enum.flat_map(ordered_keys, fn key ->
+            case Map.fetch(props, key) do
+              {:ok, val} -> [{key, val}]
+              :error -> []
+            end
+          end) ++
+            Enum.map(remaining_keys, fn key -> {key, Map.fetch!(props, key)} end)
+
+        processed
+        |> Map.put("properties", Jason.OrderedObject.new(ordered_values))
+        |> Map.delete("propertyOrdering")
+
+      _ ->
+        processed
+    end
+  end
+
+  def apply_property_ordering(data) when is_list(data) do
+    Enum.map(data, &apply_property_ordering/1)
+  end
+
+  def apply_property_ordering(data), do: data
+
   @spec deep_delete_keys(term(), [String.t() | atom()]) :: term()
   defp deep_delete_keys(map, keys) when is_map(map) do
     map

--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -989,26 +989,32 @@ defmodule ReqLLM.Schema do
   """
   @spec apply_property_ordering(term()) :: term()
   def apply_property_ordering(data) when is_map(data) and not is_struct(data) do
-    # First, recurse into all values
     processed = Map.new(data, fn {k, v} -> {k, apply_property_ordering(v)} end)
 
-    case {Map.get(processed, "properties"), Map.get(processed, "propertyOrdering")} do
-      {props, ordering} when is_map(props) and is_list(ordering) and ordering != [] ->
+    case {
+      fetch_string_or_atom_key(processed, "properties", :properties),
+      fetch_string_or_atom_key(processed, "propertyOrdering", :propertyOrdering)
+    } do
+      {{:ok, properties_key, props}, {:ok, ordering_key, ordering}}
+      when is_map(props) and is_list(ordering) and ordering != [] ->
         ordered_keys = ordering
-        remaining_keys = Map.keys(props) -- ordered_keys
 
         ordered_values =
           Enum.flat_map(ordered_keys, fn key ->
-            case Map.fetch(props, key) do
+            key_string = to_string(key)
+
+            case fetch_property_value(props, key_string) do
               {:ok, val} -> [{key, val}]
               :error -> []
             end
-          end) ++
-            Enum.map(remaining_keys, fn key -> {key, Map.fetch!(props, key)} end)
+          end) ++ remaining_ordered_values(props, ordered_keys)
 
         processed
-        |> Map.put("properties", Jason.OrderedObject.new(ordered_values))
-        |> Map.delete("propertyOrdering")
+        |> Map.put(
+          properties_key,
+          Jason.OrderedObject.new(stringify_ordered_keys(ordered_values))
+        )
+        |> Map.delete(ordering_key)
 
       _ ->
         processed
@@ -1020,6 +1026,40 @@ defmodule ReqLLM.Schema do
   end
 
   def apply_property_ordering(data), do: data
+
+  defp fetch_string_or_atom_key(map, string_key, atom_key) do
+    cond do
+      Map.has_key?(map, string_key) -> {:ok, string_key, Map.fetch!(map, string_key)}
+      Map.has_key?(map, atom_key) -> {:ok, atom_key, Map.fetch!(map, atom_key)}
+      true -> :error
+    end
+  end
+
+  defp fetch_property_value(properties, key_string) do
+    Enum.find_value(properties, :error, fn {key, value} ->
+      if to_string(key) == key_string, do: {:ok, value}
+    end)
+  end
+
+  defp remaining_ordered_values(properties, ordered_keys) do
+    ordered_key_set = MapSet.new(Enum.map(ordered_keys, &to_string/1))
+
+    properties
+    |> Enum.reduce([], fn {key, value}, acc ->
+      key_string = to_string(key)
+
+      if MapSet.member?(ordered_key_set, key_string) do
+        acc
+      else
+        [{key, value} | acc]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp stringify_ordered_keys(ordered_values) do
+    Enum.map(ordered_values, fn {key, value} -> {to_string(key), value} end)
+  end
 
   @spec deep_delete_keys(term(), [String.t() | atom()]) :: term()
   defp deep_delete_keys(map, keys) when is_map(map) do

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -368,7 +368,12 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert body["text"]["format"]["schema"]["properties"]["age"]["type"] == "integer"
       assert body["text"]["format"]["schema"]["properties"]["age"]["minimum"] == 1
       assert body["text"]["format"]["schema"]["required"] == ["name"]
-      assert body["text"]["format"]["schema"]["propertyOrdering"] == ["name", "age"]
+
+      # propertyOrdering is consumed during encoding — verify wire order instead
+      refute Map.has_key?(body["text"]["format"]["schema"], "propertyOrdering")
+
+      # Verify the actual JSON wire order of properties
+      assert encoded.body =~ ~r/"properties"\s*:\s*\{\s*"name".*"age"/s
     end
 
     test "encodes response_format with direct JSON schema (pass-through)" do

--- a/test/req_llm/property_ordering_wire_test.exs
+++ b/test/req_llm/property_ordering_wire_test.exs
@@ -1,0 +1,223 @@
+defmodule ReqLLM.PropertyOrderingWireTest do
+  @moduledoc """
+  Verifies that propertyOrdering annotations are consumed during encoding,
+  producing ordered JSON on the wire and stripping the annotation key.
+
+  Tests the actual encoded JSON string (not intermediate maps) to confirm
+  that structured output schema properties appear in declared order for
+  providers that rely on JSON key order (OpenAI, Anthropic) and that
+  Google retains the annotation as-is.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.Anthropic
+  alias ReqLLM.Providers.OpenAI.ChatAPI
+  alias ReqLLM.Providers.OpenAI.ResponsesAPI
+
+  @multi_prop_schema [
+    reasoning: [type: :string, required: true, doc: "Reasoning"],
+    answer: [type: :string, required: true, doc: "Answer"],
+    confidence: [type: :integer, doc: "Confidence score"]
+  ]
+
+  @expected_order ["reasoning", "answer", "confidence"]
+
+  # -- OpenAI Responses API ---------------------------------------------------
+
+  describe "OpenAI Responses API structured output wire order" do
+    test "schema properties are ordered on the wire" do
+      response_format = %{
+        type: "json_schema",
+        json_schema: %{
+          name: "analysis",
+          strict: true,
+          schema: @multi_prop_schema
+        }
+      }
+
+      request = build_responses_request(provider_options: [response_format: response_format])
+      encoded = ResponsesAPI.encode_body(request)
+
+      assert_no_property_ordering(encoded.body)
+
+      assert ordered_prop_keys(encoded.body, ["text", "format", "schema", "properties"]) ==
+               @expected_order
+    end
+  end
+
+  # -- OpenAI Chat API --------------------------------------------------------
+
+  describe "OpenAI Chat API structured output wire order" do
+    test "response_format json_schema properties are ordered on the wire" do
+      context = %ReqLLM.Context{
+        messages: [%ReqLLM.Message{role: :user, content: "test"}]
+      }
+
+      response_format = %{
+        type: "json_schema",
+        json_schema: %{
+          name: "analysis",
+          strict: true,
+          schema: @multi_prop_schema
+        }
+      }
+
+      request = %Req.Request{
+        method: :post,
+        url: URI.parse("https://api.openai.com/v1/chat/completions"),
+        headers: %{},
+        body: nil,
+        options: %{
+          context: context,
+          model: "gpt-4o",
+          operation: :chat,
+          stream: false,
+          provider_options: [response_format: response_format]
+        }
+      }
+
+      encoded = ChatAPI.encode_body(request)
+
+      assert_no_property_ordering(encoded.body)
+
+      assert ordered_prop_keys(
+               encoded.body,
+               ["response_format", "json_schema", "schema", "properties"]
+             ) == @expected_order
+    end
+  end
+
+  # -- Anthropic --------------------------------------------------------------
+
+  describe "Anthropic structured output wire order" do
+    test "output_format json_schema properties are ordered on the wire" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      json_schema = ReqLLM.Schema.to_json(@multi_prop_schema)
+
+      context = %ReqLLM.Context{
+        messages: [%ReqLLM.Message{role: :user, content: "test"}]
+      }
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          provider_options: [
+            output_format: %{
+              type: "json_schema",
+              schema: json_schema
+            }
+          ]
+        ]
+      }
+
+      updated = Anthropic.encode_body(mock_request)
+
+      assert_no_property_ordering(updated.body)
+
+      assert ordered_prop_keys(updated.body, ["output_format", "schema", "properties"]) ==
+               @expected_order
+    end
+  end
+
+  # -- Default encode_body_from_map path (covers many providers) --------------
+
+  describe "encode_body_from_map structured output wire order" do
+    test "properties are ordered in response_format schema" do
+      body = %{
+        model: "test-model",
+        response_format: %{
+          "type" => "json_schema",
+          "json_schema" => %{
+            "name" => "analysis",
+            "schema" => ReqLLM.Schema.to_json(@multi_prop_schema)
+          }
+        }
+      }
+
+      request = %Req.Request{
+        method: :post,
+        url: URI.parse("https://example.com"),
+        headers: %{},
+        body: nil,
+        options: %{}
+      }
+
+      encoded = ReqLLM.Provider.Defaults.encode_body_from_map(request, body)
+
+      assert_no_property_ordering(encoded.body)
+
+      assert ordered_prop_keys(
+               encoded.body,
+               ["response_format", "json_schema", "schema", "properties"]
+             ) == @expected_order
+    end
+  end
+
+  # -- Google (should retain propertyOrdering) --------------------------------
+
+  describe "Google retains propertyOrdering" do
+    test "propertyOrdering annotation is preserved in schema" do
+      schema = ReqLLM.Schema.to_json(@multi_prop_schema)
+
+      assert schema["propertyOrdering"] == @expected_order
+
+      json = Jason.encode!(schema)
+      decoded = Jason.decode!(json)
+
+      assert decoded["propertyOrdering"] == @expected_order
+    end
+  end
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp ordered_prop_keys(json, path) do
+    ordered = Jason.decode!(json, objects: :ordered_objects)
+
+    node =
+      Enum.reduce(path, ordered, fn
+        key, acc when is_binary(key) -> find_ordered_value(acc, key)
+        idx, acc when is_integer(idx) -> Enum.at(acc, idx)
+      end)
+
+    case node do
+      %Jason.OrderedObject{values: values} -> Enum.map(values, fn {k, _} -> k end)
+      _ -> flunk("Expected ordered properties at path #{inspect(path)}, got: #{inspect(node)}")
+    end
+  end
+
+  defp find_ordered_value(%Jason.OrderedObject{values: values}, key) do
+    Enum.find_value(values, fn {k, v} -> if k == key, do: v end)
+  end
+
+  defp find_ordered_value(%{} = map, key), do: Map.get(map, key)
+  defp find_ordered_value(_, _), do: nil
+
+  defp assert_no_property_ordering(json) do
+    refute json =~ "propertyOrdering",
+           "propertyOrdering should be stripped from wire JSON"
+  end
+
+  defp build_responses_request(opts) do
+    context = Keyword.get(opts, :context, %ReqLLM.Context{messages: []})
+    provider_opts = Keyword.get(opts, :provider_options, [])
+
+    req_opts = %{
+      id: Keyword.get(opts, :id, "gpt-5"),
+      context: context,
+      stream: Keyword.get(opts, :stream),
+      tools: Keyword.get(opts, :tools),
+      provider_options: provider_opts
+    }
+
+    %Req.Request{
+      method: :post,
+      url: URI.parse("https://api.openai.com/v1/responses"),
+      headers: %{},
+      body: {:json, %{}},
+      options: req_opts
+    }
+  end
+end

--- a/test/req_llm/property_ordering_wire_test.exs
+++ b/test/req_llm/property_ordering_wire_test.exs
@@ -154,6 +154,44 @@ defmodule ReqLLM.PropertyOrderingWireTest do
                ["response_format", "json_schema", "schema", "properties"]
              ) == @expected_order
     end
+
+    test "properties are ordered for raw atom-key schemas" do
+      body = %{
+        model: "test-model",
+        response_format: %{
+          type: "json_schema",
+          json_schema: %{
+            name: "analysis",
+            schema: %{
+              type: "object",
+              properties: %{
+                reasoning: %{"type" => "string"},
+                answer: %{"type" => "string"},
+                confidence: %{"type" => "integer"}
+              },
+              propertyOrdering: @expected_order
+            }
+          }
+        }
+      }
+
+      request = %Req.Request{
+        method: :post,
+        url: URI.parse("https://example.com"),
+        headers: %{},
+        body: nil,
+        options: %{}
+      }
+
+      encoded = ReqLLM.Provider.Defaults.encode_body_from_map(request, body)
+
+      assert_no_property_ordering(encoded.body)
+
+      assert ordered_prop_keys(
+               encoded.body,
+               ["response_format", "json_schema", "schema", "properties"]
+             ) == @expected_order
+    end
   end
 
   # -- Google (should retain propertyOrdering) --------------------------------

--- a/test/req_llm/schema_test.exs
+++ b/test/req_llm/schema_test.exs
@@ -1175,4 +1175,150 @@ defmodule ReqLLM.SchemaTest do
       assert result["toolSpec"]["name"] == "default_tool"
     end
   end
+
+  describe "apply_property_ordering/1" do
+    test "converts properties to ordered JSON and strips annotation" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "name" => %{"type" => "string"},
+          "age" => %{"type" => "integer"},
+          "email" => %{"type" => "string"}
+        },
+        "propertyOrdering" => ["name", "age", "email"],
+        "required" => ["name"]
+      }
+
+      result = Schema.apply_property_ordering(schema)
+
+      assert %Jason.OrderedObject{} = result["properties"]
+
+      assert result["properties"].values == [
+               {"name", %{"type" => "string"}},
+               {"age", %{"type" => "integer"}},
+               {"email", %{"type" => "string"}}
+             ]
+
+      refute Map.has_key?(result, "propertyOrdering")
+      assert result["required"] == ["name"]
+    end
+
+    test "handles nested objects recursively" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "user" => %{
+            "type" => "object",
+            "properties" => %{
+              "first" => %{"type" => "string"},
+              "last" => %{"type" => "string"}
+            },
+            "propertyOrdering" => ["first", "last"]
+          },
+          "score" => %{"type" => "integer"}
+        },
+        "propertyOrdering" => ["user", "score"]
+      }
+
+      result = Schema.apply_property_ordering(schema)
+
+      # Top level is ordered
+      assert %Jason.OrderedObject{} = result["properties"]
+      {_, user_schema} = Enum.find(result["properties"].values, fn {k, _} -> k == "user" end)
+
+      # Nested level is also ordered
+      assert %Jason.OrderedObject{} = user_schema["properties"]
+
+      assert user_schema["properties"].values == [
+               {"first", %{"type" => "string"}},
+               {"last", %{"type" => "string"}}
+             ]
+
+      refute Map.has_key?(user_schema, "propertyOrdering")
+    end
+
+    test "passes through maps without propertyOrdering unchanged" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "name" => %{"type" => "string"}
+        }
+      }
+
+      result = Schema.apply_property_ordering(schema)
+      assert result == schema
+    end
+
+    test "appends properties not in ordering at the end" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "a" => %{"type" => "string"},
+          "b" => %{"type" => "string"},
+          "c" => %{"type" => "string"}
+        },
+        "propertyOrdering" => ["c", "a"]
+      }
+
+      result = Schema.apply_property_ordering(schema)
+      keys = Enum.map(result["properties"].values, fn {k, _} -> k end)
+      assert Enum.take(keys, 2) == ["c", "a"]
+      assert "b" in keys
+    end
+
+    test "produces ordered JSON when encoded" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "zebra" => %{"type" => "string"},
+          "apple" => %{"type" => "integer"},
+          "mango" => %{"type" => "boolean"}
+        },
+        "propertyOrdering" => ["apple", "mango", "zebra"]
+      }
+
+      json = schema |> Schema.apply_property_ordering() |> Jason.encode!()
+      decoded = Jason.decode!(json, objects: :ordered_objects)
+
+      props =
+        Enum.find_value(decoded.values, fn
+          {"properties", v} -> v
+          _ -> nil
+        end)
+
+      assert Enum.map(props.values, fn {k, _} -> k end) == ["apple", "mango", "zebra"]
+    end
+
+    test "handles lists containing schemas" do
+      tools = [
+        %{
+          "type" => "function",
+          "function" => %{
+            "name" => "search",
+            "parameters" => %{
+              "type" => "object",
+              "properties" => %{
+                "query" => %{"type" => "string"},
+                "limit" => %{"type" => "integer"}
+              },
+              "propertyOrdering" => ["query", "limit"]
+            }
+          }
+        }
+      ]
+
+      [result] = Schema.apply_property_ordering(tools)
+      params = result["function"]["parameters"]
+
+      assert %Jason.OrderedObject{} = params["properties"]
+      assert Enum.map(params["properties"].values, fn {k, _} -> k end) == ["query", "limit"]
+      refute Map.has_key?(params, "propertyOrdering")
+    end
+
+    test "passes through non-map/non-list values" do
+      assert Schema.apply_property_ordering("hello") == "hello"
+      assert Schema.apply_property_ordering(42) == 42
+      assert Schema.apply_property_ordering(nil) == nil
+    end
+  end
 end

--- a/test/req_llm/schema_test.exs
+++ b/test/req_llm/schema_test.exs
@@ -1237,6 +1237,35 @@ defmodule ReqLLM.SchemaTest do
       refute Map.has_key?(user_schema, "propertyOrdering")
     end
 
+    test "handles raw JSON Schema maps with atom keys" do
+      schema = %{
+        type: "object",
+        properties: %{
+          name: %{"type" => "string"},
+          age: %{"type" => "integer"},
+          email: %{"type" => "string"}
+        },
+        propertyOrdering: ["name", "age", "email"],
+        required: ["name"]
+      }
+
+      result = Schema.apply_property_ordering(schema)
+      json = Jason.encode!(result)
+      decoded = Jason.decode!(json, objects: :ordered_objects)
+
+      assert %Jason.OrderedObject{} = result[:properties]
+      refute Map.has_key?(result, :propertyOrdering)
+      refute json =~ "propertyOrdering"
+
+      props =
+        Enum.find_value(decoded.values, fn
+          {"properties", value} -> value
+          _ -> nil
+        end)
+
+      assert Enum.map(props.values, fn {key, _value} -> key end) == ["name", "age", "email"]
+    end
+
     test "passes through maps without propertyOrdering unchanged" do
       schema = %{
         "type" => "object",


### PR DESCRIPTION
## Description

PR #599 added `propertyOrdering` annotations to generated JSON schemas, which gave us a solid foundation — Google/Gemini reads the annotation natively, and the ordering metadata flows through the pipeline correctly. However, for OpenAI and most other providers, what actually matters is the **byte order of keys in the `"properties"` JSON object on the wire**. They don't read `propertyOrdering` as an annotation.

Since Elixir maps are unordered and `Jason.encode!` produces arbitrary key order, the annotation alone was decorative for non-Google providers. This PR builds on #599 by consuming `propertyOrdering` at the encoding boundary — "late escaping" the ordering into the actual JSON structure right before it hits the wire.

**How it works:**

1. `propertyOrdering` flows through the pipeline as metadata (from #599)
2. Right before `Jason.encode!`, `Schema.apply_property_ordering/1` walks the body
3. Any map with both `"properties"` and `"propertyOrdering"` gets its properties converted to a `Jason.OrderedObject` with keys in the declared order
4. The `propertyOrdering` annotation is stripped (it's been structurally encoded)
5. Google/Vertex providers skip this — they read the annotation natively

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. Schemas that previously included `propertyOrdering` in the wire JSON for non-Google providers will no longer include it (the ordering is now expressed structurally instead). Google providers are unchanged.

## Testing

- [x] Tests pass (`mix test`) — 2812 tests, 0 failures
- [x] Quality checks pass (`mix quality`)

**New tests:**
- Unit tests for `apply_property_ordering/1` in schema_test.exs (flat, nested, recursive, pass-through, wire encoding, list traversal)
- Wire-order integration tests (`property_ordering_wire_test.exs`) verifying structured output actual JSON key order for:
  - OpenAI Responses API
  - OpenAI Chat API
  - Anthropic
  - Default `encode_body_from_map` path (covers xai, groq, openrouter, etc.)
  - Google annotation retention

**Bug fix:** `normalize_parameters` in `responses_api.ex` was rebuilding the schema map from scratch, dropping `propertyOrdering` before it could reach the encoding step.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Builds on #599