### PR TITLE
fix(stream): emit terminal :error chunk for SSE error events from OpenAI-compatible providers

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1100,6 +1100,15 @@ defmodule ReqLLM.Provider.Defaults do
   Provider.Defaults for the protocol removal refactoring.
   """
   @spec default_decode_stream_event(map(), LLMDB.Model.t()) :: [ReqLLM.StreamChunk.t()]
+  def default_decode_stream_event(%{data: %{"error" => %{"message" => msg}}}, _model)
+      when is_binary(msg) do
+    [ReqLLM.StreamChunk.meta(%{finish_reason: :error, error: msg, terminal?: true})]
+  end
+
+  def default_decode_stream_event(%{data: %{"error" => msg}}, _model) when is_binary(msg) do
+    [ReqLLM.StreamChunk.meta(%{finish_reason: :error, error: msg, terminal?: true})]
+  end
+
   def default_decode_stream_event(%{data: data}, model) when is_map(data) do
     # 1. Handle choices (content + finish_reason + reasoning_details)
     choices_chunks =

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -698,7 +698,9 @@ defmodule ReqLLM.StreamServer do
           provider_state: new_provider_state
       })
 
-    terminated? = Enum.any?(events, &termination_event?/1)
+    terminated? =
+      Enum.any?(events, &termination_event?/1) or
+        Enum.any?(stream_chunks, &terminal_chunk?/1)
 
     new_state =
       if terminated? do
@@ -753,6 +755,13 @@ defmodule ReqLLM.StreamServer do
   defp termination_event?(%{data: %{"type" => "message_stop"}}), do: true
   defp termination_event?(%{data: %{"type" => "response.completed"}}), do: true
   defp termination_event?(_), do: false
+
+  defp terminal_chunk?(%ReqLLM.StreamChunk{type: :meta, metadata: metadata})
+       when is_map(metadata) do
+    Map.get(metadata, :terminal?) == true or Map.get(metadata, "terminal?") == true
+  end
+
+  defp terminal_chunk?(_chunk), do: false
 
   defp enqueue_chunks(chunks, state) do
     {new_queue, updated_metadata, new_obj_acc, telemetry} =

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -787,6 +787,67 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert finish_chunk.metadata.finish_reason == :stop
       assert finish_chunk.metadata.terminal? == true
     end
+
+    test "emits terminal error chunk for SSE error event with nested message", %{model: model} do
+      # OpenAI-compatible providers (LMStudio, OpenRouter on overflow, Ollama, vLLM)
+      # return errors mid-stream as `data: {"error": {"message": "..."}}`. Without
+      # an explicit clause these were silently dropped, leaving downstream code
+      # with a finish_reason of `:incomplete` and no diagnostic.
+      error_event = %{
+        data: %{
+          "error" => %{
+            "message" =>
+              "The number of tokens to keep from the initial prompt is greater than the context length (n_keep: 6141 >= n_ctx: 4096)"
+          }
+        }
+      }
+
+      assert [chunk] = Defaults.default_decode_stream_event(error_event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.terminal? == true
+
+      assert chunk.metadata.error =~
+               "The number of tokens to keep from the initial prompt is greater than the context length"
+    end
+
+    test "emits terminal error chunk for SSE error event with bare string", %{model: model} do
+      # Some OpenAI-compatible providers send `data: {"error": "message"}` directly
+      # without the nested `message` key. Tolerate that variant too.
+      error_event = %{data: %{"error" => "rate limit exceeded"}}
+
+      assert [chunk] = Defaults.default_decode_stream_event(error_event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "rate limit exceeded"
+      assert chunk.metadata.terminal? == true
+    end
+
+    test "error event takes precedence over choices in same payload", %{model: model} do
+      # Defensive: even if a malformed payload contains both `error` and `choices`,
+      # the error must win because `error` is terminal by definition.
+      mixed_event = %{
+        data: %{
+          "error" => %{"message" => "boom"},
+          "choices" => [%{"delta" => %{"content" => "ignored"}}]
+        }
+      }
+
+      assert [chunk] = Defaults.default_decode_stream_event(mixed_event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "boom"
+    end
+
+    test "does not match error event when message is non-string and no fallback hits",
+         %{model: model} do
+      # Guard regression: the new clause must require `message` to be a binary.
+      # A non-string `message` (rare but possible from malformed providers) should
+      # fall through to the regular `is_map(data)` clause, which returns [].
+      weird_event = %{data: %{"error" => %{"message" => %{"nested" => "thing"}}}}
+
+      assert Defaults.default_decode_stream_event(weird_event, model) == []
+    end
   end
 
   describe "ResponseBuilder reasoning_details accumulation" do

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -114,6 +114,20 @@ defmodule ReqLLM.StreamServer.MetadataTest do
       StreamServer.cancel(server)
     end
 
+    test "terminal? flag from provider meta completes without transport done" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      payload = Jason.encode!(%{"event" => "terminal"})
+      StreamServer.http_event(server, {:data, "data: #{payload}\n\n"})
+
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 200)
+      assert metadata.finish_reason == :stop
+      refute Map.has_key?(metadata, :terminal?)
+
+      StreamServer.cancel(server)
+    end
+
     test "explicit finish_reason from provider wins over terminal? fallback" do
       server = start_server()
       _task = mock_http_task(server)


### PR DESCRIPTION
## Summary

`default_decode_stream_event/2` in `ReqLLM.Provider.Defaults` currently only matches `choices` and `usage` SSE event payloads. OpenAI-compatible providers (LMStudio, OpenRouter on overflow, Ollama, vLLM, etc.) return errors mid-stream as `data: {"error": {"message": "..."}}` SSE events. Without an explicit clause these are silently dropped, the stream completes with zero chunks, and downstream code sees `finish_reason: :incomplete` with no diagnostic info -- the actual error from the provider is lost.

This PR adds two new clauses to `default_decode_stream_event/2` that handle the `error` event shape and emit a single terminal `:meta` chunk so downstream consumers can react.

## What changes

- New clause for the typical OpenAI shape: `%{data: %{"error" => %{"message" => msg}}}` -> `[ReqLLM.StreamChunk.meta(%{finish_reason: :error, error: msg, terminal?: true})]`
- New clause for the bare-string variant: `%{data: %{"error" => msg}}` (when `msg` is binary) -> same output
- Both clauses match before the generic `is_map(data)` clause so error events take precedence (they're terminal by definition)
- Existing `choices` and `usage` parsing is unchanged

## Tested

Added four new tests in `test/req_llm/provider/defaults_test.exs` under the existing `describe "default_decode_stream_event/2"` block:

1. Nested-message variant emits a terminal error chunk with the message preserved
2. Bare-string variant is also tolerated
3. Defensive: if a malformed payload contains both `error` and `choices`, error wins
4. Guard regression: non-string `message` (e.g. nested map) does not falsely match the new clause

Full suite: `2922 tests, 0 failures, 11 skipped (145 excluded)`.

## Why this matters

This is a universal bug across OpenAI-compatible providers. The visible symptom is "stream returned successfully but with empty content" -- callers cannot distinguish a genuinely-empty model response from a silent failure. With this fix:

- `StreamResponse.classify/1` reports `finish_reason: :error` instead of `nil`
- The provider's diagnostic message is preserved in the meta chunk's `:error` key
- Downstream wrappers can map `:error` to a structured `{:error, ...}` tuple

## Discovered during

Praktical (downstream consumer): silent multi-turn failures when LMStudio rejects context-overflow requests with HTTP 200 + SSE error payload. Investigation tracked under our internal issue PRA-7ijn (root-caused via raw payload-mode telemetry, wire-body capture, and direct curl reproduction against LMStudio).