### PR TITLE
fix(vertex): preserve Claude thinking signatures in streams

### DIFF
--- a/lib/req_llm/provider/response_builder.ex
+++ b/lib/req_llm/provider/response_builder.ex
@@ -86,7 +86,8 @@ defmodule ReqLLM.Provider.ResponseBuilder do
   Routes to provider-specific builders based on model metadata:
 
     * Anthropic models → `Anthropic.ResponseBuilder`
-    * Google/Vertex models → `Google.ResponseBuilder`
+    * Google/Gemini models → `Google.ResponseBuilder`
+    * Vertex Claude models → `Anthropic.ResponseBuilder`
     * OpenAI Responses API models → `OpenAI.ResponsesAPI.ResponseBuilder`
     * All others → `Provider.Defaults.ResponseBuilder`
 
@@ -107,8 +108,13 @@ defmodule ReqLLM.Provider.ResponseBuilder do
 
   def for_model(%LLMDB.Model{provider: :google}), do: ReqLLM.Providers.Google.ResponseBuilder
 
-  def for_model(%LLMDB.Model{provider: :google_vertex}),
-    do: ReqLLM.Providers.Google.ResponseBuilder
+  def for_model(%LLMDB.Model{provider: :google_vertex} = model) do
+    if vertex_claude_model?(model) do
+      ReqLLM.Providers.Anthropic.ResponseBuilder
+    else
+      ReqLLM.Providers.Google.ResponseBuilder
+    end
+  end
 
   def for_model(%LLMDB.Model{extra: %{wire: %{protocol: "openai_responses"}}}),
     do: ReqLLM.Providers.OpenAI.ResponsesAPI.ResponseBuilder
@@ -117,4 +123,13 @@ defmodule ReqLLM.Provider.ResponseBuilder do
     do: ReqLLM.Providers.OpenAI.ResponsesAPI.ResponseBuilder
 
   def for_model(_model), do: ReqLLM.Provider.Defaults.ResponseBuilder
+
+  defp vertex_claude_model?(%LLMDB.Model{} = model) do
+    model_id = model.provider_model_id || model.id || ""
+    extra = model.extra || %{}
+    extra_family = extra[:family]
+
+    String.starts_with?(model_id, "claude-") or
+      (is_binary(extra_family) and String.starts_with?(extra_family, "claude"))
+  end
 end

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -555,6 +555,21 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   @impl ReqLLM.Provider
+  def init_stream_state(_model) do
+    ReqLLM.Providers.Anthropic.Response.init_stream_state()
+  end
+
+  @impl ReqLLM.Provider
+  def decode_stream_event(event, model, state) do
+    ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model, state)
+  end
+
+  @impl ReqLLM.Provider
+  def flush_stream_state(model, state) do
+    ReqLLM.Providers.Anthropic.Response.flush_stream_state(model, state)
+  end
+
+  @impl ReqLLM.Provider
   def translate_options(operation, _model, opts) do
     # Anthropic-specific parameter translation
     translated_opts =

--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -34,6 +34,8 @@ defmodule ReqLLM.Providers.Anthropic.Response do
 
   """
 
+  alias ReqLLM.Message.ReasoningDetails
+
   @doc """
   Decode Anthropic response data to ReqLLM.Response.
   """
@@ -129,6 +131,56 @@ defmodule ReqLLM.Providers.Anthropic.Response do
 
   def decode_stream_event(_, _model), do: []
 
+  @doc false
+  def init_stream_state do
+    %{thinking_blocks: %{}, next_reasoning_index: 0}
+  end
+
+  @doc false
+  @spec decode_stream_event(map(), LLMDB.Model.t(), map() | nil) ::
+          {[ReqLLM.StreamChunk.t()], map()}
+  def decode_stream_event(%{data: data}, _model, state) when is_map(data) do
+    state = ensure_stream_state(state)
+
+    case data do
+      %{"type" => "message_start", "message" => message} ->
+        {message_start_chunks(message), state}
+
+      %{"type" => "content_block_delta", "index" => index, "delta" => delta} ->
+        decode_content_block_delta(delta, index, state)
+
+      %{"type" => "content_block_start", "index" => index, "content_block" => block} ->
+        decode_content_block_start(block, index, state)
+
+      %{"type" => "content_block_stop", "index" => index} ->
+        finalize_thinking_block(index, state)
+
+      %{"type" => "message_stop"} ->
+        {[ReqLLM.StreamChunk.meta(%{terminal?: true})], state}
+
+      %{"type" => "message_delta", "delta" => delta} ->
+        {message_delta_chunks(data, delta), state}
+
+      %{"type" => "ping"} ->
+        {[ReqLLM.StreamChunk.meta(%{keepalive?: true, provider_event: :ping})], state}
+
+      _ ->
+        {[], state}
+    end
+  end
+
+  def decode_stream_event(_event, _model, state) do
+    {[], ensure_stream_state(state)}
+  end
+
+  @doc false
+  @spec flush_stream_state(LLMDB.Model.t(), map() | nil) :: {[ReqLLM.StreamChunk.t()], map()}
+  def flush_stream_state(_model, state) do
+    state = ensure_stream_state(state)
+    {details, state} = drain_thinking_blocks(state)
+    {reasoning_detail_chunks(details), state}
+  end
+
   # Private helper functions
 
   defp decode_content([]), do: []
@@ -188,6 +240,31 @@ defmodule ReqLLM.Providers.Anthropic.Response do
 
   defp decode_content_block_delta(_, _index), do: []
 
+  defp decode_content_block_delta(%{"type" => "thinking_delta", "thinking" => text}, index, state)
+       when is_binary(text) do
+    chunks = if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text, thinking_metadata())]
+    {chunks, append_thinking_text(state, index, text)}
+  end
+
+  defp decode_content_block_delta(%{"type" => "thinking_delta", "text" => text}, index, state)
+       when is_binary(text) do
+    chunks = if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text, thinking_metadata())]
+    {chunks, append_thinking_text(state, index, text)}
+  end
+
+  defp decode_content_block_delta(
+         %{"type" => "signature_delta", "signature" => signature},
+         index,
+         state
+       )
+       when is_binary(signature) do
+    {[], update_thinking_signature(state, index, signature)}
+  end
+
+  defp decode_content_block_delta(delta, index, state) do
+    {decode_content_block_delta(delta, index), state}
+  end
+
   defp decode_content_block_start(%{"type" => "text", "text" => text}, _index) do
     [ReqLLM.StreamChunk.text(text)]
   end
@@ -206,6 +283,19 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   end
 
   defp decode_content_block_start(_, _index), do: []
+
+  defp decode_content_block_start(%{"type" => "thinking"} = block, index, state) do
+    text = extract_thinking_text(block)
+
+    chunks =
+      if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text, thinking_metadata(block))]
+
+    {chunks, start_thinking_block(state, index, block)}
+  end
+
+  defp decode_content_block_start(block, index, state) do
+    {decode_content_block_start(block, index), state}
+  end
 
   defp build_message_from_chunks([]), do: nil
 
@@ -341,8 +431,136 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   defp parse_finish_reason(reason) when is_binary(reason), do: :error
   defp parse_finish_reason(_), do: nil
 
+  defp ensure_stream_state(nil), do: init_stream_state()
+  defp ensure_stream_state(state), do: state
+
+  defp message_start_chunks(message) do
+    usage_data = Map.get(message, "usage", %{})
+
+    if usage_data == %{} do
+      []
+    else
+      usage = parse_usage(usage_data)
+      [ReqLLM.StreamChunk.meta(%{usage: usage})]
+    end
+  end
+
+  defp message_delta_chunks(data, delta) do
+    finish_reason =
+      case Map.get(delta, "stop_reason") do
+        "end_turn" -> :stop
+        "max_tokens" -> :length
+        "stop_sequence" -> :stop
+        "tool_use" -> :tool_calls
+        _ -> :unknown
+      end
+
+    raw_usage = Map.get(data, "usage", %{})
+    chunks = [ReqLLM.StreamChunk.meta(%{finish_reason: finish_reason, terminal?: true})]
+
+    if raw_usage == %{} do
+      chunks
+    else
+      usage_chunk = ReqLLM.StreamChunk.meta(%{usage: parse_usage(raw_usage)})
+      [usage_chunk | chunks]
+    end
+  end
+
+  defp start_thinking_block(state, index, block) do
+    text = extract_thinking_text(block)
+    signature = normalize_signature(Map.get(block, "signature"))
+
+    update_thinking_block(state, index, fn thinking_block ->
+      %{
+        thinking_block
+        | text: thinking_block.text <> text,
+          signature: signature || thinking_block.signature
+      }
+    end)
+  end
+
+  defp append_thinking_text(state, index, text) do
+    update_thinking_block(state, index, fn thinking_block ->
+      %{thinking_block | text: thinking_block.text <> text}
+    end)
+  end
+
+  defp update_thinking_signature(state, index, signature) do
+    normalized_signature = normalize_signature(signature)
+
+    update_thinking_block(state, index, fn thinking_block ->
+      %{thinking_block | signature: normalized_signature || thinking_block.signature}
+    end)
+  end
+
+  defp update_thinking_block(state, index, fun) do
+    {thinking_block, state} = fetch_thinking_block(state, index)
+    updated_block = fun.(thinking_block)
+    %{state | thinking_blocks: Map.put(state.thinking_blocks, index, updated_block)}
+  end
+
+  defp fetch_thinking_block(%{thinking_blocks: thinking_blocks} = state, index) do
+    case Map.fetch(thinking_blocks, index) do
+      {:ok, thinking_block} ->
+        {thinking_block, state}
+
+      :error ->
+        thinking_block = %{text: "", signature: nil, reasoning_index: state.next_reasoning_index}
+        {thinking_block, %{state | next_reasoning_index: state.next_reasoning_index + 1}}
+    end
+  end
+
+  defp finalize_thinking_block(index, %{thinking_blocks: thinking_blocks} = state) do
+    case Map.pop(thinking_blocks, index) do
+      {nil, _remaining_blocks} ->
+        {[], state}
+
+      {thinking_block, remaining_blocks} ->
+        detail = build_reasoning_detail(thinking_block)
+        chunk = ReqLLM.StreamChunk.meta(%{reasoning_details: [detail]})
+        {[chunk], %{state | thinking_blocks: remaining_blocks}}
+    end
+  end
+
+  defp drain_thinking_blocks(%{thinking_blocks: thinking_blocks} = state) do
+    details =
+      thinking_blocks
+      |> Map.values()
+      |> Enum.sort_by(& &1.reasoning_index)
+      |> Enum.map(&build_reasoning_detail/1)
+
+    {details, %{state | thinking_blocks: %{}}}
+  end
+
+  defp reasoning_detail_chunks([]), do: []
+
+  defp reasoning_detail_chunks(details),
+    do: [ReqLLM.StreamChunk.meta(%{reasoning_details: details})]
+
+  defp build_reasoning_detail(thinking_block) do
+    signature = normalize_signature(thinking_block.signature)
+
+    %ReasoningDetails{
+      text: thinking_block.text,
+      signature: signature,
+      encrypted?: signature != nil,
+      provider: :anthropic,
+      format: "anthropic-thinking-v1",
+      index: thinking_block.reasoning_index,
+      provider_data: %{"type" => "thinking"}
+    }
+  end
+
+  defp extract_thinking_text(block) do
+    cond do
+      is_binary(block["thinking"]) -> block["thinking"]
+      is_binary(block["text"]) -> block["text"]
+      true -> ""
+    end
+  end
+
   defp thinking_metadata(block \\ %{}) do
-    signature = Map.get(block, "signature")
+    signature = normalize_signature(Map.get(block, "signature"))
 
     %{
       signature: signature,
@@ -352,4 +570,10 @@ defmodule ReqLLM.Providers.Anthropic.Response do
       provider_data: %{"type" => "thinking"}
     }
   end
+
+  defp normalize_signature(signature) when is_binary(signature) do
+    if signature == "", do: nil, else: signature
+  end
+
+  defp normalize_signature(_signature), do: nil
 end

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -929,16 +929,53 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
   @impl ReqLLM.Provider
   def decode_stream_event(event, model) do
-    # Get formatter for this model
     formatter = get_formatter(model)
 
-    # Delegate SSE parsing to formatter
-    # For Anthropic models, Vertex uses standard Anthropic SSE format
     if function_exported?(formatter, :decode_stream_event, 2) do
       formatter.decode_stream_event(event, model)
     else
-      # Fall back to Anthropic's stream decoder for models using that format
       ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model)
+    end
+  end
+
+  @impl ReqLLM.Provider
+  def init_stream_state(model) do
+    formatter = get_formatter(model)
+
+    if function_exported?(formatter, :init_stream_state, 0) do
+      formatter.init_stream_state()
+    end
+  end
+
+  @impl ReqLLM.Provider
+  def decode_stream_event(event, model, state) do
+    formatter = get_formatter(model)
+
+    cond do
+      function_exported?(formatter, :decode_stream_event, 3) ->
+        formatter.decode_stream_event(event, model, state)
+
+      function_exported?(formatter, :decode_stream_event, 2) ->
+        {formatter.decode_stream_event(event, model), state}
+
+      true ->
+        ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model, state)
+    end
+  end
+
+  @impl ReqLLM.Provider
+  def flush_stream_state(model, state) do
+    formatter = get_formatter(model)
+
+    cond do
+      function_exported?(formatter, :flush_stream_state, 2) ->
+        formatter.flush_stream_state(model, state)
+
+      function_exported?(formatter, :flush_stream_state, 1) ->
+        formatter.flush_stream_state(state)
+
+      true ->
+        {[], state}
     end
   end
 

--- a/lib/req_llm/providers/google_vertex/anthropic.ex
+++ b/lib/req_llm/providers/google_vertex/anthropic.ex
@@ -140,6 +140,36 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
   end
 
   @doc """
+  Decodes Server-Sent Events for streaming responses.
+
+  Vertex Claude uses Anthropic's native SSE format.
+  """
+  def decode_stream_event(event, model) do
+    Anthropic.Response.decode_stream_event(event, model)
+  end
+
+  @doc """
+  Initializes streaming state for Claude thinking blocks.
+  """
+  def init_stream_state do
+    Anthropic.Response.init_stream_state()
+  end
+
+  @doc """
+  Decodes Server-Sent Events with stateful thinking-block assembly.
+  """
+  def decode_stream_event(event, model, state) do
+    Anthropic.Response.decode_stream_event(event, model, state)
+  end
+
+  @doc """
+  Flushes any buffered streaming thinking blocks.
+  """
+  def flush_stream_state(model, state) do
+    Anthropic.Response.flush_stream_state(model, state)
+  end
+
+  @doc """
   Extracts usage metadata from the response body.
 
   Delegates to the native Anthropic provider.

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -813,6 +813,142 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert chunk.metadata[:keepalive?] == true
       assert chunk.metadata[:provider_event] == :ping
     end
+
+    test "decode_stream_event/3 emits one reasoning detail for a streamed thinking block" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-20250514")
+
+      events = [
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 0,
+            "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "First part "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "second part"}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "signature_delta", "signature" => "sig_test_123"}
+          }
+        },
+        %{data: %{"type" => "content_block_stop", "index" => 0}}
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], Anthropic.init_stream_state(model)}, fn event, {acc, state} ->
+          {event_chunks, next_state} = Anthropic.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      assert Enum.filter(chunks, &(&1.type == :thinking)) |> Enum.map(& &1.text) == [
+               "First part ",
+               "second part"
+             ]
+
+      reasoning_chunks =
+        Enum.filter(chunks, fn
+          %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [_detail]}} -> true
+          _ -> false
+        end)
+
+      assert [%ReqLLM.StreamChunk{metadata: %{reasoning_details: [detail]}}] = reasoning_chunks
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+      assert detail.index == 0
+    end
+
+    test "streamed thinking round-trips as a single Anthropic reasoning block" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-20250514")
+      context = %ReqLLM.Context{messages: []}
+
+      events = [
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 0,
+            "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "First part "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "second part"}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "signature_delta", "signature" => "sig_test_123"}
+          }
+        },
+        %{data: %{"type" => "content_block_stop", "index" => 0}},
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 1,
+            "content_block" => %{"type" => "text", "text" => "Answer: "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 1,
+            "delta" => %{"type" => "text_delta", "text" => "42"}
+          }
+        }
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], Anthropic.init_stream_state(model)}, fn event, {acc, state} ->
+          {event_chunks, next_state} = Anthropic.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      {:ok, response} =
+        ReqLLM.Providers.Anthropic.ResponseBuilder.build_response(
+          chunks,
+          %{finish_reason: :stop},
+          context: context,
+          model: model
+        )
+
+      assert [detail] = response.message.reasoning_details
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+
+      encoded = ReqLLM.Providers.Anthropic.Context.encode_request(response.context, model)
+      [assistant_message] = encoded[:messages]
+      [thinking_block, text_block] = assistant_message[:content]
+
+      assert thinking_block[:type] == "thinking"
+      assert thinking_block[:thinking] == "First part second part"
+      assert thinking_block[:signature] == "sig_test_123"
+      assert text_block == %{type: "text", text: "Answer: 42"}
+    end
   end
 
   describe "option translation" do
@@ -1659,20 +1795,24 @@ defmodule ReqLLM.Providers.AnthropicTest do
   describe "ResponseBuilder - streaming reasoning_details extraction" do
     alias ReqLLM.Providers.Anthropic.ResponseBuilder
 
-    test "extracts reasoning_details from thinking chunks" do
+    test "prefers finalized reasoning_details from meta chunks over delta chunks" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-20250514")
       context = %ReqLLM.Context{messages: []}
 
-      thinking_meta = %{
+      reasoning_detail = %ReqLLM.Message.ReasoningDetails{
+        text: "Let me analyze this step by stepFirst, consider the constraints",
+        signature: "sig_abc123",
+        encrypted?: true,
         provider: :anthropic,
         format: "anthropic-thinking-v1",
-        encrypted?: false,
+        index: 0,
         provider_data: %{"type" => "thinking"}
       }
 
       chunks = [
-        ReqLLM.StreamChunk.thinking("Let me analyze this step by step", thinking_meta),
-        ReqLLM.StreamChunk.thinking("First, consider the constraints", thinking_meta),
+        ReqLLM.StreamChunk.thinking("Let me analyze this step by step"),
+        ReqLLM.StreamChunk.thinking("First, consider the constraints"),
+        ReqLLM.StreamChunk.meta(%{reasoning_details: [reasoning_detail]}),
         ReqLLM.StreamChunk.text("The answer is 42.")
       ]
 
@@ -1682,17 +1822,12 @@ defmodule ReqLLM.Providers.AnthropicTest do
         ResponseBuilder.build_response(chunks, metadata, context: context, model: model)
 
       assert response.message.reasoning_details != nil
-      assert length(response.message.reasoning_details) == 2
-
-      [first, second] = response.message.reasoning_details
-      assert %ReqLLM.Message.ReasoningDetails{} = first
-      assert first.text == "Let me analyze this step by step"
-      assert first.provider == :anthropic
-      assert first.format == "anthropic-thinking-v1"
-      assert first.index == 0
-
-      assert second.text == "First, consider the constraints"
-      assert second.index == 1
+      assert [detail] = response.message.reasoning_details
+      assert detail.text == reasoning_detail.text
+      assert detail.signature == "sig_abc123"
+      assert detail.provider == :anthropic
+      assert detail.format == "anthropic-thinking-v1"
+      assert detail.index == 0
     end
 
     test "returns nil reasoning_details when no thinking chunks" do

--- a/test/providers/google_vertex_gemini_test.exs
+++ b/test/providers/google_vertex_gemini_test.exs
@@ -460,6 +460,116 @@ defmodule ReqLLM.Providers.GoogleVertex.GeminiTest do
     end
   end
 
+  describe "streaming reasoning_details extraction (Claude on Vertex)" do
+    alias ReqLLM.Provider.ResponseBuilder
+    alias ReqLLM.Providers.GoogleVertex
+    alias ReqLLM.Providers.GoogleVertex.Anthropic, as: VertexAnthropic
+
+    test "decode_stream_event/3 preserves a single Anthropic reasoning detail" do
+      {:ok, model} = ReqLLM.model("google_vertex:claude-haiku-4-5@20251001")
+
+      events = [
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 0,
+            "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "First part "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "second part"}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "signature_delta", "signature" => "sig_test_123"}
+          }
+        },
+        %{data: %{"type" => "content_block_stop", "index" => 0}}
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], GoogleVertex.init_stream_state(model)}, fn event, {acc, state} ->
+          {event_chunks, next_state} = GoogleVertex.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      assert Enum.filter(chunks, &(&1.type == :thinking)) |> Enum.map(& &1.text) == [
+               "First part ",
+               "second part"
+             ]
+
+      reasoning_chunks =
+        Enum.filter(chunks, fn
+          %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [_detail]}} -> true
+          _ -> false
+        end)
+
+      assert [%ReqLLM.StreamChunk{metadata: %{reasoning_details: [detail]}}] = reasoning_chunks
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+      assert detail.provider == :anthropic
+      assert detail.format == "anthropic-thinking-v1"
+      assert detail.index == 0
+    end
+
+    test "streamed reasoning round-trips into a single Anthropic thinking block" do
+      {:ok, model} = ReqLLM.model("google_vertex:claude-haiku-4-5@20251001")
+      context = %ReqLLM.Context{messages: []}
+
+      chunks = [
+        ReqLLM.StreamChunk.thinking("First part "),
+        ReqLLM.StreamChunk.thinking("second part"),
+        ReqLLM.StreamChunk.meta(%{
+          reasoning_details: [
+            %ReqLLM.Message.ReasoningDetails{
+              text: "First part second part",
+              signature: "sig_test_123",
+              encrypted?: true,
+              provider: :anthropic,
+              format: "anthropic-thinking-v1",
+              index: 0,
+              provider_data: %{"type" => "thinking"}
+            }
+          ]
+        }),
+        ReqLLM.StreamChunk.text("Answer: 42")
+      ]
+
+      builder = ResponseBuilder.for_model(model)
+      assert builder == ReqLLM.Providers.Anthropic.ResponseBuilder
+
+      {:ok, response} =
+        builder.build_response(chunks, %{finish_reason: :stop}, context: context, model: model)
+
+      assert [detail] = response.message.reasoning_details
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+      assert detail.provider == :anthropic
+
+      encoded = VertexAnthropic.format_request(model.id, response.context, model: model.id)
+      [assistant_message] = encoded[:messages]
+      [thinking_block, text_block] = assistant_message[:content]
+
+      assert thinking_block[:type] == "thinking"
+      assert thinking_block[:thinking] == "First part second part"
+      assert thinking_block[:signature] == "sig_test_123"
+      assert text_block == %{type: "text", text: "Answer: 42"}
+    end
+  end
+
   describe "option translation for Gemini thinking" do
     alias ReqLLM.Providers.GoogleVertex
 


### PR DESCRIPTION
## Summary
- make Vertex Claude streaming use Anthropic's stateful thinking-block decoder
- route Vertex Claude streamed responses through the Anthropic response builder
- add regressions for signature preservation and request round-tripping

Refs #629