### PR TITLE
feat(openrouter): support session_id option

### DIFF
--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -21,6 +21,7 @@ defmodule ReqLLM.Providers.OpenRouter do
   - `openrouter_structured_output_mode` - Enables `:json_schema` structured output (when tool calls are not supported)
   - `openrouter_usage` - Usage options (e.g., `%{include: true}`)
   - `openrouter_plugins` - Array of plugins (e.g., `[%{id: "web"}]`)
+  - `openrouter_session_id` - Session ID for grouping related requests in OpenRouter
   - `app_referer` - HTTP-Referer header for app identification
   - `app_title` - X-Title header for app title in rankings
 
@@ -109,6 +110,10 @@ defmodule ReqLLM.Providers.OpenRouter do
     openrouter_plugins: [
       type: {:list, :map},
       doc: "OpenRouter plugins. Example: [%{id: \"web\"}]"
+    ],
+    openrouter_session_id: [
+      type: :string,
+      doc: "OpenRouter session ID for grouping related LLM calls"
     ],
     dimensions: [
       type: :pos_integer,
@@ -309,6 +314,7 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> maybe_put(:reasoning_effort, request.options[:reasoning_effort])
     |> maybe_put(:usage, request.options[:openrouter_usage])
     |> maybe_put(:plugins, request.options[:openrouter_plugins])
+    |> maybe_put(:session_id, request.options[:openrouter_session_id])
     |> add_openrouter_specific_options(request.options)
     |> add_stream_options(request.options)
   end

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -369,7 +369,9 @@ defmodule ReqLLM.Providers.OpenRouterTest do
          fn json -> assert json["repetition_penalty"] == 1.1 end},
         {[openrouter_min_p: 0.05], fn json -> assert json["min_p"] == 0.05 end},
         {[openrouter_top_a: 0.2], fn json -> assert json["top_a"] == 0.2 end},
-        {[openrouter_top_logprobs: 5], fn json -> assert json["top_logprobs"] == 5 end}
+        {[openrouter_top_logprobs: 5], fn json -> assert json["top_logprobs"] == 5 end},
+        {[openrouter_session_id: "req-llm-test-session"],
+         fn json -> assert json["session_id"] == "req-llm-test-session" end}
       ]
 
       for {opts, assertion} <- test_cases do


### PR DESCRIPTION
## Summary
- add OpenRouter provider option `openrouter_session_id`
- encode it as OpenRouter `session_id` in chat completion request bodies
- cover request-body encoding in OpenRouter provider tests

Closes #664

## Validation
- `mix test test/providers/openrouter_test.exs`
- `mix test`
- `mix quality`
- live OpenRouter smoke test with `openrouter_session_id` returned `OK` from `openrouter:google/gemini-2.0-flash-001`