### PR TITLE
fix(bedrock): preserve native Claude thinking signatures

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -656,16 +656,6 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
   @impl ReqLLM.Provider
   def decode_stream_event(event, model) when is_map(event) do
-    # Decode AWS event stream events into StreamChunks
-    # This is called after parse_stream_protocol returns events
-    #
-    # Detect the correct formatter from the event format rather than assuming
-    # based on model ID. The request path (attach_stream) decides whether to use
-    # Converse or InvokeModel API via determine_use_converse/2, but that context
-    # isn't available here. Instead, detect from the event structure:
-    #
-    # - Converse API events use camelCase keys: "contentBlockDelta", "messageStart", etc.
-    # - InvokeModel/native API events use "type" field: "content_block_delta", "message_start", etc.
     model_id = model.provider_model_id || model.id
 
     formatter =
@@ -676,15 +666,52 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         get_formatter_module(model_family)
       end
 
-    case formatter.parse_stream_chunk(event, %{}) do
-      {:ok, nil} -> []
-      {:ok, chunk} -> [chunk]
-      {:error, _} -> []
-    end
+    decode_formatter_stream_event(formatter, event)
   end
 
   def decode_stream_event(_data, _model) do
     []
+  end
+
+  @impl ReqLLM.Provider
+  def init_stream_state(model) do
+    model_id = model.provider_model_id || model.id
+
+    case get_model_family(model_id) do
+      "anthropic" -> ReqLLM.Providers.Anthropic.Response.init_stream_state()
+      _ -> nil
+    end
+  end
+
+  @impl ReqLLM.Provider
+  def decode_stream_event(event, model, state) when is_map(event) do
+    model_id = model.provider_model_id || model.id
+
+    cond do
+      converse_event?(event) ->
+        {decode_formatter_stream_event(ReqLLM.Providers.AmazonBedrock.Converse, event), state}
+
+      get_model_family(model_id) == "anthropic" ->
+        ReqLLM.Providers.Anthropic.Response.decode_stream_event(%{data: event}, model, state)
+
+      true ->
+        formatter = get_formatter_module(get_model_family(model_id))
+        {decode_formatter_stream_event(formatter, event), state}
+    end
+  end
+
+  def decode_stream_event(_event, _model, state) do
+    {[], state}
+  end
+
+  @impl ReqLLM.Provider
+  def flush_stream_state(model, state) do
+    model_id = model.provider_model_id || model.id
+
+    case get_model_family(model_id) do
+      "anthropic" -> ReqLLM.Providers.Anthropic.Response.flush_stream_state(model, state)
+      _ -> {[], state}
+    end
   end
 
   # Note: pre_validate_options is not yet a formal Provider callback
@@ -733,6 +760,14 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   @converse_event_keys ~w(contentBlockDelta contentBlockStart contentBlockStop messageStart messageStop metadata)
   defp converse_event?(event) when is_map(event) do
     Enum.any?(@converse_event_keys, &Map.has_key?(event, &1))
+  end
+
+  defp decode_formatter_stream_event(formatter, event) do
+    case formatter.parse_stream_chunk(event, %{}) do
+      {:ok, nil} -> []
+      {:ok, chunk} -> [chunk]
+      {:error, _} -> []
+    end
   end
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -555,6 +555,21 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   @impl ReqLLM.Provider
+  def init_stream_state(_model) do
+    ReqLLM.Providers.Anthropic.Response.init_stream_state()
+  end
+
+  @impl ReqLLM.Provider
+  def decode_stream_event(event, model, state) do
+    ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model, state)
+  end
+
+  @impl ReqLLM.Provider
+  def flush_stream_state(model, state) do
+    ReqLLM.Providers.Anthropic.Response.flush_stream_state(model, state)
+  end
+
+  @impl ReqLLM.Provider
   def translate_options(operation, _model, opts) do
     # Anthropic-specific parameter translation
     translated_opts =

--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -34,6 +34,8 @@ defmodule ReqLLM.Providers.Anthropic.Response do
 
   """
 
+  alias ReqLLM.Message.ReasoningDetails
+
   @doc """
   Decode Anthropic response data to ReqLLM.Response.
   """
@@ -129,6 +131,56 @@ defmodule ReqLLM.Providers.Anthropic.Response do
 
   def decode_stream_event(_, _model), do: []
 
+  @doc false
+  def init_stream_state do
+    %{thinking_blocks: %{}, next_reasoning_index: 0}
+  end
+
+  @doc false
+  @spec decode_stream_event(map(), LLMDB.Model.t(), map() | nil) ::
+          {[ReqLLM.StreamChunk.t()], map()}
+  def decode_stream_event(%{data: data}, _model, state) when is_map(data) do
+    state = ensure_stream_state(state)
+
+    case data do
+      %{"type" => "message_start", "message" => message} ->
+        {message_start_chunks(message), state}
+
+      %{"type" => "content_block_delta", "index" => index, "delta" => delta} ->
+        decode_content_block_delta(delta, index, state)
+
+      %{"type" => "content_block_start", "index" => index, "content_block" => block} ->
+        decode_content_block_start(block, index, state)
+
+      %{"type" => "content_block_stop", "index" => index} ->
+        finalize_thinking_block(index, state)
+
+      %{"type" => "message_stop"} ->
+        {[ReqLLM.StreamChunk.meta(%{terminal?: true})], state}
+
+      %{"type" => "message_delta", "delta" => delta} ->
+        {message_delta_chunks(data, delta), state}
+
+      %{"type" => "ping"} ->
+        {[ReqLLM.StreamChunk.meta(%{keepalive?: true, provider_event: :ping})], state}
+
+      _ ->
+        {[], state}
+    end
+  end
+
+  def decode_stream_event(_event, _model, state) do
+    {[], ensure_stream_state(state)}
+  end
+
+  @doc false
+  @spec flush_stream_state(LLMDB.Model.t(), map() | nil) :: {[ReqLLM.StreamChunk.t()], map()}
+  def flush_stream_state(_model, state) do
+    state = ensure_stream_state(state)
+    {details, state} = drain_thinking_blocks(state)
+    {reasoning_detail_chunks(details), state}
+  end
+
   # Private helper functions
 
   defp decode_content([]), do: []
@@ -188,6 +240,31 @@ defmodule ReqLLM.Providers.Anthropic.Response do
 
   defp decode_content_block_delta(_, _index), do: []
 
+  defp decode_content_block_delta(%{"type" => "thinking_delta", "thinking" => text}, index, state)
+       when is_binary(text) do
+    chunks = if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text, thinking_metadata())]
+    {chunks, append_thinking_text(state, index, text)}
+  end
+
+  defp decode_content_block_delta(%{"type" => "thinking_delta", "text" => text}, index, state)
+       when is_binary(text) do
+    chunks = if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text, thinking_metadata())]
+    {chunks, append_thinking_text(state, index, text)}
+  end
+
+  defp decode_content_block_delta(
+         %{"type" => "signature_delta", "signature" => signature},
+         index,
+         state
+       )
+       when is_binary(signature) do
+    {[], update_thinking_signature(state, index, signature)}
+  end
+
+  defp decode_content_block_delta(delta, index, state) do
+    {decode_content_block_delta(delta, index), state}
+  end
+
   defp decode_content_block_start(%{"type" => "text", "text" => text}, _index) do
     [ReqLLM.StreamChunk.text(text)]
   end
@@ -206,6 +283,19 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   end
 
   defp decode_content_block_start(_, _index), do: []
+
+  defp decode_content_block_start(%{"type" => "thinking"} = block, index, state) do
+    text = extract_thinking_text(block)
+
+    chunks =
+      if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text, thinking_metadata(block))]
+
+    {chunks, start_thinking_block(state, index, block)}
+  end
+
+  defp decode_content_block_start(block, index, state) do
+    {decode_content_block_start(block, index), state}
+  end
 
   defp build_message_from_chunks([]), do: nil
 
@@ -341,8 +431,136 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   defp parse_finish_reason(reason) when is_binary(reason), do: :error
   defp parse_finish_reason(_), do: nil
 
+  defp ensure_stream_state(nil), do: init_stream_state()
+  defp ensure_stream_state(state), do: state
+
+  defp message_start_chunks(message) do
+    usage_data = Map.get(message, "usage", %{})
+
+    if usage_data == %{} do
+      []
+    else
+      usage = parse_usage(usage_data)
+      [ReqLLM.StreamChunk.meta(%{usage: usage})]
+    end
+  end
+
+  defp message_delta_chunks(data, delta) do
+    finish_reason =
+      case Map.get(delta, "stop_reason") do
+        "end_turn" -> :stop
+        "max_tokens" -> :length
+        "stop_sequence" -> :stop
+        "tool_use" -> :tool_calls
+        _ -> :unknown
+      end
+
+    raw_usage = Map.get(data, "usage", %{})
+    chunks = [ReqLLM.StreamChunk.meta(%{finish_reason: finish_reason, terminal?: true})]
+
+    if raw_usage == %{} do
+      chunks
+    else
+      usage_chunk = ReqLLM.StreamChunk.meta(%{usage: parse_usage(raw_usage)})
+      [usage_chunk | chunks]
+    end
+  end
+
+  defp start_thinking_block(state, index, block) do
+    text = extract_thinking_text(block)
+    signature = normalize_signature(Map.get(block, "signature"))
+
+    update_thinking_block(state, index, fn thinking_block ->
+      %{
+        thinking_block
+        | text: thinking_block.text <> text,
+          signature: signature || thinking_block.signature
+      }
+    end)
+  end
+
+  defp append_thinking_text(state, index, text) do
+    update_thinking_block(state, index, fn thinking_block ->
+      %{thinking_block | text: thinking_block.text <> text}
+    end)
+  end
+
+  defp update_thinking_signature(state, index, signature) do
+    normalized_signature = normalize_signature(signature)
+
+    update_thinking_block(state, index, fn thinking_block ->
+      %{thinking_block | signature: normalized_signature || thinking_block.signature}
+    end)
+  end
+
+  defp update_thinking_block(state, index, fun) do
+    {thinking_block, state} = fetch_thinking_block(state, index)
+    updated_block = fun.(thinking_block)
+    %{state | thinking_blocks: Map.put(state.thinking_blocks, index, updated_block)}
+  end
+
+  defp fetch_thinking_block(%{thinking_blocks: thinking_blocks} = state, index) do
+    case Map.fetch(thinking_blocks, index) do
+      {:ok, thinking_block} ->
+        {thinking_block, state}
+
+      :error ->
+        thinking_block = %{text: "", signature: nil, reasoning_index: state.next_reasoning_index}
+        {thinking_block, %{state | next_reasoning_index: state.next_reasoning_index + 1}}
+    end
+  end
+
+  defp finalize_thinking_block(index, %{thinking_blocks: thinking_blocks} = state) do
+    case Map.pop(thinking_blocks, index) do
+      {nil, _remaining_blocks} ->
+        {[], state}
+
+      {thinking_block, remaining_blocks} ->
+        detail = build_reasoning_detail(thinking_block)
+        chunk = ReqLLM.StreamChunk.meta(%{reasoning_details: [detail]})
+        {[chunk], %{state | thinking_blocks: remaining_blocks}}
+    end
+  end
+
+  defp drain_thinking_blocks(%{thinking_blocks: thinking_blocks} = state) do
+    details =
+      thinking_blocks
+      |> Map.values()
+      |> Enum.sort_by(& &1.reasoning_index)
+      |> Enum.map(&build_reasoning_detail/1)
+
+    {details, %{state | thinking_blocks: %{}}}
+  end
+
+  defp reasoning_detail_chunks([]), do: []
+
+  defp reasoning_detail_chunks(details),
+    do: [ReqLLM.StreamChunk.meta(%{reasoning_details: details})]
+
+  defp build_reasoning_detail(thinking_block) do
+    signature = normalize_signature(thinking_block.signature)
+
+    %ReasoningDetails{
+      text: thinking_block.text,
+      signature: signature,
+      encrypted?: signature != nil,
+      provider: :anthropic,
+      format: "anthropic-thinking-v1",
+      index: thinking_block.reasoning_index,
+      provider_data: %{"type" => "thinking"}
+    }
+  end
+
+  defp extract_thinking_text(block) do
+    cond do
+      is_binary(block["thinking"]) -> block["thinking"]
+      is_binary(block["text"]) -> block["text"]
+      true -> ""
+    end
+  end
+
   defp thinking_metadata(block \\ %{}) do
-    signature = Map.get(block, "signature")
+    signature = normalize_signature(Map.get(block, "signature"))
 
     %{
       signature: signature,
@@ -352,4 +570,10 @@ defmodule ReqLLM.Providers.Anthropic.Response do
       provider_data: %{"type" => "thinking"}
     }
   end
+
+  defp normalize_signature(signature) when is_binary(signature) do
+    if signature == "", do: nil, else: signature
+  end
+
+  defp normalize_signature(_signature), do: nil
 end

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -813,6 +813,142 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert chunk.metadata[:keepalive?] == true
       assert chunk.metadata[:provider_event] == :ping
     end
+
+    test "decode_stream_event/3 emits one reasoning detail for a streamed thinking block" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-20250514")
+
+      events = [
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 0,
+            "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "First part "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "second part"}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "signature_delta", "signature" => "sig_test_123"}
+          }
+        },
+        %{data: %{"type" => "content_block_stop", "index" => 0}}
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], Anthropic.init_stream_state(model)}, fn event, {acc, state} ->
+          {event_chunks, next_state} = Anthropic.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      assert Enum.filter(chunks, &(&1.type == :thinking)) |> Enum.map(& &1.text) == [
+               "First part ",
+               "second part"
+             ]
+
+      reasoning_chunks =
+        Enum.filter(chunks, fn
+          %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [_detail]}} -> true
+          _ -> false
+        end)
+
+      assert [%ReqLLM.StreamChunk{metadata: %{reasoning_details: [detail]}}] = reasoning_chunks
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+      assert detail.index == 0
+    end
+
+    test "streamed thinking round-trips as a single Anthropic reasoning block" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-20250514")
+      context = %ReqLLM.Context{messages: []}
+
+      events = [
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 0,
+            "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "First part "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "thinking_delta", "thinking" => "second part"}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "signature_delta", "signature" => "sig_test_123"}
+          }
+        },
+        %{data: %{"type" => "content_block_stop", "index" => 0}},
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 1,
+            "content_block" => %{"type" => "text", "text" => "Answer: "}
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 1,
+            "delta" => %{"type" => "text_delta", "text" => "42"}
+          }
+        }
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], Anthropic.init_stream_state(model)}, fn event, {acc, state} ->
+          {event_chunks, next_state} = Anthropic.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      {:ok, response} =
+        ReqLLM.Providers.Anthropic.ResponseBuilder.build_response(
+          chunks,
+          %{finish_reason: :stop},
+          context: context,
+          model: model
+        )
+
+      assert [detail] = response.message.reasoning_details
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+
+      encoded = ReqLLM.Providers.Anthropic.Context.encode_request(response.context, model)
+      [assistant_message] = encoded[:messages]
+      [thinking_block, text_block] = assistant_message[:content]
+
+      assert thinking_block[:type] == "thinking"
+      assert thinking_block[:thinking] == "First part second part"
+      assert thinking_block[:signature] == "sig_test_123"
+      assert text_block == %{type: "text", text: "Answer: 42"}
+    end
   end
 
   describe "option translation" do
@@ -1659,20 +1795,24 @@ defmodule ReqLLM.Providers.AnthropicTest do
   describe "ResponseBuilder - streaming reasoning_details extraction" do
     alias ReqLLM.Providers.Anthropic.ResponseBuilder
 
-    test "extracts reasoning_details from thinking chunks" do
+    test "prefers finalized reasoning_details from meta chunks over delta chunks" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-20250514")
       context = %ReqLLM.Context{messages: []}
 
-      thinking_meta = %{
+      reasoning_detail = %ReqLLM.Message.ReasoningDetails{
+        text: "Let me analyze this step by stepFirst, consider the constraints",
+        signature: "sig_abc123",
+        encrypted?: true,
         provider: :anthropic,
         format: "anthropic-thinking-v1",
-        encrypted?: false,
+        index: 0,
         provider_data: %{"type" => "thinking"}
       }
 
       chunks = [
-        ReqLLM.StreamChunk.thinking("Let me analyze this step by step", thinking_meta),
-        ReqLLM.StreamChunk.thinking("First, consider the constraints", thinking_meta),
+        ReqLLM.StreamChunk.thinking("Let me analyze this step by step"),
+        ReqLLM.StreamChunk.thinking("First, consider the constraints"),
+        ReqLLM.StreamChunk.meta(%{reasoning_details: [reasoning_detail]}),
         ReqLLM.StreamChunk.text("The answer is 42.")
       ]
 
@@ -1682,17 +1822,12 @@ defmodule ReqLLM.Providers.AnthropicTest do
         ResponseBuilder.build_response(chunks, metadata, context: context, model: model)
 
       assert response.message.reasoning_details != nil
-      assert length(response.message.reasoning_details) == 2
-
-      [first, second] = response.message.reasoning_details
-      assert %ReqLLM.Message.ReasoningDetails{} = first
-      assert first.text == "Let me analyze this step by step"
-      assert first.provider == :anthropic
-      assert first.format == "anthropic-thinking-v1"
-      assert first.index == 0
-
-      assert second.text == "First, consider the constraints"
-      assert second.index == 1
+      assert [detail] = response.message.reasoning_details
+      assert detail.text == reasoning_detail.text
+      assert detail.signature == "sig_abc123"
+      assert detail.provider == :anthropic
+      assert detail.format == "anthropic-thinking-v1"
+      assert detail.index == 0
     end
 
     test "returns nil reasoning_details when no thinking chunks" do

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -311,6 +311,117 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
     end
   end
 
+  describe "decode_stream_event/3" do
+    test "emits one reasoning detail for a native Anthropic thinking block" do
+      model =
+        LLMDB.Model.new!(%{
+          id: "anthropic.claude-3-haiku-20240307-v1:0",
+          provider: :amazon_bedrock
+        })
+
+      events = [
+        %{
+          "type" => "content_block_start",
+          "index" => 0,
+          "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+        },
+        %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "thinking_delta", "thinking" => "First part "}
+        },
+        %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "thinking_delta", "thinking" => "second part"}
+        },
+        %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "signature_delta", "signature" => "sig_test_123"}
+        },
+        %{"type" => "content_block_stop", "index" => 0}
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], AmazonBedrock.init_stream_state(model)}, fn event,
+                                                                             {acc, state} ->
+          {event_chunks, next_state} = AmazonBedrock.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      assert Enum.filter(chunks, &(&1.type == :thinking)) |> Enum.map(& &1.text) == [
+               "First part ",
+               "second part"
+             ]
+
+      reasoning_chunks =
+        Enum.filter(chunks, fn
+          %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [_detail]}} -> true
+          _ -> false
+        end)
+
+      assert [%ReqLLM.StreamChunk{metadata: %{reasoning_details: [detail]}}] = reasoning_chunks
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+      assert detail.provider == :anthropic
+      assert detail.format == "anthropic-thinking-v1"
+      assert detail.index == 0
+    end
+
+    test "native Anthropic streamed reasoning round-trips into a single thinking block" do
+      model =
+        LLMDB.Model.new!(%{
+          id: "anthropic.claude-3-haiku-20240307-v1:0",
+          provider: :amazon_bedrock
+        })
+
+      context = %ReqLLM.Context{messages: []}
+
+      chunks = [
+        ReqLLM.StreamChunk.thinking("First part "),
+        ReqLLM.StreamChunk.thinking("second part"),
+        ReqLLM.StreamChunk.meta(%{
+          reasoning_details: [
+            %ReqLLM.Message.ReasoningDetails{
+              text: "First part second part",
+              signature: "sig_test_123",
+              encrypted?: true,
+              provider: :anthropic,
+              format: "anthropic-thinking-v1",
+              index: 0,
+              provider_data: %{"type" => "thinking"}
+            }
+          ]
+        }),
+        ReqLLM.StreamChunk.text("Answer: 42")
+      ]
+
+      builder = ReqLLM.Provider.ResponseBuilder.for_model(model)
+
+      {:ok, response} =
+        builder.build_response(chunks, %{finish_reason: :stop}, context: context, model: model)
+
+      assert [detail] = response.message.reasoning_details
+      assert detail.text == "First part second part"
+      assert detail.signature == "sig_test_123"
+      assert detail.provider == :anthropic
+
+      encoded =
+        ReqLLM.Providers.AmazonBedrock.Anthropic.format_request(model.id, response.context,
+          model: model.id
+        )
+
+      [assistant_message] = encoded[:messages]
+      [thinking_block, text_block] = assistant_message[:content]
+
+      assert thinking_block[:type] == "thinking"
+      assert thinking_block[:thinking] == "First part second part"
+      assert thinking_block[:signature] == "sig_test_123"
+      assert text_block == %{type: "text", text: "Answer: 42"}
+    end
+  end
+
   describe "AWS session token support" do
     test "includes session token in signed Req request headers" do
       # Test non-streaming path (Req pipeline via put_aws_sigv4)


### PR DESCRIPTION
## Summary
- route native Bedrock Claude streaming through Anthropic's stateful thinking-block decoder
- preserve finalized reasoning details and signatures across the Bedrock follow-up turn
- add regressions for native streaming assembly and request round-tripping

## Scope
- fixes the native Bedrock Claude streaming path
- leaves Converse behavior unchanged

Refs #630