### PR TITLE
fix(google): nest multimodal content inside functionResponse.parts for Gemini 3+

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -946,21 +946,21 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp encode_gemini_image_body(request) do
+    model_name = request.options[:model]
+
     {system_instruction, contents} =
       case request.options[:context] do
         %ReqLLM.Context{} = ctx ->
-          model_name = request.options[:model]
-
           encoded =
             ctx
             |> normalize_context_video_urls()
             |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
 
           messages = encoded[:messages] || []
-          split_messages_for_gemini(messages)
+          split_messages_for_gemini(messages, model_name)
 
         _ ->
-          split_messages_for_gemini(request.options[:messages] || [])
+          split_messages_for_gemini(request.options[:messages] || [], model_name)
       end
 
     # Note: We intentionally keep the role field in contents.
@@ -1123,10 +1123,11 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp encode_chat_body(request) do
+    model_name = request.options[:model]
+
     {system_instruction, contents} =
       case request.options[:context] do
         %ReqLLM.Context{} = ctx ->
-          model_name = request.options[:model]
           # Convert OpenAI-style context to Gemini format
           encoded =
             ctx
@@ -1134,10 +1135,10 @@ defmodule ReqLLM.Providers.Google do
             |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
 
           messages = encoded[:messages] || []
-          split_messages_for_gemini(messages)
+          split_messages_for_gemini(messages, model_name)
 
         _ ->
-          split_messages_for_gemini(request.options[:messages] || [])
+          split_messages_for_gemini(request.options[:messages] || [], model_name)
       end
 
     tool_config = build_google_tool_config(request.options[:tool_choice])
@@ -1216,21 +1217,21 @@ defmodule ReqLLM.Providers.Google do
   end
 
   defp encode_object_body(request) do
+    model_name = request.options[:model]
+
     {system_instruction, contents} =
       case request.options[:context] do
         %ReqLLM.Context{} = ctx ->
-          model_name = request.options[:model]
-
           encoded =
             ctx
             |> normalize_context_video_urls()
             |> ReqLLM.Provider.Defaults.encode_context_to_openai_format(model_name)
 
           messages = encoded[:messages] || []
-          split_messages_for_gemini(messages)
+          split_messages_for_gemini(messages, model_name)
 
         _ ->
-          split_messages_for_gemini(request.options[:messages] || [])
+          split_messages_for_gemini(request.options[:messages] || [], model_name)
       end
 
     compiled_schema =
@@ -1242,8 +1243,6 @@ defmodule ReqLLM.Providers.Google do
     if !compiled_schema do
       raise ArgumentError, "Missing :compiled_schema in request options for :object operation"
     end
-
-    model_name = request.options[:model]
 
     generation_config =
       %{
@@ -2115,7 +2114,7 @@ defmodule ReqLLM.Providers.Google do
   end
 
   # Split messages into system instruction and contents for Google Gemini
-  defp split_messages_for_gemini(messages) do
+  defp split_messages_for_gemini(messages, model) do
     {system_msgs, chat_msgs} =
       Enum.split_with(messages, fn message ->
         case message do
@@ -2140,18 +2139,18 @@ defmodule ReqLLM.Providers.Google do
           %{parts: [%{text: combined_text}]}
       end
 
-    contents = convert_messages_to_gemini(chat_msgs)
+    contents = convert_messages_to_gemini(chat_msgs, model)
 
     {system_instruction, contents}
   end
 
-  defp convert_messages_to_gemini(messages) do
+  defp convert_messages_to_gemini(messages, model) do
     messages
-    |> Enum.map(&convert_single_message_to_gemini/1)
+    |> Enum.map(&convert_single_message_to_gemini(&1, model))
     |> merge_consecutive_roles()
   end
 
-  defp convert_single_message_to_gemini(message) do
+  defp convert_single_message_to_gemini(message, model) do
     raw_role =
       case message do
         %{role: role} -> role
@@ -2182,10 +2181,24 @@ defmodule ReqLLM.Providers.Google do
 
     thought_parts = encode_reasoning_details_for_gemini(message)
 
+    tool_result? = tool_result_message?(message)
+
+    nest_multimodal? =
+      tool_result? and multimodal_tool_result?(raw_content) and gemini_3_or_later?(model)
+
     content_parts =
-      case raw_content do
-        content when is_binary(content) -> [%{text: content}]
-        parts when is_list(parts) -> Enum.map(parts, &convert_content_part/1)
+      cond do
+        nest_multimodal? ->
+          []
+
+        is_binary(raw_content) ->
+          [%{text: raw_content}]
+
+        is_list(raw_content) ->
+          Enum.map(raw_content, &convert_content_part/1)
+
+        true ->
+          []
       end
 
     tool_call_parts =
@@ -2201,24 +2214,36 @@ defmodule ReqLLM.Providers.Google do
       end
 
     tool_result_parts =
-      case message do
-        %{tool_call_id: _call_id, role: "tool"} ->
-          [build_tool_result_part(message, raw_content)]
-
-        %{"tool_call_id" => _call_id, "role" => "tool"} ->
-          [build_tool_result_part(message, raw_content)]
-
-        %{tool_call_id: _call_id, role: :tool} ->
-          [build_tool_result_part(message, raw_content)]
-
-        _ ->
-          []
+      if tool_result? do
+        [build_tool_result_part(message, raw_content, nest_multimodal?)]
+      else
+        []
       end
 
     parts = thought_parts ++ content_parts ++ tool_call_parts ++ tool_result_parts
 
     %{role: role, parts: parts}
   end
+
+  defp tool_result_message?(%{tool_call_id: _, role: "tool"}), do: true
+  defp tool_result_message?(%{tool_call_id: _, role: :tool}), do: true
+  defp tool_result_message?(%{"tool_call_id" => _, "role" => "tool"}), do: true
+  defp tool_result_message?(_), do: false
+
+  defp multimodal_tool_result?(content) when is_list(content) do
+    Enum.any?(content, &multimodal_part?/1)
+  end
+
+  defp multimodal_tool_result?(_), do: false
+
+  defp multimodal_part?(%ReqLLM.Message.ContentPart{type: type})
+       when type in [:file, :image, :image_url],
+       do: true
+
+  defp multimodal_part?(%{type: type}) when type in [:file, :image, :image_url], do: true
+  defp multimodal_part?(%{type: type}) when type in ["file", "image", "image_url"], do: true
+  defp multimodal_part?(%{"type" => type}) when type in ["file", "image", "image_url"], do: true
+  defp multimodal_part?(_), do: false
 
   # Gemini requires that consecutive messages with the same role are merged
   # into a single entry. This is critical for parallel tool calls: N separate
@@ -2323,6 +2348,7 @@ defmodule ReqLLM.Providers.Google do
     |> Enum.map_join("", fn
       %{"type" => "text", "text" => text} -> text
       %{type: :text, text: text} -> text
+      %{type: "text", text: text} -> text
       text when is_binary(text) -> text
       _ -> ""
     end)
@@ -2330,11 +2356,26 @@ defmodule ReqLLM.Providers.Google do
 
   defp extract_content_text(_), do: ""
 
-  defp build_tool_result_part(message, raw_content) do
+  defp build_tool_result_part(message, raw_content, false) do
     %{
       functionResponse: %{
         name: tool_result_name(message),
         response: tool_result_response(message, raw_content)
+      }
+    }
+  end
+
+  defp build_tool_result_part(message, raw_content, true) do
+    media_parts =
+      raw_content
+      |> Enum.filter(&multimodal_part?/1)
+      |> Enum.map(&convert_content_part/1)
+
+    %{
+      functionResponse: %{
+        name: tool_result_name(message),
+        response: tool_result_response(message, raw_content),
+        parts: media_parts
       }
     }
   end

--- a/test/coverage/google/multimodal_tool_result_test.exs
+++ b/test/coverage/google/multimodal_tool_result_test.exs
@@ -1,0 +1,87 @@
+defmodule ReqLLM.Coverage.Google.MultimodalToolResultTest do
+  @moduledoc """
+  Google multimodal tool result coverage tests.
+
+  Validates the Gemini 3+ `functionResponse.parts` encoding: a tool
+  returning text alongside a PDF must deliver both to the model with
+  the binary nested inside `functionResponse.parts` and the text in
+  `functionResponse.response.content`.
+
+  Run with REQ_LLM_FIXTURES_MODE=record to test against live API and record fixtures.
+  Otherwise uses fixtures for fast, reliable testing.
+  """
+
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  @moduletag :coverage
+  @moduletag provider: "google"
+  @moduletag timeout: 180_000
+
+  @model_spec "google:gemini-3-pro-preview"
+
+  setup_all do
+    LLMDB.load(allow: :all, custom: %{})
+    :ok
+  end
+
+  @tag scenario: :multimodal_tool_result
+  @tag model: "gemini-3-pro-preview"
+  test "tool result with PDF and accompanying text reaches the model" do
+    pdf_bytes = File.read!(Path.join(File.cwd!(), "priv/examples/test.pdf"))
+
+    tools = [
+      ReqLLM.tool(
+        name: "get_document",
+        description: "Fetch the requested document and return its raw contents.",
+        parameter_schema: [
+          name: [type: :string, required: true]
+        ],
+        callback: fn _args ->
+          {:ok,
+           [
+             ReqLLM.Message.ContentPart.text("Here is the file you requested:"),
+             ReqLLM.Message.ContentPart.file(pdf_bytes, "test.pdf", "application/pdf")
+           ]}
+        end
+      )
+    ]
+
+    base_opts =
+      param_bundles().deterministic
+      |> Keyword.put(:max_tokens, 256)
+
+    {:ok, resp1} =
+      ReqLLM.generate_text(
+        @model_spec,
+        "Call get_document with name=\"test.pdf\" to fetch the file, then quote the text it contains in full.",
+        fixture_opts(
+          "multimodal_tool_result_1",
+          base_opts ++
+            [
+              tools: tools,
+              tool_choice: %{type: "tool", name: "get_document"}
+            ]
+        )
+      )
+
+    tool_calls = ReqLLM.Response.tool_calls(resp1)
+    assert tool_calls != [], "expected the model to call get_document"
+
+    ctx2 = ReqLLM.Context.execute_and_append_tools(resp1.context, tool_calls, tools)
+
+    {:ok, resp2} =
+      ReqLLM.generate_text(
+        @model_spec,
+        ctx2,
+        fixture_opts("multimodal_tool_result_2", base_opts ++ [tools: tools])
+      )
+
+    text = ReqLLM.Response.text(resp2) || ""
+    assert text != "", "expected a follow-up response after the tool result"
+
+    assert String.match?(text, ~r/test pdf document/i),
+           "expected model to quote PDF contents in follow-up, got: #{text}"
+  end
+end

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -374,6 +374,206 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert function_response["response"]["temperature"] == 72
     end
 
+    test "encode_body nests file content in functionResponse.parts for Gemini 3+" do
+      {:ok, model} = ReqLLM.model("google:gemini-3-pro-preview")
+
+      pdf_bytes = <<37, 80, 68, 70, 1, 2, 3>>
+
+      tool_result = %ReqLLM.Message{
+        role: :tool,
+        name: "extract_pdf",
+        tool_call_id: "call_1",
+        content: [
+          ReqLLM.Message.ContentPart.text("Here is the file:"),
+          ReqLLM.Message.ContentPart.file(pdf_bytes, "doc.pdf", "application/pdf")
+        ],
+        metadata: %{}
+      }
+
+      context =
+        Context.new([
+          Context.user("Summarise this PDF."),
+          Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "call_1",
+                type: "function",
+                function: %{name: "extract_pdf", arguments: ~s({"path":"doc.pdf"})}
+              }
+            ]
+          ),
+          tool_result
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      tool_user_msg =
+        decoded["contents"]
+        |> Enum.find(fn entry ->
+          entry["role"] == "user" and
+            Enum.any?(entry["parts"], &Map.has_key?(&1, "functionResponse"))
+        end)
+
+      assert tool_user_msg, "expected a user message carrying functionResponse"
+
+      function_response_parts =
+        Enum.filter(tool_user_msg["parts"], &Map.has_key?(&1, "functionResponse"))
+
+      assert [function_response_part] = function_response_parts
+
+      function_response = function_response_part["functionResponse"]
+      assert function_response["name"] == "extract_pdf"
+
+      assert is_list(function_response["parts"]),
+             "functionResponse must carry a nested parts array on Gemini 3+"
+
+      assert Enum.any?(function_response["parts"], fn
+               %{"inline_data" => %{"mime_type" => "application/pdf", "data" => data}} ->
+                 Base.decode64!(data) == pdf_bytes
+
+               _ ->
+                 false
+             end),
+             "PDF payload must live inside functionResponse.parts"
+
+      refute Enum.any?(tool_user_msg["parts"], &Map.has_key?(&1, "inline_data")),
+             "PDF must not be emitted as a sibling inline_data part on Gemini 3+"
+
+      assert function_response["response"]["content"] =~ "Here is the file:",
+             "accompanying text must survive into functionResponse.response.content"
+    end
+
+    test "encode_body keeps legacy shape for Gemini 2.5 multimodal tool results" do
+      {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
+
+      pdf_bytes = <<37, 80, 68, 70, 1, 2, 3>>
+
+      tool_result = %ReqLLM.Message{
+        role: :tool,
+        name: "extract_pdf",
+        tool_call_id: "call_1",
+        content: [
+          ReqLLM.Message.ContentPart.text("Here is the file:"),
+          ReqLLM.Message.ContentPart.file(pdf_bytes, "doc.pdf", "application/pdf")
+        ],
+        metadata: %{}
+      }
+
+      context =
+        Context.new([
+          Context.user("Summarise this PDF."),
+          Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "call_1",
+                type: "function",
+                function: %{name: "extract_pdf", arguments: ~s({"path":"doc.pdf"})}
+              }
+            ]
+          ),
+          tool_result
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      tool_user_msg =
+        decoded["contents"]
+        |> Enum.find(fn entry ->
+          entry["role"] == "user" and
+            Enum.any?(entry["parts"], &Map.has_key?(&1, "functionResponse"))
+        end)
+
+      assert tool_user_msg
+
+      function_response_parts =
+        Enum.filter(tool_user_msg["parts"], &Map.has_key?(&1, "functionResponse"))
+
+      assert [function_response_part] = function_response_parts
+
+      refute Map.has_key?(function_response_part["functionResponse"], "parts"),
+             "Gemini 2.5 must not emit functionResponse.parts"
+
+      assert Enum.any?(tool_user_msg["parts"], fn
+               %{"inline_data" => %{"mime_type" => "application/pdf"}} -> true
+               _ -> false
+             end),
+             "Gemini 2.5 must keep the file as a sibling inline_data part (legacy behavior)"
+    end
+
+    test "encode_body keeps text-only tool results unchanged on Gemini 3+" do
+      {:ok, model} = ReqLLM.model("google:gemini-3-pro-preview")
+
+      tool_result = %ReqLLM.Message{
+        role: :tool,
+        name: "get_weather",
+        tool_call_id: "call_1",
+        content: [ReqLLM.Message.ContentPart.text("just text")],
+        metadata: %{}
+      }
+
+      context =
+        Context.new([
+          Context.user("Weather?"),
+          Context.assistant("",
+            tool_calls: [
+              %ReqLLM.ToolCall{
+                id: "call_1",
+                type: "function",
+                function: %{name: "get_weather", arguments: ~s({"location":"SF"})}
+              }
+            ]
+          ),
+          tool_result
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      tool_user_msg =
+        decoded["contents"]
+        |> Enum.find(fn entry ->
+          entry["role"] == "user" and
+            Enum.any?(entry["parts"], &Map.has_key?(&1, "functionResponse"))
+        end)
+
+      assert tool_user_msg
+
+      [function_response_part] =
+        Enum.filter(tool_user_msg["parts"], &Map.has_key?(&1, "functionResponse"))
+
+      refute Map.has_key?(function_response_part["functionResponse"], "parts"),
+             "text-only tool results must not gain a functionResponse.parts field"
+    end
+
     test "encode_body excludes id from functionCall parts" do
       {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
 

--- a/test/support/fixtures/google/gemini_3_pro_preview/multimodal_tool_result_1.json
+++ b/test/support/fixtures/google/gemini_3_pro_preview/multimodal_tool_result_1.json
@@ -1,0 +1,142 @@
+{
+  "model_spec": "google:gemini-3-pro-preview",
+  "provider": "google",
+  "request": {
+    "body": {
+      "b64": "eyJjb250ZW50cyI6W3sicGFydHMiOlt7InRleHQiOiJDYWxsIGdldF9kb2N1bWVudCB3aXRoIG5hbWU9XCJ0ZXN0LnBkZlwiIHRvIGZldGNoIHRoZSBmaWxlLCB0aGVuIHF1b3RlIHRoZSB0ZXh0IGl0IGNvbnRhaW5zIGluIGZ1bGwuIn1dLCJyb2xlIjoidXNlciJ9XSwiZ2VuZXJhdGlvbkNvbmZpZyI6eyJjYW5kaWRhdGVDb3VudCI6MSwibWF4T3V0cHV0VG9rZW5zIjoyNTYsInRlbXBlcmF0dXJlIjowLjB9LCJ0b29scyI6W3siZnVuY3Rpb25EZWNsYXJhdGlvbnMiOlt7ImRlc2NyaXB0aW9uIjoiRmV0Y2ggdGhlIHJlcXVlc3RlZCBkb2N1bWVudCBhbmQgcmV0dXJuIGl0cyByYXcgY29udGVudHMuIiwibmFtZSI6ImdldF9kb2N1bWVudCIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6eyJuYW1lIjp7InR5cGUiOiJzdHJpbmcifX0sInByb3BlcnR5T3JkZXJpbmciOlsibmFtZSJdLCJyZXF1aXJlZCI6WyJuYW1lIl0sInR5cGUiOiJvYmplY3QifX1dfV19"
+    },
+    "canonical_json": {
+      "contents": [
+        {
+          "parts": [
+            {
+              "text": "Call get_document with name=\"test.pdf\" to fetch the file, then quote the text it contains in full."
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "generationConfig": {
+        "candidateCount": 1,
+        "maxOutputTokens": 256,
+        "temperature": 0.0
+      },
+      "tools": [
+        {
+          "functionDeclarations": [
+            {
+              "description": "Fetch the requested document and return its raw contents.",
+              "name": "get_document",
+              "parameters": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "propertyOrdering": [
+                  "name"
+                ],
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "headers": {
+      "accept-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "user-agent": [
+        "req/0.5.17"
+      ]
+    },
+    "method": "post",
+    "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key=[REDACTED]"
+  },
+  "response": {
+    "body": {
+      "candidates": [
+        {
+          "content": {
+            "parts": [
+              {
+                "functionCall": {
+                  "args": {
+                    "name": "test.pdf"
+                  },
+                  "id": "8chljcyh",
+                  "name": "get_document"
+                },
+                "thoughtSignature": "EpgFCpUFAQw51scX3YZxs0iSf+TOcHSktDOoSeFBBaPTNiLC6yP3FFzl/fg61rPOzDhPnA2RdFwR3hZqAOi+4896lMxw17YzcM6ehy7dDT5qewrAJrj5qjcF+Iwf8rbC9i/dt+oqjCklaNpZR4U3EZoWvDeLosx3niHUsNQkz7v//bT9K6HdpE6T+rf9IkcMmxa+Hj202AUiXuODBRppa7NkI1PXxYh71olNzVGhB+wQcRlVc2Z1e7c2H0JZJChBhVfejKbll30z1hgb22pftE7EeSfmLWrFIiePSzSGnW0ARX+zF+eZd2m/tUxo1e8X39DvazH8NwCi90I4v7Zx3ofyA2iclrsmHKzV+zylBo0ZnfdPIvg6k7mB39fLq9O5tDwgijJecihutps56AlLk9Vs+aNXypWytl6UVRfS/Wson7xercPmp3I2Uvum7p9VuIVfJYcaJfwVd3UZuxHzkke3HOdQ2l8yPgQG7xZVHPspizaZw4SgwESxPo3h1lpLlQFG5zqjptu8wtoIJ7+Ro4ymyIx3e8872bt8n3+p601HERFu1mvwHKYwr/ajwzdBtkFhddrkT6WFqSjVJDycVhZTC3Ba+rXfrv5frFNb6OLVRP9xX/MQqJI3ViCUOFxo1Vw+QlT7FVWafCrt3UgbPent3AtylbDBIdVUvqrGJqkwlaGoCROavcUvvEpUxL6Qh7G0j6Klw8BbLJ5Nh7dPZq4Koq+xN+qN5tjddPvQqcSj+R1niC2A0FcTvJBiIGZMsOfrG8kEKuktpTA4862svzzvZfh05UQnelmfwj6ncwJ4qeUmEPx1EWntCAjfpxORVYeGBwzT7rgs2bFq/gXy6ZcwT1Uwn5yGyEB5m4Z7Z/AmBFAUKaRqJQcnZg=="
+              }
+            ],
+            "role": "model"
+          },
+          "finishMessage": "Model generated function call(s).",
+          "finishReason": "STOP",
+          "index": 0
+        }
+      ],
+      "modelVersion": "gemini-3.1-pro-preview",
+      "responseId": "jw0Lao7QIf6BkdUPo-OG2A4",
+      "usageMetadata": {
+        "candidatesTokenCount": 18,
+        "promptTokenCount": 73,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 73
+          }
+        ],
+        "serviceTier": "standard",
+        "thoughtsTokenCount": 160,
+        "totalTokenCount": 251
+      }
+    },
+    "headers": {
+      "alt-svc": [
+        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+      ],
+      "content-type": [
+        "application/json; charset=UTF-8"
+      ],
+      "date": [
+        "Mon, 18 May 2026 13:01:06 GMT"
+      ],
+      "server": [
+        "scaffolding on HTTPServer2"
+      ],
+      "server-timing": [
+        "gfet4t7; dur=3042"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "vary": [
+        "Origin",
+        "X-Origin",
+        "Referer"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-gemini-service-tier": [
+        "standard"
+      ],
+      "x-xss-protection": [
+        "0"
+      ]
+    },
+    "status": 200
+  }
+}

--- a/test/support/fixtures/google/gemini_3_pro_preview/multimodal_tool_result_2.json
+++ b/test/support/fixtures/google/gemini_3_pro_preview/multimodal_tool_result_2.json
@@ -1,0 +1,177 @@
+{
+  "model_spec": "google:gemini-3-pro-preview",
+  "provider": "google",
+  "request": {
+    "body": {
+      "b64": "eyJjb250ZW50cyI6W3sicGFydHMiOlt7InRleHQiOiJDYWxsIGdldF9kb2N1bWVudCB3aXRoIG5hbWU9XCJ0ZXN0LnBkZlwiIHRvIGZldGNoIHRoZSBmaWxlLCB0aGVuIHF1b3RlIHRoZSB0ZXh0IGl0IGNvbnRhaW5zIGluIGZ1bGwuIn1dLCJyb2xlIjoidXNlciJ9LHsicGFydHMiOlt7InRleHQiOiIifSx7ImZ1bmN0aW9uQ2FsbCI6eyJhcmdzIjp7Im5hbWUiOiJ0ZXN0LnBkZiJ9LCJuYW1lIjoiZ2V0X2RvY3VtZW50In0sInRob3VnaHRTaWduYXR1cmUiOiJjMnRwY0Y5MGFHOTFaMmgwWDNOcFoyNWhkSFZ5WlY5MllXeHBaR0YwYjNJPSJ9XSwicm9sZSI6Im1vZGVsIn0seyJwYXJ0cyI6W3siZnVuY3Rpb25SZXNwb25zZSI6eyJuYW1lIjoiZ2V0X2RvY3VtZW50IiwicGFydHMiOlt7ImlubGluZV9kYXRhIjp7ImRhdGEiOiJKVkJFUmkweExqUUtNU0F3SUc5aWFnbzhQQW92Vkhsd1pTQXZRMkYwWVd4dlp3b3ZVR0ZuWlhNZ01pQXdJRklLUGo0S1pXNWtiMkpxQ2pJZ01DQnZZbW9LUER3S0wxUjVjR1VnTDFCaFoyVnpDaTlMYVdSeklGc3pJREFnVWwwS0wwTnZkVzUwSURFS1BqNEtaVzVrYjJKcUNqTWdNQ0J2WW1vS1BEd0tMMVI1Y0dVZ0wxQmhaMlVLTDFCaGNtVnVkQ0F5SURBZ1Vnb3ZVbVZ6YjNWeVkyVnpJRHc4Q2k5R2IyNTBJRHc4Q2k5R01TQThQQW92Vkhsd1pTQXZSbTl1ZEFvdlUzVmlkSGx3WlNBdlZIbHdaVEVLTDBKaGMyVkdiMjUwSUM5SVpXeDJaWFJwWTJFS1BqNEtQajRLUGo0S0wwMWxaR2xoUW05NElGc3dJREFnTmpFeUlEYzVNbDBLTDBOdmJuUmxiblJ6SURRZ01DQlNDajQrQ21WdVpHOWlhZ28wSURBZ2IySnFDanc4Q2k5TVpXNW5kR2dnTkRRS1BqNEtjM1J5WldGdENrSlVDaTlHTVNBeE1pQlVaZ294TURBZ056QXdJRlJrQ2loVVpYTjBJRkJFUmlCRWIyTjFiV1Z1ZENrZ1ZHb0tSVlFLWlc1a2MzUnlaV0Z0Q21WdVpHOWlhZ3A0Y21WbUNqQWdOUW93TURBd01EQXdNREF3SURZMU5UTTFJR1lLTURBd01EQXdNREF3T1NBd01EQXdNQ0J1Q2pBd01EQXdNREF3TlRnZ01EQXdNREFnYmdvd01EQXdNREF3TVRFMUlEQXdNREF3SUc0S01EQXdNREF3TURNeE5DQXdNREF3TUNCdUNuUnlZV2xzWlhJS1BEd0tMMU5wZW1VZ05Rb3ZVbTl2ZENBeElEQWdVZ28rUGdwemRHRnlkSGh5WldZS05EQTNDaVVsUlU5R0NnPT0iLCJtaW1lX3R5cGUiOiJhcHBsaWNhdGlvbi9wZGYifX1dLCJyZXNwb25zZSI6eyJjb250ZW50IjoiSGVyZSBpcyB0aGUgZmlsZSB5b3UgcmVxdWVzdGVkOiJ9fX1dLCJyb2xlIjoidXNlciJ9XSwiZ2VuZXJhdGlvbkNvbmZpZyI6eyJjYW5kaWRhdGVDb3VudCI6MSwibWF4T3V0cHV0VG9rZW5zIjoyNTYsInRlbXBlcmF0dXJlIjowLjB9LCJ0b29scyI6W3siZnVuY3Rpb25EZWNsYXJhdGlvbnMiOlt7ImRlc2NyaXB0aW9uIjoiRmV0Y2ggdGhlIHJlcXVlc3RlZCBkb2N1bWVudCBhbmQgcmV0dXJuIGl0cyByYXcgY29udGVudHMuIiwibmFtZSI6ImdldF9kb2N1bWVudCIsInBhcmFtZXRlcnMiOnsicHJvcGVydGllcyI6eyJuYW1lIjp7InR5cGUiOiJzdHJpbmcifX0sInByb3BlcnR5T3JkZXJpbmciOlsibmFtZSJdLCJyZXF1aXJlZCI6WyJuYW1lIl0sInR5cGUiOiJvYmplY3QifX1dfV19"
+    },
+    "canonical_json": {
+      "contents": [
+        {
+          "parts": [
+            {
+              "text": "Call get_document with name=\"test.pdf\" to fetch the file, then quote the text it contains in full."
+            }
+          ],
+          "role": "user"
+        },
+        {
+          "parts": [
+            {
+              "text": ""
+            },
+            {
+              "functionCall": {
+                "args": {
+                  "name": "test.pdf"
+                },
+                "name": "get_document"
+              },
+              "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+            }
+          ],
+          "role": "model"
+        },
+        {
+          "parts": [
+            {
+              "functionResponse": {
+                "name": "get_document",
+                "parts": [
+                  {
+                    "inline_data": {
+                      "data": "JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5kb2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFszIDAgUl0KL0NvdW50IDEKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovUmVzb3VyY2VzIDw8Ci9Gb250IDw8Ci9GMSA8PAovVHlwZSAvRm9udAovU3VidHlwZSAvVHlwZTEKL0Jhc2VGb250IC9IZWx2ZXRpY2EKPj4KPj4KPj4KL01lZGlhQm94IFswIDAgNjEyIDc5Ml0KL0NvbnRlbnRzIDQgMCBSCj4+CmVuZG9iago0IDAgb2JqCjw8Ci9MZW5ndGggNDQKPj4Kc3RyZWFtCkJUCi9GMSAxMiBUZgoxMDAgNzAwIFRkCihUZXN0IFBERiBEb2N1bWVudCkgVGoKRVQKZW5kc3RyZWFtCmVuZG9iagp4cmVmCjAgNQowMDAwMDAwMDAwIDY1NTM1IGYKMDAwMDAwMDAwOSAwMDAwMCBuCjAwMDAwMDAwNTggMDAwMDAgbgowMDAwMDAwMTE1IDAwMDAwIG4KMDAwMDAwMDMxNCAwMDAwMCBuCnRyYWlsZXIKPDwKL1NpemUgNQovUm9vdCAxIDAgUgo+PgpzdGFydHhyZWYKNDA3CiUlRU9GCg==",
+                      "mime_type": "application/pdf"
+                    }
+                  }
+                ],
+                "response": {
+                  "content": "Here is the file you requested:"
+                }
+              }
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "generationConfig": {
+        "candidateCount": 1,
+        "maxOutputTokens": 256,
+        "temperature": 0.0
+      },
+      "tools": [
+        {
+          "functionDeclarations": [
+            {
+              "description": "Fetch the requested document and return its raw contents.",
+              "name": "get_document",
+              "parameters": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "propertyOrdering": [
+                  "name"
+                ],
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "headers": {
+      "accept-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "user-agent": [
+        "req/0.5.17"
+      ]
+    },
+    "method": "post",
+    "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key=[REDACTED]"
+  },
+  "response": {
+    "body": {
+      "candidates": [
+        {
+          "content": {
+            "parts": [
+              {
+                "text": "Here is the text contained in the document:\n\n> Test PDF Document",
+                "thoughtSignature": "EukECuYEAQw51sffnyUvWoM9bQ0vBiWKV9BPxA//Yjx6qtnVtPXtNcPp6IqLPCf4XcTCMwA7/Kg09+IXAC/xtQE1CZ1YxpsXxU+UuZgkVssw7uGtcKg2qd08PX66wAaEpFD8bnxwUj4S4nEdXHbCa2dQLkyCyAwdnxwVXAkOf6WH2hlFD+ZqzcrjtR+fQkhclHe8WqZkfOA4kT1ftkZ8DZEfFchxM2WEv25yvPrFXXU3BpujSIx3qE1HlL7qjFwjjoSpW5sERAEADZGwAvKXpcTVVqmT56rT4h0O+3JIUFOYUzV+EES/3njkQ7EyMRFJwyIxWt4vnFyrEZ2VtkEIiE8qRavr09sb83/g5wJesN6hiSC7GDhIzRzsRp/zvcbGqdV20GieclhMWWECo0V8wHL1p9eqrcm0tAXqcp0i+oax+LcLd67HuMpOGTpY1MpLGor4oFxpKuaTXoF+Ty6v5hXpd/yquGhT+uUL8arRIM4qJmlgLmN9RpIwyHuQvIfKjc5dPaKRQ05bRGmt1g4FGF+acIJ+eXmfLzm/dQ9uUFLvzwklMjKHaFAureFHf1rPSqaSZFBfxkqbmzVaaykLr4AdcL8SKPMbuIsVznpbyuQQ8bI5SEWxS4p3CuNIsWIUOcsMEaOWFs1noLlvSn5dM57xnA/FPk451sPeTgnOWGauKazuNMGra7XpCLtDVWG05ghOKq+T+OSHUvWsU8GyaSy9XqHSSoEQ6KveePYqYQDYLDPWrxIfWIM4hsPUUwpnL2W95cNX6hDEYxstDKozt3l6yCZ9Kop8uhbr4Pxx/0S28cHKoTobr91gdkg="
+              }
+            ],
+            "role": "model"
+          },
+          "finishReason": "STOP",
+          "index": 0
+        }
+      ],
+      "modelVersion": "gemini-3.1-pro-preview",
+      "responseId": "kg0LarLgJ4j3nsEPmY23wAE",
+      "usageMetadata": {
+        "candidatesTokenCount": 14,
+        "promptTokenCount": 1213,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 111
+          },
+          {
+            "modality": "IMAGE",
+            "tokenCount": 1102
+          }
+        ],
+        "serviceTier": "standard",
+        "thoughtsTokenCount": 154,
+        "totalTokenCount": 1381
+      }
+    },
+    "headers": {
+      "alt-svc": [
+        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+      ],
+      "content-type": [
+        "application/json; charset=UTF-8"
+      ],
+      "date": [
+        "Mon, 18 May 2026 13:01:10 GMT"
+      ],
+      "server": [
+        "scaffolding on HTTPServer2"
+      ],
+      "server-timing": [
+        "gfet4t7; dur=4087"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "vary": [
+        "Origin",
+        "X-Origin",
+        "Referer"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-gemini-service-tier": [
+        "standard"
+      ],
+      "x-xss-protection": [
+        "0"
+      ]
+    },
+    "status": 200
+  }
+}


### PR DESCRIPTION
## Summary
- nest Gemini 3+ multimodal tool-result content (`ContentPart.file`, image) under `functionResponse.parts` instead of emitting a free-floating `inline_data` sibling — gated on `gemini_3_or_later?/1` so Gemini 2.5 keeps the existing wire format
- fix accompanying text being silently dropped from `response.content`: `extract_content_text/1` missed the `%{type: "text", text: ...}` shape produced by `encode_context_to_openai_format` (atom key, string value)
- mirrors the OpenAI Responses API multimodal-tool-output approach in #624
- adds provider unit tests covering Gemini 3+ multimodal, Gemini 2.5 legacy shape, and Gemini 3+ text-only paths, plus a live-recorded coverage fixture against `google:gemini-3-pro-preview` where the model quotes the returned PDF's contents

Refs: https://ai.google.dev/gemini-api/docs/function-calling#multimodal-function-responses

## Testing
- `mix test test/providers/google_test.exs test/coverage/google/multimodal_tool_result_test.exs`
- `mix test`
- `mix quality`
- live fixture recorded against `google:gemini-3-pro-preview` — model quoted PDF contents in the follow-up turn, confirming the multimodal payload reached the model attached to its functionResponse