### PR TITLE
fix(openai_codex): omit unsupported token limit

### DIFF
--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -409,7 +409,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     body
     |> Map.put("input", Enum.reject(List.wrap(body["input"]), &system_input?/1))
     |> Map.delete("max_output_tokens")
-    |> maybe_put_max_completion_tokens(opts)
+    |> Map.delete("max_completion_tokens")
     |> Map.put("store", false)
     |> Map.put("stream", true)
     |> Map.put("include", ["reasoning.encrypted_content"])
@@ -503,13 +503,6 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
   defp maybe_put_event(event, nil), do: event
   defp maybe_put_event(event, type), do: Map.put(event, :event, type)
-
-  defp maybe_put_max_completion_tokens(map, opts) do
-    case Keyword.get(opts, :max_completion_tokens) || Keyword.get(opts, :max_tokens) do
-      nil -> map
-      tokens -> Map.put(map, "max_completion_tokens", tokens)
-    end
-  end
 
   defp normalize_response_payload(data) do
     update_in(data, ["response"], fn

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -111,7 +111,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert body["include"] == ["reasoning.encrypted_content"]
       assert body["text"] == %{"verbosity" => "medium"}
       refute Map.has_key?(body, "max_output_tokens")
-      assert body["max_completion_tokens"] == model.limits.output
+      refute Map.has_key?(body, "max_completion_tokens")
       assert Enum.all?(body["input"], &(&1["role"] != "system"))
     end
 
@@ -141,7 +141,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert payload["model"] == "gpt-5.3-codex-spark"
       assert payload["store"] == false
       assert payload["stream"] == true
-      assert payload["max_completion_tokens"] == model.limits.output
+      refute Map.has_key?(payload, "max_completion_tokens")
       refute Map.has_key?(payload, "response")
     end
 


### PR DESCRIPTION
## Summary
- Remove `max_completion_tokens` from OpenAI Codex response payloads because the ChatGPT Codex backend rejects it.
- Keep existing default-token behavior for other providers while preserving Codex `store=false` and streaming behavior.
- Update Codex SSE/websocket request tests to assert the unsupported field is omitted.

## Test
- `mix test test/providers/openai_codex_test.exs`