### PR TITLE
fix(bedrock): clarify canonical specs and inference profiles

### DIFF
--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -21,13 +21,13 @@ AWS_REGION=us-east-1
 
 For the full model-spec workflow, see [Model Specs](model-specs.md).
 
-Use exact Bedrock IDs from [LLMDB.xyz](https://llmdb.xyz) when possible. For inference profiles, custom deployments, or new Bedrock model IDs, use a full explicit model spec when the registry has not caught up yet.
+Use exact Bedrock IDs from [LLMDB.xyz](https://llmdb.xyz) when possible. The canonical ReqLLM provider prefix is `amazon_bedrock:`. For inference profiles, custom deployments, or new Bedrock model IDs, use a full explicit model spec when the registry has not caught up yet.
 
 **Provider Options:**
 
 ```elixir
 ReqLLM.generate_text(
-  "bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
+  "amazon_bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
   "Hello",
   provider_options: [api_key: "your-api-key", region: "us-east-1"]
 )
@@ -63,7 +63,7 @@ ReqLLM.put_key(:aws_bedrock, %{
 
 ```elixir
 ReqLLM.generate_text(
-  "bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
+  "amazon_bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
   "Hello",
   provider_options: [
     region: "us-east-1",
@@ -160,27 +160,27 @@ Passed via `:provider_options` keyword:
 - **All capabilities**: Tool calling, streaming with tools, attachments, reasoning, prompt caching
 - **Inference profiles**: Supports region-specific routing (`global.`, `us.`, `eu.`)
 - **Models**: Claude 3.x, 4.x (Sonnet, Opus, Haiku)
-- **Example**: `bedrock:global.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- **Example**: `amazon_bedrock:global.anthropic.claude-sonnet-4-6`
 
 ### Cohere Command R/R+
 
 - **Tool calling**: Full support including streaming with tools
 - **RAG-optimized**: Excellent for production RAG workloads with citations
 - **Works with Converse API** directly without custom formatter
-- **Example**: `bedrock:cohere.command-r-plus-v1:0`
+- **Example**: `amazon_bedrock:cohere.command-r-plus-v1:0`
 
 ### OpenAI OSS
 
 - **Smart routing**: Native `/invoke` for simple requests, `/converse` when tools present
 - **Tool calling**: Full support in non-streaming mode
 - **Models**: gpt-oss-20b, gpt-oss-120b
-- **Example**: `bedrock:openai.gpt-oss-120b-1:0`
+- **Example**: `amazon_bedrock:openai.gpt-oss-120b-1:0`
 
 ### Meta Llama
 
 - **Inference profiles only**: us.meta.llama3-2-3b-instruct-v1:0
 - **No tool calling**: Basic text generation only
-- **Example**: `bedrock:us.meta.llama3-2-3b-instruct-v1:0`
+- **Example**: `amazon_bedrock:us.meta.llama3-2-3b-instruct-v1:0`
 
 ## Wire Format Notes
 

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -24,7 +24,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
       # Option 2: Pass directly in options
       ReqLLM.generate_text(
-        "bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
+        "amazon_bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
         "Hello",
         api_key: "your-api-key",
         region: "us-east-1"
@@ -44,7 +44,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
       # Option 2: Pass directly in options
       ReqLLM.generate_text(
-        "bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
+        "amazon_bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
         "Hello",
         access_key_id: "AKIA...",
         secret_access_key: "...",
@@ -81,7 +81,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   ## Examples
 
       # Simple text generation with Claude on Bedrock
-      model = ReqLLM.model("bedrock:anthropic.claude-3-sonnet-20240229-v1:0")
+      model = ReqLLM.model("amazon_bedrock:anthropic.claude-3-sonnet-20240229-v1:0")
       {:ok, response} = ReqLLM.generate_text(model, "Hello!")
 
       # Streaming

--- a/lib/req_llm/providers/amazon_bedrock/sts.ex
+++ b/lib/req_llm/providers/amazon_bedrock/sts.ex
@@ -17,7 +17,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.STS do
       )
 
       # Use temporary credentials with Bedrock
-      model = ReqLLM.model("bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
+      model = ReqLLM.model("amazon_bedrock:anthropic.claude-3-sonnet-20240229-v1:0",
         access_key_id: temp_creds.access_key_id,
         secret_access_key: temp_creds.secret_access_key,
         session_token: temp_creds.session_token,

--- a/test/providers/amazon_bedrock_provider_test.exs
+++ b/test/providers/amazon_bedrock_provider_test.exs
@@ -584,6 +584,22 @@ defmodule ReqLLM.Providers.AmazonBedrockProviderTest do
       assert request.url.path == "/model/global.anthropic.claude-opus-4-6-v1/invoke"
     end
 
+    test "global prefix is preserved for Claude Sonnet 4.6" do
+      {:ok, model} = ReqLLM.model("amazon_bedrock:global.anthropic.claude-sonnet-4-6")
+      context = context_fixture()
+
+      opts = [
+        api_key: "test-api-key",
+        region: "us-east-1"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert model.provider == :amazon_bedrock
+      assert model.provider_model_id == "global.anthropic.claude-sonnet-4-6"
+      assert request.url.path == "/model/global.anthropic.claude-sonnet-4-6/invoke"
+    end
+
     test "us prefix is preserved in URL when model spec includes it" do
       {:ok, model} =
         ReqLLM.model("amazon_bedrock:us.anthropic.claude-opus-4-1-20250805-v1:0")


### PR DESCRIPTION
## Summary
- update Bedrock docs/examples to use canonical `amazon_bedrock:` model specs
- add canonical Claude Sonnet 4.6 inference-profile coverage

## Testing
- `mix test`
- `mix quality`

Addresses the ReqLLM-owned Bedrock docs and inference-profile portions of #690.

Follow-up: Bedrock provider aliases and embedding capability discovery for `cohere.embed-english-v3` should be handled in LLMDB.