### PR TITLE
feat: support reusable Responses WebSocket sessions

### DIFF
--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -192,6 +192,18 @@ defmodule ReqLLM.Providers.OpenAI do
       doc:
         "Streaming transport for Responses models. Use :websocket for OpenAI WebSocket mode; SSE remains the default."
     ],
+    openai_reuse_websocket: [
+      type: :boolean,
+      default: false,
+      doc:
+        "Request that higher-level agent runtimes reuse one Responses API WebSocket across multiple response.create turns."
+    ],
+    openai_websocket_session: [
+      type: :any,
+      doc:
+        "Existing ReqLLM.Streaming.WebSocketSession pid to reuse for Responses API streams. " <>
+          "When set, ReqLLM sends the response.create event on that socket and leaves socket ownership to the caller."
+    ],
     openai_compatible_backend: [
       type: {:or, [{:in, [:ollama]}, {:in, ["ollama"]}]},
       doc:
@@ -713,6 +725,10 @@ defmodule ReqLLM.Providers.OpenAI do
            "OpenAI WebSocket mode is only supported for Responses models. #{LLMDB.Model.spec(model)} routes to #{inspect(api_mod)}."
        )}
     end
+  end
+
+  def start_responses_session(%LLMDB.Model{} = model, opts \\ []) do
+    ReqLLM.Providers.OpenAI.WebSocket.start_responses_session(model, opts)
   end
 
   def stream_transport(_model, opts) do

--- a/lib/req_llm/providers/openai/web_socket.ex
+++ b/lib/req_llm/providers/openai/web_socket.ex
@@ -2,6 +2,7 @@ defmodule ReqLLM.Providers.OpenAI.WebSocket do
   @moduledoc false
 
   alias ReqLLM.Streaming.Fixtures.HTTPContext
+  alias ReqLLM.Streaming.WebSocketSession
 
   @spec headers(LLMDB.Model.t(), keyword()) :: [{String.t(), String.t()}]
   def headers(%LLMDB.Model{} = model, opts) do
@@ -11,6 +12,11 @@ defmodule ReqLLM.Providers.OpenAI.WebSocket do
       ReqLLM.Providers.OpenAI.resolve_request_credential!(model, opts)
     ) ++
       custom_headers
+  end
+
+  @spec start_responses_session(LLMDB.Model.t(), keyword()) :: GenServer.on_start()
+  def start_responses_session(%LLMDB.Model{} = model, opts \\ []) do
+    WebSocketSession.start_link(responses_url(model, opts), headers: headers(model, opts))
   end
 
   @spec responses_url(LLMDB.Model.t(), keyword()) :: String.t()

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -84,6 +84,23 @@ defmodule ReqLLM.Providers.OpenAICodex do
       type: {:or, [:atom, :string]},
       doc: "Service tier for request prioritization"
     ],
+    openai_stream_transport: [
+      type: {:in, [:sse, :websocket, "sse", "websocket"]},
+      default: :sse,
+      doc: "Streaming transport for the Codex Responses endpoint"
+    ],
+    openai_reuse_websocket: [
+      type: :boolean,
+      default: false,
+      doc:
+        "Request that higher-level agent runtimes reuse one Codex Responses WebSocket across multiple response.create turns."
+    ],
+    openai_websocket_session: [
+      type: :any,
+      doc:
+        "Existing ReqLLM.Streaming.WebSocketSession pid to reuse for Codex Responses streams. " <>
+          "When set, ReqLLM sends the response.create event on that socket and leaves socket ownership to the caller."
+    ],
     verbosity: [
       type: {:or, [:atom, :string]},
       doc: "Text verbosity. Defaults to medium."
@@ -240,6 +257,15 @@ defmodule ReqLLM.Providers.OpenAICodex do
     ResponsesAPI.decode_stream_event(normalized_event, model, state)
   end
 
+  def stream_transport(_model, opts) do
+    provider_opts = Keyword.get(opts, :provider_options, [])
+
+    case Keyword.get(provider_opts, :openai_stream_transport, :sse) do
+      transport when transport in [:websocket, "websocket"] -> :websocket
+      _ -> :http
+    end
+  end
+
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, _finch_name) do
     opts = normalize_stream_opts(opts)
@@ -279,6 +305,58 @@ defmodule ReqLLM.Providers.OpenAICodex do
        ReqLLM.Error.API.Request.exception(
          reason: "Failed to build OpenAI Codex streaming request: #{Exception.message(error)}"
        )}
+  end
+
+  def attach_websocket_stream(model, context, opts) do
+    opts = normalize_stream_opts(opts)
+    ensure_oauth_mode!(opts)
+
+    credential = ReqLLM.Auth.resolve!(model, opts)
+    account_id = resolve_account_id!(credential, opts)
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, opts)
+    headers = websocket_headers(credential.token, account_id, opts)
+    url = codex_websocket_url(base_url)
+
+    cleaned_opts =
+      opts
+      |> Keyword.delete(:finch_name)
+      |> Keyword.delete(:compiled_schema)
+      |> Keyword.put(:provider_options, Keyword.get(opts, :provider_options, []))
+      |> Keyword.put(:stream, nil)
+      |> Keyword.put(:model, model.id)
+      |> Keyword.put(:context, context)
+      |> Keyword.put(:base_url, base_url)
+
+    body = build_codex_body(context, model.id, cleaned_opts, nil)
+    create_event = Map.put(body, "type", "response.create")
+
+    {:ok,
+     %{
+       url: url,
+       headers: headers,
+       initial_messages: [Jason.encode!(create_event)],
+       http_context: ReqLLM.Providers.OpenAI.WebSocket.http_context(url, headers),
+       canonical_json: body
+     }}
+  rescue
+    error ->
+      {:error,
+       ReqLLM.Error.API.Request.exception(
+         reason: "Failed to build OpenAI Codex websocket request: #{Exception.message(error)}"
+       )}
+  end
+
+  def start_responses_session(%LLMDB.Model{} = model, opts \\ []) do
+    opts = normalize_stream_opts(opts)
+    ensure_oauth_mode!(opts)
+
+    credential = ReqLLM.Auth.resolve!(model, opts)
+    account_id = resolve_account_id!(credential, opts)
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, opts)
+
+    ReqLLM.Streaming.WebSocketSession.start_link(codex_websocket_url(base_url),
+      headers: websocket_headers(credential.token, account_id, opts)
+    )
   end
 
   defp build_codex_body(context, model_name, opts, request) do
@@ -483,6 +561,31 @@ defmodule ReqLLM.Providers.OpenAICodex do
       String.ends_with?(normalized, "/codex") -> normalized <> "/responses"
       true -> normalized <> codex_path()
     end
+  end
+
+  defp codex_websocket_url(base_url) do
+    base_url
+    |> codex_url()
+    |> ReqLLM.Providers.OpenAI.WebSocket.websocket_url("")
+  end
+
+  defp websocket_headers(token, account_id, opts) do
+    request_id = codex_request_id(opts)
+
+    [
+      {"authorization", "Bearer " <> token},
+      {"chatgpt-account-id", account_id},
+      {"originator", codex_originator(opts)},
+      {"openai-beta", "responses_websockets=2026-02-06"},
+      {"x-client-request-id", request_id},
+      {"session_id", request_id}
+    ] ++ ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options])
+  end
+
+  defp codex_request_id(opts) do
+    opts
+    |> provider_options()
+    |> Keyword.get_lazy(:session_id, fn -> "req_#{System.unique_integer([:positive])}" end)
   end
 
   defp normalize_stream_opts(opts) when is_list(opts) do

--- a/lib/req_llm/streaming/web_socket_client.ex
+++ b/lib/req_llm/streaming/web_socket_client.ex
@@ -105,17 +105,15 @@ defmodule ReqLLM.Streaming.WebSocketClient do
   defp start_streaming_task(config, stream_server_pid, opts) do
     task_pid =
       Task.Supervisor.async(ReqLLM.TaskSupervisor, fn ->
-        case WebSocketSession.start_link(
-               config.url,
-               headers: config.headers,
-               initial_messages: config.initial_messages
-             ) do
-          {:ok, session_pid} ->
-            await_connect_and_stream(session_pid, stream_server_pid, opts)
+        case reusable_session(opts) do
+          nil ->
+            start_owned_session(config, stream_server_pid, opts)
 
-          {:error, reason} ->
-            safe_http_event(stream_server_pid, {:error, reason})
-            {:error, reason}
+          session_pid when is_pid(session_pid) ->
+            await_connect_and_stream(session_pid, stream_server_pid, opts,
+              initial_messages: config.initial_messages,
+              close_on_terminal?: false
+            )
         end
       end)
 
@@ -126,15 +124,14 @@ defmodule ReqLLM.Streaming.WebSocketClient do
       {:error, {:task_start_failed, error}}
   end
 
-  defp await_connect_and_stream(session_pid, stream_server_pid, opts) do
-    connect_timeout =
-      Keyword.get(opts, :connect_timeout, Keyword.get(opts, :receive_timeout, 30_000))
-
-    case WebSocketSession.await_connected(session_pid, connect_timeout) do
-      :ok ->
-        safe_http_event(stream_server_pid, {:status, 101})
-        safe_http_event(stream_server_pid, {:headers, [{"upgrade", "websocket"}]})
-        relay_messages(session_pid, stream_server_pid, opts)
+  defp start_owned_session(config, stream_server_pid, opts) do
+    case WebSocketSession.start_link(
+           config.url,
+           headers: config.headers,
+           initial_messages: config.initial_messages
+         ) do
+      {:ok, session_pid} ->
+        await_connect_and_stream(session_pid, stream_server_pid, opts, close_on_terminal?: true)
 
       {:error, reason} ->
         safe_http_event(stream_server_pid, {:error, reason})
@@ -142,7 +139,33 @@ defmodule ReqLLM.Streaming.WebSocketClient do
     end
   end
 
-  defp relay_messages(session_pid, stream_server_pid, opts) do
+  defp await_connect_and_stream(session_pid, stream_server_pid, opts, session_opts) do
+    connect_timeout =
+      Keyword.get(opts, :connect_timeout, Keyword.get(opts, :receive_timeout, 30_000))
+
+    case WebSocketSession.await_connected(session_pid, connect_timeout) do
+      :ok ->
+        safe_http_event(stream_server_pid, {:status, 101})
+        safe_http_event(stream_server_pid, {:headers, [{"upgrade", "websocket"}]})
+
+        case send_initial_messages(session_pid, Keyword.get(session_opts, :initial_messages, [])) do
+          :ok ->
+            relay_messages(session_pid, stream_server_pid, opts,
+              close_on_terminal?: Keyword.get(session_opts, :close_on_terminal?, true)
+            )
+
+          {:error, reason} ->
+            safe_http_event(stream_server_pid, {:error, reason})
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        safe_http_event(stream_server_pid, {:error, reason})
+        {:error, reason}
+    end
+  end
+
+  defp relay_messages(session_pid, stream_server_pid, opts, relay_opts) do
     receive_timeout = Keyword.get(opts, :receive_timeout, 30_000)
 
     case WebSocketSession.next_message(session_pid, receive_timeout) do
@@ -156,10 +179,12 @@ defmodule ReqLLM.Streaming.WebSocketClient do
               safe_http_event(stream_server_pid, {:data, message})
 
               if WebSocketProtocol.terminal_event?(%{data: decoded}) do
-                :ok = WebSocketSession.close(session_pid)
-                :ok
+                maybe_close_session(
+                  session_pid,
+                  Keyword.get(relay_opts, :close_on_terminal?, true)
+                )
               else
-                relay_messages(session_pid, stream_server_pid, opts)
+                relay_messages(session_pid, stream_server_pid, opts, relay_opts)
               end
             end
 
@@ -179,6 +204,24 @@ defmodule ReqLLM.Streaming.WebSocketClient do
         {:error, reason}
     end
   end
+
+  defp reusable_session(opts) do
+    opts
+    |> Keyword.get(:provider_options, [])
+    |> Keyword.get(:openai_websocket_session)
+  end
+
+  defp send_initial_messages(session_pid, messages) do
+    Enum.reduce_while(messages, :ok, fn message, :ok ->
+      case WebSocketSession.send_text(session_pid, message) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp maybe_close_session(session_pid, true), do: WebSocketSession.close(session_pid)
+  defp maybe_close_session(_session_pid, false), do: :ok
 
   defp maybe_replay_fixture(model, opts) do
     case Code.ensure_loaded(ReqLLM.Test.Fixtures) do

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -114,6 +114,35 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert Enum.all?(body["input"], &(&1["role"] != "system"))
     end
 
+    test "builds websocket request with codex websocket beta" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
+
+      {:ok, config} =
+        OpenAICodex.attach_websocket_stream(
+          model,
+          ReqLLM.context([ReqLLM.Context.user("Say hi")]),
+          provider_options: [
+            auth_mode: :oauth,
+            access_token: jwt_with_account_id("acct_ws"),
+            session_id: "req_ws"
+          ]
+        )
+
+      assert config.url == "wss://chatgpt.com/backend-api/codex/responses"
+      assert {"openai-beta", "responses_websockets=2026-02-06"} in config.headers
+      assert {"session_id", "req_ws"} in config.headers
+      assert {"x-client-request-id", "req_ws"} in config.headers
+      refute Enum.any?(config.headers, &(elem(&1, 0) == "content-type"))
+
+      payload = config.initial_messages |> hd() |> Jason.decode!()
+
+      assert payload["type"] == "response.create"
+      assert payload["model"] == "gpt-5.3-codex-spark"
+      assert payload["store"] == false
+      assert payload["stream"] == true
+      refute Map.has_key?(payload, "response")
+    end
+
     test "loads oauth_file without explicit auth_mode for streaming" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
       path = oauth_file_path("stream")

--- a/test/req_llm/openai_websocket_test.exs
+++ b/test/req_llm/openai_websocket_test.exs
@@ -147,6 +147,42 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     assert Enum.any?(request["input"], fn item -> item["role"] == "user" end)
   end
 
+  test "stream_text can reuse caller-owned OpenAI responses websocket sessions", %{
+    base_url: base_url
+  } do
+    {:ok, model} = ReqLLM.model("openai:gpt-5")
+
+    {:ok, session} =
+      ReqLLM.Providers.OpenAI.WebSocket.start_responses_session(model,
+        base_url: base_url,
+        api_key: "test-key-12345"
+      )
+
+    try do
+      for prompt <- ["Say hello", "Say hello again"] do
+        {:ok, stream_response} =
+          ReqLLM.stream_text(
+            model,
+            prompt,
+            base_url: base_url,
+            receive_timeout: 5_000,
+            provider_options: [
+              openai_stream_transport: :websocket,
+              openai_websocket_session: session
+            ]
+          )
+
+        assert ReqLLM.StreamResponse.text(stream_response) == "Hello"
+        assert Process.alive?(session)
+      end
+    after
+      ReqLLM.Streaming.WebSocketSession.close(session)
+    end
+
+    assert_received {:responses_socket_message, %{"type" => "response.create"}}
+    assert_received {:responses_socket_message, %{"type" => "response.create"}}
+  end
+
   test "Realtime session can connect, send events, and receive events", %{base_url: base_url} do
     {:ok, session} =
       Realtime.connect("gpt-realtime",


### PR DESCRIPTION
## Description

ReqLLM already supports OpenAI Responses streaming over WebSocket for supported OpenAI models, but each `stream_text/3` call owns the socket lifecycle: it opens a WebSocket, sends one `response.create`, streams until the terminal response event, then closes the socket.

This adds an opt-in path for agent runtimes to keep a Responses WebSocket open across multiple `response.create` turns. Callers can create a session once, pass it through `provider_options[:openai_websocket_session]`, and remain responsible for closing it.

The default path is unchanged. If no caller-owned session is provided, ReqLLM still creates and closes a socket for that single stream call.

This also adds WebSocket support for the ChatGPT Codex backend. Codex uses a different WebSocket request shape than the standard OpenAI Responses API:

- `OpenAI-Beta: responses_websockets=2026-02-06`
- top-level `{"type": "response.create", ...body}`
- `session_id` and `x-client-request-id` headers
- no nested `"response"` wrapper

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Targeted tests:

- `mix test test/provider/openai/web_socket_test.exs test/provider/openai/responses_api_unit_test.exs test/req_llm/streaming/web_socket_client_test.exs test/req_llm/openai_websocket_test.exs test/providers/openai_codex_test.exs`

Live Codex smoke with Exy OAuth credentials:

- SSE sanity: `TEXT="codex-ok"`
- WebSocket: `TEXT="codex-ws-ok"`
- Reused WebSocket session:
  - `TEXT="first-reuse-ok"`
  - `TEXT="second-reuse-ok"`
  - `SESSION_ALIVE_AFTER_TWO=true`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)


