### PR TITLE
refactor: fix ex_slop refactoring findings

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -554,9 +554,7 @@ defmodule ReqLLM do
 
   defp normalize_google_cost(cost, tiered_rates) do
     baseline_cost =
-      Enum.reduce(tiered_rates, %{}, fn {key, {standard_rate, _long_context_rate}}, acc ->
-        Map.put(acc, key, standard_rate)
-      end)
+      Map.new(tiered_rates, fn {key, {standard_rate, _}} -> {key, standard_rate} end)
 
     if is_map(cost), do: Map.merge(cost, baseline_cost), else: baseline_cost
   end

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -88,9 +88,6 @@ defmodule ReqLLM.Generation do
             cache_ref
           )
       end
-    else
-      {:error, error} ->
-        {:error, error}
     end
   end
 
@@ -272,9 +269,6 @@ defmodule ReqLLM.Generation do
             cache_ref
           )
       end
-    else
-      {:error, error} ->
-        {:error, error}
     end
   end
 

--- a/lib/req_llm/openai/realtime.ex
+++ b/lib/req_llm/openai/realtime.ex
@@ -49,15 +49,8 @@ defmodule ReqLLM.OpenAI.Realtime do
 
   @spec next_event(Session.t(), non_neg_integer()) :: {:ok, map()} | :halt | {:error, term()}
   def next_event(%Session{pid: pid}, timeout \\ 30_000) do
-    with {:ok, message} <- WebSocketSession.next_message(pid, timeout),
-         {:ok, event} <- Jason.decode(message) do
-      {:ok, event}
-    else
-      :halt ->
-        :halt
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, message} <- WebSocketSession.next_message(pid, timeout) do
+      Jason.decode(message)
     end
   end
 

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -55,8 +55,8 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     normalized_tool_calls = normalize_tool_calls(reconstructed_tool_calls)
 
     # Build message content
-    text_content = acc_data.text_content |> Enum.reverse() |> Enum.join("")
-    thinking_content = acc_data.thinking_content |> Enum.reverse() |> Enum.join("")
+    text_content = acc_data.text_content |> Enum.reverse() |> Enum.join()
+    thinking_content = acc_data.thinking_content |> Enum.reverse() |> Enum.join()
     content_parts = build_content_parts(text_content, thinking_content, normalized_tool_calls)
 
     # Build reasoning_details: prefer from meta chunks, fall back to extraction from thinking chunks

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1597,7 +1597,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
     texts
     |> Enum.reject(&is_nil/1)
-    |> Enum.join("")
+    |> Enum.join()
   end
 
   defp extract_from_message_segments(segments) do
@@ -1609,7 +1609,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> Enum.filter(&(&1["type"] in ["output_text", "text"]))
       |> Enum.map(&extract_text_field/1)
     end)
-    |> Enum.join("")
+    |> Enum.join()
     |> case do
       "" -> nil
       text -> text
@@ -1714,7 +1714,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
     reasoning_parts
     |> Enum.reject(&is_nil/1)
-    |> Enum.join("")
+    |> Enum.join()
   end
 
   defp extract_reasoning_summary(segments) do
@@ -1723,7 +1723,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     |> Enum.map(& &1["summary"])
     |> Enum.map(&extract_summary_text/1)
     |> Enum.reject(&is_nil/1)
-    |> Enum.join("")
+    |> Enum.join()
     |> case do
       "" -> nil
       text -> text
@@ -1738,7 +1738,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> Enum.map(& &1["text"])
       |> Enum.reject(&is_nil/1)
     end)
-    |> Enum.join("")
+    |> Enum.join()
     |> case do
       "" -> nil
       text -> text
@@ -1783,7 +1783,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     |> Enum.filter(&(&1["type"] == "summary_text"))
     |> Enum.map(& &1["text"])
     |> Enum.reject(&is_nil/1)
-    |> Enum.join("")
+    |> Enum.join()
     |> case do
       "" -> nil
       text -> text

--- a/lib/req_llm/response/stream.ex
+++ b/lib/req_llm/response/stream.ex
@@ -63,8 +63,8 @@ defmodule ReqLLM.Response.Stream do
     tool_calls = reconstruct_tool_calls(acc)
 
     %{
-      text: acc.text_content |> Enum.reverse() |> Enum.join(""),
-      thinking: acc.thinking_content |> Enum.reverse() |> Enum.join(""),
+      text: acc.text_content |> Enum.reverse() |> Enum.join(),
+      thinking: acc.thinking_content |> Enum.reverse() |> Enum.join(),
       tool_calls: tool_calls,
       finish_reason: normalize_finish_reason(acc.finish_reason),
       usage: acc.usage

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -168,7 +168,7 @@ defmodule ReqLLM.StreamResponse do
   def text(%__MODULE__{} = stream_response) do
     stream_response
     |> tokens()
-    |> Enum.join("")
+    |> Enum.join()
   end
 
   @doc """

--- a/lib/req_llm/telemetry/open_telemetry.ex
+++ b/lib/req_llm/telemetry/open_telemetry.ex
@@ -381,7 +381,7 @@ defmodule ReqLLM.Telemetry.OpenTelemetry do
       end
     end)
     |> Enum.reverse()
-    |> Enum.join("")
+    |> Enum.join()
   end
 
   defp content_mode(opts) do

--- a/test/req_llm/response_test.exs
+++ b/test/req_llm/response_test.exs
@@ -382,11 +382,11 @@ defmodule ReqLLM.ResponseTest do
       streamed_text =
         response
         |> Response.text_stream()
-        |> Enum.join("")
+        |> Enum.join()
 
       # Property: both methods should produce the same result
       assert joined_text == streamed_text
-      assert joined_text == Enum.join(text_parts, "")
+      assert joined_text == Enum.join(text_parts)
     end
   end
 

--- a/test/req_llm/stream_chunk_test.exs
+++ b/test/req_llm/stream_chunk_test.exs
@@ -285,7 +285,7 @@ defmodule ReqLLM.StreamChunkTest do
       many_keys = %{a: 1, b: 2, c: 3, d: 4, e: 5}
       multi_chunk = StreamChunk.meta(many_keys)
       multi_inspect = inspect(multi_chunk)
-      comma_count = multi_inspect |> String.graphemes() |> Enum.count(&(&1 == ","))
+      comma_count = multi_inspect |> String.codepoints() |> Enum.count(&(&1 == ","))
       # 5 keys = 4 commas
       assert comma_count == 4
     end

--- a/test/req_llm/stream_response_test.exs
+++ b/test/req_llm/stream_response_test.exs
@@ -1113,7 +1113,7 @@ defmodule ReqLLM.StreamResponseTest do
 
       # Collect via tokens/1 stream (need fresh stream_response)
       stream_response2 = create_stream_response(stream: chunks)
-      streamed_text = StreamResponse.tokens(stream_response2) |> Enum.join("")
+      streamed_text = StreamResponse.tokens(stream_response2) |> Enum.join()
 
       # Property: both methods should produce same result
       assert direct_text == streamed_text

--- a/test/support/fixture.ex
+++ b/test/support/fixture.ex
@@ -298,7 +298,7 @@ defmodule ReqLLM.Step.Fixture.Backend do
       rescue
         e ->
           Logger.error("VCR.record exception: #{Exception.format(:error, e, __STACKTRACE__)}")
-          {:error, e}
+          reraise e, __STACKTRACE__
       end
 
     case result do


### PR DESCRIPTION
## Description

Mechanical fixes for patterns flagged by [`ex_slop`](https://hex.pm/packages/ex_slop):

- Remove redundant `""` separator from `Enum.join/2` calls (15 occurrences)
- Drop identity `else` blocks from `with` expressions
- Replace `Enum.reduce(%{}, ..., Map.put)` with `Map.new/2`
- Reraise instead of swallowing in fixture recording rescue

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)