### PR TITLE
fix: encode thinking content parts as reasoning_content for OpenAI-compatible providers

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -836,9 +836,21 @@ defmodule ReqLLM.Provider.Defaults do
          reasoning_details: rd,
          metadata: metadata
        }) do
+    {thinking_texts, content_without_thinking} =
+      Enum.split_with(c, fn
+        %ReqLLM.Message.ContentPart{type: :thinking} -> true
+        _ -> false
+      end)
+
+    reasoning_content =
+      case thinking_texts do
+        [] -> nil
+        parts -> parts |> Enum.map(& &1.text) |> Enum.join("")
+      end
+
     base_message = %{
       role: to_string(r),
-      content: encode_openai_content(c)
+      content: encode_openai_content(content_without_thinking)
     }
 
     base_message
@@ -847,6 +859,7 @@ defmodule ReqLLM.Provider.Defaults do
     |> maybe_add_field(:name, name)
     |> maybe_add_field(:reasoning_details, rd)
     |> maybe_add_field(:metadata, metadata)
+    |> maybe_add_field(:reasoning_content, reasoning_content)
   end
 
   defp maybe_add_field(message, _key, nil), do: message


### PR DESCRIPTION
## Problem
Moonshot, DeepSeek, and other OpenAI-compatible providers that support thinking/reasoning return reasoning_content as a top-level message field.

ReqLLM correctly decodes this into ContentPart{type: :thinking} during response parsing, but when encoding messages back to the API request, the thinking parts were dropped (encode_openai_content_part returned nil).

This caused multi-turn conversations with reasoning models to fail with:
> thinking is enabled but reasoning_content is missing in assistant tool call message

## Fix
Extract thinking content parts during message encoding, join their text into a reasoning_content string, and place it at the top level of the message object while removing thinking parts from the content array.

## Backwards Compatibility
Non-reasoning messages are unaffected (maybe_add_field skips nil values). Providers that do not use reasoning_content simply ignore the extra field.