### PR TITLE
fix(schema): infer integer type for Nimble enum choices

### DIFF
--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -468,7 +468,7 @@ defmodule ReqLLM.Schema do
 
         # Handle :in type for enums and ranges
         {:in, choices} when is_list(choices) ->
-          %{"type" => "string", "enum" => choices}
+          %{"type" => infer_enum_type(choices), "enum" => choices}
 
         {:in, first..last//_step} ->
           %{"type" => "integer", "minimum" => first, "maximum" => last}
@@ -1055,6 +1055,10 @@ defmodule ReqLLM.Schema do
       end
     end)
     |> Enum.reverse()
+  end
+
+  defp infer_enum_type(choices) do
+    if Enum.all?(choices, &is_integer/1), do: "integer", else: "string"
   end
 
   defp stringify_ordered_keys(ordered_values) do

--- a/test/req_llm/schema_test.exs
+++ b/test/req_llm/schema_test.exs
@@ -237,6 +237,14 @@ defmodule ReqLLM.SchemaTest do
       assert result == %{"type" => "string", "enum" => ["small", "medium", "large"]}
     end
 
+    test "converts :in type with integer choices to integer type" do
+      result = Schema.nimble_type_to_json_schema({:in, [1, 2, 3]}, [])
+      assert result == %{"type" => "integer", "enum" => [1, 2, 3]}
+
+      result = Schema.nimble_type_to_json_schema({:in, [1, 2]}, doc: "Level")
+      assert result == %{"type" => "integer", "enum" => [1, 2], "description" => "Level"}
+    end
+
     test "converts :in type with range choices" do
       result = Schema.nimble_type_to_json_schema({:in, 1..10}, [])
       assert result == %{"type" => "integer", "minimum" => 1, "maximum" => 10}


### PR DESCRIPTION
## Description

When a Nimble `:in` type contains all integer choices (e.g. `{:in, [1, 2, 3]}`), the generated JSON schema now correctly emits `"type": "integer"` instead of always defaulting to `"type": "string"`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A