### PR TITLE
fix(anthropic): reject trailing assistant object contexts

### DIFF
--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -209,14 +209,16 @@ defmodule ReqLLM.Providers.Anthropic do
     compiled_schema = Keyword.fetch!(opts, :compiled_schema)
     {:ok, model} = ReqLLM.model(model_spec)
 
-    mode = determine_output_mode(model, opts)
+    with :ok <- validate_object_context(prompt) do
+      mode = determine_output_mode(model, opts)
 
-    case mode do
-      :json_schema ->
-        prepare_json_schema_request(model_spec, prompt, compiled_schema, opts)
+      case mode do
+        :json_schema ->
+          prepare_json_schema_request(model_spec, prompt, compiled_schema, opts)
 
-      :tool_strict ->
-        prepare_strict_tool_request(model_spec, prompt, compiled_schema, opts)
+        :tool_strict ->
+          prepare_strict_tool_request(model_spec, prompt, compiled_schema, opts)
+      end
     end
   end
 
@@ -265,6 +267,28 @@ defmodule ReqLLM.Providers.Anthropic do
       |> Keyword.put(:operation, :object)
 
     prepare_request(:chat, model_spec, prompt, opts_with_format)
+  end
+
+  defp validate_object_context(prompt) do
+    with {:ok, context} <- ReqLLM.Context.normalize(prompt, []) do
+      case last_non_system_message(context) do
+        %{role: :assistant} ->
+          {:error,
+           ReqLLM.Error.Invalid.Parameter.exception(
+             parameter:
+               "Anthropic generate_object/4 does not support contexts ending with an assistant message. Append a user message requesting the structured output."
+           )}
+
+        _message ->
+          :ok
+      end
+    end
+  end
+
+  defp last_non_system_message(%ReqLLM.Context{messages: messages}) do
+    messages
+    |> Enum.reject(&(&1.role == :system))
+    |> List.last()
   end
 
   @spec prepare_strict_tool_request(LLMDB.Model.t() | String.t(), any(), any(), keyword()) ::

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -1913,6 +1913,47 @@ defmodule ReqLLM.Providers.AnthropicTest do
     end
   end
 
+  describe "prepare_request(:object) - context validation" do
+    test "rejects json_schema structured output when context ends with assistant" do
+      {:ok, schema} =
+        ReqLLM.Schema.compile(answer: [type: :boolean, required: true])
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.assistant("I will inform the user if I support context pre-filling")
+        ])
+
+      {:error, error} =
+        Anthropic.prepare_request(:object, "anthropic:claude-sonnet-4-5-20250929", context,
+          compiled_schema: schema
+        )
+
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+      assert error.parameter =~ "does not support contexts ending with an assistant message"
+      assert error.parameter =~ "Append a user message requesting the structured output"
+    end
+
+    test "rejects tool_strict structured output when context ends with assistant" do
+      {:ok, schema} =
+        ReqLLM.Schema.compile(answer: [type: :boolean, required: true])
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.assistant("I will inform the user if I support context pre-filling")
+        ])
+
+      {:error, error} =
+        Anthropic.prepare_request(:object, "anthropic:claude-sonnet-4-5-20250929", context,
+          compiled_schema: schema,
+          provider_options: [anthropic_structured_output_mode: :tool_strict]
+        )
+
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+      assert error.parameter =~ "does not support contexts ending with an assistant message"
+      assert error.parameter =~ "Append a user message requesting the structured output"
+    end
+  end
+
   describe "prepare_request(:object) - schema constraint stripping" do
     test "strips minimum constraint from pos_integer schema in json_schema mode" do
       {:ok, schema} =

--- a/test/req_llm/generation_test.exs
+++ b/test/req_llm/generation_test.exs
@@ -449,6 +449,25 @@ defmodule ReqLLM.GenerationTest do
                Generation.generate_object("invalid:model", "Return a person", [])
     end
 
+    test "returns an error before HTTP for Anthropic object contexts ending with assistant" do
+      Req.Test.stub(FailingHTTP, fn _conn ->
+        raise "HTTP request should not execute for invalid Anthropic object context"
+      end)
+
+      {:error, error} =
+        Generation.generate_object(
+          "anthropic:claude-sonnet-4-5-20250929",
+          [Context.assistant("I will inform the user if I support context pre-filling")],
+          [answer: [type: :boolean, required: true]],
+          api_key: "test-key",
+          req_http_options: [plug: {Req.Test, FailingHTTP}]
+        )
+
+      assert %ReqLLM.Error.Invalid.Parameter{} = error
+      assert error.parameter =~ "does not support contexts ending with an assistant message"
+      assert error.parameter =~ "Append a user message requesting the structured output"
+    end
+
     test "returns schema compilation errors" do
       assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
                Generation.generate_object(@chat_model, "Return a person", "invalid")


### PR DESCRIPTION
## Summary
- reject Anthropic `generate_object/4` requests before HTTP when the normalized context ends with an assistant message
- return a clear invalid-parameter error telling callers to append a user message requesting structured output
- cover both native `output_format` json schema mode and explicit `:tool_strict` mode

## Validation
- `mix test test/providers/anthropic_test.exs`
- `mix test`
- `mix quality`

Fixes #642