### PR TITLE
fix: Add support for reasoning effort and parallel_tool_calls (Azure)

### DIFF
--- a/lib/req_llm/providers/azure/responses_api.ex
+++ b/lib/req_llm/providers/azure/responses_api.ex
@@ -36,6 +36,7 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
         max_tokens: opts[:max_tokens],
         max_output_tokens: opts[:max_output_tokens],
         max_completion_tokens: opts[:max_completion_tokens],
+        reasoning_effort: opts[:reasoning_effort],
         tools: opts[:tools],
         tool_choice: opts[:tool_choice],
         provider_options: provider_opts

--- a/lib/req_llm/providers/azure/responses_api.ex
+++ b/lib/req_llm/providers/azure/responses_api.ex
@@ -15,6 +15,12 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
   Models with `"api": "responses"` in their metadata:
   - codex-mini, gpt-5-codex, gpt-5.1-codex-mini
   - Future models that use the Responses API format
+
+  ## Reasoning Effort
+
+  Accepts the top-level `:reasoning_effort` option (`:minimal | :low | :medium |
+  :high | :xhigh | :none` or the equivalent string) and forwards it to the
+  Responses API as `"reasoning": {"effort": <level>}`.
   """
 
   alias ReqLLM.Providers.OpenAI.ResponsesAPI

--- a/lib/req_llm/providers/azure/responses_api.ex
+++ b/lib/req_llm/providers/azure/responses_api.ex
@@ -21,6 +21,14 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
   Accepts the top-level `:reasoning_effort` option (`:minimal | :low | :medium |
   :high | :xhigh | :none` or the equivalent string) and forwards it to the
   Responses API as `"reasoning": {"effort": <level>}`.
+
+  ## Parallel Tool Calls
+
+  Accepts `parallel_tool_calls` via the top-level option, or via
+  `provider_options[:openai_parallel_tool_calls]` (Azure's preferred key) or
+  `provider_options[:parallel_tool_calls]`. Forwarded to the Responses API
+  as the top-level `"parallel_tool_calls"` boolean. An explicit `false` is
+  preserved.
   """
 
   alias ReqLLM.Providers.OpenAI.ResponsesAPI
@@ -33,6 +41,13 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
   def format_request(model_id, context, opts) when is_list(opts) do
     provider_opts = opts[:provider_options] || []
 
+    parallel_tool_calls =
+      fetch_first([
+        {opts, :parallel_tool_calls},
+        {provider_opts, :openai_parallel_tool_calls},
+        {provider_opts, :parallel_tool_calls}
+      ])
+
     fake_request = %{
       options: %{
         model: model_id,
@@ -43,6 +58,7 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
         max_output_tokens: opts[:max_output_tokens],
         max_completion_tokens: opts[:max_completion_tokens],
         reasoning_effort: opts[:reasoning_effort],
+        parallel_tool_calls: parallel_tool_calls,
         tools: opts[:tools],
         tool_choice: opts[:tool_choice],
         provider_options: provider_opts
@@ -50,6 +66,15 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
     }
 
     ResponsesAPI.build_body(fake_request)
+  end
+
+  defp fetch_first([]), do: nil
+
+  defp fetch_first([{source, key} | rest]) do
+    case Keyword.fetch(source, key) do
+      {:ok, value} -> value
+      :error -> fetch_first(rest)
+    end
   end
 
   @doc """

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -823,6 +823,24 @@ defmodule ReqLLM.Providers.AzureTest do
       assert body[:reasoning_effort] == "high"
     end
 
+    test "Responses API models forward reasoning_effort to the encoded body" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Complex reasoning task")])
+      opts = [stream: false, reasoning_effort: :high]
+
+      body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
+
+      assert body["reasoning"] == %{"effort" => "high"}
+    end
+
+    test "Responses API models omit reasoning when reasoning_effort is absent" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+      opts = [stream: false]
+
+      body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
+
+      refute Map.has_key?(body, "reasoning")
+    end
+
     test "Claude reasoning models override temperature to 1.0" do
       model = %LLMDB.Model{
         id: "claude-3-5-sonnet-20241022",

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -841,6 +841,33 @@ defmodule ReqLLM.Providers.AzureTest do
       refute Map.has_key?(body, "reasoning")
     end
 
+    test "Responses API models forward openai_parallel_tool_calls from provider_options" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+      opts = [stream: false, provider_options: [openai_parallel_tool_calls: false]]
+
+      body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
+
+      assert body["parallel_tool_calls"] == false
+    end
+
+    test "Responses API models accept parallel_tool_calls alias in provider_options" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+      opts = [stream: false, provider_options: [parallel_tool_calls: true]]
+
+      body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
+
+      assert body["parallel_tool_calls"] == true
+    end
+
+    test "Responses API models omit parallel_tool_calls when not provided" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+      opts = [stream: false]
+
+      body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
+
+      refute Map.has_key?(body, "parallel_tool_calls")
+    end
+
     test "Claude reasoning models override temperature to 1.0" do
       model = %LLMDB.Model{
         id: "claude-3-5-sonnet-20241022",


### PR DESCRIPTION
## Description

Support Reasoning Effort and Parallel Tool Calls in responses API (for Azure) by passing on the parameters

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
