### PR TITLE
fix(openai): dedupe Responses API commentary and final answer

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1341,6 +1341,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> Enum.filter(&(&1["type"] in ["output_text", "text"]))
       |> Enum.map(&extract_text_field/1)
     end)
+    |> Enum.uniq()
     |> Enum.join("")
     |> case do
       "" -> nil

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1336,18 +1336,27 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   defp extract_from_message_segments(segments) do
     segments
     |> Enum.filter(&(&1["type"] == "message"))
+    |> dedupe_phased_messages()
     |> Enum.flat_map(fn seg ->
       (seg["content"] || [])
       |> Enum.filter(&(&1["type"] in ["output_text", "text"]))
       |> Enum.map(&extract_text_field/1)
     end)
-    |> Enum.uniq()
     |> Enum.join("")
     |> case do
       "" -> nil
       text -> text
     end
   end
+
+  defp dedupe_phased_messages([
+         %{"phase" => "commentary", "content" => content} = commentary,
+         %{"phase" => "final_answer", "content" => content} | rest
+       ]) do
+    [%{commentary | "phase" => "final_answer"} | rest]
+  end
+
+  defp dedupe_phased_messages(messages), do: messages
 
   defp extract_direct_output_text(segments) do
     segments

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -539,6 +539,60 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert part.text == "Part 1 Part 2"
     end
 
+    test "deduplicates identical commentary and final_answer message segments" do
+      text = "Do you want a shortcut for all users or just the current user?"
+
+      response_body = %{
+        "id" => "resp_123",
+        "model" => "gpt-5.4",
+        "output" => [
+          %{
+            "type" => "message",
+            "phase" => "commentary",
+            "content" => [%{"type" => "output_text", "text" => text}]
+          },
+          %{
+            "type" => "message",
+            "phase" => "final_answer",
+            "content" => [%{"type" => "output_text", "text" => text}]
+          }
+        ],
+        "usage" => %{"input_tokens" => 5, "output_tokens" => 10}
+      }
+
+      {_req, resp} = ResponsesAPI.decode_response(build_response(200, response_body))
+
+      assert [part] = resp.body.message.content
+      assert part.type == :text
+      assert part.text == text
+    end
+
+    test "preserves distinct commentary and final_answer message segments" do
+      response_body = %{
+        "id" => "resp_123",
+        "model" => "gpt-5.4",
+        "output" => [
+          %{
+            "type" => "message",
+            "phase" => "commentary",
+            "content" => [%{"type" => "output_text", "text" => "Let me check that. "}]
+          },
+          %{
+            "type" => "message",
+            "phase" => "final_answer",
+            "content" => [%{"type" => "output_text", "text" => "Here is the result."}]
+          }
+        ],
+        "usage" => %{"input_tokens" => 5, "output_tokens" => 10}
+      }
+
+      {_req, resp} = ResponsesAPI.decode_response(build_response(200, response_body))
+
+      assert [part] = resp.body.message.content
+      assert part.type == :text
+      assert part.text == "Let me check that. Here is the result."
+    end
+
     test "decodes response with direct output_text segments" do
       response_body = %{
         "id" => "resp_123",


### PR DESCRIPTION
We found a really small edge case (that I'm frankly surprised we noticed at all) where GPT-5.4 sometimes produces a commentary and final_answer that is the same so when concatenated it looks like a duplicate output.

## Description

Fixes duplicate text in OpenAI Responses API output when phased `message` segments include identical `commentary` and `final_answer` text. Adds targeted unit tests covering both the duplicate phased-output case and the case where commentary differs from the final answer, which should remain preserved.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Ran focused validation: `mix test test/provider/openai/responses_api_unit_test.exs`

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

N/A