### PR TITLE
fix: encode thinking content parts as reasoning_content for OpenAI-compatible providers

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -847,7 +847,7 @@ defmodule ReqLLM.Provider.Defaults do
     |> maybe_add_field(:tool_calls, tc)
     |> maybe_add_field(:tool_call_id, tcid)
     |> maybe_add_field(:name, name)
-    |> maybe_add_field(:reasoning_content, reasoning_content)
+    |> maybe_add_assistant_reasoning(r, reasoning_content)
     |> maybe_add_field(:reasoning_details, rd)
     |> maybe_add_field(:metadata, metadata)
   end
@@ -865,8 +865,7 @@ defmodule ReqLLM.Provider.Defaults do
 
     reasoning_content =
       thinking_parts
-      |> Enum.map(fn %ReqLLM.Message.ContentPart{text: text} -> text end)
-      |> Enum.join("")
+      |> Enum.map_join("", fn %ReqLLM.Message.ContentPart{text: text} -> text end)
 
     if reasoning_content == "" do
       {nil, content}
@@ -879,6 +878,12 @@ defmodule ReqLLM.Provider.Defaults do
   defp maybe_add_field(message, _key, []), do: message
   defp maybe_add_field(message, _key, %{} = value) when map_size(value) == 0, do: message
   defp maybe_add_field(message, key, value), do: Map.put(message, key, value)
+
+  defp maybe_add_assistant_reasoning(message, :assistant, reasoning_content) do
+    maybe_add_field(message, :reasoning_content, reasoning_content)
+  end
+
+  defp maybe_add_assistant_reasoning(message, _, _), do: message
 
   defp encode_openai_content(content) when is_binary(content), do: content
 
@@ -976,8 +981,8 @@ defmodule ReqLLM.Provider.Defaults do
     }
   end
 
-  # Reasoning model artifacts (e.g. chain-of-thought) — strip from OpenAI encoding
-  # since the format has no standard representation for thinking content.
+  # Thinking content is extracted to the top-level reasoning_content field
+  # for assistant messages on OpenAI-compatible providers that support it.
   defp encode_openai_content_part(%ReqLLM.Message.ContentPart{type: :thinking}), do: nil
 
   defp encode_openai_content_part(_), do: nil

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -836,17 +836,43 @@ defmodule ReqLLM.Provider.Defaults do
          reasoning_details: rd,
          metadata: metadata
        }) do
+    {reasoning_content, content_without_thinking} = extract_reasoning_content(c)
+
     base_message = %{
       role: to_string(r),
-      content: encode_openai_content(c)
+      content: encode_openai_content(content_without_thinking)
     }
 
     base_message
     |> maybe_add_field(:tool_calls, tc)
     |> maybe_add_field(:tool_call_id, tcid)
     |> maybe_add_field(:name, name)
+    |> maybe_add_field(:reasoning_content, reasoning_content)
     |> maybe_add_field(:reasoning_details, rd)
     |> maybe_add_field(:metadata, metadata)
+  end
+
+  # Extract thinking content parts and return {reasoning_content_string, content_without_thinking_parts}
+  defp extract_reasoning_content(nil), do: {nil, nil}
+  defp extract_reasoning_content(content) when is_binary(content), do: {nil, content}
+
+  defp extract_reasoning_content(content) when is_list(content) do
+    {thinking_parts, rest} =
+      Enum.split_with(content, fn
+        %ReqLLM.Message.ContentPart{type: :thinking} -> true
+        _ -> false
+      end)
+
+    reasoning_content =
+      thinking_parts
+      |> Enum.map(fn %ReqLLM.Message.ContentPart{text: text} -> text end)
+      |> Enum.join("")
+
+    if reasoning_content == "" do
+      {nil, content}
+    else
+      {reasoning_content, rest}
+    end
   end
 
   defp maybe_add_field(message, _key, nil), do: message

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -310,7 +310,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
       refute Map.has_key?(encoded_message, :reasoning_details)
     end
 
-    test "strips :thinking content parts from encoding" do
+    test "strips :thinking content parts from encoding and emits reasoning_content for assistant" do
       message = %Message{
         role: :assistant,
         content: [
@@ -325,9 +325,45 @@ defmodule ReqLLM.Provider.DefaultsTest do
       [encoded_message] = result.messages
       # :thinking part stripped, single text part flattened to string
       assert encoded_message.content == "Here is the answer."
+      assert encoded_message.reasoning_content == "Let me reason about this..."
     end
 
-    test "collapses to empty string when all content parts are :thinking" do
+    test "joins multiple thinking parts into single reasoning_content" do
+      message = %Message{
+        role: :assistant,
+        content: [
+          %ContentPart{type: :thinking, text: "Step 1: analyze"},
+          %ContentPart{type: :thinking, text: "Step 2: conclude"},
+          %ContentPart{type: :text, text: "Final answer."}
+        ]
+      }
+
+      context = %Context{messages: [message]}
+      result = Defaults.encode_context_to_openai_format(context, "gpt-4")
+
+      [encoded_message] = result.messages
+      assert encoded_message.content == "Final answer."
+      assert encoded_message.reasoning_content == "Step 1: analyzeStep 2: conclude"
+    end
+
+    test "does not emit reasoning_content for non-assistant roles" do
+      message = %Message{
+        role: :user,
+        content: [
+          %ContentPart{type: :thinking, text: "User-provided thought"},
+          %ContentPart{type: :text, text: "Hello"}
+        ]
+      }
+
+      context = %Context{messages: [message]}
+      result = Defaults.encode_context_to_openai_format(context, "gpt-4")
+
+      [encoded_message] = result.messages
+      assert encoded_message.content == "Hello"
+      refute Map.has_key?(encoded_message, :reasoning_content)
+    end
+
+    test "preserves tool_calls alongside reasoning_content for assistant" do
       message = %Message{
         role: :assistant,
         content: [
@@ -350,6 +386,8 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert encoded_message.content == ""
       # Tool calls still present
       assert length(encoded_message.tool_calls) == 1
+      # reasoning_content emitted for assistant
+      assert encoded_message.reasoning_content == "Internal chain-of-thought"
     end
 
     test "collapses empty content list to empty string" do


### PR DESCRIPTION
When assistant messages contain ContentPart.thinking(...) parts (e.g. from Moonshot reasoning models), the OpenAI encoder was stripping them via encode_openai_content_part returning nil for :thinking parts.

This caused multi-turn conversations with Moonshot to fail with:
> thinking is enabled but reasoning_content is missing in assistant tool call message

Changes:
- Add extract_reasoning_content/1 to pull thinking parts out of message content
- In encode_openai_message, extract reasoning_content before encoding content, then add it as a top-level reasoning_content field on the encoded message
- Remove thinking parts from the content list so they don't get encoded as nil

This matches the OpenAI/Moonshot API contract where reasoning_content lives at the message level, not inside the content array.