### PR TITLE
Fixes Gemini SSE Stream losing finish-reason

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -420,8 +420,6 @@ defmodule Mix.Tasks.ReqLlm.Gen do
         if Map.has_key?(usage, :total_cost) do
           cost = :erlang.float_to_binary(usage.total_cost, decimals: 6)
           log_puts("   Cost: $#{cost}", :debug, log_level)
-          # credo:disable-for-next-line Credo.Check.Warning.IoInspect
-          IO.inspect(usage, label: "DEBUG: Full usage object")
         end
 
       _ ->

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -2352,7 +2352,7 @@ defmodule ReqLLM.Providers.Google do
         convert_url_content_part(part, url)
 
       _ ->
-        %{text: to_string(part)}
+        %{text: inspect(part)}
     end
   end
 
@@ -2363,7 +2363,7 @@ defmodule ReqLLM.Providers.Google do
         convert_url_content_part(part, url)
 
       _ ->
-        %{text: to_string(part)}
+        %{text: inspect(part)}
     end
   end
 
@@ -2550,6 +2550,31 @@ defmodule ReqLLM.Providers.Google do
         else
           chunks
         end
+
+      %{
+        "candidates" => [%{"finishReason" => finish_reason} | _],
+        "usageMetadata" => usage
+      }
+      when finish_reason != nil ->
+        meta = %{
+          usage: convert_google_usage_for_streaming(usage),
+          finish_reason: normalize_google_finish_reason(finish_reason),
+          model: model.id,
+          terminal?: true
+        }
+
+        meta = if provider_meta, do: Map.put(meta, :provider_meta, provider_meta), else: meta
+        [ReqLLM.StreamChunk.meta(meta)]
+
+      %{"candidates" => [%{"finishReason" => finish_reason} | _]}
+      when finish_reason != nil ->
+        meta = %{
+          finish_reason: normalize_google_finish_reason(finish_reason),
+          terminal?: true
+        }
+
+        meta = if provider_meta, do: Map.put(meta, :provider_meta, provider_meta), else: meta
+        [ReqLLM.StreamChunk.meta(meta)]
 
       %{"usageMetadata" => usage} ->
         meta = %{

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -974,11 +974,17 @@ defmodule ReqLLM.StreamServer do
       |> maybe_put_request_id(state.telemetry)
       |> normalize_public_stream_finish_reason()
 
-    if state.terminated? do
-      Map.put_new(meta, :finish_reason, :stop)
-    else
-      Map.put_new(meta, :finish_reason, :incomplete)
-    end
+    cleanly_terminated? =
+      state.terminated? or Map.get(state.metadata, :terminal?) == true
+
+    meta =
+      if cleanly_terminated? do
+        Map.put_new(meta, :finish_reason, :stop)
+      else
+        Map.put_new(meta, :finish_reason, :incomplete)
+      end
+
+    Map.delete(meta, :terminal?)
   end
 
   defp reply_to_waiting_callers(state) do

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -935,6 +935,88 @@ defmodule ReqLLM.Providers.GoogleTest do
     end
   end
 
+  describe "decode_stream_event/2 finish_reason capture" do
+    setup do
+      {:ok, model: %LLMDB.Model{id: "gemini-2.5-flash", provider: :google}}
+    end
+
+    test "finishReason on candidate without content.parts + usageMetadata", %{model: model} do
+      event = %{
+        data: %{
+          "candidates" => [%{"finishReason" => "STOP", "index" => 0}],
+          "usageMetadata" => %{
+            "promptTokenCount" => 10,
+            "candidatesTokenCount" => 5,
+            "totalTokenCount" => 15
+          }
+        }
+      }
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.type == :meta
+      assert meta_chunk.metadata[:finish_reason] == "stop"
+      assert meta_chunk.metadata[:terminal?] == true
+      assert meta_chunk.metadata[:usage][:input_tokens] == 10
+    end
+
+    test "finishReason on candidate without content.parts (no usage)", %{model: model} do
+      event = %{data: %{"candidates" => [%{"finishReason" => "STOP", "index" => 0}]}}
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.type == :meta
+      assert meta_chunk.metadata[:finish_reason] == "stop"
+      assert meta_chunk.metadata[:terminal?] == true
+    end
+
+    test "finishReason on candidate with content role but no parts key", %{model: model} do
+      event = %{
+        data: %{
+          "candidates" => [
+            %{"content" => %{"role" => "model"}, "finishReason" => "STOP", "index" => 0}
+          ],
+          "usageMetadata" => %{"promptTokenCount" => 1, "totalTokenCount" => 1}
+        }
+      }
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.type == :meta
+      assert meta_chunk.metadata[:finish_reason] == "stop"
+      assert meta_chunk.metadata[:terminal?] == true
+    end
+
+    test "usageMetadata alone still has no finish_reason (unchanged)", %{model: model} do
+      event = %{
+        data: %{
+          "usageMetadata" => %{"promptTokenCount" => 1, "totalTokenCount" => 1}
+        }
+      }
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.type == :meta
+      refute Map.has_key?(meta_chunk.metadata, :finish_reason)
+      assert meta_chunk.metadata[:terminal?] == true
+    end
+
+    test "content.parts + finishReason still preferred (regression)", %{model: model} do
+      event = %{
+        data: %{
+          "candidates" => [
+            %{
+              "content" => %{"parts" => [%{"text" => "hello"}], "role" => "model"},
+              "finishReason" => "STOP"
+            }
+          ],
+          "usageMetadata" => %{"promptTokenCount" => 2, "totalTokenCount" => 2}
+        }
+      }
+
+      chunks = Google.decode_stream_event(event, model)
+      assert Enum.any?(chunks, &match?(%{type: :content, text: "hello"}, &1))
+      meta_chunk = Enum.find(chunks, &(&1.type == :meta))
+      assert meta_chunk.metadata[:finish_reason] == "stop"
+    end
+  end
+
   describe "option translation" do
     test "provider implements translate_options/3" do
       # Google implements translate_options/3 for stream? alias handling

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -98,5 +98,37 @@ defmodule ReqLLM.StreamServer.MetadataTest do
       assert_receive {:EXIT, ^server, :normal}, 200
       refute Process.alive?(server)
     end
+
+    test "terminal? flag from provider meta flips finish_reason to :stop" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      payload = Jason.encode!(%{"event" => "terminal"})
+      StreamServer.http_event(server, {:data, "data: #{payload}\n\n"})
+      StreamServer.http_event(server, :done)
+
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 200)
+      assert metadata.finish_reason == :stop
+      refute Map.has_key?(metadata, :terminal?)
+
+      StreamServer.cancel(server)
+    end
+
+    test "explicit finish_reason from provider wins over terminal? fallback" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      finish_payload = Jason.encode!(%{"choices" => [%{"finish_reason" => "length"}]})
+      terminal_payload = Jason.encode!(%{"event" => "terminal"})
+
+      StreamServer.http_event(server, {:data, "data: #{finish_payload}\n\n"})
+      StreamServer.http_event(server, {:data, "data: #{terminal_payload}\n\n"})
+      StreamServer.http_event(server, :done)
+
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 200)
+      assert metadata.finish_reason == :length
+
+      StreamServer.cancel(server)
+    end
   end
 end

--- a/test/support/stream_server_helpers.ex
+++ b/test/support/stream_server_helpers.ex
@@ -49,6 +49,10 @@ defmodule ReqLLM.Test.StreamServerHelpers do
       [StreamChunk.meta(%{finish_reason: reason})]
     end
 
+    def decode_stream_event(%{data: %{"event" => "terminal"}}, _model) do
+      [StreamChunk.meta(%{terminal?: true})]
+    end
+
     def decode_stream_event(_event, _model), do: []
 
     def prepare_request(_op, _model, _data, _opts), do: {:error, :not_implemented}


### PR DESCRIPTION
## Description

Gemini's SSE stream has no termination sentinel, so StreamServer.state.terminated? never flips to true. When Gemini emits a final event shaped like {"candidates":
[{"finishReason": "STOP"}], "usageMetadata": {...}} (candidate with finishReason but no content.parts, which happens e.g. when content ended in a prior event and the last
event is "done + usage"), the five existing patterns in decode_google_event/2 all required content.parts to capture finishReason — so the only pattern that matched was
%{"usageMetadata" => usage}, which drops finishReason silently.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #638 
