### PR TITLE
feat(azure): support Azure OpenAI v1 GA API (no api-version)

### DIFF
--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -88,6 +88,17 @@ defmodule ReqLLM.Providers.Azure do
         deployment: "deepseek-v3"
       )
 
+      # Azure OpenAI v1 GA API (auto-detected from /openai/v1 path).
+      # No api-version parameter; deployment name is sent in the request body.
+      # See https://learn.microsoft.com/azure/ai-services/openai/api-version-lifecycle
+      ReqLLM.generate_text(
+        "azure:gpt-5.3-chat",
+        "Hello!",
+        api_key: "your-api-key",
+        base_url: "https://my-resource.openai.azure.com/openai/v1",
+        deployment: "gpt-5.3-chat"
+      )
+
   ## Examples
 
       # Basic usage
@@ -1123,18 +1134,24 @@ defmodule ReqLLM.Providers.Azure do
   end
 
   # Builds the endpoint path based on model type, family, and endpoint format.
-  # Supports two Azure endpoint formats:
+  # Supports three Azure endpoint formats:
   # - Traditional (cognitiveservices.azure.com): /deployments/{deployment}/chat/completions
   # - Foundry (services.ai.azure.com): /models/chat/completions (model in body)
+  # - v1 GA (/openai/v1 path): /chat/completions or /responses (no api-version, model in body)
   # Special cases:
   # - Responses API models: /responses (model in body)
   # - Claude: /v1/messages (model in body)
   defp get_chat_endpoint_path(model_id, model, deployment, api_version, base_url)
        when is_struct(model) do
-    if uses_responses_api?(model) do
-      "/responses?api-version=#{api_version}"
-    else
-      get_chat_endpoint_path_by_family(model_id, deployment, api_version, base_url)
+    cond do
+      uses_v1_ga_format?(base_url) and uses_responses_api?(model) ->
+        "/responses"
+
+      uses_responses_api?(model) ->
+        "/responses?api-version=#{api_version}"
+
+      true ->
+        get_chat_endpoint_path_by_family(model_id, deployment, api_version, base_url)
     end
   end
 
@@ -1147,24 +1164,36 @@ defmodule ReqLLM.Providers.Azure do
         "/v1/messages"
 
       _ ->
-        if uses_foundry_format?(base_url) do
-          # Azure AI Foundry: model specified in request body
-          "/models/chat/completions?api-version=#{api_version}"
-        else
-          # Azure OpenAI (traditional): deployment in URL determines model
-          "/deployments/#{deployment}/chat/completions?api-version=#{api_version}"
+        cond do
+          uses_v1_ga_format?(base_url) ->
+            # Azure OpenAI v1 GA: no api-version, model in body
+            "/chat/completions"
+
+          uses_foundry_format?(base_url) ->
+            # Azure AI Foundry: model specified in request body
+            "/models/chat/completions?api-version=#{api_version}"
+
+          true ->
+            # Azure OpenAI (traditional): deployment in URL determines model
+            "/deployments/#{deployment}/chat/completions?api-version=#{api_version}"
         end
     end
   end
 
   # Builds the embedding endpoint path based on endpoint format.
   defp get_embedding_endpoint_path(deployment, api_version, base_url) do
-    if uses_foundry_format?(base_url) do
-      # Azure AI Foundry: model specified in request body
-      "/models/embeddings?api-version=#{api_version}"
-    else
-      # Azure OpenAI (traditional): deployment in URL determines model
-      "/deployments/#{deployment}/embeddings?api-version=#{api_version}"
+    cond do
+      uses_v1_ga_format?(base_url) ->
+        # Azure OpenAI v1 GA: no api-version, model in body
+        "/embeddings"
+
+      uses_foundry_format?(base_url) ->
+        # Azure AI Foundry: model specified in request body
+        "/models/embeddings?api-version=#{api_version}"
+
+      true ->
+        # Azure OpenAI (traditional): deployment in URL determines model
+        "/deployments/#{deployment}/embeddings?api-version=#{api_version}"
     end
   end
 
@@ -1246,12 +1275,30 @@ defmodule ReqLLM.Providers.Azure do
 
   def uses_foundry_format?(_), do: false
 
-  # Adds the model field to request body when using Foundry format.
-  # Traditional Azure OpenAI format doesn't need model in body (deployment in URL determines it).
-  # Foundry format requires model in body since URL is generic /models/chat/completions.
+  # Detects if the base_url targets the Azure OpenAI v1 GA API.
+  # v1 GA URLs have `/openai/v1` in the path. They drop the `api-version`
+  # query parameter and require `model` in the request body (deployment name).
+  # See https://learn.microsoft.com/azure/ai-services/openai/api-version-lifecycle
+  @doc false
+  def uses_v1_ga_format?(base_url) when is_binary(base_url) do
+    case URI.parse(base_url) do
+      %URI{path: nil} ->
+        false
+
+      %URI{path: path} ->
+        String.contains?(path, "/openai/v1")
+    end
+  end
+
+  def uses_v1_ga_format?(_), do: false
+
+  # Adds the model field to request body when the URL doesn't carry the
+  # deployment. Required for Foundry (/models/...) and v1 GA (/openai/v1/...).
+  # Traditional Azure OpenAI format puts the deployment in the URL path so
+  # the body must NOT include a model field.
   defp maybe_add_model_for_foundry(body, deployment, base_url)
        when is_map(body) and is_binary(deployment) and deployment != "" do
-    if uses_foundry_format?(base_url) do
+    if uses_foundry_format?(base_url) or uses_v1_ga_format?(base_url) do
       Map.put(body, "model", deployment)
     else
       body

--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -694,7 +694,7 @@ defmodule ReqLLM.Providers.Azure do
     formatter = get_formatter(model_id, model)
 
     path = get_chat_endpoint_path(model_id, model, deployment, api_version, base_url)
-    url = "#{base_url}#{path}"
+    url = join_url(base_url, path)
 
     Logger.debug(
       "[Azure attach_stream] model_family=#{model_family}, url=#{url}, formatter=#{inspect(formatter)}"
@@ -1306,4 +1306,12 @@ defmodule ReqLLM.Providers.Azure do
   end
 
   defp maybe_add_model_for_foundry(body, _deployment, _base_url), do: body
+
+  # Joins a base URL and a path without producing a double-slash when the
+  # caller passes a trailing-slash base URL (e.g. ".../openai/v1/").
+  # Path is always expected to start with "/"; we strip duplicate leading
+  # slashes after the base URL has been trimmed.
+  defp join_url(base_url, path) when is_binary(base_url) and is_binary(path) do
+    String.trim_trailing(base_url, "/") <> path
+  end
 end

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -1768,6 +1768,32 @@ defmodule ReqLLM.Providers.AzureTest do
       refute url_string =~ "api-version="
       refute url_string =~ "/deployments/"
     end
+
+    test "streaming handles trailing-slash base URL without producing //" do
+      model = traditional_openai_model()
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      {:ok, finch_request} =
+        Azure.attach_stream(
+          model,
+          context,
+          [
+            api_key: "test-api-key",
+            deployment: "gpt-4o-deployment",
+            # Trailing slash, as documented in the moduledoc usage example.
+            base_url: "https://my-resource.openai.azure.com/openai/v1/"
+          ],
+          :req_llm_finch
+        )
+
+      path =
+        case finch_request do
+          %{path: p} -> p
+        end
+
+      refute path =~ "//", "expected single-slash path, got: #{inspect(path)}"
+      assert path =~ "/openai/v1/chat/completions"
+    end
   end
 
   defp traditional_openai_model do

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -1659,6 +1659,117 @@ defmodule ReqLLM.Providers.AzureTest do
     end
   end
 
+  describe "Azure OpenAI v1 GA format detection" do
+    test "detects v1 GA format from /openai/v1 path" do
+      assert Azure.uses_v1_ga_format?("https://my-resource.openai.azure.com/openai/v1")
+      assert Azure.uses_v1_ga_format?("https://my-resource.openai.azure.com/openai/v1/")
+
+      assert Azure.uses_v1_ga_format?("https://my-resource.services.ai.azure.com/openai/v1")
+    end
+
+    test "does not detect v1 GA format for traditional /openai path" do
+      refute Azure.uses_v1_ga_format?("https://my-resource.openai.azure.com/openai")
+      refute Azure.uses_v1_ga_format?("https://my-resource.services.ai.azure.com")
+      refute Azure.uses_v1_ga_format?("https://example.com")
+    end
+
+    test "handles edge cases safely" do
+      refute Azure.uses_v1_ga_format?(nil)
+      refute Azure.uses_v1_ga_format?("")
+      refute Azure.uses_v1_ga_format?("not-a-url")
+      refute Azure.uses_v1_ga_format?(12_345)
+    end
+
+    test "uses /chat/completions path with no api-version for v1 GA" do
+      model = traditional_openai_model()
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          deployment: "gpt-4o",
+          base_url: "https://my-resource.openai.azure.com/openai/v1",
+          api_key: "test-key"
+        )
+
+      url_string = URI.to_string(request.url)
+      assert url_string =~ "/chat/completions"
+      refute url_string =~ "api-version="
+      refute url_string =~ "/deployments/"
+    end
+
+    test "adds model to request body for v1 GA format" do
+      model = traditional_openai_model()
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          deployment: "gpt-4o-deployment",
+          base_url: "https://my-resource.openai.azure.com/openai/v1",
+          api_key: "test-key"
+        )
+
+      body = get_json_body(request)
+      assert body["model"] == "gpt-4o-deployment"
+    end
+
+    test "uses /embeddings path with no api-version for v1 GA" do
+      model = %LLMDB.Model{
+        id: "text-embedding-3-small",
+        provider: :azure,
+        capabilities: %{embeddings: true}
+      }
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :embedding,
+          model,
+          "Hello",
+          deployment: "my-embedding-deployment",
+          base_url: "https://my-resource.openai.azure.com/openai/v1",
+          api_key: "test-key"
+        )
+
+      url_string = URI.to_string(request.url)
+      assert url_string =~ "/embeddings"
+      refute url_string =~ "api-version="
+      refute url_string =~ "/deployments/"
+    end
+
+    test "streaming uses /chat/completions with no api-version for v1 GA" do
+      model = traditional_openai_model()
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      {:ok, finch_request} =
+        Azure.attach_stream(
+          model,
+          context,
+          [
+            api_key: "test-api-key",
+            deployment: "gpt-4o-deployment",
+            base_url: "https://my-resource.openai.azure.com/openai/v1"
+          ],
+          :req_llm_finch
+        )
+
+      url_string =
+        case finch_request do
+          %{path: path, query: query} when is_binary(query) and query != "" ->
+            path <> "?" <> query
+
+          %{path: path} ->
+            path
+        end
+
+      assert url_string =~ "/chat/completions"
+      refute url_string =~ "api-version="
+      refute url_string =~ "/deployments/"
+    end
+  end
+
   defp traditional_openai_model do
     %LLMDB.Model{
       id: "gpt-4o",


### PR DESCRIPTION
## Description

Adds support for Azure OpenAI's [v1 GA API](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-lifecycle) in the existing `:azure` provider. The v1 GA API (launched August 2025) drops the dated `api-version` query parameter and uses `/openai/v1/...` URL paths with the model/deployment name in the request body — matching standard OpenAI shape.

Detection is automatic from the base URL: when the path contains `/openai/v1`, chat/responses/embedding requests use the GA paths and skip the `api-version` query string. No new options or breaking changes — existing dated/Foundry users are unaffected.

| Endpoint   | Dated                                                                         | v1 GA                |
|------------|-------------------------------------------------------------------------------|----------------------|
| chat       | `/deployments/{deployment}/chat/completions?api-version=...`                  | `/chat/completions`  |
| responses  | `/responses?api-version=...`                                                  | `/responses`         |
| embeddings | `/deployments/{deployment}/embeddings?api-version=...`                        | `/embeddings`        |

For v1 GA, the deployment name is added to the request body's `model` field (same mechanism as the existing Foundry path).

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Breaking Changes

None. Existing `:azure` users on dated `api-version` URLs and Foundry URLs see no change in behavior.

## Testing

- [x] Tests pass (`mix test`) — 101 Azure tests, 0 failures
- [x] Quality checks pass (`mix quality`) — format, compile, dialyzer (0 errors), credo --strict
- [x] Live-tested end-to-end against a real Azure resource (`gpt-5.3-chat` deployment, `https://*.cognitiveservices.azure.com/openai/v1` base URL): request hits `/chat/completions` with no `api-version`, model name in body, returns 200 with usage tokens.

New unit tests cover:
- `uses_v1_ga_format?/1` detection (positive, negative, edge cases)
- v1 GA chat URL path + no `api-version`
- v1 GA embedding URL path + no `api-version`
- v1 GA streaming URL path + no `api-version`
- Model name added to request body for v1 GA

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (moduledoc usage example for v1 GA)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited \`CHANGELOG.md\` (it is auto-generated by git_ops)

## Related Issues

N/A — opened directly as a feature contribution. Happy to file a tracking issue if preferred.