### PR TITLE
fix(anthropic): avoid blank system prompt blocks

### DIFF
--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -172,7 +172,7 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   end
 
   defp encode_system_message(%ReqLLM.Message{content: content}) when is_binary(content) do
-    if content == "" do
+    if String.trim(content) == "" do
       []
     else
       [%{type: "text", text: content}]
@@ -182,10 +182,18 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   defp encode_system_message(%ReqLLM.Message{content: content}) when is_list(content) do
     content
     |> Enum.map(&encode_content_part/1)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.reject(&blank_system_content_block?/1)
   end
 
   defp encode_system_message(_message), do: []
+
+  defp blank_system_content_block?(nil), do: true
+
+  defp blank_system_content_block?(%{type: "text", text: text}) when is_binary(text) do
+    String.trim(text) == ""
+  end
+
+  defp blank_system_content_block?(_block), do: false
 
   defp normalize_system_content([]), do: nil
   defp normalize_system_content([%{type: "text", text: text}]), do: text

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -167,7 +167,6 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     messages
     |> Enum.map(&encode_system_message/1)
     |> Enum.reject(&(&1 == []))
-    |> Enum.intersperse([%{type: "text", text: "\n\n"}])
     |> List.flatten()
     |> normalize_system_content()
   end

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -918,7 +918,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
              end)
     end
 
-    test "encode_request combines multiple system messages" do
+    test "encode_request encodes multiple system messages as non-empty blocks" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 
       context =
@@ -932,7 +932,6 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
       assert request[:system] == [
                %{type: "text", text: "Talk like a pirate"},
-               %{type: "text", text: "\n\n"},
                %{type: "text", text: "Respond in verses"}
              ]
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -938,6 +938,33 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert request[:messages] == [%{role: "user", content: "Tell me about Elixir"}]
     end
 
+    test "encode_request drops whitespace-only system text blocks" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.system("\n\n"),
+          ReqLLM.Context.system("Talk like a pirate"),
+          ReqLLM.Context.user("Tell me about Elixir"),
+          %ReqLLM.Message{
+            role: :system,
+            content: [
+              ReqLLM.Message.ContentPart.text("\t  "),
+              ReqLLM.Message.ContentPart.text("Respond in verses")
+            ]
+          }
+        ])
+
+      request = ReqLLM.Providers.Anthropic.Context.encode_request(context, model)
+
+      assert request[:system] == [
+               %{type: "text", text: "Talk like a pirate"},
+               %{type: "text", text: "Respond in verses"}
+             ]
+
+      assert request[:messages] == [%{role: "user", content: "Tell me about Elixir"}]
+    end
+
     test "encode_body sanitizes OpenAI-style tool call IDs for Anthropic" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 


### PR DESCRIPTION
## Summary
- stop emitting a standalone whitespace `system` content block between multiple Anthropic system messages
- drop whitespace-only Anthropic system text blocks supplied directly by users or multipart content
- update Anthropic encoding regression tests to assert only non-empty system blocks

Closes #711

## Tests
- `mix test test/providers/anthropic_test.exs:921 test/providers/anthropic_test.exs:941`
- `mix test test/providers/anthropic_test.exs test/provider/azure/anthropic_test.exs test/req_llm/providers/amazon_bedrock/anthropic_test.exs test/req_llm/providers/anthropic_prompt_cache_test.exs`
- `mix quality`
- `mix test`