### PR TITLE
fix: strip minItems and maxItems from Anthropic schemas

### DIFF
--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1699,7 +1699,7 @@ defmodule ReqLLM.Providers.Anthropic do
 
   defp strip_constraints_recursive(schema) when is_map(schema) do
     schema
-    |> Map.drop(["minimum", "maximum", "minLength", "maxLength"])
+    |> Map.drop(["minimum", "maximum", "minLength", "maxLength", "minItems", "maxItems"])
     |> Map.new(fn
       {"properties", props} when is_map(props) ->
         {"properties", Map.new(props, fn {k, v} -> {k, strip_constraints_recursive(v)} end)}


### PR DESCRIPTION
## Summary

- Anthropic's structured output API rejects schemas containing `minItems` or `maxItems` on array-type properties with a 400 error: `output_format.schema: For 'array' type, property 'maxItems' is not supported`
- `strip_constraints_recursive/1` already strips the analogous numeric/string constraints (`minimum`, `maximum`, `minLength`, `maxLength`) but was missing the two array equivalents
- This PR adds `"minItems"` and `"maxItems"` to the `Map.drop/2` call

## Test plan

- [ ] Verify a schema with `maxItems` on an array property no longer raises a 400 from Anthropic's API
- [ ] Verify `minItems` is also stripped
- [ ] Verify other constraints (`minimum`, `maximum`, `minLength`, `maxLength`) are still stripped (no regression)
- [ ] Verify the fix applies to both `prepare_json_schema_request/4` and `prepare_strict_tool_request/4` code paths (both call `strip_constraints_recursive/1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)