### PR TITLE
fix(openai): encode multimodal tool outputs in Responses API

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -519,24 +519,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
             # most recent round's outputs were appended, which caused
             # "No tool output found for function call" errors on multi-turn
             # tool calling with the Responses API.
-            output =
-              case ReqLLM.ToolResult.output_from_message(msg) do
-                nil -> extract_tool_output_text(msg.content)
-                value -> value
-              end
-
-            output_string =
-              cond do
-                is_binary(output) -> output
-                is_map(output) or is_list(output) -> Jason.encode!(output)
-                true -> to_string(output)
-              end
-
-            encoded = %{
-              "type" => "function_call_output",
-              "call_id" => msg.tool_call_id,
-              "output" => output_string
-            }
+            encoded = encode_tool_message_inline(msg)
 
             {input_acc ++ [encoded], tool_acc, reasoning_acc}
 
@@ -639,6 +622,50 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       body
     end
   end
+
+  defp encode_tool_message_inline(%ReqLLM.Message{role: :tool} = msg) do
+    if has_image_content?(msg.content) do
+      output_parts =
+        Enum.flat_map(msg.content, fn part ->
+          encode_input_content_part(part, "input_text")
+        end)
+
+      %{
+        "type" => "function_call_output",
+        "call_id" => msg.tool_call_id,
+        "output" => output_parts
+      }
+    else
+      output =
+        case ReqLLM.ToolResult.output_from_message(msg) do
+          nil -> extract_tool_output_text(msg.content)
+          value -> value
+        end
+
+      output_string =
+        cond do
+          is_binary(output) -> output
+          is_map(output) or is_list(output) -> Jason.encode!(output)
+          true -> to_string(output)
+        end
+
+      %{
+        "type" => "function_call_output",
+        "call_id" => msg.tool_call_id,
+        "output" => output_string
+      }
+    end
+  end
+
+  defp has_image_content?(content) when is_list(content) do
+    Enum.any?(content, fn
+      %ReqLLM.Message.ContentPart{type: :image} -> true
+      %ReqLLM.Message.ContentPart{type: :image_url} -> true
+      _ -> false
+    end)
+  end
+
+  defp has_image_content?(_), do: false
 
   defp encode_input_content_part(%ReqLLM.Message.ContentPart{type: :text, text: text}, type) do
     [%{"type" => type, "text" => text}]

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -661,6 +661,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     Enum.any?(content, fn
       %ReqLLM.Message.ContentPart{type: :image} -> true
       %ReqLLM.Message.ContentPart{type: :image_url} -> true
+      %ReqLLM.Message.ContentPart{type: :file} -> true
       _ -> false
     end)
   end

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -215,6 +215,49 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert Jason.decode!(tool_output["output"]) == %{"temp" => 72}
     end
 
+    test "encodes multimodal tool results as array function_call_output" do
+      tool_call = %ReqLLM.ToolCall{
+        id: "call_1",
+        type: "function",
+        function: %{name: "take_screenshot", arguments: ~s({})}
+      }
+
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [],
+        tool_calls: [tool_call]
+      }
+
+      tool_result =
+        ReqLLM.Context.tool_result("call_1", [
+          ReqLLM.Message.ContentPart.text("Captured screenshot"),
+          ReqLLM.Message.ContentPart.image(<<137, 80, 78, 71>>, "image/png")
+        ])
+
+      context = %ReqLLM.Context{messages: [assistant_msg, tool_result]}
+      request = build_request(context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      tool_output =
+        Enum.find(body["input"], fn item ->
+          item["type"] == "function_call_output"
+        end)
+
+      assert tool_output["call_id"] == "call_1"
+      assert is_list(tool_output["output"])
+
+      assert Enum.any?(tool_output["output"], fn part ->
+               part["type"] == "input_text" and part["text"] == "Captured screenshot"
+             end)
+
+      assert Enum.any?(tool_output["output"], fn part ->
+               part["type"] == "input_image" and
+                 String.starts_with?(part["image_url"], "data:image/png;base64,")
+             end)
+    end
+
     test "encodes specific tool choice with atom keys" do
       request =
         build_request(tool_choice: %{type: "function", function: %{name: "get_weather"}})

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -258,6 +258,50 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              end)
     end
 
+    test "encodes file-bearing tool results as array function_call_output" do
+      tool_call = %ReqLLM.ToolCall{
+        id: "call_1",
+        type: "function",
+        function: %{name: "export_report", arguments: ~s({})}
+      }
+
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [],
+        tool_calls: [tool_call]
+      }
+
+      tool_result =
+        ReqLLM.Context.tool_result("call_1", [
+          ReqLLM.Message.ContentPart.text("Attached report"),
+          ReqLLM.Message.ContentPart.file("report-bytes", "report.txt", "text/plain")
+        ])
+
+      context = %ReqLLM.Context{messages: [assistant_msg, tool_result]}
+      request = build_request(context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      tool_output =
+        Enum.find(body["input"], fn item ->
+          item["type"] == "function_call_output"
+        end)
+
+      assert tool_output["call_id"] == "call_1"
+      assert is_list(tool_output["output"])
+
+      assert Enum.any?(tool_output["output"], fn part ->
+               part["type"] == "input_text" and part["text"] == "Attached report"
+             end)
+
+      assert Enum.any?(tool_output["output"], fn part ->
+               part["type"] == "input_file" and
+                 part["filename"] == "report.txt" and
+                 String.starts_with?(part["file_data"], "data:text/plain;base64,")
+             end)
+    end
+
     test "encodes specific tool choice with atom keys" do
       request =
         build_request(tool_choice: %{type: "function", function: %{name: "get_weather"}})


### PR DESCRIPTION
## Summary
- route inline `:tool` messages in Responses API request building through a shared encoder
- emit array `function_call_output.output` when tool result content contains image parts (`input_text` + `input_image` items)
- preserve existing string output behavior for non-multimodal tool results
- add unit coverage for a text+image tool result to ensure array output is produced

## Testing
- `mix test test/provider/openai/responses_api_unit_test.exs`