### PR TITLE
feat: support Anthropic uploaded file references

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -1030,6 +1030,12 @@ defmodule ReqLLM.Context do
           :error -> []
         end
 
+      type when type in ["file", "file_id", "document", "image"] ->
+        case file_content_part(part) do
+          {:ok, file_part} -> [file_part]
+          :error -> []
+        end
+
       _ ->
         []
     end
@@ -1064,6 +1070,13 @@ defmodule ReqLLM.Context do
       :video_url ->
         case url_content_part(part, :video_url) do
           {:ok, url_part} -> [url_part]
+          :error -> []
+        end
+
+      type
+      when type in [:file, "file", :file_id, "file_id", :document, "document", :image, "image"] ->
+        case file_content_part(part) do
+          {:ok, file_part} -> [file_part]
           :error -> []
         end
 
@@ -1132,6 +1145,61 @@ defmodule ReqLLM.Context do
   end
 
   defp maybe_put_url_media_type(%ContentPart{} = part, _media_type), do: part
+
+  defp file_content_part(part) do
+    metadata = file_content_metadata(part)
+
+    nested =
+      Map.get(part, :file) ||
+        Map.get(part, "file") ||
+        Map.get(part, :document) ||
+        Map.get(part, "document") ||
+        Map.get(part, :source) ||
+        Map.get(part, "source")
+
+    file_id =
+      Map.get(part, :file_id) ||
+        Map.get(part, "file_id") ||
+        if(is_map(nested), do: Map.get(nested, :file_id) || Map.get(nested, "file_id"))
+
+    media_type =
+      Map.get(part, :media_type) ||
+        Map.get(part, "media_type") ||
+        if(is_map(nested), do: Map.get(nested, :media_type) || Map.get(nested, "media_type"))
+
+    filename =
+      Map.get(part, :filename) ||
+        Map.get(part, "filename") ||
+        if(is_map(nested), do: Map.get(nested, :filename) || Map.get(nested, "filename"))
+
+    if is_binary(file_id) and file_id != "" do
+      file_part = ContentPart.file_id(file_id, media_type || "application/pdf", metadata)
+      {:ok, maybe_put_file_filename(file_part, filename)}
+    else
+      :error
+    end
+  end
+
+  defp maybe_put_file_filename(%ContentPart{} = part, filename)
+       when is_binary(filename) and filename != "" do
+    %{part | filename: filename}
+  end
+
+  defp maybe_put_file_filename(%ContentPart{} = part, _filename), do: part
+
+  defp file_content_metadata(part) do
+    metadata = Map.get(part, :metadata) || Map.get(part, "metadata") || %{}
+
+    Enum.reduce([:title, :context, :citations], metadata, fn key, acc ->
+      value = Map.get(part, key) || Map.get(part, Atom.to_string(key))
+
+      if is_nil(value) do
+        acc
+      else
+        Map.put_new(acc, key, value)
+      end
+    end)
+  end
 
   defp convert_loose_role_list_content(role, content, metadata, reasoning_details) do
     case role do

--- a/lib/req_llm/message/content_part.ex
+++ b/lib/req_llm/message/content_part.ex
@@ -7,7 +7,7 @@ defmodule ReqLLM.Message.ContentPart do
   - `:image_url` - Image from URL
   - `:video_url` - Video from URL
   - `:image` - Image from binary data
-  - `:file` - File attachment
+  - `:file` - File attachment or uploaded file reference
   - `:thinking` - Chain-of-thought thinking content
 
   ## See also
@@ -20,6 +20,7 @@ defmodule ReqLLM.Message.ContentPart do
             text: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             url: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             data: Zoi.any() |> Zoi.nullable() |> Zoi.default(nil),
+            file_id: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             media_type: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             filename: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             metadata: Zoi.map() |> Zoi.default(%{})
@@ -74,6 +75,22 @@ defmodule ReqLLM.Message.ContentPart do
   def file(data, filename, media_type \\ "application/octet-stream"),
     do: %__MODULE__{type: :file, data: data, filename: filename, media_type: media_type}
 
+  @spec file_id(String.t()) :: t()
+  @spec file_id(String.t(), String.t() | map()) :: t()
+  @spec file_id(String.t(), String.t(), map()) :: t()
+  def file_id(file_id, media_type_or_metadata \\ "application/pdf", metadata \\ %{})
+
+  def file_id(file_id, metadata, %{}) when is_map(metadata),
+    do: %__MODULE__{
+      type: :file,
+      file_id: file_id,
+      media_type: "application/pdf",
+      metadata: metadata
+    }
+
+  def file_id(file_id, media_type, metadata),
+    do: %__MODULE__{type: :file, file_id: file_id, media_type: media_type, metadata: metadata}
+
   defimpl Inspect do
     def inspect(%{type: type} = part, opts) do
       content_desc =
@@ -82,8 +99,8 @@ defmodule ReqLLM.Message.ContentPart do
           :thinking -> inspect_text(part.text, opts)
           :image_url -> "url: #{part.url}"
           :video_url -> "url: #{part.url}"
-          :image -> "#{part.media_type} (#{byte_size(part.data)} bytes)"
-          :file -> "#{part.media_type} (#{byte_size(part.data || <<>>)} bytes)"
+          :image -> "#{part.media_type} (#{byte_size(part.data || <<>>)} bytes)"
+          :file -> inspect_file(part)
         end
 
       Inspect.Algebra.concat([
@@ -101,6 +118,12 @@ defmodule ReqLLM.Message.ContentPart do
       truncated = String.slice(text, 0, 30)
       if String.length(text) > 30, do: "\"#{truncated}...\"", else: "\"#{truncated}\""
     end
+
+    defp inspect_file(%{file_id: file_id}) when is_binary(file_id) and file_id != "" do
+      "file_id: #{file_id}"
+    end
+
+    defp inspect_file(part), do: "#{part.media_type} (#{byte_size(part.data || <<>>)} bytes)"
   end
 
   defimpl Jason.Encoder do

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -158,6 +158,7 @@ defmodule ReqLLM.Providers.Anthropic do
   @default_anthropic_version "2023-06-01"
   @anthropic_beta_tools "tools-2024-05-16"
   @anthropic_beta_prompt_caching "prompt-caching-2024-07-31"
+  @anthropic_beta_files_api "files-api-2025-04-14"
   @claude_subscription_betas ["oauth-2025-04-20", "interleaved-thinking-2025-05-14"]
   @claude_subscription_user_agent "claude-cli/2.1.112 (external, cli)"
   @claude_subscription_x_app "claude-code"
@@ -737,7 +738,7 @@ defmodule ReqLLM.Providers.Anthropic do
     credential = ReqLLM.Auth.resolve!(model, translated_opts)
     headers = build_request_headers(translated_opts, credential)
     streaming_headers = [{"Accept", "text/event-stream"} | headers]
-    beta_headers = build_beta_headers(translated_opts, credential)
+    beta_headers = build_beta_headers(Keyword.put(translated_opts, :context, context), credential)
 
     custom_headers =
       ReqLLM.Provider.Utils.extract_custom_headers(translated_opts[:req_http_options])
@@ -868,6 +869,13 @@ defmodule ReqLLM.Providers.Anthropic do
         beta_features
       end
 
+    beta_features =
+      if has_files_api_reference?(opts) do
+        [@anthropic_beta_files_api | beta_features]
+      else
+        beta_features
+      end
+
     Enum.uniq(beta_features)
   end
 
@@ -904,6 +912,43 @@ defmodule ReqLLM.Providers.Anthropic do
   def has_prompt_caching?(opts) do
     get_option(opts, :anthropic_prompt_cache, false) == true
   end
+
+  defp has_files_api_reference?(opts) do
+    opts
+    |> get_option(:context)
+    |> context_has_files_api_reference?()
+  end
+
+  defp context_has_files_api_reference?(%ReqLLM.Context{messages: messages}) do
+    Enum.any?(messages, &message_has_files_api_reference?/1)
+  end
+
+  defp context_has_files_api_reference?(_context), do: false
+
+  defp message_has_files_api_reference?(%ReqLLM.Message{content: content}) do
+    content
+    |> List.wrap()
+    |> Enum.any?(&content_part_has_file_id?/1)
+  end
+
+  defp message_has_files_api_reference?(_message), do: false
+
+  defp content_part_has_file_id?(%ReqLLM.Message.ContentPart{file_id: file_id}) do
+    is_binary(file_id) and file_id != ""
+  end
+
+  defp content_part_has_file_id?(part) when is_map(part) do
+    source = Map.get(part, :source) || Map.get(part, "source")
+
+    file_id =
+      Map.get(part, :file_id) ||
+        Map.get(part, "file_id") ||
+        if(is_map(source), do: Map.get(source, :file_id) || Map.get(source, "file_id"))
+
+    is_binary(file_id) and file_id != ""
+  end
+
+  defp content_part_has_file_id?(_part), do: false
 
   @doc false
   def cache_control_meta(opts) do

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -36,6 +36,8 @@ defmodule ReqLLM.Providers.Anthropic.Context do
 
   require Logger
 
+  @document_file_metadata_keys [:title, :context, :citations]
+
   @doc """
   Encode context and model to Anthropic Messages API format.
   """
@@ -243,10 +245,28 @@ defmodule ReqLLM.Providers.Anthropic.Context do
 
   defp encode_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
+         file_id: file_id,
+         media_type: media_type,
+         metadata: metadata
+       })
+       when is_binary(file_id) and file_id != "" do
+    %{
+      type: file_block_type(media_type),
+      source: %{
+        type: "file",
+        file_id: file_id
+      }
+    }
+    |> maybe_add_document_file_metadata(metadata)
+  end
+
+  defp encode_content_part(%ReqLLM.Message.ContentPart{
+         type: :file,
          data: data,
          media_type: media_type,
          filename: _filename
-       }) do
+       })
+       when is_binary(data) do
     base64 = Base.encode64(data)
 
     %{
@@ -260,6 +280,27 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   end
 
   defp encode_content_part(_), do: nil
+
+  defp file_block_type(media_type) when is_binary(media_type) do
+    if String.starts_with?(media_type, "image/"), do: "image", else: "document"
+  end
+
+  defp file_block_type(_media_type), do: "document"
+
+  defp maybe_add_document_file_metadata(%{type: "document"} = block, metadata)
+       when is_map(metadata) do
+    Enum.reduce(@document_file_metadata_keys, block, fn key, acc ->
+      value = Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
+
+      if is_nil(value) do
+        acc
+      else
+        Map.put(acc, key, value)
+      end
+    end)
+  end
+
+  defp maybe_add_document_file_metadata(block, _metadata), do: block
 
   defp encode_tool_call_to_tool_use(%ToolCall{id: id, function: %{name: name, arguments: args}}) do
     %{type: "tool_use", id: id, name: name, input: decode_tool_arguments(args)}

--- a/lib/req_llm/telemetry.ex
+++ b/lib/req_llm/telemetry.ex
@@ -799,6 +799,7 @@ defmodule ReqLLM.Telemetry do
   defp sanitize_content_part(%ContentPart{type: :file} = part) do
     %{
       type: :file,
+      file_id: part.file_id,
       filename: part.filename,
       media_type: part.media_type,
       bytes: binary_size_or_nil(part.data),
@@ -817,11 +818,12 @@ defmodule ReqLLM.Telemetry do
 
   defp sanitize_content_part(%{type: :file} = part) when is_map(part) do
     %{
-      type: part.type,
-      filename: part[:filename],
-      media_type: part[:media_type],
-      bytes: binary_size_or_nil(part[:data]),
-      metadata: Map.get(part, :metadata, %{})
+      type: Map.get(part, :type) || Map.get(part, "type"),
+      file_id: Map.get(part, :file_id) || Map.get(part, "file_id"),
+      filename: Map.get(part, :filename) || Map.get(part, "filename"),
+      media_type: Map.get(part, :media_type) || Map.get(part, "media_type"),
+      bytes: binary_size_or_nil(Map.get(part, :data) || Map.get(part, "data")),
+      metadata: Map.get(part, :metadata) || Map.get(part, "metadata", %{})
     }
   end
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -185,6 +185,45 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert request.headers["anthropic-beta"] == ["advanced-tool-use-test"]
     end
 
+    test "prepare_request adds files beta header for uploaded file references" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user([
+            ContentPart.text("Summarize this document."),
+            ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w")
+          ])
+        ])
+
+      {:ok, request} = Anthropic.prepare_request(:chat, model, context, api_key: "test-key")
+
+      assert request.headers["anthropic-beta"] == ["files-api-2025-04-14"]
+    end
+
+    test "prepare_request combines files beta header with manual beta headers" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user([
+            ContentPart.text("Summarize this document."),
+            ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w")
+          ])
+        ])
+
+      {:ok, request} =
+        Anthropic.prepare_request(:chat, model, context,
+          api_key: "test-key",
+          provider_options: [anthropic_beta: ["manual-beta-flag"]]
+        )
+
+      [beta_header] = request.headers["anthropic-beta"]
+
+      assert beta_header =~ "files-api-2025-04-14"
+      assert beta_header =~ "manual-beta-flag"
+    end
+
     test "attach combines Claude subscription and manual beta headers" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 
@@ -273,6 +312,24 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
       headers = Map.new(finch_request.headers)
       assert headers["anthropic-beta"] == "tools-2024-05-16"
+    end
+
+    test "attach_stream adds files beta header for uploaded file references" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user([
+            ContentPart.text("Summarize this document."),
+            ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w")
+          ])
+        ])
+
+      {:ok, finch_request} =
+        Anthropic.attach_stream(model, context, [api_key: "anthropic-test-key"], nil)
+
+      headers = Map.new(finch_request.headers)
+      assert headers["anthropic-beta"] == "files-api-2025-04-14"
     end
 
     test "attach_stream shapes oauth requests" do
@@ -465,6 +522,61 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
       assert Enum.any?(content_blocks, fn block -> block["type"] == "image" end)
       assert Enum.any?(content_blocks, fn block -> block["type"] == "document" end)
+    end
+
+    test "encode_body converts file_id content parts to Anthropic file sources" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      document_part =
+        ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w", "application/pdf", %{
+          title: "Quarterly report",
+          context: "Uploaded once through the Anthropic Files API",
+          citations: %{enabled: true}
+        })
+
+      image_part = ContentPart.file_id("file_011CPMxVD3fHLUhvTqtsQA5w", "image/png")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user([
+            ContentPart.text("Compare these files."),
+            document_part,
+            image_part
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = Anthropic.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [user_message] = decoded["messages"]
+      [_text_block, document_block, image_block] = user_message["content"]
+
+      assert document_block == %{
+               "type" => "document",
+               "source" => %{
+                 "type" => "file",
+                 "file_id" => "file_011CNha8iCJcU1wXNR6q4V8w"
+               },
+               "title" => "Quarterly report",
+               "context" => "Uploaded once through the Anthropic Files API",
+               "citations" => %{"enabled" => true}
+             }
+
+      assert image_block == %{
+               "type" => "image",
+               "source" => %{
+                 "type" => "file",
+                 "file_id" => "file_011CPMxVD3fHLUhvTqtsQA5w"
+               }
+             }
     end
 
     test "encode_body without tools" do

--- a/test/req_llm/context_round_trip_test.exs
+++ b/test/req_llm/context_round_trip_test.exs
@@ -20,6 +20,7 @@ defmodule ReqLLM.ContextRoundTripTest do
             text: part_data["text"],
             url: part_data["url"],
             data: decoded_data,
+            file_id: part_data["file_id"],
             media_type: part_data["media_type"],
             filename: part_data["filename"],
             metadata: part_data["metadata"] || %{}

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -1112,6 +1112,60 @@ defmodule ReqLLM.ContextTest do
       assert Enum.map(message.content, & &1.media_type) == ["image/png", "video/mp4"]
     end
 
+    test "normalizes file_id content maps" do
+      input = [
+        %{
+          "role" => "user",
+          "content" => [
+            %{
+              "type" => "document",
+              "source" => %{
+                "type" => "file",
+                "file_id" => "file_011CNha8iCJcU1wXNR6q4V8w"
+              },
+              "media_type" => "application/pdf"
+            }
+          ]
+        }
+      ]
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      [message] = context.messages
+
+      assert [%ContentPart{type: :file, file_id: "file_011CNha8iCJcU1wXNR6q4V8w"}] =
+               message.content
+
+      assert hd(message.content).media_type == "application/pdf"
+    end
+
+    test "normalizes Anthropic image file source content maps" do
+      input = [
+        %{
+          "role" => "user",
+          "content" => [
+            %{
+              "type" => "image",
+              "source" => %{
+                "type" => "file",
+                "file_id" => "file_011CPMxVD3fHLUhvTqtsQA5w",
+                "media_type" => "image/png"
+              }
+            }
+          ]
+        }
+      ]
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      [message] = context.messages
+
+      assert [%ContentPart{type: :file, file_id: "file_011CPMxVD3fHLUhvTqtsQA5w"}] =
+               message.content
+
+      assert hd(message.content).media_type == "image/png"
+    end
+
     test "raises for invalid direct tool call normalization inputs" do
       assert_raise ArgumentError, ~r/invalid tool_call/, fn ->
         Context.assistant("", tool_calls: [:invalid])

--- a/test/req_llm/message/content_part_test.exs
+++ b/test/req_llm/message/content_part_test.exs
@@ -137,6 +137,41 @@ defmodule ReqLLM.Message.ContentPartTest do
                media_type: "text/plain"
              } = part
     end
+
+    test "creates file reference content part with default media type" do
+      part = ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w")
+
+      assert %ContentPart{
+               type: :file,
+               file_id: "file_011CNha8iCJcU1wXNR6q4V8w",
+               media_type: "application/pdf",
+               data: nil
+             } = part
+    end
+
+    test "creates file reference with custom media type and metadata" do
+      metadata = %{title: "Quarterly report", citations: %{enabled: true}}
+      part = ContentPart.file_id("file_011CPMxVD3fHLUhvTqtsQA5w", "image/png", metadata)
+
+      assert %ContentPart{
+               type: :file,
+               file_id: "file_011CPMxVD3fHLUhvTqtsQA5w",
+               media_type: "image/png",
+               metadata: ^metadata
+             } = part
+    end
+
+    test "creates file reference with metadata as second argument" do
+      metadata = %{title: "Quarterly report"}
+      part = ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w", metadata)
+
+      assert %ContentPart{
+               type: :file,
+               file_id: "file_011CNha8iCJcU1wXNR6q4V8w",
+               media_type: "application/pdf",
+               metadata: ^metadata
+             } = part
+    end
   end
 
   describe "struct validation and edge cases" do
@@ -258,6 +293,13 @@ defmodule ReqLLM.Message.ContentPartTest do
       assert output =~ "text/plain (0 bytes)"
     end
 
+    test "inspects file reference content part" do
+      part = ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w")
+      output = inspect(part)
+
+      assert output =~ "file_id: file_011CNha8iCJcU1wXNR6q4V8w"
+    end
+
     test "handles nil text in inspect" do
       part = struct!(ContentPart, %{type: :text, text: nil})
       output = inspect(part)
@@ -274,7 +316,8 @@ defmodule ReqLLM.Message.ContentPartTest do
         ContentPart.image_url("https://example.com/pic.jpg"),
         ContentPart.video_url("https://example.com/clip.mp4"),
         ContentPart.image(<<1, 2, 3>>, "image/png"),
-        ContentPart.file("data", "file.txt", "text/plain")
+        ContentPart.file("data", "file.txt", "text/plain"),
+        ContentPart.file_id("file_011CNha8iCJcU1wXNR6q4V8w")
       ]
 
       for part <- parts do

--- a/test/req_llm/messaging_test.exs
+++ b/test/req_llm/messaging_test.exs
@@ -22,6 +22,9 @@ defmodule ReqLLM.MessagingTest do
 
       assert %ContentPart{type: :file, data: ^data, filename: "doc.txt", media_type: "text/plain"} =
                ContentPart.file(data, "doc.txt", "text/plain")
+
+      assert %ContentPart{type: :file, file_id: "file_123", media_type: "application/pdf"} =
+               ContentPart.file_id("file_123")
     end
 
     test "inspect protocol shows compact representation" do


### PR DESCRIPTION
## Summary
- Add `ContentPart.file_id/1,2,3` for referencing uploaded Anthropic Files API assets without embedding bytes.
- Encode file references as Anthropic document/image file sources and automatically add the required files beta header.
- Normalize file-reference content maps and preserve file ids in telemetry sanitization.

Closes #672

## Validation
- `mix test test/providers/anthropic_test.exs test/req_llm/context_test.exs test/req_llm/context_round_trip_test.exs test/req_llm/message/content_part_test.exs test/req_llm/messaging_test.exs`
- `mix test`
- `mix quality`