### PR TITLE
fix: preserve capabilities when model/1 receives a populated LLMDB.Model struct

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -288,11 +288,15 @@ defmodule ReqLLM do
   """
   @spec model(model_input()) :: {:ok, LLMDB.Model.t()} | {:error, term()}
   def model(%LLMDB.Model{} = model) do
-    model
-    |> Map.from_struct()
-    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-    |> Map.new()
-    |> LLMDB.Enrich.enrich_model()
+    non_nil =
+      model
+      |> Map.from_struct()
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    enriched = LLMDB.Enrich.enrich_model(non_nil)
+
+    Map.merge(enriched, non_nil)
     |> LLMDB.Model.new()
     |> normalize_model_result()
   end

--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -176,6 +176,28 @@ defmodule ReqLLMTest do
               }} = ReqLLM.model(model)
     end
 
+    test "preserves caller-provided fields from LLMDB.Model structs" do
+      model =
+        LLMDB.Model.new!(%{
+          id: "test-model-not-in-catalog",
+          provider: :openai,
+          base_url: "http://my-custom-endpoint.example.com",
+          capabilities: %{
+            chat: true,
+            json: %{schema: true},
+            tools: %{enabled: true, strict: true},
+            reasoning: %{enabled: true}
+          }
+        })
+
+      {:ok, result} = ReqLLM.model(model)
+
+      assert result.base_url == "http://my-custom-endpoint.example.com"
+      assert result.capabilities.json.schema == true
+      assert result.capabilities.tools.enabled == true
+      assert result.capabilities.reasoning.enabled == true
+    end
+
     test "returns error for map missing required fields" do
       assert {:error, error} = ReqLLM.model(%{id: "no-provider"})
       assert Exception.message(error) =~ "Inline model specs require :provider"


### PR DESCRIPTION
## Description

When `ReqLLM.model/1` receives a fully-populated `%LLMDB.Model{}` struct (e.g. constructed via `LLMDB.Model.new!/1` with explicit capabilities), it was tearing the struct apart, stripping nil fields, running it through `LLMDB.Enrich.enrich_model/1`, and rebuilding via `LLMDB.Model.new()`. This caused caller-provided fields like `capabilities` to be overwritten by Zoi schema defaults (e.g. `json.schema: false`, `tools.enabled: false`).

This matters because the recommended advanced usage path — constructing an explicit `LLMDB.Model` struct for models not yet in the catalog or with incorrect catalog data — was silently losing the capabilities the caller set. This caused `determine_output_mode/2` to fall back to `:tool_strict` instead of using native `:json_schema` structured output, even when the caller explicitly declared `json: %{schema: true}`.

**Root cause:** `LLMDB.Enrich.enrich_model/1` only derives `family` and `provider_model_id` — it doesn't do catalog lookups. After enrichment, the original non-nil values were being discarded. The fix merges enriched fields (family, provider_model_id) back *under* the caller's original values, so explicit capabilities are never overwritten.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. The existing behavior for bare structs (e.g. `LLMDB.Model.new!(%{id: "foo", provider: :openai})` with no capabilities) is unchanged — enrichment still fills in `family` and `provider_model_id`.

## Testing

- [x] Tests pass (`mix test`) — 2814 tests, 0 failures
- [x] Quality checks pass (`mix quality`)
- [x] New test: verifies capabilities survive the `model/1` round-trip for a fully-populated struct
- [x] Existing enrichment test still passes (bare struct gets family/provider_model_id derived)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Discovered while investigating why `determine_output_mode/2` was returning `:tool_strict` for models with `json.schema: true` capabilities — the capabilities were being silently dropped during `model/1` normalization.