### PR TITLE
feat(azure): support Kimi family (Moonshot) on Azure AI Foundry

### DIFF
--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -277,7 +277,9 @@ defmodule ReqLLM.Providers.Azure do
     "deepseek" => __MODULE__.OpenAI,
     "mai-ds" => __MODULE__.OpenAI,
     "claude" => __MODULE__.Anthropic,
-    "grok" => __MODULE__.OpenAI
+    "grok" => __MODULE__.OpenAI,
+    "Kimi" => __MODULE__.OpenAI,
+    "kimi" => __MODULE__.OpenAI
   }
 
   @model_family_prefixes @model_families |> Map.keys() |> Enum.sort_by(&String.length/1, :desc)
@@ -295,7 +297,9 @@ defmodule ReqLLM.Providers.Azure do
     "o3" => "AZURE_OPENAI_BASE_URL",
     "o4" => "AZURE_OPENAI_BASE_URL",
     "deepseek" => "AZURE_DEEPSEEK_BASE_URL",
-    "mai-ds" => "AZURE_MAI_BASE_URL"
+    "mai-ds" => "AZURE_MAI_BASE_URL",
+    "Kimi" => "AZURE_KIMI_BASE_URL",
+    "kimi" => "AZURE_KIMI_BASE_URL"
   }
 
   @family_api_key_env_vars %{
@@ -307,7 +311,9 @@ defmodule ReqLLM.Providers.Azure do
     "o3" => "AZURE_OPENAI_API_KEY",
     "o4" => "AZURE_OPENAI_API_KEY",
     "deepseek" => "AZURE_DEEPSEEK_API_KEY",
-    "mai-ds" => "AZURE_MAI_API_KEY"
+    "mai-ds" => "AZURE_MAI_API_KEY",
+    "Kimi" => "AZURE_KIMI_API_KEY",
+    "kimi" => "AZURE_KIMI_API_KEY"
   }
 
   @doc """

--- a/lib/req_llm/providers/azure/openai.ex
+++ b/lib/req_llm/providers/azure/openai.ex
@@ -53,7 +53,9 @@ defmodule ReqLLM.Providers.Azure.OpenAI do
     "text-embedding",
     "deepseek",
     "mai-ds",
-    "grok"
+    "grok",
+    "Kimi",
+    "kimi"
   ]
 
   @anthropic_specific_options [

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -1846,6 +1846,67 @@ defmodule ReqLLM.Providers.AzureTest do
     end
   end
 
+  describe "Kimi family routing" do
+    import ExUnit.CaptureLog
+
+    test "resolves Kimi family for lowercase model id from LLMDB" do
+      {:ok, model} = ReqLLM.model("azure:kimi-k2.5")
+
+      assert model.provider == :azure
+      assert model.id == "kimi-k2.5"
+
+      {:ok, _request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          base_url: "https://my-resource.services.ai.azure.com/openai/v1",
+          deployment: "kimi-k2.5"
+        )
+    end
+
+    test "resolves Kimi family for uppercase Azure deployment id" do
+      model = %LLMDB.Model{
+        id: "Kimi-K2.6",
+        provider: :azure,
+        capabilities: %{chat: true},
+        extra: %{}
+      }
+
+      {:ok, _request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          api_key: "test-key",
+          base_url: "https://my-resource.services.ai.azure.com/openai/v1",
+          deployment: "Kimi-K2.6"
+        )
+    end
+
+    test "format_request does not warn for Kimi models (lowercase)" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      log =
+        capture_log(fn ->
+          _body = Azure.OpenAI.format_request("kimi-k2.5", context, stream: false)
+        end)
+
+      refute log =~ "does not appear to be OpenAI-compatible"
+    end
+
+    test "format_request does not warn for Kimi models (uppercase)" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      log =
+        capture_log(fn ->
+          _body = Azure.OpenAI.format_request("Kimi-K2.6", context, stream: false)
+        end)
+
+      refute log =~ "does not appear to be OpenAI-compatible"
+    end
+  end
+
   defp traditional_openai_model do
     %LLMDB.Model{
       id: "gpt-4o",


### PR DESCRIPTION
## Summary
Azure AI Foundry hosts Moonshot's Kimi-K2 family — `kimi-k2-thinking` and `kimi-k2.5` are already in LLMDB, and the newer `Kimi-K2.6` is deployable in Azure today. But `lib/req_llm/providers/azure.ex` doesn't list a Kimi prefix in `@model_families`, so any `azure:Kimi-...`/`azure:kimi-...` model crashes at `prepare_request/4` time:

```
ArgumentError: Unknown Azure model family for 'Kimi-K2.6'
```

A second symptom: even after stubbing the family map, `Azure.OpenAI.format_request/3` keeps an independent prefix allowlist (`@openai_compatible_prefixes`) and emits a `Logger.warning` on every Kimi request:

> Model 'Kimi-K2.6' does not appear to be OpenAI-compatible. Proceeding with OpenAI formatting (may fail).

The request actually succeeds (Foundry exposes Kimi via the standard OpenAI-compatible `/openai/v1/chat/completions` endpoint), so the warning is misleading.

## Changes
1. **`@model_families`** in `lib/req_llm/providers/azure.ex` — add `"Kimi" => Azure.OpenAI` and `"kimi" => Azure.OpenAI`. Both casings because LLMDB-canonical ids are lowercase (`kimi-k2.5`, `kimi-k2-thinking`) but Azure deployment names are commonly uppercased (`Kimi-K2.6`), and `String.starts_with?/2` is case-sensitive.
2. **`@family_env_vars` / `@family_api_key_env_vars`** — add matching `AZURE_KIMI_BASE_URL` / `AZURE_KIMI_API_KEY` entries (both casings) for symmetry with `deepseek` / `mai-ds`.
3. **`@openai_compatible_prefixes`** in `lib/req_llm/providers/azure/openai.ex` — same two casings, suppresses the spurious "may fail" warning.
4. **Tests** — 4 new tests under `describe "Kimi family routing"`:
   - `azure:kimi-k2.5` (lowercase, LLMDB-resolved) prepares a request without raising.
   - `Kimi-K2.6` (uppercase, hand-built `%LLMDB.Model{}`) prepares a request without raising.
   - `format_request/3` emits no "does not appear to be OpenAI-compatible" warning for either casing.

No new formatter module needed — Foundry's `/openai/v1/chat/completions` is OpenAI-compatible, so reusing `Azure.OpenAI` matches the existing pattern for `deepseek` / `mai-ds` / `grok`.

## Test plan
- [x] `mix test test/provider/azure/azure_test.exs` — 107/107 pass (4 new + 103 existing).
- [x] Verified end-to-end against a real Azure Foundry Kimi-K2.6 deployment (cmesh.ai's HIPAA tenant) — chat completions succeed, no warning.

## References
- Moonshot Kimi-K2 announcement: https://www.moonshot.ai
- Azure AI Foundry model catalog (Kimi entries): https://ai.azure.com/explore/models

🤖 Generated with [Claude Code](https://claude.com/claude-code)