### PR TITLE
fix: include embedding cost metadata

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -1172,6 +1172,7 @@ defmodule ReqLLM do
 
     * `:dimensions` - Number of dimensions for embeddings
     * `:provider_options` - Provider-specific options
+    * `:return_usage` - Return `%{embedding: vectors, usage: usage_map}` with token and cost metadata
 
   ## Examples
 
@@ -1185,6 +1186,13 @@ defmodule ReqLLM do
         ["Hello", "World"]
       )
       #=> {:ok, [[0.1, -0.2, ...], [0.3, 0.4, ...]]}
+
+      # With usage and cost data
+      {:ok, %{embedding: embedding, usage: usage}} =
+        ReqLLM.embed("openai:text-embedding-3-small", "Hello world", return_usage: true)
+
+      Map.has_key?(usage, :total_cost)
+      #=> true
 
   """
   defdelegate embed(model_spec, input, opts \\ []), to: Embedding

--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -15,7 +15,8 @@ defmodule ReqLLM.Embedding do
       {:ok, %{embedding: vectors, usage: usage}} =
         ReqLLM.embed("openai:text-embedding-3-small", "Hello", return_usage: true)
 
-  Usage availability depends on provider support.
+  Usage maps include canonical token fields and, when model pricing is
+  available, flat cost fields such as `total_cost`.
   """
 
   alias LLMDB.Model
@@ -192,7 +193,8 @@ defmodule ReqLLM.Embedding do
         "Hello world",
         return_usage: true
       )
-      #=> {:ok, %{embedding: [0.1, ...], usage: %{input_tokens: 2, total_tokens: 2}}}
+      Map.has_key?(usage, :total_cost)
+      #=> true
 
   """
   @spec embed(
@@ -309,8 +311,19 @@ defmodule ReqLLM.Embedding do
 
   defp extract_usage(%Req.Response{private: private}) do
     case get_in(private, [:req_llm, :usage]) do
-      %{tokens: tokens} -> tokens
-      _ -> nil
+      %{tokens: tokens} = usage_meta when is_map(tokens) ->
+        usage_meta
+        |> Map.take([:input_cost, :output_cost, :reasoning_cost, :total_cost])
+        |> Enum.reduce(tokens, fn
+          {_key, nil}, acc -> acc
+          {key, value}, acc -> Map.put(acc, key, value)
+        end)
+
+      usage when is_map(usage) ->
+        usage
+
+      _ ->
+        nil
     end
   end
 end

--- a/test/coverage/openai/embedding_test.exs
+++ b/test/coverage/openai/embedding_test.exs
@@ -7,4 +7,20 @@ defmodule ReqLLM.Coverage.OpenAI.EmbeddingTest do
   """
 
   use ReqLLM.ProviderTest.Embedding, provider: :openai
+
+  @tag category: :embedding
+  @tag scenario: :embed_basic
+  @tag model: "text-embedding-3-small"
+  test "return_usage includes cost fields" do
+    {:ok, %{usage: usage}} =
+      ReqLLM.embed(
+        "openai:text-embedding-3-small",
+        "Hello world",
+        fixture_opts("embed_basic", return_usage: true)
+      )
+
+    assert usage.input_tokens > 0
+    assert is_number(usage.input_cost)
+    assert is_number(usage.total_cost)
+  end
 end

--- a/test/req_llm/embedding_test.exs
+++ b/test/req_llm/embedding_test.exs
@@ -228,6 +228,54 @@ defmodule ReqLLM.EmbeddingTest do
     end
   end
 
+  describe "embed/3 - OpenAI cost metadata" do
+    setup do
+      Req.Test.stub(__MODULE__.OpenAIEmbedUsage, fn conn ->
+        Req.Test.json(conn, %{
+          "data" => [
+            %{
+              "embedding" => [0.1, -0.2, 0.3],
+              "index" => 0,
+              "object" => "embedding"
+            }
+          ],
+          "model" => "text-embedding-3-small",
+          "object" => "list",
+          "usage" => %{
+            "prompt_tokens" => 50_000,
+            "total_tokens" => 50_000
+          }
+        })
+      end)
+
+      :ok
+    end
+
+    test "returns canonical usage with cost fields" do
+      {:ok, %{embedding: embedding, usage: usage}} =
+        Embedding.embed(
+          "openai:text-embedding-3-small",
+          "Hello world",
+          api_key: "test-key",
+          return_usage: true,
+          req_http_options: [plug: {Req.Test, __MODULE__.OpenAIEmbedUsage}]
+        )
+
+      assert embedding == [0.1, -0.2, 0.3]
+      assert usage.input == 50_000
+      assert usage.input_tokens == 50_000
+      assert usage.output == 0
+      assert usage.output_tokens == 0
+      assert usage.total_tokens == 50_000
+      assert is_number(usage.input_cost)
+      assert is_number(usage.output_cost)
+      assert is_number(usage.reasoning_cost)
+      assert is_number(usage.total_cost)
+      assert usage.input_cost > 0
+      assert usage.total_cost > 0
+    end
+  end
+
   describe "embed_many/3 - basic functionality" do
     test "validates model before attempting embedding" do
       case Embedding.validate_model("openai:text-embedding-3-small") do


### PR DESCRIPTION
## Summary
- return canonical embedding usage maps with flat cost fields when `return_usage: true`
- add regression coverage for OpenAI embedding usage extraction
- document embedding usage/cost metadata in the public API docs

## Validation
- `mix test test/req_llm/embedding_test.exs`
- `mix test --include coverage test/coverage/openai/embedding_test.exs`
- live verification: `mix run -e ...` against `openai:text-embedding-3-large` returned `%{input_tokens: 5000, total_tokens: 5000, input_cost: 1.0e-6, total_cost: 1.0e-6}`

Closes #619