### PR TITLE
feat(openai): include encrypted reasoning content

### DIFF
--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -150,6 +150,11 @@ defmodule ReqLLM.Providers.OpenAI do
       type: :integer,
       doc: "Maximum output tokens for Responses API models"
     ],
+    include: [
+      type: {:list, :string},
+      doc:
+        "Responses API include values, such as reasoning.encrypted_content for reasoning signatures"
+    ],
     openai_structured_output_mode: [
       type: {:in, [:auto, :json_schema, :tool_strict]},
       default: :auto,

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -75,6 +75,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     "x_search_call" => :x_search_call
   }
   @assistant_phases ["commentary", "final_answer"]
+  @reasoning_encrypted_content_include ["reasoning.encrypted_content"]
 
   @impl true
   def path, do: "/responses"
@@ -680,6 +681,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     tool_choice = encode_tool_choice(opts_map[:tool_choice])
     reasoning = encode_reasoning_effort(opts_map[:reasoning_effort])
     service_tier = opts_map[:service_tier] || provider_opts[:service_tier]
+    include = response_include(provider_opts, model_name)
 
     text_format = encode_text_format(provider_opts[:response_format], provider_opts[:verbosity])
 
@@ -701,6 +703,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("tool_choice", tool_choice)
       |> maybe_put_string("parallel_tool_calls", opts_map[:parallel_tool_calls])
       |> maybe_put_string("service_tier", service_tier)
+      |> maybe_put_string("include", include)
       |> maybe_put_string("text", text_format)
 
     body =
@@ -721,6 +724,19 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp default_store(model_name) do
     !ReqLLM.Providers.OpenAI.AdapterHelpers.codex_model?(model_name)
+  end
+
+  defp response_include(provider_opts, model_name) do
+    cond do
+      Keyword.has_key?(provider_opts, :include) ->
+        provider_opts[:include]
+
+      ReqLLM.Providers.OpenAI.AdapterHelpers.reasoning_model?(model_name) ->
+        @reasoning_encrypted_content_include
+
+      true ->
+        nil
+    end
   end
 
   defp encode_tool_message_inline(%ReqLLM.Message{role: :tool} = msg) do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -261,10 +261,18 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       end
 
     meta = Map.merge(meta, extract_assistant_phase_metadata(response_output))
+
+    meta =
+      maybe_put_reasoning_details(meta, extract_reasoning_details_from_segments(response_output))
+
     meta = merge_response_provider_meta(meta, data["response"] || %{})
 
     [ReqLLM.StreamChunk.meta(meta)]
   end
+
+  defp maybe_put_reasoning_details(meta, []), do: meta
+
+  defp maybe_put_reasoning_details(meta, details), do: Map.put(meta, :reasoning_details, details)
 
   # Mirrors the drop-list used by the non-streaming response builder (see
   # `decode_response_body/4` ~line 1546) so streaming and non-streaming

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1475,6 +1475,40 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              ]
     end
 
+    test "extracts encrypted reasoning details from completed event output items", %{model: model} do
+      event = %{
+        data: %{
+          "event" => "response.completed",
+          "response" => %{
+            "id" => "resp_123",
+            "output" => [
+              %{
+                "id" => "rs_123",
+                "type" => "reasoning",
+                "summary" => [%{"type" => "summary_text", "text" => "Checked constraints."}],
+                "encrypted_content" => "encrypted_reasoning_payload"
+              },
+              %{
+                "type" => "message",
+                "content" => [%{"type" => "output_text", "text" => "OK"}]
+              }
+            ]
+          }
+        }
+      }
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert [detail] = chunk.metadata.reasoning_details
+      assert detail.text == "Checked constraints."
+      assert detail.signature == "encrypted_reasoning_payload"
+      assert detail.encrypted? == true
+      assert detail.provider == :openai
+      assert detail.format == "openai-responses-v1"
+      assert detail.index == 0
+      assert detail.provider_data == %{"id" => "rs_123", "type" => "reasoning"}
+    end
+
     test "decodes incomplete event", %{model: model} do
       event = %{data: %{"event" => "response.incomplete", "reason" => "length"}}
 

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -445,6 +445,43 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       refute Map.has_key?(body, "reasoning")
     end
 
+    test "passes explicit include through unchanged" do
+      include = ["reasoning.encrypted_content", "file_search_call.results"]
+      request = build_request(provider_options: [include: include])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      assert body["include"] == include
+    end
+
+    test "defaults include for reasoning models" do
+      request = build_request(id: "gpt-5-mini")
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      assert body["include"] == ["reasoning.encrypted_content"]
+    end
+
+    test "respects empty include override for reasoning models" do
+      request = build_request(id: "gpt-5-mini", provider_options: [include: []])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      assert body["include"] == []
+    end
+
+    test "does not default include for non-reasoning Responses models" do
+      request = build_request(id: "gpt-4o-mini")
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "include")
+    end
+
     test "encodes input messages correctly" do
       msg1 = %ReqLLM.Message{
         role: :user,


### PR DESCRIPTION
## Summary
- add OpenAI `include` provider option support
- pass `include` through to Responses API request bodies exactly when callers provide it
- default Responses API reasoning models to `include: ["reasoning.encrypted_content"]` when omitted, while preserving explicit empty overrides

Fixes #693

## Validation
- `mix test test/provider/openai/responses_api_unit_test.exs`
- `mix quality`
- `mix test`