### PR TITLE
feat(anthropic): signal tool execution failures with is_error

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -497,12 +497,12 @@ defmodule ReqLLM.Context do
           append(ctx, tool_result_msg)
 
         {:error, %ToolResult{} = result} ->
-          tool_result_msg = tool_result_message(name, id, result)
+          tool_result_msg = tool_result_message(name, id, result, %{is_error: true})
           append(ctx, tool_result_msg)
 
         {:error, error} ->
           error_result = %{error: to_string(error)}
-          tool_result_msg = tool_result_message(name, id, error_result)
+          tool_result_msg = tool_result_message(name, id, error_result, %{is_error: true})
           append(ctx, tool_result_msg)
       end
     end)

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -497,7 +497,13 @@ defmodule ReqLLM.Context do
           append(ctx, tool_result_msg)
 
         {:error, %ToolResult{} = result} ->
-          tool_result_msg = tool_result_message(name, id, result, %{is_error: true})
+          tool_result_msg = tool_result_message(name, id, result)
+
+          tool_result_msg = %{
+            tool_result_msg
+            | metadata: Map.put(tool_result_msg.metadata, :is_error, true)
+          }
+
           append(ctx, tool_result_msg)
 
         {:error, error} ->

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -135,16 +135,22 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     }
   end
 
-  defp encode_message(%ReqLLM.Message{role: :tool, tool_call_id: id} = msg) do
+  defp encode_message(%ReqLLM.Message{role: :tool, tool_call_id: id, metadata: metadata} = msg) do
+    tool_result_block =
+      %{
+        type: "tool_result",
+        tool_use_id: id,
+        content: encode_tool_result_content(msg)
+      }
+
+    tool_result_block =
+      if metadata[:is_error],
+        do: Map.put(tool_result_block, :is_error, true),
+        else: tool_result_block
+
     %{
       role: "user",
-      content: [
-        %{
-          type: "tool_result",
-          tool_use_id: id,
-          content: encode_tool_result_content(msg)
-        }
-      ]
+      content: [tool_result_block]
     }
   end
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -410,6 +410,95 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert decoded["tool_choice"] == %{"type" => "tool", "name" => "test_tool"}
     end
 
+    test "encode_body emits is_error on tool_result when metadata contains is_error" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      error_tool_msg =
+        ReqLLM.Context.tool_result_message(
+          "get_weather",
+          "tool_err",
+          "ConnectionError: service unavailable",
+          %{is_error: true}
+        )
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user("What's the weather?"),
+          ReqLLM.Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "tool_err",
+                type: "function",
+                function: %{name: "get_weather", arguments: ~s({"location":"Paris"})}
+              }
+            ]
+          ),
+          error_tool_msg
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = Anthropic.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      tool_result_msg = List.last(decoded["messages"])
+      [tool_result_block] = tool_result_msg["content"]
+
+      assert tool_result_block["type"] == "tool_result"
+      assert tool_result_block["tool_use_id"] == "tool_err"
+      assert tool_result_block["is_error"] == true
+    end
+
+    test "encode_body omits is_error on successful tool_result" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      ok_tool_msg =
+        ReqLLM.Context.tool_result_message(
+          "get_weather",
+          "tool_ok",
+          "22°C and sunny"
+        )
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user("What's the weather?"),
+          ReqLLM.Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "tool_ok",
+                type: "function",
+                function: %{name: "get_weather", arguments: ~s({"location":"Paris"})}
+              }
+            ]
+          ),
+          ok_tool_msg
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = Anthropic.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      tool_result_msg = List.last(decoded["messages"])
+      [tool_result_block] = tool_result_msg["content"]
+
+      assert tool_result_block["type"] == "tool_result"
+      assert tool_result_block["tool_use_id"] == "tool_ok"
+      refute Map.has_key?(tool_result_block, "is_error")
+    end
+
     test "encode_request accepts map-based streaming tool calls" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -455,6 +455,57 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert tool_result_block["is_error"] == true
     end
 
+    test "encode_body keeps is_error true when ToolResult metadata conflicts" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      failing_tool =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Fails with conflicting metadata",
+          parameter_schema: [location: [type: :string, required: true]],
+          callback: fn _args ->
+            {:error,
+             %ReqLLM.ToolResult{
+               output: %{reason: "service unavailable"},
+               content: [ContentPart.text("service unavailable")],
+               metadata: %{is_error: false}
+             }}
+          end
+        )
+
+      tool_call =
+        %ReqLLM.ToolCall{
+          id: "tool_err_conflict",
+          type: "function",
+          function: %{name: "get_weather", arguments: ~s({"location":"Paris"})}
+        }
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user("What's the weather?"),
+          ReqLLM.Context.assistant("", tool_calls: [tool_call])
+        ])
+        |> ReqLLM.Context.execute_and_append_tools([tool_call], [failing_tool])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = Anthropic.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      tool_result_msg = List.last(decoded["messages"])
+      [tool_result_block] = tool_result_msg["content"]
+
+      assert tool_result_block["type"] == "tool_result"
+      assert tool_result_block["tool_use_id"] == "tool_err_conflict"
+      assert tool_result_block["is_error"] == true
+    end
+
     test "encode_body omits is_error on successful tool_result" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 

--- a/test/req_llm/context_conversational_test.exs
+++ b/test/req_llm/context_conversational_test.exs
@@ -165,5 +165,169 @@ defmodule ReqLLM.ContextConversationalTest do
       assert message.name == "test_tool"
       assert message.tool_call_id == "call_456"
     end
+
+    test "propagates is_error metadata" do
+      message = Context.tool_result_message("failing_tool", "call_err", "boom", %{is_error: true})
+
+      assert message.metadata[:is_error] == true
+      assert message.role == :tool
+      assert message.name == "failing_tool"
+    end
+
+    test "success path does not set is_error" do
+      message = Context.tool_result_message("ok_tool", "call_ok", "all good")
+
+      refute Map.has_key?(message.metadata, :is_error)
+    end
+  end
+
+  describe "execute_and_append_tools/3" do
+    setup do
+      success_tool =
+        ReqLLM.Tool.new!(
+          name: "echo",
+          description: "Echoes input",
+          parameter_schema: [text: [type: :string, required: true, doc: "Text to echo"]],
+          callback: fn args -> {:ok, args["text"]} end
+        )
+
+      error_tool =
+        ReqLLM.Tool.new!(
+          name: "fail",
+          description: "Always fails",
+          parameter_schema: [text: [type: :string, required: true, doc: "Ignored"]],
+          callback: fn _args -> {:error, "something went wrong"} end
+        )
+
+      error_tool_result =
+        ReqLLM.Tool.new!(
+          name: "fail_structured",
+          description: "Fails with ToolResult",
+          parameter_schema: [text: [type: :string, required: true, doc: "Ignored"]],
+          callback: fn _args ->
+            {:error,
+             %ToolResult{output: %{reason: "not found"}, content: [ContentPart.text("not found")]}}
+          end
+        )
+
+      context =
+        Context.new([
+          Context.user("Use the tools"),
+          Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "call_1",
+                type: "function",
+                function: %{name: "echo", arguments: ~s({"text":"hello"})}
+              }
+            ]
+          )
+        ])
+
+      %{
+        success_tool: success_tool,
+        error_tool: error_tool,
+        error_tool_result: error_tool_result,
+        context: context
+      }
+    end
+
+    test "success path does not set is_error in metadata", %{success_tool: tool, context: ctx} do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "call_1",
+          type: "function",
+          function: %{name: "echo", arguments: ~s({"text":"hello"})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [tool])
+      tool_msg = List.last(result.messages)
+
+      assert tool_msg.role == :tool
+      assert tool_msg.name == "echo"
+      refute Map.has_key?(tool_msg.metadata, :is_error)
+    end
+
+    test "error path sets is_error for generic errors", %{error_tool: tool, context: ctx} do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "call_1",
+          type: "function",
+          function: %{name: "fail", arguments: ~s({"text":"x"})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [tool])
+      tool_msg = List.last(result.messages)
+
+      assert tool_msg.role == :tool
+      assert tool_msg.metadata[:is_error] == true
+    end
+
+    test "error path sets is_error for ToolResult errors", %{
+      error_tool_result: tool,
+      context: ctx
+    } do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "call_1",
+          type: "function",
+          function: %{name: "fail_structured", arguments: ~s({"text":"x"})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [tool])
+      tool_msg = List.last(result.messages)
+
+      assert tool_msg.role == :tool
+      assert tool_msg.metadata[:is_error] == true
+    end
+
+    test "tool not found sets is_error", %{context: ctx} do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "call_1",
+          type: "function",
+          function: %{name: "nonexistent", arguments: ~s({"text":"x"})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [])
+      tool_msg = List.last(result.messages)
+
+      assert tool_msg.role == :tool
+      assert tool_msg.metadata[:is_error] == true
+    end
+
+    test "mixed success and error tool calls", %{
+      success_tool: ok_tool,
+      error_tool: fail_tool,
+      context: ctx
+    } do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "call_ok",
+          type: "function",
+          function: %{name: "echo", arguments: ~s({"text":"hello"})}
+        },
+        %ReqLLM.ToolCall{
+          id: "call_fail",
+          type: "function",
+          function: %{name: "fail", arguments: ~s({"text":"x"})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [ok_tool, fail_tool])
+      tool_messages = Enum.filter(result.messages, &(&1.role == :tool))
+
+      assert length(tool_messages) == 2
+
+      ok_msg = Enum.find(tool_messages, &(&1.tool_call_id == "call_ok"))
+      fail_msg = Enum.find(tool_messages, &(&1.tool_call_id == "call_fail"))
+
+      refute Map.has_key?(ok_msg.metadata, :is_error)
+      assert fail_msg.metadata[:is_error] == true
+    end
   end
 end

--- a/test/req_llm/context_conversational_test.exs
+++ b/test/req_llm/context_conversational_test.exs
@@ -210,6 +210,21 @@ defmodule ReqLLM.ContextConversationalTest do
           end
         )
 
+      error_tool_result_conflict =
+        ReqLLM.Tool.new!(
+          name: "fail_structured_conflict",
+          description: "Fails with conflicting ToolResult metadata",
+          parameter_schema: [text: [type: :string, required: true, doc: "Ignored"]],
+          callback: fn _args ->
+            {:error,
+             %ToolResult{
+               output: %{reason: "not found"},
+               content: [ContentPart.text("not found")],
+               metadata: %{is_error: false, source: "tool"}
+             }}
+          end
+        )
+
       context =
         Context.new([
           Context.user("Use the tools"),
@@ -228,6 +243,7 @@ defmodule ReqLLM.ContextConversationalTest do
         success_tool: success_tool,
         error_tool: error_tool,
         error_tool_result: error_tool_result,
+        error_tool_result_conflict: error_tool_result_conflict,
         context: context
       }
     end
@@ -281,6 +297,26 @@ defmodule ReqLLM.ContextConversationalTest do
       tool_msg = List.last(result.messages)
 
       assert tool_msg.role == :tool
+      assert tool_msg.metadata[:is_error] == true
+    end
+
+    test "error path keeps is_error true when ToolResult metadata conflicts", %{
+      error_tool_result_conflict: tool,
+      context: ctx
+    } do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "call_1",
+          type: "function",
+          function: %{name: "fail_structured_conflict", arguments: ~s({"text":"x"})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [tool])
+      tool_msg = List.last(result.messages)
+
+      assert tool_msg.role == :tool
+      assert tool_msg.metadata[:source] == "tool"
       assert tool_msg.metadata[:is_error] == true
     end
 


### PR DESCRIPTION
## Summary
- propagate tool execution failures in `ReqLLM.Context.execute_and_append_tools/3` by tagging tool-result metadata with `is_error: true`
- encode Anthropic `tool_result` blocks with `is_error: true` only for failed tool executions
- add focused tests for generic errors, `%ToolResult{}` errors, missing tools, mixed success/error execution, and Anthropic wire encoding

## Why
Anthropic expects failed tool outcomes to be explicitly marked with `is_error` on `tool_result` blocks. This keeps tool error semantics accurate across conversation turns.

## Validation
- `mix test test/req_llm/context_conversational_test.exs test/providers/anthropic_test.exs`