### PR TITLE
fix(deepseek): inject reasoning_content to all assistant messages

### DIFF
--- a/lib/req_llm/providers/deepseek.ex
+++ b/lib/req_llm/providers/deepseek.ex
@@ -60,13 +60,7 @@ defmodule ReqLLM.Providers.Deepseek do
           nil
 
         msgs when is_list(msgs) ->
-          Enum.map(msgs, fn msg ->
-            if Map.get(msg, :role) == "assistant" or Map.get(msg, "role") == "assistant" do
-              Map.put_new(msg, :reasoning_content, "")
-            else
-              msg
-            end
-          end)
+          Enum.map(msgs, &ensure_assistant_reasoning_content/1)
 
         other ->
           other
@@ -78,4 +72,24 @@ defmodule ReqLLM.Providers.Deepseek do
       body
     end
   end
+
+  defp ensure_assistant_reasoning_content(msg) do
+    if assistant_message?(msg) and not has_reasoning_content?(msg) do
+      Map.put(msg, :reasoning_content, "")
+    else
+      msg
+    end
+  end
+
+  defp assistant_message?(msg) when is_map(msg) do
+    Map.get(msg, :role) == "assistant" or Map.get(msg, "role") == "assistant"
+  end
+
+  defp assistant_message?(_msg), do: false
+
+  defp has_reasoning_content?(msg) when is_map(msg) do
+    Map.has_key?(msg, :reasoning_content) or Map.has_key?(msg, "reasoning_content")
+  end
+
+  defp has_reasoning_content?(_msg), do: false
 end

--- a/lib/req_llm/providers/deepseek.ex
+++ b/lib/req_llm/providers/deepseek.ex
@@ -49,4 +49,33 @@ defmodule ReqLLM.Providers.Deepseek do
   use ReqLLM.Provider.Defaults
 
   @provider_schema []
+
+  @impl ReqLLM.Provider
+  def build_body(request) do
+    body = ReqLLM.Provider.Defaults.default_build_body(request)
+
+    messages =
+      case Map.get(body, :messages) do
+        nil ->
+          nil
+
+        msgs when is_list(msgs) ->
+          Enum.map(msgs, fn msg ->
+            if Map.get(msg, :role) == "assistant" or Map.get(msg, "role") == "assistant" do
+              Map.put_new(msg, :reasoning_content, "")
+            else
+              msg
+            end
+          end)
+
+        other ->
+          other
+      end
+
+    if messages do
+      Map.put(body, :messages, messages)
+    else
+      body
+    end
+  end
 end

--- a/test/providers/deepseek_test.exs
+++ b/test/providers/deepseek_test.exs
@@ -244,4 +244,63 @@ defmodule ReqLLM.Providers.DeepseekTest do
       assert headers_map["Authorization"] == "Bearer test-key-12345"
     end
   end
+
+  describe "build_body regression" do
+    test "adds reasoning_content to assistant messages without it" do
+      model = deepseek_model()
+
+      follow_up_context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.system("You are a helpful assistant."),
+          ReqLLM.Context.user("Hello"),
+          ReqLLM.Context.assistant("Hi there!"),
+          ReqLLM.Context.user("How are you?")
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: follow_up_context,
+          model: model.model
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assistant_msg =
+        Enum.find(body.messages, fn msg ->
+          Map.get(msg, :role) == "assistant" or Map.get(msg, "role") == "assistant"
+        end)
+
+      refute is_nil(assistant_msg)
+      assert Map.get(assistant_msg, :reasoning_content) == ""
+    end
+
+    test "preserves existing reasoning_content in assistant messages" do
+      model = deepseek_model()
+
+      messages_with_reasoning = [
+        %{role: "system", content: "You are helpful."},
+        %{role: "user", content: "Hello"},
+        %{role: "assistant", content: "Previous response", reasoning_content: "kept reasoning"},
+        %{role: "user", content: "Follow up"}
+      ]
+
+      mock_request = %Req.Request{
+        options: [
+          messages: messages_with_reasoning,
+          model: model.model
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assistant_msg =
+        Enum.find(body.messages, fn msg ->
+          Map.get(msg, "role") == "assistant" or Map.get(msg, :role) == "assistant"
+        end)
+
+      refute is_nil(assistant_msg)
+      assert Map.get(assistant_msg, :reasoning_content) == "kept reasoning"
+    end
+  end
 end

--- a/test/providers/deepseek_test.exs
+++ b/test/providers/deepseek_test.exs
@@ -302,5 +302,37 @@ defmodule ReqLLM.Providers.DeepseekTest do
       refute is_nil(assistant_msg)
       assert Map.get(assistant_msg, :reasoning_content) == "kept reasoning"
     end
+
+    test "preserves existing string-keyed reasoning_content in assistant messages" do
+      model = deepseek_model()
+
+      messages_with_reasoning = [
+        %{"role" => "user", "content" => "Hello"},
+        %{
+          "role" => "assistant",
+          "content" => "Previous response",
+          "reasoning_content" => "kept reasoning"
+        },
+        %{"role" => "user", "content" => "Follow up"}
+      ]
+
+      mock_request = %Req.Request{
+        options: [
+          messages: messages_with_reasoning,
+          model: model.model
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assistant_msg =
+        Enum.find(body.messages, fn msg ->
+          Map.get(msg, "role") == "assistant" or Map.get(msg, :role) == "assistant"
+        end)
+
+      refute is_nil(assistant_msg)
+      assert Map.get(assistant_msg, "reasoning_content") == "kept reasoning"
+      refute Map.has_key?(assistant_msg, :reasoning_content)
+    end
   end
 end


### PR DESCRIPTION
## Description

DeepSeek v4 requires the `reasoning_content` field to be passed back in the message history, even if the value is empty. While a previous commit (735bc83) addressed part of this requirement, an edge case remained: 

*   **The Issue:** If an assistant replies without a "thinking" phase, the resulting message object lacks the `reasoning_content` key entirely. During the subsequent turn, the API rejects the request because the `reasoning_content` in missing from the previous assistant message.
*   **The Solution:** This PR ensures that an empty string is explicitly assigned to `reasoning_content` for all assistant messages where the field is currently missing.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
