### PR TITLE
feat(xai): expose explicit Responses API routing via xai_api provider option

### DIFF
--- a/guides/xai.md
+++ b/guides/xai.md
@@ -48,6 +48,15 @@ Passed via `:provider_options` keyword:
 - **Note**: `search_parameters` is deprecated and will be removed in a future release
 - **Note**: `live_search` is no longer supported by xAI and will be filtered out
 
+### `xai_api`
+- **Type**: `:auto` | `:chat` | `:responses`
+- **Default**: `:auto`
+- **Purpose**: Force the xAI API endpoint
+- **`:auto`** routes through `/responses` only when `xai_tools` includes built-in tools (`web_search` / `x_search`), otherwise `/chat/completions`
+- **`:chat`** always uses `/chat/completions`
+- **`:responses`** always uses `/responses` — required when you want the stateful Responses API (e.g. continuing a reasoning loop across turns via `previous_response_id`) without enabling any built-in tools
+- **Example**: `provider_options: [xai_api: :responses]`
+
 ### `parallel_tool_calls`
 
 - **Type**: Boolean

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -37,8 +37,9 @@ defmodule ReqLLM.Providers.XAI do
 
   Beyond standard OpenAI parameters, xAI supports:
   - `max_completion_tokens` - Preferred over max_tokens for Grok-4 models
-  - `reasoning_effort` - Reasoning level (low, medium, high) for Grok-3 mini models only
+  - `reasoning_effort` - Reasoning level (low, medium, high) for Grok-3 mini and Grok-4 family models
   - `xai_tools` - Agent tools configuration (e.g., web_search, x_search)
+  - `xai_api` - Force the API endpoint (:auto, :chat, :responses). Default :auto routes through the stateful Responses API only when built-in tools (web_search/x_search) are used. Set `:responses` to enable threaded reasoning across turns (`previous_response_id`) without built-in tools.
   - `parallel_tool_calls` - Allow parallel function calls (default: true)
   - `stream_options` - Streaming configuration (include_usage)
   - `xai_structured_output_mode` - Control structured output implementation (:auto, :json_schema, :tool_strict)
@@ -123,6 +124,20 @@ defmodule ReqLLM.Providers.XAI do
     xai_tools: [
       type: {:list, :map},
       doc: "Agent tools configuration (e.g., [%{type: \"web_search\"}])"
+    ],
+    xai_api: [
+      type: {:in, [:auto, :chat, :responses]},
+      default: :auto,
+      doc: """
+      Which xAI API endpoint to route through:
+      - `:auto` (default) — uses `/responses` when xai_tools include built-in
+        tools (web_search/x_search), otherwise `/chat/completions`.
+      - `:chat` — always uses `/chat/completions`.
+      - `:responses` — always uses `/responses`. Required when you want the
+        stateful, threaded conversation behavior (e.g. continuing a reasoning
+        loop across turns via `previous_response_id`) without enabling any
+        built-in tools.
+      """
     ],
     parallel_tool_calls: [
       type: :boolean,
@@ -341,13 +356,39 @@ defmodule ReqLLM.Providers.XAI do
     end
   end
 
+  # `xai_api` (and `xai_tools`) can sit either at the top level (when the
+  # caller passes them directly) or nested under `:provider_options` (which
+  # is how `ReqLLM.Provider.Options.process!/4` re-shapes provider-schema
+  # keys before they reach `attach_stream`). Read from both locations so
+  # the explicit `xai_api: :responses` toggle works on both the
+  # `prepare_request` and `attach_stream` paths.
   defp use_responses_api?(opts) do
-    xai_tools = Keyword.get(opts, :xai_tools, [])
+    case resolve_xai_api(opts) do
+      :responses ->
+        true
 
-    Enum.any?(xai_tools, fn tool ->
-      tool_type = normalize_tool_type(Map.get(tool, :type))
-      tool_type in ["web_search", "x_search"]
-    end)
+      :chat ->
+        false
+
+      :auto ->
+        opts |> resolve_xai_tools() |> Enum.any?(&built_in_tool?/1)
+    end
+  end
+
+  defp resolve_xai_api(opts) do
+    Keyword.get(opts, :xai_api) ||
+      get_in(opts, [:provider_options, :xai_api]) ||
+      :auto
+  end
+
+  defp resolve_xai_tools(opts) do
+    Keyword.get(opts, :xai_tools) ||
+      get_in(opts, [:provider_options, :xai_tools]) ||
+      []
+  end
+
+  defp built_in_tool?(tool) do
+    normalize_tool_type(Map.get(tool, :type)) in ["web_search", "x_search"]
   end
 
   defp ensure_min_tokens(model, opts) do

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -202,6 +202,47 @@ defmodule ReqLLM.Providers.XAITest do
     end
   end
 
+  describe "xai_api routing override" do
+    test "auto routes chat-only requests through /chat/completions" do
+      {:ok, req} =
+        XAI.prepare_request(:chat, "xai:grok-4.3", "hi", provider_options: [xai_api: :auto])
+
+      assert req.options[:xai_api_type] == :chat
+      assert req.url.path == "/chat/completions"
+    end
+
+    test "explicit :responses forces /responses without built-in tools" do
+      {:ok, req} =
+        XAI.prepare_request(:chat, "xai:grok-4.3", "hi", provider_options: [xai_api: :responses])
+
+      assert req.options[:xai_api_type] == :responses
+      assert req.url.path == "/responses"
+    end
+
+    test "explicit :chat overrides the built-in-tools auto upgrade" do
+      {:ok, req} =
+        XAI.prepare_request(:chat, "xai:grok-4.3", "hi",
+          provider_options: [
+            xai_api: :chat,
+            xai_tools: [%{type: "web_search"}]
+          ]
+        )
+
+      assert req.options[:xai_api_type] == :chat
+      assert req.url.path == "/chat/completions"
+    end
+
+    test "auto still upgrades when built-in tools are present" do
+      {:ok, req} =
+        XAI.prepare_request(:chat, "xai:grok-4.3", "hi",
+          provider_options: [xai_tools: [%{type: "web_search"}]]
+        )
+
+      assert req.options[:xai_api_type] == :responses
+      assert req.url.path == "/responses"
+    end
+  end
+
   describe "mode selection - response_format forcing" do
     test "forces :json_schema when response_format has json_schema" do
       {:ok, model} = ReqLLM.model("xai:grok-3")


### PR DESCRIPTION
## Description

Add `xai_api: :auto | :chat | :responses` provider option so callers can force xAI's `/responses` endpoint without enabling a built-in `web_search` / `x_search` tool. Default `:auto` preserves the existing behavior.

`use_responses_api?/1` now reads `xai_api` and `xai_tools` from both the top level and `:provider_options`, so the toggle works on the streaming path too (`Options.process!/4` re-nests provider-schema keys before they reach `attach_stream`).

Adds a `guides/xai.md` entry under Provider Options and 4 tests for the routing-override matrix.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
