### PR TITLE
fix(openrouter): encode file-parser PDFs as files

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -1176,9 +1176,66 @@ defmodule ReqLLM.Context do
       file_part = ContentPart.file_id(file_id, media_type || "application/pdf", metadata)
       {:ok, maybe_put_file_filename(file_part, filename)}
     else
-      :error
+      case file_content_data(part, nested, media_type) do
+        {:ok, data, media_type} ->
+          file_part =
+            data
+            |> ContentPart.file(filename || "file", media_type)
+            |> Map.put(:metadata, metadata)
+
+          {:ok, file_part}
+
+        :error ->
+          :error
+      end
     end
   end
+
+  defp file_content_data(part, nested, media_type) do
+    data =
+      Map.get(part, :file_data) ||
+        Map.get(part, "file_data") ||
+        if(is_map(nested), do: Map.get(nested, :file_data) || Map.get(nested, "file_data"))
+
+    case data do
+      data when is_binary(data) ->
+        decode_file_data(data, media_type)
+
+      _ ->
+        :error
+    end
+  end
+
+  defp decode_file_data("data:" <> _ = data_uri, media_type) do
+    case Regex.run(~r/^data:([^;,]*)(?:;[^,]*)*;base64,(.*)$/s, data_uri) do
+      [_, uri_media_type, encoded] ->
+        decoded = String.replace(encoded, ~r/\s+/, "")
+
+        case Base.decode64(decoded) do
+          {:ok, data} -> {:ok, data, file_data_media_type(uri_media_type, media_type)}
+          :error -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp decode_file_data(data, media_type) when is_binary(data) do
+    {:ok, data, media_type || "application/octet-stream"}
+  end
+
+  defp file_data_media_type(uri_media_type, _media_type)
+       when is_binary(uri_media_type) and uri_media_type != "" do
+    uri_media_type
+  end
+
+  defp file_data_media_type(_uri_media_type, media_type)
+       when is_binary(media_type) and media_type != "" do
+    media_type
+  end
+
+  defp file_data_media_type(_uri_media_type, _media_type), do: "application/octet-stream"
 
   defp maybe_put_file_filename(%ContentPart{} = part, filename)
        when is_binary(filename) and filename != "" do

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -47,6 +47,8 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   import ReqLLM.Provider.Utils, only: [maybe_put: 3]
 
+  alias ReqLLM.Message.ContentPart
+
   require Logger
 
   @provider_schema [
@@ -302,6 +304,7 @@ defmodule ReqLLM.Providers.OpenRouter do
   @impl ReqLLM.Provider
   def build_body(request) do
     ReqLLM.Provider.Defaults.default_build_body(request)
+    |> encode_file_parser_pdf_files(request.options)
     |> add_embedding_options(request.options)
     |> translate_tool_choice_format()
     |> encode_reasoning_details_in_messages()
@@ -321,6 +324,195 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> add_openrouter_specific_options(request.options)
     |> add_stream_options(request.options)
   end
+
+  defp encode_file_parser_pdf_files(body, request_options) do
+    context = request_options[:context]
+    plugins = request_options[:openrouter_plugins]
+
+    if file_parser_plugin?(plugins) and match?(%ReqLLM.Context{}, context) do
+      replace_file_parser_messages(body, context)
+    else
+      body
+    end
+  end
+
+  defp file_parser_plugin?(plugins) when is_list(plugins) do
+    Enum.any?(plugins, fn
+      %{id: "file-parser"} -> true
+      %{"id" => "file-parser"} -> true
+      _ -> false
+    end)
+  end
+
+  defp file_parser_plugin?(_plugins), do: false
+
+  defp replace_file_parser_messages(%{messages: encoded_messages} = body, context)
+       when is_list(encoded_messages) do
+    Map.put(body, :messages, encode_file_parser_messages(encoded_messages, context.messages))
+  end
+
+  defp replace_file_parser_messages(%{"messages" => encoded_messages} = body, context)
+       when is_list(encoded_messages) do
+    Map.put(body, "messages", encode_file_parser_messages(encoded_messages, context.messages))
+  end
+
+  defp replace_file_parser_messages(body, _context), do: body
+
+  defp encode_file_parser_messages(encoded_messages, context_messages)
+       when length(encoded_messages) == length(context_messages) do
+    encoded_messages
+    |> Enum.zip(context_messages)
+    |> Enum.map(fn {encoded_message, context_message} ->
+      encode_file_parser_message(encoded_message, context_message)
+    end)
+  end
+
+  defp encode_file_parser_messages(encoded_messages, _context_messages), do: encoded_messages
+
+  defp encode_file_parser_message(encoded_message, %ReqLLM.Message{content: content})
+       when is_list(content) do
+    if Enum.any?(content, &openrouter_pdf_file_part?/1) do
+      put_message_content(encoded_message, encode_openrouter_content(content))
+    else
+      encoded_message
+    end
+  end
+
+  defp encode_file_parser_message(encoded_message, _message), do: encoded_message
+
+  defp put_message_content(%{content: _} = message, content),
+    do: Map.put(message, :content, content)
+
+  defp put_message_content(%{"content" => _} = message, content),
+    do: Map.put(message, "content", content)
+
+  defp put_message_content(message, content), do: Map.put(message, :content, content)
+
+  defp encode_openrouter_content(content) do
+    content
+    |> Enum.map(&encode_openrouter_content_part/1)
+    |> Enum.reject(&is_nil/1)
+    |> normalize_openrouter_content()
+  end
+
+  defp normalize_openrouter_content([]), do: ""
+
+  defp normalize_openrouter_content([%{type: "text", text: text} = block]) do
+    if map_size(block) == 2, do: text, else: [block]
+  end
+
+  defp normalize_openrouter_content(content), do: content
+
+  defp encode_openrouter_content_part(%ContentPart{type: :text, text: text, metadata: metadata}) do
+    %{type: "text", text: text}
+    |> merge_content_metadata(metadata)
+  end
+
+  defp encode_openrouter_content_part(%ContentPart{
+         type: :image,
+         data: data,
+         media_type: media_type,
+         metadata: metadata
+       })
+       when is_binary(data) do
+    data
+    |> image_url_content_part(media_type)
+    |> merge_content_metadata(metadata)
+  end
+
+  defp encode_openrouter_content_part(%ContentPart{
+         type: :image_url,
+         url: url,
+         media_type: media_type,
+         metadata: metadata
+       }) do
+    image_url_map = %{url: url}
+
+    image_url_map =
+      if is_binary(media_type) and media_type != "" do
+        Map.put(image_url_map, :media_type, media_type)
+      else
+        image_url_map
+      end
+
+    %{type: "image_url", image_url: image_url_map}
+    |> merge_content_metadata(metadata)
+  end
+
+  defp encode_openrouter_content_part(%ContentPart{type: :file, data: data} = part)
+       when is_binary(data) do
+    if openrouter_pdf_file_part?(part) do
+      %{
+        type: "file",
+        file: %{
+          filename: openrouter_file_filename(part),
+          file_data: "data:#{openrouter_file_media_type(part)};base64,#{Base.encode64(data)}"
+        }
+      }
+    else
+      image_url_content_part(data, part.media_type)
+    end
+  end
+
+  defp encode_openrouter_content_part(%ContentPart{type: :thinking}), do: nil
+  defp encode_openrouter_content_part(_part), do: nil
+
+  defp image_url_content_part(data, media_type) do
+    %{
+      type: "image_url",
+      image_url: %{
+        url: "data:#{media_type};base64,#{Base.encode64(data)}"
+      }
+    }
+  end
+
+  defp openrouter_pdf_file_part?(%ContentPart{type: :file, data: data} = part)
+       when is_binary(data) do
+    part.media_type == "application/pdf" or openrouter_pdf_filename?(part.filename)
+  end
+
+  defp openrouter_pdf_file_part?(_part), do: false
+
+  defp openrouter_pdf_filename?(filename) when is_binary(filename) do
+    filename
+    |> String.downcase()
+    |> String.ends_with?(".pdf")
+  end
+
+  defp openrouter_pdf_filename?(_filename), do: false
+
+  defp openrouter_file_filename(%ContentPart{filename: filename})
+       when is_binary(filename) and filename != "" do
+    filename
+  end
+
+  defp openrouter_file_filename(_part), do: "document.pdf"
+
+  defp openrouter_file_media_type(%ContentPart{media_type: media_type, filename: filename}) do
+    cond do
+      openrouter_pdf_filename?(filename) -> "application/pdf"
+      is_binary(media_type) and media_type != "" -> media_type
+      true -> "application/pdf"
+    end
+  end
+
+  defp openrouter_file_media_type(_part), do: "application/pdf"
+
+  @passthrough_content_metadata_keys [:cache_control, "cache_control"]
+
+  defp merge_content_metadata(base, metadata) when is_map(metadata) and map_size(metadata) > 0 do
+    passthrough =
+      metadata
+      |> Map.take(@passthrough_content_metadata_keys)
+      |> Map.new(fn
+        {"cache_control", value} -> {:cache_control, value}
+        {key, value} -> {key, value}
+      end)
+
+    Map.merge(base, passthrough)
+  end
+
+  defp merge_content_metadata(base, _metadata), do: base
 
   defp add_embedding_options(body, request_options) do
     if request_options[:operation] == :embedding do

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -9,6 +9,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
   use ReqLLM.ProviderCase, provider: ReqLLM.Providers.OpenRouter
 
   alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.Providers.OpenRouter
 
   describe "provider contract" do
@@ -327,6 +328,113 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       decoded = Jason.decode!(updated_request.body)
 
       assert decoded["plugins"] == [%{"id" => "web"}, %{"id" => "code"}]
+    end
+
+    test "encode_body with file-parser plugin encodes PDF files in OpenRouter format" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      pdf_data = "%PDF test"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Summarize this PDF"),
+            ContentPart.file(pdf_data, "document.pdf", "application/pdf")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          openrouter_plugins: [%{id: "file-parser", pdf: %{engine: "mistral-ocr"}}]
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [message] = decoded["messages"]
+      [text_part, file_part] = message["content"]
+
+      assert text_part == %{"type" => "text", "text" => "Summarize this PDF"}
+
+      assert file_part == %{
+               "type" => "file",
+               "file" => %{
+                 "filename" => "document.pdf",
+                 "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               }
+             }
+    end
+
+    test "encode_body without file-parser keeps OpenAI-compatible file encoding" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      pdf_data = "%PDF test"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Summarize this PDF"),
+            ContentPart.file(pdf_data, "document.pdf", "application/pdf")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [message] = decoded["messages"]
+      [_, file_part] = message["content"]
+
+      assert file_part == %{
+               "type" => "image_url",
+               "image_url" => %{
+                 "url" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               }
+             }
+    end
+
+    test "attach_stream with file-parser plugin encodes PDF files in OpenRouter format" do
+      model = ReqLLM.model!("openrouter:openai/gpt-4")
+      pdf_data = "%PDF stream"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Summarize this PDF"),
+            ContentPart.file(pdf_data, "stream.pdf", "application/pdf")
+          ])
+        ])
+
+      opts = [openrouter_plugins: [%{id: "file-parser", pdf: %{engine: "mistral-ocr"}}]]
+
+      {:ok, finch_request} = OpenRouter.attach_stream(model, context, opts, MyApp.Finch)
+
+      decoded = Jason.decode!(finch_request.body)
+      [message] = decoded["messages"]
+      [_, file_part] = message["content"]
+
+      assert decoded["stream"] == true
+
+      assert decoded["plugins"] == [
+               %{"id" => "file-parser", "pdf" => %{"engine" => "mistral-ocr"}}
+             ]
+
+      assert file_part == %{
+               "type" => "file",
+               "file" => %{
+                 "filename" => "stream.pdf",
+                 "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               }
+             }
     end
 
     test "encode_body with response_format" do

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -1139,6 +1139,34 @@ defmodule ReqLLM.ContextTest do
       assert hd(message.content).media_type == "application/pdf"
     end
 
+    test "normalizes OpenRouter file_data content maps" do
+      pdf_data = "%PDF test"
+
+      input = [
+        %{
+          "role" => "user",
+          "content" => [
+            %{
+              "type" => "file",
+              "file" => %{
+                "filename" => "document.pdf",
+                "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+              }
+            }
+          ]
+        }
+      ]
+
+      {:ok, context} = Context.normalize(input, validate: false)
+
+      [message] = context.messages
+
+      assert [%ContentPart{type: :file, data: ^pdf_data, filename: "document.pdf"}] =
+               message.content
+
+      assert hd(message.content).media_type == "application/pdf"
+    end
+
     test "normalizes Anthropic image file source content maps" do
       input = [
         %{


### PR DESCRIPTION
## Summary
- encode OpenRouter file-parser PDF `ContentPart.file` content as `type: "file"` with nested `file_data`
- preserve OpenRouter raw `file.file_data` maps through context normalization
- add non-streaming and streaming regression coverage

## Testing
- `mix test test/providers/openrouter_test.exs test/req_llm/context_test.exs`
- `mix test`
- `mix quality`

Closes #678