### PR TITLE
fix(azure): route responses models correctly

### DIFF
--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -658,28 +658,27 @@ defmodule ReqLLM.Providers.Azure do
 
     model_id = effective_model_id(model)
     model_family = get_model_family(model_id)
+    resolved_base_url = resolve_base_url(model_family, opts)
 
-    {provider_options, standard_opts} = Keyword.pop(opts, :provider_options, [])
-    flattened_opts = Keyword.merge(standard_opts, provider_options)
+    opts_with_context =
+      opts
+      |> Keyword.put(:context, context)
+      |> Keyword.put(:base_url, resolved_base_url)
 
-    # Resolve base_url early (attach_stream doesn't use Options.process)
-    resolved_base_url = resolve_base_url(model_family, flattened_opts)
-    flattened_opts = Keyword.put(flattened_opts, :base_url, resolved_base_url)
-
-    {pre_validated_opts, _warnings} = pre_validate_options(:chat, model, flattened_opts)
-    {translated_opts, _warnings} = translate_options(:chat, model, pre_validated_opts)
+    {:ok, processed_opts} =
+      ReqLLM.Provider.Options.process(__MODULE__, :chat, model, opts_with_context)
 
     operation = opts[:operation] || :chat
 
-    translated_opts =
-      translated_opts
+    processed_opts =
+      processed_opts
       |> maybe_clean_thinking_after_translation(model_family, operation)
       |> maybe_warn_service_tier(model_family, model_id)
 
-    {api_key, _extra_option_keys} = resolve_api_key(model_family, model, translated_opts)
+    {api_key, _extra_option_keys} = resolve_api_key(model_family, model, processed_opts)
 
     {api_version, deployment, base_url} =
-      extract_azure_credentials(model, translated_opts)
+      extract_azure_credentials(model, processed_opts)
 
     formatter = get_formatter(model_id, model)
 
@@ -696,8 +695,11 @@ defmodule ReqLLM.Providers.Azure do
       {"accept", "text/event-stream"}
     ]
 
-    extra_headers = get_anthropic_headers(model_id, translated_opts)
-    custom_headers = ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options])
+    extra_headers = get_anthropic_headers(model_id, processed_opts)
+
+    custom_headers =
+      ReqLLM.Provider.Utils.extract_custom_headers(processed_opts[:req_http_options])
+
     headers = base_headers ++ extra_headers ++ custom_headers
 
     body =
@@ -708,9 +710,9 @@ defmodule ReqLLM.Providers.Azure do
           operation,
           model,
           context,
-          translated_opts
+          processed_opts
         ),
-        Keyword.put(translated_opts, :stream, true)
+        Keyword.put(processed_opts, :stream, true)
       )
       |> maybe_add_model_for_foundry(deployment, base_url)
 
@@ -1054,10 +1056,18 @@ defmodule ReqLLM.Providers.Azure do
   # Returns the model ID to use for API calls, preferring provider_model_id if set.
   defp effective_model_id(model), do: model.provider_model_id || model.id
 
-  # Checks if a model uses the Responses API (based on model.extra.wire.protocol metadata).
-  # The model metadata should have `extra: %{wire: %{protocol: "openai_responses"}}` for Responses API models.
+  # Checks if a model uses the Responses API.
+  # Supports both nested `extra.wire.protocol` and flat `extra.wire_protocol`
+  # metadata shapes used by llm_db.
   defp uses_responses_api?(%LLMDB.Model{} = model) do
-    get_in(model, [Access.key(:extra, %{}), :wire, :protocol]) == "openai_responses"
+    wire_protocol(model) in ["openai_responses", "openai_codex_responses"]
+  end
+
+  defp wire_protocol(%LLMDB.Model{} = model) do
+    get_in(model, [Access.key(:extra, %{}), :wire, :protocol]) ||
+      get_in(model, [Access.key(:extra, %{}), "wire", "protocol"]) ||
+      get_in(model, [Access.key(:extra, %{}), :wire_protocol]) ||
+      get_in(model, [Access.key(:extra, %{}), "wire_protocol"])
   end
 
   # Determines the model family (claude, gpt-4o, o1, etc.) from a model ID.

--- a/lib/req_llm/providers/azure/responses_api.ex
+++ b/lib/req_llm/providers/azure/responses_api.ex
@@ -89,6 +89,41 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
   end
 
   @doc """
+  Extracts usage from Azure Responses API payloads.
+  """
+  def extract_usage(body, _model) do
+    parsed_body = ReqLLM.Provider.Utils.ensure_parsed_body(body)
+
+    case parsed_body do
+      %{"usage" => usage} ->
+        input_tokens = usage["input_tokens"] || 0
+        output_tokens = usage["output_tokens"] || 0
+        total_tokens = usage["total_tokens"] || input_tokens + output_tokens
+
+        reasoning_tokens =
+          usage["reasoning_tokens"] ||
+            get_in(usage, ["output_tokens_details", "reasoning_tokens"]) ||
+            get_in(usage, ["completion_tokens_details", "reasoning_tokens"]) || 0
+
+        cached_tokens =
+          get_in(usage, ["input_tokens_details", "cached_tokens"]) ||
+            get_in(usage, ["prompt_tokens_details", "cached_tokens"]) || 0
+
+        {:ok,
+         %{
+           input_tokens: input_tokens,
+           output_tokens: output_tokens,
+           total_tokens: total_tokens,
+           cached_tokens: cached_tokens,
+           reasoning_tokens: reasoning_tokens
+         }}
+
+      _ ->
+        {:error, :no_usage_found}
+    end
+  end
+
+  @doc """
   Azure Responses API models do not support embeddings.
   """
   def format_embedding_request(_model_id, _text, _opts) do

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -32,7 +32,7 @@ defmodule ReqLLM.Providers.AzureTest do
 
   describe "prepare_request/4" do
     test "constructs URL with deployment from options" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -49,7 +49,7 @@ defmodule ReqLLM.Providers.AzureTest do
     end
 
     test "uses model.id as default deployment when not specified" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -199,8 +199,10 @@ defmodule ReqLLM.Providers.AzureTest do
   end
 
   describe "attach_stream/4" do
+    import ExUnit.CaptureLog
+
     test "builds Finch request with correct URL and headers" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
       {:ok, finch_request} =
@@ -232,6 +234,31 @@ defmodule ReqLLM.Providers.AzureTest do
       header_map = Map.new(finch_request.headers)
       assert header_map["api-key"] == "test-api-key"
       assert header_map["content-type"] == "application/json"
+    end
+
+    test "logs unsupported parameter warnings for reasoning models" do
+      {:ok, model} = ReqLLM.model("azure:gpt-5.4")
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      log =
+        capture_log(fn ->
+          {:ok, _finch_request} =
+            Azure.attach_stream(
+              model,
+              context,
+              [
+                api_key: "test-api-key",
+                deployment: "my-deployment",
+                base_url: "https://my-resource.openai.azure.com/openai",
+                temperature: 0.2,
+                max_tokens: 50
+              ],
+              :req_llm_finch
+            )
+        end)
+
+      assert log =~ "Renamed :max_tokens to :max_completion_tokens for reasoning models"
+      assert log =~ "This model does not support sampling parameters"
     end
 
     test "uses Authorization Bearer header when api_key starts with 'Bearer '" do
@@ -623,7 +650,7 @@ defmodule ReqLLM.Providers.AzureTest do
 
   describe "extract_usage/2" do
     test "extracts usage for OpenAI models" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       body = %{
         "usage" => %{
@@ -640,15 +667,36 @@ defmodule ReqLLM.Providers.AzureTest do
       assert usage.total_tokens == 30
     end
 
+    test "extracts usage for Responses API models" do
+      {:ok, model} = ReqLLM.model("azure:gpt-5.4")
+
+      body = %{
+        "usage" => %{
+          "input_tokens" => 10,
+          "output_tokens" => 20,
+          "total_tokens" => 30,
+          "input_tokens_details" => %{"cached_tokens" => 4}
+        }
+      }
+
+      {:ok, usage} = Azure.extract_usage(body, model)
+
+      assert usage.input_tokens == 10
+      assert usage.output_tokens == 20
+      assert usage.total_tokens == 30
+      assert usage.cached_tokens == 4
+      assert usage.reasoning_tokens == 0
+    end
+
     test "extracts reasoning tokens for o1 models" do
       {:ok, model} = ReqLLM.model("azure:o1-mini")
 
       body = %{
         "usage" => %{
-          "prompt_tokens" => 100,
-          "completion_tokens" => 200,
+          "input_tokens" => 100,
+          "output_tokens" => 200,
           "total_tokens" => 300,
-          "completion_tokens_details" => %{
+          "output_tokens_details" => %{
             "reasoning_tokens" => 150
           }
         }
@@ -1125,7 +1173,7 @@ defmodule ReqLLM.Providers.AzureTest do
     end
 
     test "uses traditional URL path for .openai.azure.com domain" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -1161,7 +1209,7 @@ defmodule ReqLLM.Providers.AzureTest do
     end
 
     test "does not add model to request body for traditional format" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -1252,7 +1300,7 @@ defmodule ReqLLM.Providers.AzureTest do
     end
 
     test "streaming uses traditional URL path for .openai.azure.com domain" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
       {:ok, finch_request} =
@@ -1594,5 +1642,14 @@ defmodule ReqLLM.Providers.AzureTest do
 
       assert response.message.reasoning_details == nil
     end
+  end
+
+  defp traditional_openai_model do
+    %LLMDB.Model{
+      id: "gpt-4o",
+      provider: :azure,
+      capabilities: %{chat: true},
+      extra: %{}
+    }
   end
 end

--- a/test/provider/azure/error_handling_test.exs
+++ b/test/provider/azure/error_handling_test.exs
@@ -96,7 +96,7 @@ defmodule ReqLLM.Providers.Azure.ErrorHandlingTest do
     end
 
     test "handles successful response with missing expected fields gracefully" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
       request =
@@ -529,5 +529,14 @@ defmodule ReqLLM.Providers.Azure.ErrorHandlingTest do
       assert %ReqLLM.Error.API.Response{} = result
       assert result.status == 504
     end
+  end
+
+  defp traditional_openai_model do
+    %LLMDB.Model{
+      id: "gpt-4o",
+      provider: :azure,
+      capabilities: %{chat: true},
+      extra: %{}
+    }
   end
 end

--- a/test/provider/azure/routing_test.exs
+++ b/test/provider/azure/routing_test.exs
@@ -16,7 +16,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
 
   describe "multi-family routing" do
     test "routes GPT models to chat/completions endpoint" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -33,7 +33,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
     end
 
     test "routes o1 models to chat/completions endpoint" do
-      {:ok, model} = ReqLLM.model("azure:o1-mini")
+      model = traditional_reasoning_model()
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
       {:ok, finch_request} =
@@ -59,6 +59,61 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
 
       assert url_string =~ "/chat/completions"
       refute url_string =~ "/messages"
+    end
+
+    test "routes gpt-5.4 models to responses endpoint" do
+      {:ok, model} = ReqLLM.model("azure:gpt-5.4")
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          base_url: "https://my-resource.openai.azure.com/openai",
+          deployment: "my-deployment"
+        )
+
+      url = URI.to_string(request.url)
+      assert url =~ "/responses"
+      refute url =~ "/chat/completions"
+
+      assert request.options[:json]["model"] == "gpt-5.4"
+      assert is_list(request.options[:json]["input"])
+      refute Map.has_key?(request.options[:json], :messages)
+    end
+
+    test "routes gpt-5.4 streaming requests to responses endpoint" do
+      {:ok, model} = ReqLLM.model("azure:gpt-5.4")
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      {:ok, finch_request} =
+        Azure.attach_stream(
+          model,
+          context,
+          [
+            api_key: "test-api-key",
+            deployment: "my-deployment",
+            base_url: "https://my-resource.openai.azure.com/openai"
+          ],
+          :req_llm_finch
+        )
+
+      url_string =
+        case finch_request do
+          %{path: path, query: query} when is_binary(query) and query != "" ->
+            path <> "?" <> query
+
+          %{path: path} ->
+            path
+        end
+
+      assert url_string =~ "/responses"
+      refute url_string =~ "/chat/completions"
+
+      body = Jason.decode!(finch_request.body)
+      assert body["model"] == "gpt-5.4"
+      assert is_list(body["input"])
+      refute Map.has_key?(body, "messages")
     end
 
     test "uses correct headers for GPT models" do
@@ -184,7 +239,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
     end
 
     test "recognizes gpt family" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -222,7 +277,8 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
         id: "my-custom-alias",
         provider: :azure,
         provider_model_id: "gpt-4o",
-        capabilities: %{chat: true}
+        capabilities: %{chat: true},
+        extra: %{}
       }
 
       {:ok, request} =
@@ -514,7 +570,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
 
   describe "deployment name edge cases" do
     test "accepts deployment with hyphens" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -530,7 +586,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
     end
 
     test "accepts deployment with underscores" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -546,7 +602,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
     end
 
     test "accepts deployment with numbers" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -562,7 +618,7 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
     end
 
     test "uses model.id as default deployment" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       {:ok, request} =
         Azure.prepare_request(
@@ -583,5 +639,23 @@ defmodule ReqLLM.Providers.Azure.RoutingTest do
       {_, value} when is_binary(value) -> value
       nil -> nil
     end
+  end
+
+  defp traditional_openai_model do
+    %LLMDB.Model{
+      id: "gpt-4o",
+      provider: :azure,
+      capabilities: %{chat: true},
+      extra: %{}
+    }
+  end
+
+  defp traditional_reasoning_model do
+    %LLMDB.Model{
+      id: "o1-mini",
+      provider: :azure,
+      capabilities: %{chat: true},
+      extra: %{}
+    }
   end
 end

--- a/test/provider/azure/streaming_test.exs
+++ b/test/provider/azure/streaming_test.exs
@@ -15,7 +15,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
 
   describe "decode_stream_event/2" do
     test "decodes OpenAI SSE event for GPT models" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -39,7 +39,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "handles [DONE] event for OpenAI models" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{data: "[DONE]"}
 
@@ -93,14 +93,14 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
 
   describe "streaming error handling" do
     test "OpenAI: empty event data returns empty list" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       assert Azure.decode_stream_event(%{data: %{}}, model) == []
       assert Azure.decode_stream_event(%{}, model) == []
     end
 
     test "OpenAI: non-map event data returns empty list" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       assert Azure.decode_stream_event("invalid", model) == []
       assert Azure.decode_stream_event(nil, model) == []
@@ -108,7 +108,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: malformed event missing choices returns empty list" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{data: %{"id" => "chatcmpl-123", "object" => "chat.completion.chunk"}}
 
@@ -116,7 +116,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: invalid JSON in tool arguments returns chunk with empty arguments" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -149,7 +149,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: nil tool name in streaming delta returns meta chunk" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -176,7 +176,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: empty choices array returns empty list" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -281,7 +281,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: streaming finish_reason variations" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       length_event = %{
         data: %{
@@ -330,7 +330,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: streaming with usage metadata" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -352,7 +352,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: streaming tool call with incremental arguments" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -487,7 +487,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: handles [DONE] marker as terminal meta chunk" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       result = Azure.decode_stream_event(%{data: "[DONE]"}, model)
       assert [%ReqLLM.StreamChunk{type: :meta} = chunk] = result
@@ -495,7 +495,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: handles nil delta gracefully" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -699,7 +699,7 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
     end
 
     test "OpenAI: streaming usage includes cached tokens when present" do
-      {:ok, model} = ReqLLM.model("azure:gpt-4o")
+      model = traditional_openai_model()
 
       event = %{
         data: %{
@@ -721,5 +721,14 @@ defmodule ReqLLM.Providers.Azure.StreamingTest do
       assert chunk.type == :meta
       assert chunk.metadata[:usage]
     end
+  end
+
+  defp traditional_openai_model do
+    %LLMDB.Model{
+      id: "gpt-4o",
+      provider: :azure,
+      capabilities: %{chat: true},
+      extra: %{}
+    }
   end
 end


### PR DESCRIPTION
## Description

Fix Azure Responses routing for catalog models that advertise flat `wire_protocol` metadata. This also adds Azure Responses usage extraction and routes Azure streaming requests through the normal options-processing path so unsupported-parameter warnings are preserved in streaming as well as non-streaming.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Also ran `mix mc "*:*"`, which is currently failing on upstream `main` due unrelated fixture/base-url gaps across many providers. This patch does not introduce those repo-wide failures.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Related: #602

