### PR TITLE
feat(openai): add logprobs support for chat completions (request encoding, response decoding, tests)

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1090,6 +1090,16 @@ defmodule ReqLLM.Provider.Defaults do
                   []
               end
 
+            # Extract logprobs per token from this chunk
+            logprobs_chunks =
+              case get_in(choice, ["logprobs", "content"]) do
+                tokens when is_list(tokens) and tokens != [] ->
+                  [ReqLLM.StreamChunk.meta(%{logprobs: tokens})]
+
+                _ ->
+                  []
+              end
+
             # Extract finish_reason
             finish_reason = Map.get(choice, "finish_reason")
 
@@ -1099,9 +1109,10 @@ defmodule ReqLLM.Provider.Defaults do
               meta = %{finish_reason: normalized_reason}
               meta = if normalized_reason, do: Map.put(meta, :terminal?, true), else: meta
 
-              content_chunks ++ reasoning_details_chunks ++ [ReqLLM.StreamChunk.meta(meta)]
+              content_chunks ++
+                reasoning_details_chunks ++ logprobs_chunks ++ [ReqLLM.StreamChunk.meta(meta)]
             else
-              content_chunks ++ reasoning_details_chunks
+              content_chunks ++ reasoning_details_chunks ++ logprobs_chunks
             end
           end)
 

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1038,6 +1038,15 @@ defmodule ReqLLM.Provider.Defaults do
       messages: [message]
     }
 
+    logprobs = get_in(first_choice, ["logprobs", "content"])
+
+    provider_meta =
+      data
+      |> Map.drop(["id", "model", "choices", "usage"])
+      |> then(fn meta ->
+        if logprobs, do: Map.put(meta, :logprobs, logprobs), else: meta
+      end)
+
     response = %ReqLLM.Response{
       id: id,
       model: model_name,
@@ -1047,7 +1056,7 @@ defmodule ReqLLM.Provider.Defaults do
       stream: nil,
       usage: usage,
       finish_reason: finish_reason,
-      provider_meta: Map.drop(data, ["id", "model", "choices", "usage"])
+      provider_meta: provider_meta
     }
 
     {:ok, response}

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -84,6 +84,15 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     # Normalize finish_reason to atom (providers may emit strings)
     finish_reason = normalize_finish_reason(metadata[:finish_reason])
 
+    # Merge streaming logprobs into provider_meta
+    base_provider_meta = metadata[:provider_meta] || %{}
+
+    provider_meta =
+      case acc_data.logprobs do
+        [] -> base_provider_meta
+        tokens -> Map.put(base_provider_meta, :logprobs, tokens)
+      end
+
     # Build response
     base_response = %Response{
       id: metadata[:response_id] || generate_response_id(),
@@ -95,7 +104,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       stream: nil,
       usage: usage,
       finish_reason: finish_reason,
-      provider_meta: metadata[:provider_meta] || %{},
+      provider_meta: provider_meta,
       error: nil
     }
 
@@ -120,7 +129,8 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
         thinking_content: [],
         tool_calls: [],
         arg_fragments: %{},
-        reasoning_details: []
+        reasoning_details: [],
+        logprobs: []
       },
       &accumulate_chunk/2
     )
@@ -156,9 +166,18 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
           acc
       end
 
+    acc =
+      case meta do
+        %{reasoning_details: details} when is_list(details) ->
+          %{acc | reasoning_details: acc.reasoning_details ++ details}
+
+        _ ->
+          acc
+      end
+
     case meta do
-      %{reasoning_details: details} when is_list(details) ->
-        %{acc | reasoning_details: acc.reasoning_details ++ details}
+      %{logprobs: tokens} when is_list(tokens) ->
+        %{acc | logprobs: acc.logprobs ++ tokens}
 
       _ ->
         acc

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -210,6 +210,15 @@ defmodule ReqLLM.Providers.OpenAI do
       type: {:or, [:atom, :string]},
       doc:
         "Constrains the verbosity of the model's response. Supported values: 'low', 'medium', 'high'. Defaults to 'medium'."
+    ],
+    openai_logprobs: [
+      type: :boolean,
+      doc: "Whether to return log probabilities of output tokens"
+    ],
+    openai_top_logprobs: [
+      type: :non_neg_integer,
+      doc:
+        "Number of most likely tokens to return at each position (0–20, requires openai_logprobs: true)"
     ]
   ]
 

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -216,7 +216,7 @@ defmodule ReqLLM.Providers.OpenAI do
       doc: "Whether to return log probabilities of output tokens"
     ],
     openai_top_logprobs: [
-      type: :non_neg_integer,
+      type: {:in, 0..20},
       doc:
         "Number of most likely tokens to return at each position (0–20, requires openai_logprobs: true)"
     ]

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -112,6 +112,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
         |> add_verbosity(opts_map)
         |> add_response_format(opts_map)
         |> add_parallel_tool_calls(opts_map)
+        |> add_logprobs(opts_map)
         |> translate_tool_choice_format()
         |> add_strict_to_tools()
     end
@@ -270,6 +271,14 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
     body
     |> Map.drop(["response_format", :response_format])
     |> maybe_put(:response_format, normalized)
+  end
+
+  defp add_logprobs(body, request_options) do
+    provider_opts = request_options[:provider_options] || []
+
+    body
+    |> maybe_put(:logprobs, provider_opts[:openai_logprobs])
+    |> maybe_put(:top_logprobs, provider_opts[:openai_top_logprobs])
   end
 
   defp add_parallel_tool_calls(body, request_options) do

--- a/test/coverage/openai/logprobs_test.exs
+++ b/test/coverage/openai/logprobs_test.exs
@@ -1,0 +1,59 @@
+defmodule ReqLLM.Coverage.OpenAI.LogprobsTest do
+  @moduledoc """
+  OpenAI logprobs feature coverage tests.
+
+  Validates that logprobs requested via openai_logprobs: true are returned
+  in response.provider_meta.logprobs as a list of per-token maps.
+
+  Run with REQ_LLM_FIXTURES_MODE=record to test against live API and record fixtures.
+  Otherwise uses fixtures for fast, reliable testing.
+  """
+
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  @moduletag :coverage
+  @moduletag provider: "openai"
+  @moduletag timeout: 60_000
+
+  @model_spec "openai:gpt-3.5-turbo"
+
+  setup_all do
+    LLMDB.load(allow: :all, custom: %{})
+    :ok
+  end
+
+  @tag scenario: :logprobs_non_streaming
+  @tag model: "gpt-3.5-turbo"
+  test "logprobs are returned in provider_meta when requested" do
+    opts =
+      fixture_opts("logprobs_non_streaming",
+        provider_options: [openai_logprobs: true]
+      )
+
+    {:ok, response} = ReqLLM.generate_text(@model_spec, "test prompt", opts)
+
+    logprobs = response.provider_meta[:logprobs]
+
+    assert is_list(logprobs), "expected logprobs to be a list, got: #{inspect(logprobs)}"
+    assert logprobs != []
+
+    Enum.each(logprobs, fn entry ->
+      assert is_map(entry)
+      assert is_binary(entry["token"])
+      assert is_number(entry["logprob"])
+      assert entry["logprob"] <= 0.0
+    end)
+  end
+
+  @tag scenario: :basic
+  @tag model: "gpt-3.5-turbo"
+  test "logprobs are absent from provider_meta when not requested" do
+    opts = fixture_opts("basic")
+
+    {:ok, response} = ReqLLM.generate_text(@model_spec, "Hello world!", opts)
+
+    refute Map.has_key?(response.provider_meta, :logprobs)
+  end
+end

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -1338,6 +1338,142 @@ defmodule ReqLLM.Providers.OpenAITest do
     end
   end
 
+  describe "logprobs support" do
+    test "encode_body includes logprobs when openai_logprobs is true" do
+      {:ok, model} = ReqLLM.model("openai:gpt-3.5-turbo")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          provider_options: [openai_logprobs: true]
+        ]
+      }
+
+      updated_request = OpenAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["logprobs"] == true
+      refute Map.has_key?(decoded, "top_logprobs")
+    end
+
+    test "encode_body includes top_logprobs when openai_top_logprobs is set" do
+      {:ok, model} = ReqLLM.model("openai:gpt-3.5-turbo")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          provider_options: [openai_logprobs: true, openai_top_logprobs: 5]
+        ]
+      }
+
+      updated_request = OpenAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      assert decoded["logprobs"] == true
+      assert decoded["top_logprobs"] == 5
+    end
+
+    test "encode_body omits logprobs when not requested" do
+      {:ok, model} = ReqLLM.model("openai:gpt-3.5-turbo")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = OpenAI.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      refute Map.has_key?(decoded, "logprobs")
+      refute Map.has_key?(decoded, "top_logprobs")
+    end
+
+    test "decode_response extracts logprobs into provider_meta" do
+      mock_response_body = %{
+        "id" => "chatcmpl-123",
+        "object" => "chat.completion",
+        "created" => 1_677_652_288,
+        "model" => "gpt-3.5-turbo",
+        "choices" => [
+          %{
+            "index" => 0,
+            "message" => %{"role" => "assistant", "content" => "Hello!"},
+            "finish_reason" => "stop",
+            "logprobs" => %{
+              "content" => [
+                %{"token" => "Hello", "logprob" => -0.03, "bytes" => [72], "top_logprobs" => []},
+                %{"token" => "!", "logprob" => 0.0, "bytes" => [33], "top_logprobs" => []}
+              ]
+            }
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 2, "total_tokens" => 12}
+      }
+
+      mock_resp = %Req.Response{status: 200, body: mock_response_body}
+
+      {:ok, model} = ReqLLM.model("openai:gpt-3.5-turbo")
+      context = context_fixture()
+      mock_req = %Req.Request{options: [context: context, stream: false, model: model.model]}
+
+      {_req, resp} = OpenAI.decode_response({mock_req, mock_resp})
+
+      assert %ReqLLM.Response{} = resp.body
+      logprobs = resp.body.provider_meta[:logprobs]
+
+      assert is_list(logprobs)
+      assert length(logprobs) == 2
+      assert Enum.at(logprobs, 0)["token"] == "Hello"
+      assert Enum.at(logprobs, 0)["logprob"] == -0.03
+      assert Enum.at(logprobs, 1)["token"] == "!"
+    end
+
+    test "decode_response leaves provider_meta without logprobs key when not present" do
+      mock_response_body = %{
+        "id" => "chatcmpl-123",
+        "object" => "chat.completion",
+        "created" => 1_677_652_288,
+        "model" => "gpt-3.5-turbo",
+        "choices" => [
+          %{
+            "index" => 0,
+            "message" => %{"role" => "assistant", "content" => "Hello!"},
+            "finish_reason" => "stop",
+            "logprobs" => nil
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 2, "total_tokens" => 12}
+      }
+
+      mock_resp = %Req.Response{status: 200, body: mock_response_body}
+
+      {:ok, model} = ReqLLM.model("openai:gpt-3.5-turbo")
+      context = context_fixture()
+      mock_req = %Req.Request{options: [context: context, stream: false, model: model.model]}
+
+      {_req, resp} = OpenAI.decode_response({mock_req, mock_resp})
+
+      assert %ReqLLM.Response{} = resp.body
+      refute Map.has_key?(resp.body.provider_meta, :logprobs)
+    end
+
+    test "openai_logprobs schema option is valid" do
+      valid_keys = OpenAI.provider_schema().schema |> Keyword.keys()
+      assert :openai_logprobs in valid_keys
+      assert :openai_top_logprobs in valid_keys
+    end
+  end
+
   describe "ResponsesAPI tool encoding" do
     test "passes through built-in web_search tool definitions" do
       {:ok, model} = ReqLLM.model("openai:gpt-5-nano")

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -1472,6 +1472,15 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert :openai_logprobs in valid_keys
       assert :openai_top_logprobs in valid_keys
     end
+
+    test "openai_top_logprobs rejects values outside 0-20" do
+      schema = OpenAI.provider_schema()
+
+      assert {:ok, _} = NimbleOptions.validate([openai_top_logprobs: 0], schema)
+      assert {:ok, _} = NimbleOptions.validate([openai_top_logprobs: 20], schema)
+      assert {:error, _} = NimbleOptions.validate([openai_top_logprobs: 21], schema)
+      assert {:error, _} = NimbleOptions.validate([openai_top_logprobs: -1], schema)
+    end
   end
 
   describe "ResponsesAPI tool encoding" do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -837,6 +837,163 @@ defmodule ReqLLM.Provider.DefaultsTest do
     end
   end
 
+  describe "ResponseBuilder logprobs accumulation" do
+    setup do
+      model = %LLMDB.Model{provider: :openai, id: "gpt-4"}
+      context = %Context{messages: []}
+      %{model: model, context: context}
+    end
+
+    test "sets provider_meta logprobs from meta chunks", %{model: model, context: context} do
+      tokens = [
+        %{"token" => "Hello", "logprob" => -0.5, "bytes" => [72, 101, 108, 108, 111]},
+        %{"token" => " world", "logprob" => -0.3, "bytes" => [32, 119, 111, 114, 108, 100]}
+      ]
+
+      chunks = [
+        StreamChunk.text("Hello world"),
+        StreamChunk.meta(%{logprobs: tokens})
+      ]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{}, model: model, context: context)
+
+      assert response.provider_meta[:logprobs] == tokens
+    end
+
+    test "accumulates logprobs across multiple meta chunks", %{model: model, context: context} do
+      tokens1 = [%{"token" => "Hello", "logprob" => -0.5}]
+      tokens2 = [%{"token" => " world", "logprob" => -0.3}]
+
+      chunks = [
+        StreamChunk.text("Hello"),
+        StreamChunk.meta(%{logprobs: tokens1}),
+        StreamChunk.text(" world"),
+        StreamChunk.meta(%{logprobs: tokens2})
+      ]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{}, model: model, context: context)
+
+      assert response.provider_meta[:logprobs] == tokens1 ++ tokens2
+    end
+
+    test "omits logprobs key from provider_meta when no logprobs chunks", %{
+      model: model,
+      context: context
+    } do
+      chunks = [StreamChunk.text("Hello world")]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{}, model: model, context: context)
+
+      refute Map.has_key?(response.provider_meta, :logprobs)
+    end
+
+    test "merges logprobs into existing provider_meta", %{model: model, context: context} do
+      tokens = [%{"token" => "Hi", "logprob" => -0.1}]
+
+      chunks = [
+        StreamChunk.text("Hi"),
+        StreamChunk.meta(%{logprobs: tokens})
+      ]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{provider_meta: %{model_version: "gpt-4-0125"}},
+          model: model,
+          context: context
+        )
+
+      assert response.provider_meta[:logprobs] == tokens
+      assert response.provider_meta[:model_version] == "gpt-4-0125"
+    end
+  end
+
+  describe "default_decode_stream_event/2 logprobs" do
+    setup do
+      %{model: %LLMDB.Model{provider: :openai, id: "gpt-4"}}
+    end
+
+    test "emits meta chunk with logprobs when choice has logprobs content", %{model: model} do
+      tokens = [
+        %{"token" => "Hello", "logprob" => -0.5, "bytes" => [72]},
+        %{"token" => " world", "logprob" => -0.3, "bytes" => [32]}
+      ]
+
+      event = %{
+        data: %{
+          "choices" => [
+            %{
+              "delta" => %{"content" => "Hello world"},
+              "logprobs" => %{"content" => tokens}
+            }
+          ]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(event, model)
+
+      content_chunk = Enum.find(chunks, &(&1.type == :content))
+      assert content_chunk.text == "Hello world"
+
+      logprobs_chunk =
+        Enum.find(chunks, fn c -> c.type == :meta and Map.has_key?(c.metadata, :logprobs) end)
+
+      assert logprobs_chunk != nil
+      assert logprobs_chunk.metadata.logprobs == tokens
+    end
+
+    test "does not emit logprobs meta chunk when logprobs is nil", %{model: model} do
+      event = %{
+        data: %{
+          "choices" => [
+            %{
+              "delta" => %{"content" => "Hello"},
+              "logprobs" => nil
+            }
+          ]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(event, model)
+
+      assert Enum.any?(chunks, &(&1.type == :content))
+
+      refute Enum.any?(chunks, fn c -> c.type == :meta and Map.has_key?(c.metadata, :logprobs) end)
+    end
+
+    test "does not emit logprobs meta chunk when logprobs key is absent", %{model: model} do
+      event = %{
+        data: %{
+          "choices" => [
+            %{"delta" => %{"content" => "Hello"}}
+          ]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(event, model)
+
+      assert [%StreamChunk{type: :content, text: "Hello"}] = chunks
+    end
+
+    test "does not emit logprobs meta chunk when logprobs content is empty list", %{model: model} do
+      event = %{
+        data: %{
+          "choices" => [
+            %{
+              "delta" => %{"content" => "Hello"},
+              "logprobs" => %{"content" => []}
+            }
+          ]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(event, model)
+
+      refute Enum.any?(chunks, fn c -> c.type == :meta and Map.has_key?(c.metadata, :logprobs) end)
+    end
+  end
+
   describe "default_decode_response/1" do
     test "handles unknown provider prefix in model string without atomizing" do
       req =

--- a/test/support/fixtures/openai/gpt_3_5_turbo/logprobs_non_streaming.json
+++ b/test/support/fixtures/openai/gpt_3_5_turbo/logprobs_non_streaming.json
@@ -1,0 +1,260 @@
+{
+  "request": {
+    "body": {
+      "b64": ""
+    },
+    "canonical_json": {
+      "logprobs": true,
+      "messages": [
+        {
+          "content": "test prompt",
+          "role": "user"
+        }
+      ],
+      "model": "gpt-3.5-turbo",
+      "stream": false
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": ["application/json"]
+    },
+    "method": "post",
+    "url": "https://api.openai.com/v1/chat/completions"
+  },
+  "response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": {
+            "content": [
+              {
+                "bytes": [60, 124, 99, 104, 97, 110, 110, 101, 108, 124, 62],
+                "logprob": 0.0,
+                "token": "<|channel|>",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [97, 110, 97, 108, 121, 115, 105, 115],
+                "logprob": 0.0,
+                "token": "analysis",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [60, 124, 109, 101, 115, 115, 97, 103, 101, 124, 62],
+                "logprob": -1.1920928244535389e-7,
+                "token": "<|message|>",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [84, 104, 101],
+                "logprob": -0.3350403308868408,
+                "token": "The",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 117, 115, 101, 114],
+                "logprob": -8.928377064876258e-5,
+                "token": " user",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 115, 97, 105, 100],
+                "logprob": -4.281442642211914,
+                "token": " said",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 34],
+                "logprob": -0.01131416019052267,
+                "token": " \"",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [116, 101, 115, 116],
+                "logprob": 0.0,
+                "token": "test",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 112, 114, 111, 109, 112, 116],
+                "logprob": -3.814689989667386e-6,
+                "token": " prompt",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [34, 46],
+                "logprob": -9.667406266089529e-5,
+                "token": "\".",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 76, 105, 107],
+                "logprob": -0.24640733003616333,
+                "token": " Lik",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [101, 108, 121],
+                "logprob": 0.0,
+                "token": "ely",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 116, 104, 101, 121],
+                "logprob": -0.06277547776699066,
+                "token": " they",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 97, 114, 101],
+                "logprob": -1.0429126024246216,
+                "token": " are",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 116, 101, 115, 116, 105, 110, 103],
+                "logprob": -0.1722620576620102,
+                "token": " testing",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [46],
+                "logprob": -0.10133710503578186,
+                "token": ".",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [72, 101, 108, 108, 111],
+                "logprob": -0.03345026075839996,
+                "token": "Hello",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [33],
+                "logprob": -3.576278118089249e-7,
+                "token": "!",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 73],
+                "logprob": -0.4261932373046875,
+                "token": " I",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [226, 128, 153, 109],
+                "logprob": -4.768360213347478e-6,
+                "token": "'m",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 104, 101, 114, 101],
+                "logprob": -1.0358751023886725e-4,
+                "token": " here",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 97, 110, 100],
+                "logprob": -3.576278118089249e-7,
+                "token": " and",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 114, 101, 97, 100, 121],
+                "logprob": -3.3378546504536644e-6,
+                "token": " ready",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 116, 111],
+                "logprob": -5.671561229974031e-4,
+                "token": " to",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 104, 101, 108, 112],
+                "logprob": -9.786603914108127e-5,
+                "token": " help",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [46],
+                "logprob": -1.5925093612167984e-4,
+                "token": ".",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 87, 104, 97, 116],
+                "logprob": -0.19318924844264984,
+                "token": " What",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 99, 97, 110],
+                "logprob": -0.6931490898132324,
+                "token": " can",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 73],
+                "logprob": 0.0,
+                "token": " I",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 97, 115, 115, 105, 115, 116],
+                "logprob": -2.5788941383361816,
+                "token": " assist",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 121, 111, 117],
+                "logprob": -3.576278118089249e-7,
+                "token": " you",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 119, 105, 116, 104],
+                "logprob": 0.0,
+                "token": " with",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [32, 116, 111, 100, 97, 121],
+                "logprob": 0.0,
+                "token": " today",
+                "top_logprobs": []
+              },
+              {
+                "bytes": [63],
+                "logprob": 0.0,
+                "token": "?",
+                "top_logprobs": []
+              }
+            ]
+          },
+          "message": {
+            "content": "Hello! I'm here and ready to help. What can I assist you with today?",
+            "role": "assistant",
+            "tool_calls": []
+          }
+        }
+      ],
+      "created": 1777069870,
+      "id": "chatcmpl-e8016571-6540-4c50-a2a4-e32ca9f1142d",
+      "model": "gpt-3.5-turbo",
+      "object": "chat.completion",
+      "usage": {
+        "completion_tokens": 34,
+        "prompt_tokens": 11,
+        "total_tokens": 45
+      }
+    },
+    "headers": {
+      "content-type": ["application/json"]
+    },
+    "status": 200
+  }
+}


### PR DESCRIPTION
## Description

Adds openai_logprobs and openai_top_logprobs provider options to the OpenAI schema. When enabled, logprobs are encoded in the request body and extracted from `choices[0].logprobs.content` in the shared `decode_response_body_openai_format`, making them available as `response.provider_meta[:logprobs]` for all OpenAI Chat Completions responses.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes
NA

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

