### PR TITLE
fix(openai): disable response storage for codex models

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -505,7 +505,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     opts_map = if is_map(opts), do: opts, else: Map.new(opts)
     provider_opts = opts_map[:provider_options] || []
 
-    store = Keyword.get(provider_opts, :store, true)
+    store = Keyword.get(provider_opts, :store, default_store(model_name))
 
     previous_response_id =
       if store != false do
@@ -616,6 +616,10 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     else
       body
     end
+  end
+
+  defp default_store(model_name) do
+    !ReqLLM.Providers.OpenAI.AdapterHelpers.codex_model?(model_name)
   end
 
   defp encode_tool_message_inline(%ReqLLM.Message{role: :tool} = msg) do

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -71,6 +71,11 @@ defmodule ReqLLM.Providers.OpenAICodex do
       type: :string,
       doc: "Previous response ID for tool resume flow"
     ],
+    store: [
+      type: {:in, [false]},
+      default: false,
+      doc: "Codex requests are always sent with store disabled"
+    ],
     tool_outputs: [
       type: {:list, :any},
       doc: "Tool execution results for Responses API tool resume flow"
@@ -277,7 +282,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
   end
 
   defp build_codex_body(context, model_name, opts, request) do
-    opts = if is_list(opts), do: Keyword.put_new(opts, :provider_options, []), else: opts
+    opts = opts |> ensure_provider_options() |> force_store_false()
     body = ResponsesAPI.build_request_body(context, model_name, opts, request)
     provider_opts = provider_options(opts)
     instructions = extract_instructions(context) || ""
@@ -299,6 +304,29 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Map.put("instructions", instructions)
     |> maybe_put_parallel_tool_calls(provider_opts[:openai_parallel_tool_calls])
   end
+
+  defp ensure_provider_options(opts) when is_list(opts),
+    do: Keyword.put_new(opts, :provider_options, [])
+
+  defp ensure_provider_options(opts), do: opts
+
+  defp force_store_false(opts) when is_list(opts) do
+    provider_opts = opts |> Keyword.get(:provider_options, []) |> provider_options_store_false()
+    Keyword.put(opts, :provider_options, provider_opts)
+  end
+
+  defp force_store_false(opts) when is_map(opts) do
+    provider_opts = opts |> Map.get(:provider_options, []) |> provider_options_store_false()
+    Map.put(opts, :provider_options, provider_opts)
+  end
+
+  defp provider_options_store_false(provider_opts) when is_list(provider_opts),
+    do: Keyword.put(provider_opts, :store, false)
+
+  defp provider_options_store_false(provider_opts) when is_map(provider_opts),
+    do: provider_opts |> Map.to_list() |> Keyword.put(:store, false)
+
+  defp provider_options_store_false(_provider_opts), do: [store: false]
 
   defp tool_resume_body?(%{"input" => input}) when is_list(input) do
     Enum.any?(input, fn

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1594,6 +1594,28 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert body["store"] == true
     end
 
+    test "codex models default store to false and suppress previous_response_id" do
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
+        metadata: %{response_id: "resp_prev_codex"}
+      }
+
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
+      request = build_request(id: "gpt-5.3-codex", context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+    end
+
     test "store: false without prior response_id omits both fields" do
       user_msg = %ReqLLM.Message{
         role: :user,

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -183,6 +183,34 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
              )
     end
 
+    test "omits previous_response_id from context metadata while keeping store=false" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
+
+      context =
+        ReqLLM.context([
+          ReqLLM.Context.assistant("Previous answer", metadata: %{response_id: "resp_prev_789"}),
+          ReqLLM.Context.user("Follow up")
+        ])
+
+      {:ok, request} =
+        OpenAICodex.attach_stream(
+          model,
+          context,
+          [
+            provider_options: [
+              auth_mode: :oauth,
+              access_token: jwt_with_account_id("acct_context_resume")
+            ]
+          ],
+          nil
+        )
+
+      body = Jason.decode!(request.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+    end
+
     test "omits previous_response_id for explicit tool_outputs resume while keeping store=false" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
       context = ReqLLM.context([ReqLLM.Context.user("Use the provided tool output")])


### PR DESCRIPTION
## Summary
- Default OpenAI Responses API Codex model requests to `store: false` so `previous_response_id` is not sent automatically.
- Enforce `store: false` for the dedicated OpenAI Codex provider before reusing the shared Responses encoder.
- Add regression coverage for Codex context metadata and shared Responses API Codex defaults.

## Tests
- `mix test test/providers/openai_codex_test.exs test/provider/openai/responses_api_unit_test.exs`
- `mix test test/providers/openai_test.exs`