### PR TITLE
fix(openai_codex): omit previous_response_id on tool resume

### DIFF
--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -283,7 +283,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     instructions = extract_instructions(context) || ""
 
     body =
-      if tool_resume_context?(context) do
+      if tool_resume_body?(body) do
         Map.delete(body, "previous_response_id")
       else
         body
@@ -300,12 +300,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> maybe_put_parallel_tool_calls(provider_opts[:openai_parallel_tool_calls])
   end
 
-  defp tool_resume_context?(context) do
-    Enum.any?(context.messages, fn
-      %{role: :tool, tool_call_id: id} when is_binary(id) -> true
+  defp tool_resume_body?(%{"input" => input}) when is_list(input) do
+    Enum.any?(input, fn
+      %{"type" => "function_call_output", "call_id" => id} when is_binary(id) -> true
       _ -> false
     end)
   end
+
+  defp tool_resume_body?(_), do: false
 
   defp normalize_stream_event!(%{data: "[DONE]"} = event), do: event
 

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -282,6 +282,13 @@ defmodule ReqLLM.Providers.OpenAICodex do
     provider_opts = provider_options(opts)
     instructions = extract_instructions(context) || ""
 
+    body =
+      if tool_resume_context?(context) do
+        Map.delete(body, "previous_response_id")
+      else
+        body
+      end
+
     body
     |> Map.put("input", Enum.reject(List.wrap(body["input"]), &system_input?/1))
     |> Map.delete("max_output_tokens")
@@ -291,6 +298,13 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Map.put_new("text", %{"verbosity" => normalize_codex_verbosity(provider_opts[:verbosity])})
     |> Map.put("instructions", instructions)
     |> maybe_put_parallel_tool_calls(provider_opts[:openai_parallel_tool_calls])
+  end
+
+  defp tool_resume_context?(context) do
+    Enum.any?(context.messages, fn
+      %{role: :tool, tool_call_id: id} when is_binary(id) -> true
+      _ -> false
+    end)
   end
 
   defp normalize_stream_event!(%{data: "[DONE]"} = event), do: event

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -143,6 +143,45 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert {"authorization", "Bearer #{jwt_with_account_id("acct_file_stream")}"} in request.headers
       assert {"chatgpt-account-id", "acct_file_stream"} in request.headers
     end
+
+    test "omits previous_response_id for tool resume flow while keeping store=false" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
+
+      assistant =
+        ReqLLM.Context.assistant(
+          "",
+          tool_calls: [{"test", %{a: 1, b: 2}, id: "call_123"}],
+          metadata: %{response_id: "resp_prev_123"}
+        )
+
+      tool_result = ReqLLM.Context.tool_result("call_123", "test", %{result: "1 + 2"})
+
+      context =
+        ReqLLM.context([assistant, tool_result, ReqLLM.Context.user("Use the tool result")])
+
+      {:ok, request} =
+        OpenAICodex.attach_stream(
+          model,
+          context,
+          [
+            provider_options: [
+              auth_mode: :oauth,
+              access_token: jwt_with_account_id("acct_resume")
+            ]
+          ],
+          nil
+        )
+
+      body = Jason.decode!(request.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+
+      assert Enum.any?(
+               body["input"],
+               &(&1["type"] == "function_call_output" and &1["call_id"] == "call_123")
+             )
+    end
   end
 
   describe "decode_stream_event/3" do

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -182,6 +182,36 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
                &(&1["type"] == "function_call_output" and &1["call_id"] == "call_123")
              )
     end
+
+    test "omits previous_response_id for explicit tool_outputs resume while keeping store=false" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
+      context = ReqLLM.context([ReqLLM.Context.user("Use the provided tool output")])
+
+      {:ok, request} =
+        OpenAICodex.attach_stream(
+          model,
+          context,
+          [
+            provider_options: [
+              auth_mode: :oauth,
+              access_token: jwt_with_account_id("acct_manual_resume"),
+              previous_response_id: "resp_prev_manual",
+              tool_outputs: [[call_id: "call_456", output: %{result: "manual"}]]
+            ]
+          ],
+          nil
+        )
+
+      body = Jason.decode!(request.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+
+      assert Enum.any?(
+               body["input"],
+               &(&1["type"] == "function_call_output" and &1["call_id"] == "call_456")
+             )
+    end
   end
 
   describe "decode_stream_event/3" do


### PR DESCRIPTION
## Description
Drop previous_response_id from ChatGPT Codex tool-resume requests while keeping function_call_output items and store=false. This matches the backend's actual resume contract and prevents tool-calling turns from failing after successful tool execution.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
