### PR TITLE
fix: preserve partial Google usage metadata

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -626,23 +626,77 @@ defmodule ReqLLM.Providers.Google do
   def extract_usage(_, _), do: {:error, :invalid_body}
 
   defp normalize_google_usage(usage_metadata) do
-    input = Map.get(usage_metadata, "promptTokenCount", 0)
-    total = Map.get(usage_metadata, "totalTokenCount", 0)
-    cached = Map.get(usage_metadata, "cachedContentTokenCount", 0)
-    reasoning = Map.get(usage_metadata, "thoughtsTokenCount", 0)
+    google_usage_from_metadata(usage_metadata)
+  end
 
-    output =
-      case Map.get(usage_metadata, "candidatesTokenCount") do
-        nil -> max(0, total - input)
-        count -> count + reasoning
-      end
+  defp google_usage_from_metadata(usage_metadata) when is_map(usage_metadata) do
+    input =
+      google_metadata_count(usage_metadata, "promptTokenCount") ||
+        google_token_details_count(usage_metadata["promptTokensDetails"]) ||
+        0
+
+    total = google_metadata_count(usage_metadata, "totalTokenCount")
+    reasoning = google_metadata_count(usage_metadata, "thoughtsTokenCount") || 0
+    cached = google_metadata_count(usage_metadata, "cachedContentTokenCount") || 0
+    candidates = google_metadata_count(usage_metadata, "candidatesTokenCount")
+    output = google_output_tokens(candidates, reasoning, total, input)
 
     %{
       input_tokens: input,
       output_tokens: output,
-      total_tokens: total,
+      total_tokens: total || input + output,
       cached_tokens: cached,
       reasoning_tokens: reasoning
+    }
+  end
+
+  defp google_usage_from_metadata(_usage_metadata), do: google_zero_usage()
+
+  defp google_metadata_count(usage_metadata, key) do
+    case Map.get(usage_metadata, key) do
+      count when is_integer(count) and count >= 0 -> count
+      _ -> nil
+    end
+  end
+
+  defp google_token_details_count(details) when is_list(details) do
+    Enum.reduce(details, nil, fn detail, total ->
+      case detail do
+        %{"tokenCount" => count} when is_integer(count) and count >= 0 ->
+          add_google_token_count(total, count)
+
+        _ ->
+          total
+      end
+    end)
+  end
+
+  defp google_token_details_count(_details), do: nil
+
+  defp add_google_token_count(nil, count), do: count
+  defp add_google_token_count(total, count), do: total + count
+
+  defp google_output_tokens(candidates, reasoning, _total, _input) when is_integer(candidates) do
+    candidates + reasoning
+  end
+
+  defp google_output_tokens(_candidates, _reasoning, total, input) when is_integer(total) do
+    max(0, total - input)
+  end
+
+  defp google_output_tokens(_candidates, reasoning, _total, _input) when reasoning > 0 do
+    reasoning
+  end
+
+  defp google_output_tokens(_candidates, _reasoning, _total, _input), do: 0
+
+  defp google_zero_usage do
+    %{
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      cached_tokens: 0,
+      reasoning_tokens: 0
     }
   end
 
@@ -1884,31 +1938,26 @@ defmodule ReqLLM.Providers.Google do
   defp normalize_google_finish_reason("OTHER"), do: "error"
   defp normalize_google_finish_reason(_), do: "error"
 
-  defp convert_google_usage(%{"promptTokenCount" => prompt, "totalTokenCount" => total} = usage) do
-    thoughts = usage["thoughtsTokenCount"] || 0
-    cached = usage["cachedContentTokenCount"] || 0
-
-    completion =
-      case usage["candidatesTokenCount"] do
-        nil -> max(0, total - prompt)
-        count -> count + thoughts
-      end
+  defp convert_google_usage(usage) when is_map(usage) do
+    normalized = normalize_google_usage(usage)
 
     base = %{
-      "prompt_tokens" => prompt,
-      "completion_tokens" => completion,
-      "total_tokens" => total
+      "prompt_tokens" => normalized.input_tokens,
+      "completion_tokens" => normalized.output_tokens,
+      "total_tokens" => normalized.total_tokens
     }
 
     base =
-      if thoughts > 0 do
-        Map.put(base, "completion_tokens_details", %{"reasoning_tokens" => thoughts})
+      if normalized.reasoning_tokens > 0 do
+        Map.put(base, "completion_tokens_details", %{
+          "reasoning_tokens" => normalized.reasoning_tokens
+        })
       else
         base
       end
 
-    if cached > 0 do
-      Map.put(base, "prompt_tokens_details", %{"cached_tokens" => cached})
+    if normalized.cached_tokens > 0 do
+      Map.put(base, "prompt_tokens_details", %{"cached_tokens" => normalized.cached_tokens})
     else
       base
     end

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -854,6 +854,90 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert response.usage.reasoning_tokens == 5
     end
 
+    test "decode_response derives usage from partial usageMetadata" do
+      google_response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [%{"text" => "The answer is 42."}],
+              "role" => "model"
+            },
+            "finishReason" => "STOP"
+          }
+        ],
+        "usageMetadata" => %{
+          "candidatesTokenCount" => 486,
+          "thoughtsTokenCount" => 4297,
+          "serviceTier" => "standard"
+        }
+      }
+
+      mock_resp = %Req.Response{
+        status: 200,
+        body: google_response
+      }
+
+      {:ok, model} = ReqLLM.model("google:gemini-2.5-flash")
+      context = context_fixture()
+
+      mock_req = %Req.Request{
+        options: [context: context, stream: false, model: model.model]
+      }
+
+      {_req, resp} = Google.decode_response({mock_req, mock_resp})
+
+      assert %ReqLLM.Response{} = resp.body
+      response = resp.body
+      assert response.usage.input_tokens == 0
+      assert response.usage.output_tokens == 4783
+      assert response.usage.total_tokens == 4783
+      assert response.usage.reasoning_tokens == 4297
+    end
+
+    test "decode_response derives prompt tokens from usage detail entries" do
+      google_response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [%{"text" => ~s({"summary":"ok"})}],
+              "role" => "model"
+            },
+            "finishReason" => "STOP"
+          }
+        ],
+        "usageMetadata" => %{
+          "promptTokensDetails" => [
+            %{"modality" => "TEXT", "tokenCount" => 12},
+            %{"modality" => "IMAGE", "tokenCount" => 5}
+          ],
+          "candidatesTokenCount" => 3,
+          "thoughtsTokenCount" => 2
+        }
+      }
+
+      mock_resp = %Req.Response{
+        status: 200,
+        body: google_response
+      }
+
+      {:ok, model} = ReqLLM.model("google:gemini-2.5-flash")
+      context = context_fixture()
+
+      mock_req = %Req.Request{
+        options: [context: context, stream: false, operation: :object, model: model.model]
+      }
+
+      {_req, resp} = Google.decode_response({mock_req, mock_resp})
+
+      assert %ReqLLM.Response{} = resp.body
+      response = resp.body
+      assert response.object == %{"summary" => "ok"}
+      assert response.usage.input_tokens == 17
+      assert response.usage.output_tokens == 5
+      assert response.usage.total_tokens == 22
+      assert response.usage.reasoning_tokens == 2
+    end
+
     test "decode_response preserves tool calls" do
       google_response = %{
         "candidates" => [
@@ -1061,6 +1145,25 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert meta_chunk.metadata[:usage][:output_tokens] == 20
       assert meta_chunk.metadata[:usage][:total_tokens] == 30
       assert meta_chunk.metadata[:usage][:reasoning_tokens] == 5
+    end
+
+    test "streaming usageMetadata derives totals from partial counts", %{model: model} do
+      event = %{
+        data: %{
+          "candidates" => [%{"finishReason" => "STOP", "index" => 0}],
+          "usageMetadata" => %{
+            "candidatesTokenCount" => 486,
+            "thoughtsTokenCount" => 4297
+          }
+        }
+      }
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.type == :meta
+      assert meta_chunk.metadata[:usage][:input_tokens] == 0
+      assert meta_chunk.metadata[:usage][:output_tokens] == 4783
+      assert meta_chunk.metadata[:usage][:total_tokens] == 4783
+      assert meta_chunk.metadata[:usage][:reasoning_tokens] == 4297
     end
 
     test "finishReason on candidate without content.parts (no usage)", %{model: model} do


### PR DESCRIPTION
## Summary
- derive Google usage from partial Gemini usageMetadata instead of zeroing it
- use promptTokensDetails as a prompt-token fallback
- keep streaming and non-streaming Google usage conversion aligned

Fixes #694

## Tests
- mix test test/providers/google_test.exs
- mix test
- mix format --check-formatted
- mix compile --warnings-as-errors