### PR TITLE
fix: default token limits from model metadata

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -178,11 +178,20 @@ defmodule ReqLLM.Provider.Defaults do
       """
       @impl ReqLLM.Provider
       def attach_stream(model, context, opts, finch_name) do
+        processed_opts =
+          ReqLLM.Provider.Options.process_stream!(
+            __MODULE__,
+            opts[:operation] || :chat,
+            model,
+            context,
+            opts
+          )
+
         ReqLLM.Provider.Defaults.default_attach_stream(
           __MODULE__,
           model,
           context,
-          opts,
+          processed_opts,
           finch_name
         )
       end
@@ -299,7 +308,7 @@ defmodule ReqLLM.Provider.Defaults do
       opts
       |> Keyword.update(:tools, [structured_output_tool], &[structured_output_tool | &1])
       |> Keyword.put(:tool_choice, tool_choice)
-      |> Keyword.put_new(:max_tokens, 4096)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
       |> Keyword.put(:operation, :object)
 
     prepare_chat_request(provider_mod, model_spec, prompt, opts_with_tool)

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -232,6 +232,20 @@ defmodule ReqLLM.Provider.Options do
     :context
   ]
 
+  @stream_request_option_keys [
+    :api_mod,
+    :auth,
+    :finch,
+    :json,
+    :model,
+    :params,
+    :plug,
+    :pool_timeout,
+    :retry,
+    :retry_log_level,
+    :telemetry_original_opts
+  ]
+
   @doc """
   Returns the core generation options schema.
   """
@@ -337,6 +351,25 @@ defmodule ReqLLM.Provider.Options do
     final_opts
     |> Keyword.put(:telemetry_original_opts, telemetry_original_opts)
   end
+
+  @doc """
+  Processes options for provider streaming callbacks.
+
+  Streaming can receive options copied from prepared `Req.Request` structs, so this
+  trims request-only keys before running the normal generation option pipeline.
+  """
+  @spec process_stream!(module(), atom(), LLMDB.Model.t(), ReqLLM.Context.t(), keyword()) ::
+          keyword()
+  def process_stream!(provider_mod, operation, model, context, opts) do
+    opts
+    |> strip_stream_request_options()
+    |> Keyword.merge(stream: true, context: context, operation: operation)
+    |> then(&process!(provider_mod, operation, model, &1))
+  end
+
+  @doc false
+  @spec strip_stream_request_options(keyword()) :: keyword()
+  def strip_stream_request_options(opts), do: Keyword.drop(opts, @stream_request_option_keys)
 
   # Public utility functions
 
@@ -524,6 +557,47 @@ defmodule ReqLLM.Provider.Options do
     result
   end
 
+  @doc """
+  Adds a default generated-token limit from model metadata.
+
+  Explicit `:max_tokens`, `:max_completion_tokens`, `:max_output_tokens`, or matching
+  nested `:provider_options` values are preserved. When model metadata does not expose
+  an output limit, `:fallback` is used if provided.
+  """
+  @spec put_model_max_tokens_default(keyword(), LLMDB.Model.t() | ReqLLM.model_input(), keyword()) ::
+          keyword()
+  def put_model_max_tokens_default(opts, model_input, options \\ [])
+
+  def put_model_max_tokens_default(opts, %LLMDB.Model{} = model, options) do
+    key = Keyword.get(options, :key, :max_tokens)
+    fallback = Keyword.get(options, :fallback)
+    output_limit = model_output_limit(model)
+
+    cond do
+      token_limit_present?(opts) ->
+        opts
+
+      is_integer(output_limit) and output_limit > 0 ->
+        Keyword.put(opts, key, output_limit)
+
+      is_integer(fallback) and fallback > 0 ->
+        Keyword.put(opts, key, fallback)
+
+      true ->
+        opts
+    end
+  end
+
+  def put_model_max_tokens_default(opts, model_input, options) do
+    case ReqLLM.model(model_input) do
+      {:ok, %LLMDB.Model{} = model} ->
+        put_model_max_tokens_default(opts, model, options)
+
+      _ ->
+        put_fallback_max_tokens_default(opts, options)
+    end
+  end
+
   # Private helper functions
 
   defp normalize_legacy_options(opts) do
@@ -547,25 +621,37 @@ defmodule ReqLLM.Provider.Options do
     do: extract_model_options(model, opts)
 
   defp maybe_extract_max_tokens(%LLMDB.Model{} = model, opts) do
-    cond do
-      Keyword.has_key?(opts, :max_tokens) or
-        Keyword.has_key?(opts, :max_completion_tokens) or
-          provider_option_present?(opts, :max_completion_tokens) ->
-        opts
+    put_model_max_tokens_default(opts, model)
+  end
 
-      is_map(model.limits) and is_integer(model.limits[:output]) and model.limits[:output] > 0 ->
-        Keyword.put(opts, :max_tokens, model.limits.output)
-
-      true ->
-        opts
-    end
+  defp token_limit_present?(opts) do
+    Enum.any?([:max_tokens, :max_completion_tokens, :max_output_tokens], fn key ->
+      Keyword.has_key?(opts, key) or provider_option_present?(opts, key)
+    end)
   end
 
   defp provider_option_present?(opts, key) do
-    opts
-    |> Keyword.get(:provider_options, [])
-    |> Keyword.has_key?(key)
+    provider_options = Keyword.get(opts, :provider_options, [])
+
+    Keyword.keyword?(provider_options) and Keyword.has_key?(provider_options, key)
   end
+
+  defp put_fallback_max_tokens_default(opts, options) do
+    key = Keyword.get(options, :key, :max_tokens)
+    fallback = Keyword.get(options, :fallback)
+
+    if token_limit_present?(opts) or !is_integer(fallback) or fallback <= 0 do
+      opts
+    else
+      Keyword.put(opts, key, fallback)
+    end
+  end
+
+  defp model_output_limit(%LLMDB.Model{limits: limits}) when is_map(limits) do
+    limits[:output] || limits["output"]
+  end
+
+  defp model_output_limit(%LLMDB.Model{}), do: nil
 
   defp maybe_extract_model_base_url(opts, %LLMDB.Model{} = model) do
     if is_bitstring(model.base_url) do

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -631,9 +631,16 @@ defmodule ReqLLM.Provider.Options do
   end
 
   defp provider_option_present?(opts, key) do
-    provider_options = Keyword.get(opts, :provider_options, [])
+    case Keyword.get(opts, :provider_options, []) do
+      provider_options when is_list(provider_options) ->
+        Keyword.keyword?(provider_options) and Keyword.has_key?(provider_options, key)
 
-    Keyword.keyword?(provider_options) and Keyword.has_key?(provider_options, key)
+      provider_options when is_map(provider_options) ->
+        Map.has_key?(provider_options, key) or Map.has_key?(provider_options, Atom.to_string(key))
+
+      _ ->
+        false
+    end
   end
 
   defp put_fallback_max_tokens_default(opts, options) do

--- a/lib/req_llm/providers/alibaba/shared.ex
+++ b/lib/req_llm/providers/alibaba/shared.ex
@@ -186,11 +186,12 @@ defmodule ReqLLM.Providers.Alibaba.Shared do
   """
   def attach_stream(provider_mod, model, context, opts, finch_name) do
     processed_opts =
-      ReqLLM.Provider.Options.process!(
+      ReqLLM.Provider.Options.process_stream!(
         provider_mod,
         :chat,
         model,
-        Keyword.merge(opts, stream: true, context: context)
+        context,
+        opts
       )
 
     ReqLLM.Provider.Defaults.default_attach_stream(

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -534,12 +534,16 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # Validate we have necessary AWS credentials
     validate_aws_credentials!(aws_creds)
 
-    # Apply pre-validation (reasoning params, etc.) - streaming bypasses Options.process
-    {pre_validated_opts, _warnings} = pre_validate_options(:chat, model, other_opts)
+    operation = other_opts[:operation] || :chat
 
-    # Apply option translation (temperature/top_p conflicts, etc.)
-    # This is critical for streaming requests which bypass the normal Options.process pipeline
-    {translated_opts, _warnings} = translate_options(:chat, model, pre_validated_opts)
+    translated_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        operation,
+        model,
+        context,
+        other_opts
+      )
 
     # Get model ID - use provider_model_id if set (for models requiring specific API format),
     # otherwise fall back to canonical model ID
@@ -578,7 +582,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     context =
       ReqLLM.ToolCallIdCompat.apply_context(
         __MODULE__,
-        :chat,
+        operation,
         model,
         context,
         translated_opts

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -263,7 +263,7 @@ defmodule ReqLLM.Providers.Anthropic do
           })
         end
       )
-      |> Keyword.put_new(:max_tokens, 4096)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
       |> Keyword.put(:operation, :object)
 
     prepare_request(:chat, model_spec, prompt, opts_with_format)
@@ -312,7 +312,7 @@ defmodule ReqLLM.Providers.Anthropic do
           opts
           |> Keyword.update(:tools, [structured_output_tool], &[structured_output_tool | &1])
           |> Keyword.put(:tool_choice, %{type: "tool", name: "structured_output"})
-          |> Keyword.put_new(:max_tokens, 4096)
+          |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
           |> Keyword.put(:operation, :object)
 
         prepare_request(:chat, model_spec, prompt, opts_with_tool)
@@ -521,14 +521,17 @@ defmodule ReqLLM.Providers.Anthropic do
 
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, _finch_name) do
-    # Extract and merge provider_options for translation
-    {provider_options, standard_opts} = Keyword.pop(opts, :provider_options, [])
-    flattened_opts = Keyword.merge(standard_opts, provider_options)
+    operation = opts[:operation] || :chat
 
-    # Translate provider options (including reasoning_effort) before building body
-    {translated_opts, _warnings} = translate_options(:chat, model, flattened_opts)
+    translated_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        operation,
+        model,
+        context,
+        opts
+      )
 
-    # Set default timeout for reasoning models
     default_timeout =
       if Keyword.has_key?(translated_opts, :thinking) do
         Application.get_env(:req_llm, :thinking_timeout, 300_000)
@@ -541,14 +544,14 @@ defmodule ReqLLM.Providers.Anthropic do
     base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
     translated_opts = Keyword.put(translated_opts, :base_url, base_url)
 
-    # Build request using shared helpers
     headers = build_request_headers(model, translated_opts)
     streaming_headers = [{"Accept", "text/event-stream"} | headers]
     beta_headers = build_beta_headers(translated_opts)
-    custom_headers = ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options])
-    all_headers = streaming_headers ++ beta_headers ++ custom_headers
 
-    operation = opts[:operation] || :chat
+    custom_headers =
+      ReqLLM.Provider.Utils.extract_custom_headers(translated_opts[:req_http_options])
+
+    all_headers = streaming_headers ++ beta_headers ++ custom_headers
 
     context =
       ReqLLM.ToolCallIdCompat.apply_context(

--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -339,7 +339,7 @@ defmodule ReqLLM.Providers.Azure do
 
     opts_for_object =
       opts
-      |> Keyword.put_new(:max_tokens, 4096)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model, fallback: 4096)
       |> Keyword.put(:operation, :object)
 
     case model_family do
@@ -677,18 +677,16 @@ defmodule ReqLLM.Providers.Azure do
     model_family = get_model_family(model_id)
     resolved_base_url = resolve_base_url(model_family, opts)
 
-    opts_with_context =
-      opts
-      |> Keyword.put(:context, context)
-      |> Keyword.put(:base_url, resolved_base_url)
-
-    {:ok, processed_opts} =
-      ReqLLM.Provider.Options.process(__MODULE__, :chat, model, opts_with_context)
-
     operation = opts[:operation] || :chat
 
     processed_opts =
-      processed_opts
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        operation,
+        model,
+        context,
+        Keyword.put(opts, :base_url, resolved_base_url)
+      )
       |> maybe_clean_thinking_after_translation(model_family, operation)
       |> maybe_warn_service_tier(model_family, model_id)
 

--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -259,6 +259,10 @@ defmodule ReqLLM.Providers.Azure do
       type: :any,
       doc: "Maximum completion tokens (OpenAI reasoning models)"
     ],
+    max_output_tokens: [
+      type: :any,
+      doc: "Maximum output tokens (OpenAI Responses API models)"
+    ],
     verbosity: [
       type: {:or, [:atom, :string]},
       doc:

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -284,10 +284,15 @@ defmodule ReqLLM.Providers.Google do
       with {:ok, model} <- ReqLLM.model(model_spec),
            {:ok, context} <- ReqLLM.Context.normalize(prompt, opts) do
         opts_with_tokens =
-          case Keyword.get(opts, :max_tokens) do
-            nil -> Keyword.put(opts, :max_tokens, 4096)
-            tokens when tokens < 200 -> Keyword.put(opts, :max_tokens, 200)
-            _tokens -> opts
+          ReqLLM.Provider.Options.put_model_max_tokens_default(opts, model, fallback: 4096)
+
+        opts_with_tokens =
+          case Keyword.get(opts_with_tokens, :max_tokens) do
+            tokens when is_integer(tokens) and tokens < 200 ->
+              Keyword.put(opts_with_tokens, :max_tokens, 200)
+
+            _tokens ->
+              opts_with_tokens
           end
 
         opts_with_context =
@@ -1985,11 +1990,17 @@ defmodule ReqLLM.Providers.Google do
     {req_opts, user_opts} = Keyword.split(opts, req_only_keys)
 
     operation = Keyword.get(user_opts, :operation, :chat)
-    opts_to_process = Keyword.merge(user_opts, context: context, stream: true)
 
-    with {:ok, processed_opts0} <-
-           ReqLLM.Provider.Options.process(__MODULE__, operation, model, opts_to_process),
-         :ok <- validate_version_feature_compat(processed_opts0) do
+    processed_opts0 =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        operation,
+        model,
+        context,
+        user_opts
+      )
+
+    with :ok <- validate_version_feature_compat(processed_opts0) do
       require Logger
 
       Logger.debug(

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -873,6 +873,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, _finch_name) do
     # Process and validate options
+    opts = ReqLLM.Provider.Options.strip_stream_request_options(opts)
     operation = opts[:operation] || :chat
 
     {gcp_creds, other_opts, model_family, formatter} =

--- a/lib/req_llm/providers/groq.ex
+++ b/lib/req_llm/providers/groq.ex
@@ -79,11 +79,14 @@ defmodule ReqLLM.Providers.Groq do
 
     # Adjust max_tokens for structured output with Groq-specific minimums
     opts_with_tokens =
-      case Keyword.get(opts_with_tool, :max_tokens) do
-        nil -> Keyword.put(opts_with_tool, :max_tokens, 4096)
-        tokens when tokens < 200 -> Keyword.put(opts_with_tool, :max_tokens, 200)
-        _tokens -> opts_with_tool
-      end
+      opts_with_tool
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
+      |> then(fn opts ->
+        case Keyword.get(opts, :max_tokens) do
+          tokens when is_integer(tokens) and tokens < 200 -> Keyword.put(opts, :max_tokens, 200)
+          _tokens -> opts
+        end
+      end)
 
     # Preserve the :object operation for response decoding
     opts_with_operation = Keyword.put(opts_with_tokens, :operation, :object)
@@ -197,9 +200,17 @@ defmodule ReqLLM.Providers.Groq do
   """
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
-    {translated_opts, _warnings} = translate_options(:chat, model, opts)
-    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
-    opts_with_base_url = Keyword.put(translated_opts, :base_url, base_url)
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        opts[:operation] || :chat,
+        model,
+        context,
+        opts
+      )
+
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
+    opts_with_base_url = Keyword.put(processed_opts, :base_url, base_url)
     ReqLLM.Providers.OpenAI.ChatAPI.attach_stream(model, context, opts_with_base_url, finch_name)
   end
 

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -127,9 +127,17 @@ defmodule ReqLLM.Providers.Minimax do
 
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
-    {translated_opts, _warnings} = translate_options(:chat, model, opts)
-    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
-    opts_with_base_url = Keyword.put(translated_opts, :base_url, base_url)
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        opts[:operation] || :chat,
+        model,
+        context,
+        opts
+      )
+
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
+    opts_with_base_url = Keyword.put(processed_opts, :base_url, base_url)
 
     ReqLLM.Provider.Defaults.default_attach_stream(
       __MODULE__,

--- a/lib/req_llm/providers/mistral.ex
+++ b/lib/req_llm/providers/mistral.ex
@@ -130,9 +130,17 @@ defmodule ReqLLM.Providers.Mistral do
 
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
-    {translated_opts, _warnings} = translate_options(:chat, model, opts)
-    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
-    opts_with_base_url = Keyword.put(translated_opts, :base_url, base_url)
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        opts[:operation] || :chat,
+        model,
+        context,
+        opts
+      )
+
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
+    opts_with_base_url = Keyword.put(processed_opts, :base_url, base_url)
 
     ReqLLM.Provider.Defaults.default_attach_stream(
       __MODULE__,

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -146,6 +146,10 @@ defmodule ReqLLM.Providers.OpenAI do
       type: :integer,
       doc: "Maximum completion tokens (required for reasoning models like o1, o3, gpt-5)"
     ],
+    max_output_tokens: [
+      type: :integer,
+      doc: "Maximum output tokens for Responses API models"
+    ],
     openai_structured_output_mode: [
       type: {:in, [:auto, :json_schema, :tool_strict]},
       default: :auto,

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -586,7 +586,7 @@ defmodule ReqLLM.Providers.OpenAI do
           |> Keyword.put(:openai_parallel_tool_calls, false)
         end
       )
-      |> put_default_max_tokens_for_model(model_spec)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
       |> Keyword.put(:operation, :object)
 
     prepare_request(:chat, model_spec, prompt, opts_with_format)
@@ -615,7 +615,7 @@ defmodule ReqLLM.Providers.OpenAI do
         [],
         &Keyword.put(&1, :openai_parallel_tool_calls, false)
       )
-      |> put_default_max_tokens_for_model(model_spec)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
       |> Keyword.put(:operation, :object)
 
     prepare_request(:chat, model_spec, prompt, opts_with_tool)
@@ -710,7 +710,18 @@ defmodule ReqLLM.Providers.OpenAI do
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
     api_mod = select_api_mod(model)
-    api_mod.attach_stream(model, context, opts, finch_name)
+    operation = opts[:operation] || :chat
+
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        operation,
+        model,
+        context,
+        opts
+      )
+
+    api_mod.attach_stream(model, context, processed_opts, finch_name)
   end
 
   def attach_websocket_stream(model, context, opts) do
@@ -814,22 +825,6 @@ defmodule ReqLLM.Providers.OpenAI do
     else
       chunks = ReqLLM.Providers.OpenAI.ChatAPI.decode_stream_event(event, model)
       {chunks, state}
-    end
-  end
-
-  defp put_default_max_tokens_for_model(opts, model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, model} ->
-        case get_api_type(model) do
-          "responses" ->
-            Keyword.put_new(opts, :max_completion_tokens, 4096)
-
-          _ ->
-            Keyword.put_new(opts, :max_tokens, 4096)
-        end
-
-      _ ->
-        Keyword.put_new(opts, :max_tokens, 4096)
     end
   end
 

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -39,6 +39,10 @@ defmodule ReqLLM.Providers.OpenAICodex do
       type: :string,
       doc: "Explicit ChatGPT account id override for Codex requests"
     ],
+    session_id: [
+      type: :string,
+      doc: "Stable request/session id used for Codex websocket headers"
+    ],
     codex_originator: [
       type: :string,
       default: "pi",
@@ -268,7 +272,22 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, _finch_name) do
-    opts = normalize_stream_opts(opts)
+    opts =
+      opts
+      |> normalize_stream_opts()
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model,
+        key: :max_completion_tokens
+      )
+      |> then(fn opts ->
+        ReqLLM.Provider.Options.process_stream!(
+          __MODULE__,
+          opts[:operation] || :chat,
+          model,
+          context,
+          opts
+        )
+      end)
+
     ensure_oauth_mode!(opts)
 
     credential = ReqLLM.Auth.resolve!(model, opts)
@@ -308,7 +327,22 @@ defmodule ReqLLM.Providers.OpenAICodex do
   end
 
   def attach_websocket_stream(model, context, opts) do
-    opts = normalize_stream_opts(opts)
+    opts =
+      opts
+      |> normalize_stream_opts()
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model,
+        key: :max_completion_tokens
+      )
+      |> then(fn opts ->
+        ReqLLM.Provider.Options.process_stream!(
+          __MODULE__,
+          opts[:operation] || :chat,
+          model,
+          context,
+          opts
+        )
+      end)
+
     ensure_oauth_mode!(opts)
 
     credential = ReqLLM.Auth.resolve!(model, opts)
@@ -375,6 +409,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     body
     |> Map.put("input", Enum.reject(List.wrap(body["input"]), &system_input?/1))
     |> Map.delete("max_output_tokens")
+    |> maybe_put_max_completion_tokens(opts)
     |> Map.put("store", false)
     |> Map.put("stream", true)
     |> Map.put("include", ["reasoning.encrypted_content"])
@@ -468,6 +503,13 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
   defp maybe_put_event(event, nil), do: event
   defp maybe_put_event(event, type), do: Map.put(event, :event, type)
+
+  defp maybe_put_max_completion_tokens(map, opts) do
+    case Keyword.get(opts, :max_completion_tokens) || Keyword.get(opts, :max_tokens) do
+      nil -> map
+      tokens -> Map.put(map, "max_completion_tokens", tokens)
+    end
+  end
 
   defp normalize_response_payload(data) do
     update_in(data, ["response"], fn
@@ -674,7 +716,11 @@ defmodule ReqLLM.Providers.OpenAICodex do
           |> Keyword.put(:openai_parallel_tool_calls, false)
         end
       )
-      |> put_default_max_tokens_for_model(model_spec)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(
+        model_spec,
+        key: :max_completion_tokens,
+        fallback: 4096
+      )
       |> Keyword.put(:operation, :object)
 
     prepare_request(:chat, model_spec, prompt, opts_with_format)
@@ -702,20 +748,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
         [],
         &Keyword.put(&1, :openai_parallel_tool_calls, false)
       )
-      |> put_default_max_tokens_for_model(model_spec)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(
+        model_spec,
+        key: :max_completion_tokens,
+        fallback: 4096
+      )
       |> Keyword.put(:operation, :object)
 
     prepare_request(:chat, model_spec, prompt, opts_with_tool)
-  end
-
-  defp put_default_max_tokens_for_model(opts, model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, _model} ->
-        Keyword.put_new(opts, :max_completion_tokens, 4096)
-
-      _ ->
-        Keyword.put_new(opts, :max_completion_tokens, 4096)
-    end
   end
 
   defp enforce_strict_schema_requirements(schema) do

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -188,11 +188,14 @@ defmodule ReqLLM.Providers.OpenRouter do
       end
 
     opts =
-      case Keyword.get(opts, :max_tokens) do
-        nil -> Keyword.put(opts, :max_tokens, 4096)
-        tokens when tokens < 200 -> Keyword.put(opts, :max_tokens, 200)
-        _tokens -> opts
-      end
+      opts
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
+      |> then(fn opts ->
+        case Keyword.get(opts, :max_tokens) do
+          tokens when is_integer(tokens) and tokens < 200 -> Keyword.put(opts, :max_tokens, 200)
+          _tokens -> opts
+        end
+      end)
 
     opts = Keyword.put(opts, :operation, :object)
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -111,6 +111,10 @@ defmodule ReqLLM.Providers.XAI do
       type: :integer,
       doc: "Maximum completion tokens (preferred over max_tokens for Grok-4)"
     ],
+    max_output_tokens: [
+      type: :integer,
+      doc: "Maximum output tokens for Responses API requests"
+    ],
     search_parameters: [
       type: :map,
       doc:

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -155,7 +155,7 @@ defmodule ReqLLM.Providers.XAI do
     compiled_schema = Keyword.fetch!(opts, :compiled_schema)
     {:ok, model} = ReqLLM.model(model_spec)
 
-    opts_with_tokens = ensure_min_tokens(opts)
+    opts_with_tokens = ensure_min_tokens(model, opts)
     mode = determine_output_mode(model, opts_with_tokens)
 
     case mode do
@@ -346,13 +346,11 @@ defmodule ReqLLM.Providers.XAI do
     end)
   end
 
-  defp ensure_min_tokens(opts) do
+  defp ensure_min_tokens(model, opts) do
+    opts = ReqLLM.Provider.Options.put_model_max_tokens_default(opts, model, fallback: 4096)
     max_tokens = Keyword.get(opts, :max_tokens) || Keyword.get(opts, :max_completion_tokens)
 
     case max_tokens do
-      nil ->
-        Keyword.put(opts, :max_tokens, 4096)
-
       tokens when tokens < 200 ->
         Keyword.put(opts, :max_tokens, 200)
 
@@ -665,9 +663,17 @@ defmodule ReqLLM.Providers.XAI do
   """
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
-    {translated_opts, _warnings} = translate_options(:chat, model, opts)
-    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
-    opts_with_base_url = Keyword.put(translated_opts, :base_url, base_url)
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        opts[:operation] || :chat,
+        model,
+        context,
+        opts
+      )
+
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
+    opts_with_base_url = Keyword.put(processed_opts, :base_url, base_url)
     use_responses = use_responses_api?(opts_with_base_url)
 
     opts_with_base_url =

--- a/lib/req_llm/providers/zai_coding_plan.ex
+++ b/lib/req_llm/providers/zai_coding_plan.ex
@@ -93,7 +93,22 @@ defmodule ReqLLM.Providers.ZaiCodingPlan do
 
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
-    ReqLLM.Provider.Defaults.default_attach_stream(__MODULE__, model, context, opts, finch_name)
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        opts[:operation] || :chat,
+        model,
+        context,
+        opts
+      )
+
+    ReqLLM.Provider.Defaults.default_attach_stream(
+      __MODULE__,
+      model,
+      context,
+      processed_opts,
+      finch_name
+    )
   end
 
   defdelegate decode_stream_event(event, model), to: ReqLLM.Providers.ZaiCoder

--- a/lib/req_llm/providers/zenmux.ex
+++ b/lib/req_llm/providers/zenmux.ex
@@ -98,11 +98,14 @@ defmodule ReqLLM.Providers.Zenmux do
       |> Keyword.put(:tool_choice, %{type: "function", function: %{name: "structured_output"}})
 
     opts_with_tokens =
-      case Keyword.get(opts_with_tool, :max_tokens) do
-        nil -> Keyword.put(opts_with_tool, :max_tokens, 4096)
-        tokens when tokens < 200 -> Keyword.put(opts_with_tool, :max_tokens, 200)
-        _tokens -> opts_with_tool
-      end
+      opts_with_tool
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
+      |> then(fn opts ->
+        case Keyword.get(opts, :max_tokens) do
+          tokens when is_integer(tokens) and tokens < 200 -> Keyword.put(opts, :max_tokens, 200)
+          _tokens -> opts
+        end
+      end)
 
     opts_with_operation = Keyword.put(opts_with_tokens, :operation, :object)
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -146,6 +146,17 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert body["max_tokens"] == model.limits.output
     end
 
+    test "attach_stream preserves explicit max_tokens" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Write a detailed answer")])
+
+      {:ok, finch_request} =
+        Anthropic.attach_stream(model, context, [api_key: "test-key", max_tokens: 123], nil)
+
+      body = Jason.decode!(finch_request.body)
+      assert body["max_tokens"] == 123
+    end
+
     test "prepare_request for :object defaults max_tokens from model output limit" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
       context = ReqLLM.Context.new([ReqLLM.Context.user("Generate a person")])

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -136,6 +136,27 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert headers["anthropic-beta"] == "tools-2024-05-16"
     end
 
+    test "attach_stream defaults max_tokens from model output limit" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Write a detailed answer")])
+
+      {:ok, finch_request} = Anthropic.attach_stream(model, context, [api_key: "test-key"], nil)
+
+      body = Jason.decode!(finch_request.body)
+      assert body["max_tokens"] == model.limits.output
+    end
+
+    test "prepare_request for :object defaults max_tokens from model output limit" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Generate a person")])
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+
+      {:ok, request} = Anthropic.prepare_request(:object, model, context, compiled_schema: schema)
+
+      body = request |> Anthropic.encode_body() |> Map.fetch!(:body) |> Jason.decode!()
+      assert body["max_tokens"] == model.limits.output
+    end
+
     test "error handling for invalid configurations" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
       prompt = "Hello world"

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1422,7 +1422,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       opts = [compiled_schema: schema]
       {:ok, request} = Google.prepare_request(:object, model, context, opts)
 
-      assert request.options[:max_tokens] == 4096
+      assert request.options[:max_tokens] == model.limits.output
     end
 
     test "prepare_request for :object with sufficient max_tokens unchanged" do

--- a/test/providers/groq_test.exs
+++ b/test/providers/groq_test.exs
@@ -536,8 +536,7 @@ defmodule ReqLLM.Providers.GroqTest do
       opts = [compiled_schema: schema]
       {:ok, request} = Groq.prepare_request(:object, model, prompt, opts)
 
-      # Should get default of 4096
-      assert request.options[:max_tokens] == 4096
+      assert request.options[:max_tokens] == model.limits.output
     end
 
     test "prepare_request for :object with sufficient max_tokens unchanged" do

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -111,6 +111,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert body["include"] == ["reasoning.encrypted_content"]
       assert body["text"] == %{"verbosity" => "medium"}
       refute Map.has_key?(body, "max_output_tokens")
+      assert body["max_completion_tokens"] == model.limits.output
       assert Enum.all?(body["input"], &(&1["role"] != "system"))
     end
 
@@ -140,6 +141,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert payload["model"] == "gpt-5.3-codex-spark"
       assert payload["store"] == false
       assert payload["stream"] == true
+      assert payload["max_completion_tokens"] == model.limits.output
       refute Map.has_key?(payload, "response")
     end
 

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -117,6 +117,17 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert body["max_tokens"] == model.limits.output
     end
 
+    test "attach_stream preserves explicit chat max_tokens" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4")
+      context = context_fixture()
+
+      {:ok, request} =
+        OpenAI.attach_stream(model, context, [api_key: "test-key", max_tokens: 123], nil)
+
+      body = Jason.decode!(request.body)
+      assert body["max_tokens"] == 123
+    end
+
     test "attach_stream defaults responses max_output_tokens from model output limit" do
       {:ok, model} = ReqLLM.model("openai:gpt-4o")
       context = context_fixture()
@@ -125,6 +136,22 @@ defmodule ReqLLM.Providers.OpenAITest do
 
       body = Jason.decode!(request.body)
       assert body["max_output_tokens"] == model.limits.output
+    end
+
+    test "attach_stream preserves explicit responses max_completion_tokens" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      context = context_fixture()
+
+      {:ok, request} =
+        OpenAI.attach_stream(
+          model,
+          context,
+          [api_key: "test-key", max_completion_tokens: 456],
+          nil
+        )
+
+      body = Jason.decode!(request.body)
+      assert body["max_output_tokens"] == 456
     end
 
     test "prepare_request for :object defaults token limit from model output limit" do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -107,6 +107,41 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert request.method == :post
     end
 
+    test "attach_stream defaults chat max_tokens from model output limit" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4")
+      context = context_fixture()
+
+      {:ok, request} = OpenAI.attach_stream(model, context, [api_key: "test-key"], nil)
+
+      body = Jason.decode!(request.body)
+      assert body["max_tokens"] == model.limits.output
+    end
+
+    test "attach_stream defaults responses max_output_tokens from model output limit" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      context = context_fixture()
+
+      {:ok, request} = OpenAI.attach_stream(model, context, [api_key: "test-key"], nil)
+
+      body = Jason.decode!(request.body)
+      assert body["max_output_tokens"] == model.limits.output
+    end
+
+    test "prepare_request for :object defaults token limit from model output limit" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o-mini")
+      context = context_fixture()
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+
+      {:ok, request} = OpenAI.prepare_request(:object, model, context, compiled_schema: schema)
+
+      body = request |> OpenAI.encode_body() |> Map.fetch!(:body) |> Jason.decode!()
+
+      token_limit =
+        body["max_tokens"] || body["max_completion_tokens"] || body["max_output_tokens"]
+
+      assert token_limit == model.limits.output
+    end
+
     test "prepare_request honors explicit string-key openai_chat wire protocol" do
       {:ok, model} =
         ReqLLM.model(%{

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -154,6 +154,17 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert body["max_output_tokens"] == 456
     end
 
+    test "attach_stream preserves explicit responses max_output_tokens" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      context = context_fixture()
+
+      {:ok, request} =
+        OpenAI.attach_stream(model, context, [api_key: "test-key", max_output_tokens: 789], nil)
+
+      body = Jason.decode!(request.body)
+      assert body["max_output_tokens"] == 789
+    end
+
     test "prepare_request for :object defaults token limit from model output limit" do
       {:ok, model} = ReqLLM.model("openai:gpt-4o-mini")
       context = context_fixture()

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -475,7 +475,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
 
       refute Map.has_key?(request.options, :tools)
       refute Map.has_key?(request.options, :tool_choice)
-      assert request.options[:max_tokens] == 4096
+      assert request.options[:max_tokens] == model.limits.output
     end
 
     test "prepare_request for :object with json_schema mode respects custom max_tokens" do
@@ -527,7 +527,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
              }
 
       refute Map.has_key?(request.options, :response_format)
-      assert request.options[:max_tokens] == 4096
+      assert request.options[:max_tokens] == model.limits.output
     end
 
     test "decode_response handles streaming responses" do
@@ -749,8 +749,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       opts = [compiled_schema: schema]
       {:ok, request} = OpenRouter.prepare_request(:object, model, context, opts)
 
-      # Should get default of 4096
-      assert request.options[:max_tokens] == 4096
+      assert request.options[:max_tokens] == model.limits.output
     end
 
     test "prepare_request for :object with sufficient max_tokens unchanged" do

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -384,12 +384,16 @@ defmodule ReqLLM.Providers.XAITest do
   end
 
   describe "token limit enforcement" do
-    test "sets default max_tokens to 4096 when not specified", %{compiled_schema: schema} do
+    test "sets default max_tokens from model output limit when not specified", %{
+      compiled_schema: schema
+    } do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
       {:ok, request} =
-        XAI.prepare_request(:object, "xai:grok-3", "Generate data", compiled_schema: schema)
+        XAI.prepare_request(:object, model, "Generate data", compiled_schema: schema)
 
       max_tokens = request.options[:max_completion_tokens] || request.options[:max_tokens]
-      assert max_tokens == 4096
+      assert max_tokens == model.limits.output
     end
 
     test "enforces minimum 200 tokens", %{compiled_schema: schema} do

--- a/test/providers/zenmux_test.exs
+++ b/test/providers/zenmux_test.exs
@@ -256,9 +256,8 @@ defmodule ReqLLM.Providers.ZenmuxTest do
       context = context_fixture()
       {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string])
 
-      # Case 1: No max_tokens -> 4096
       {:ok, req1} = Zenmux.prepare_request(:object, model, context, compiled_schema: schema)
-      assert req1.options[:max_completion_tokens] == 4096
+      assert req1.options[:max_completion_tokens] == model.limits.output
 
       # Case 2: Low max_tokens -> 200
       {:ok, req2} =

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -287,6 +287,31 @@ defmodule ReqLLM.Provider.OptionsTest do
 
       refute log =~ "Renamed :max_tokens to :max_completion_tokens"
     end
+
+    test "does not synthesize max_tokens when max_output_tokens is already provided" do
+      model = %LLMDB.Model{provider: :mock, id: "test-model", limits: %{output: 1000}}
+
+      processed =
+        Options.put_model_max_tokens_default(
+          [max_output_tokens: 123],
+          model,
+          fallback: 4096
+        )
+
+      assert processed[:max_output_tokens] == 123
+      refute Keyword.has_key?(processed, :max_tokens)
+    end
+
+    test "public max token default helper uses metadata before fallback" do
+      model = %LLMDB.Model{provider: :mock, id: "test-model", limits: %{output: 1000}}
+
+      assert Options.put_model_max_tokens_default([], model, fallback: 4096)[:max_tokens] == 1000
+
+      fallback_model = %LLMDB.Model{provider: :mock, id: "fallback-model"}
+
+      assert Options.put_model_max_tokens_default([], fallback_model, fallback: 4096)[:max_tokens] ==
+               4096
+    end
   end
 
   describe "Options.process/4 - req_http_options handling" do

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -364,6 +364,32 @@ defmodule ReqLLM.Provider.OptionsTest do
       refute Keyword.has_key?(processed, :json)
       refute Keyword.has_key?(processed, :retry)
     end
+
+    test "accepts max_output_tokens for responses-style providers" do
+      {:ok, openai_model} = ReqLLM.model("openai:gpt-4o")
+
+      assert {:ok, processed} =
+               Options.process(OpenAI, :chat, openai_model, max_output_tokens: 123)
+
+      assert processed[:max_output_tokens] == 123
+      refute Keyword.has_key?(processed, :max_tokens)
+
+      azure_model = %LLMDB.Model{provider: :azure, id: "gpt-4o", limits: %{output: 1000}}
+
+      assert {:ok, processed} =
+               Options.process(ReqLLM.Providers.Azure, :chat, azure_model, max_output_tokens: 456)
+
+      assert processed[:max_output_tokens] == 456
+      refute Keyword.has_key?(processed, :max_tokens)
+
+      xai_model = %LLMDB.Model{provider: :xai, id: "grok-4", limits: %{output: 1000}}
+
+      assert {:ok, processed} =
+               Options.process(ReqLLM.Providers.XAI, :chat, xai_model, max_output_tokens: 789)
+
+      assert processed[:max_output_tokens] == 789
+      refute Keyword.has_key?(processed, :max_tokens)
+    end
   end
 
   describe "Options.process/4 - req_http_options handling" do

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -302,6 +302,30 @@ defmodule ReqLLM.Provider.OptionsTest do
       refute Keyword.has_key?(processed, :max_tokens)
     end
 
+    test "does not synthesize max_tokens when provider_options already include a token limit" do
+      model = %LLMDB.Model{provider: :mock, id: "test-model", limits: %{output: 1000}}
+
+      processed =
+        Options.put_model_max_tokens_default(
+          [provider_options: [max_completion_tokens: 123]],
+          model,
+          fallback: 4096
+        )
+
+      assert processed[:provider_options][:max_completion_tokens] == 123
+      refute Keyword.has_key?(processed, :max_tokens)
+
+      processed =
+        Options.put_model_max_tokens_default(
+          [provider_options: %{"max_output_tokens" => 456}],
+          model,
+          fallback: 4096
+        )
+
+      assert processed[:provider_options]["max_output_tokens"] == 456
+      refute Keyword.has_key?(processed, :max_tokens)
+    end
+
     test "public max token default helper uses metadata before fallback" do
       model = %LLMDB.Model{provider: :mock, id: "test-model", limits: %{output: 1000}}
 
@@ -311,6 +335,34 @@ defmodule ReqLLM.Provider.OptionsTest do
 
       assert Options.put_model_max_tokens_default([], fallback_model, fallback: 4096)[:max_tokens] ==
                4096
+    end
+
+    test "process_stream strips prepared request options before validation" do
+      model = %LLMDB.Model{provider: :mock, id: "test-model", limits: %{output: 1000}}
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      processed =
+        Options.process_stream!(
+          MockProvider,
+          :chat,
+          model,
+          context,
+          auth: {:bearer, "token"},
+          finch: ReqLLM.Finch,
+          json: %{},
+          model: model,
+          plug: {Req.Test, []},
+          retry: :transient,
+          temperature: 0.3
+        )
+
+      assert processed[:context] == context
+      assert processed[:stream] == true
+      assert processed[:max_tokens] == 1000
+      assert processed[:temperature] == 0.3
+      refute Keyword.has_key?(processed, :auth)
+      refute Keyword.has_key?(processed, :json)
+      refute Keyword.has_key?(processed, :retry)
     end
   end
 


### PR DESCRIPTION
## Summary
- default generated-token limits from LLMDB model output metadata instead of fixed 4096/1024 fallbacks
- route streaming option processing through the provider option pipeline so overrides and provider translations are consistent
- preserve explicit max token overrides and provider-specific wire keys, including OpenAI Responses/Codex, Anthropic, Google, Azure, Bedrock, Groq, OpenRouter, xAI, Zenmux, Minimax, Mistral, Alibaba, and defaults-based providers

Closes #669

## Verification
- MIX_ENV=test mix test
- mix quality
