### PR TITLE
feat: add NEAR AI Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ LLM APIs are inconsistent. ReqLLM provides a unified, idiomatic Elixir interface
 - **High-level API** – Vercel AI SDK-inspired functions (`generate_text/3`, `stream_text/3`, `generate_object/4` and more) that work uniformly across providers. Standard features, minimal configuration.
 - **Low-level API** – Direct Req plugin access for full HTTP control. Built around OpenAI Chat Completions baseline with provider-specific callbacks for non-compatible APIs (e.g., Anthropic).
 
-**20 Supported Providers:**
+**21 Supported Providers:**
 
 | Provider | ID | Guide |
 |---|---|---|
@@ -37,6 +37,7 @@ LLM APIs are inconsistent. ReqLLM provides a unified, idiomatic Elixir interface
 | [Fireworks AI](https://fireworks.ai) | `fireworks_ai` | [Guide](guides/fireworks_ai.md) |
 | [Meta Llama](https://llama.meta.com) | `meta` | [Guide](guides/meta.md) |
 | [MiniMax](https://www.minimax.io) | `minimax` | — |
+| [NEAR AI Cloud](https://cloud.near.ai) | `nearai` | [Guide](guides/nearai.md) |
 | [Z.AI](https://z.ai) | `zai` | [Guide](guides/zai.md) |
 | [Z.AI Coder](https://z.ai) | `zai_coder` | [Guide](guides/zai_coder.md) |
 | [Zenmux](https://zenmux.ai) | `zenmux` | [Guide](guides/zenmux.md) |
@@ -461,7 +462,7 @@ This approach gives you full control over the Req pipeline, allowing you to add 
 - [Mix Tasks](guides/mix-tasks.md) – model sync, compatibility testing, code generation
 - [Fixture Testing](guides/fixture-testing.md) – model validation and supported models
 - [Adding a Provider](guides/adding_a_provider.md) – extend with new providers
-- Provider Guides: [Anthropic](guides/anthropic.md), [OpenAI](guides/openai.md), [Google](guides/google.md), [Google Vertex](guides/google_vertex.md), [xAI](guides/xai.md), [Groq](guides/groq.md), [OpenRouter](guides/openrouter.md), [Amazon Bedrock](guides/amazon_bedrock.md), [Azure](guides/azure.md), [Cerebras](guides/cerebras.md), [Meta](guides/meta.md), [Z.AI](guides/zai.md), [Z.AI Coder](guides/zai_coder.md), [Zenmux](guides/zenmux.md), [Ollama/vLLM](guides/ollama.md)
+- Provider Guides: [Anthropic](guides/anthropic.md), [OpenAI](guides/openai.md), [Google](guides/google.md), [Google Vertex](guides/google_vertex.md), [xAI](guides/xai.md), [Groq](guides/groq.md), [OpenRouter](guides/openrouter.md), [Amazon Bedrock](guides/amazon_bedrock.md), [Azure](guides/azure.md), [Cerebras](guides/cerebras.md), [Meta](guides/meta.md), [NEAR AI Cloud](guides/nearai.md), [Z.AI](guides/zai.md), [Z.AI Coder](guides/zai_coder.md), [Zenmux](guides/zenmux.md), [Ollama/vLLM](guides/ollama.md)
 
 ## Roadmap & Status
 

--- a/guides/nearai.md
+++ b/guides/nearai.md
@@ -1,0 +1,68 @@
+# NEAR AI Cloud
+
+TEE-backed private inference through NEAR AI Cloud's OpenAI-compatible Chat Completions API.
+
+## Configuration
+
+```bash
+NEARAI_API_KEY=your-api-key
+```
+
+Or programmatically:
+
+```elixir
+ReqLLM.put_key(:nearai_api_key, "your-api-key")
+```
+
+## Model Specs
+
+NEAR AI Cloud model IDs use provider-style paths such as `anthropic/claude-haiku-4-5`.
+Use the public catalog endpoint to inspect currently available models:
+
+```bash
+curl https://cloud-api.near.ai/v1/model/list
+```
+
+Then call a model with the `nearai:` prefix:
+
+```elixir
+ReqLLM.generate_text(
+  "nearai:anthropic/claude-haiku-4-5",
+  "Hello!"
+)
+```
+
+If a model is not in the shared registry yet, a full explicit model spec also works:
+
+```elixir
+model =
+  ReqLLM.model!(%{
+    provider: :nearai,
+    id: "openai/gpt-5.4-mini",
+    base_url: "https://cloud-api.near.ai/v1"
+  })
+
+ReqLLM.generate_text(model, "Hello!")
+```
+
+## Compatibility Notes
+
+NEAR AI Cloud uses the standard OpenAI Chat Completions request shape with Bearer token auth.
+ReqLLM sends chat requests to `https://cloud-api.near.ai/v1/chat/completions`.
+
+The provider translates `max_completion_tokens` to `max_tokens` because NEAR AI Cloud expects
+the Chat Completions token limit field. Unsupported reasoning options are removed before the
+request is sent, and strict tool schemas are sent without OpenAI's `strict` marker.
+
+Streaming uses the same OpenAI-compatible SSE handling as other compatible providers.
+
+## TEE Metadata
+
+The model catalog includes per-model metadata such as `verifiable` and `attestationSupported`.
+Use those fields when you need to distinguish TEE-verifiable models from proxied external models.
+
+## Resources
+
+- NEAR AI Cloud API base URL: `https://cloud-api.near.ai/v1`
+- Public model catalog: `https://cloud-api.near.ai/v1/model/list`
+- Model Specs Guide: [Model Specs](model-specs.md)

--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -89,6 +89,7 @@ defmodule Mix.Tasks.ReqLlm.Gen do
       anthropic   - Anthropic Claude models
       groq        - Groq models (fast inference)
       google      - Google Gemini models
+      nearai      - NEAR AI Cloud TEE inference
       openrouter  - OpenRouter (access to multiple providers)
       xai         - xAI Grok models
 
@@ -106,6 +107,7 @@ defmodule Mix.Tasks.ReqLlm.Gen do
       OPENAI_API_KEY      - For OpenAI models
       ANTHROPIC_API_KEY   - For Anthropic models
       GOOGLE_API_KEY      - For Google models
+      NEARAI_API_KEY      - For NEAR AI Cloud models
       OPENROUTER_API_KEY  - For OpenRouter
       XAI_API_KEY         - For xAI models
 
@@ -134,6 +136,7 @@ defmodule Mix.Tasks.ReqLlm.Gen do
       anthropic   - Good support, tool-based JSON generation
       groq        - Fast streaming, limited JSON support
       google      - Experimental JSON/streaming support
+      nearai      - OpenAI-compatible TEE inference
       openrouter  - Depends on underlying model
       xai         - Basic support across modes
   """

--- a/lib/req_llm/providers/nearai.ex
+++ b/lib/req_llm/providers/nearai.ex
@@ -1,0 +1,140 @@
+defmodule ReqLLM.Providers.NearAI do
+  @moduledoc """
+  NEAR AI Cloud provider using the OpenAI-compatible Chat Completions API.
+
+  NEAR AI Cloud exposes TEE-backed inference through an OpenAI-compatible
+  endpoint at `https://cloud-api.near.ai/v1`. ReqLLM reuses the shared OpenAI
+  wire-format implementation and adds NEAR-specific compatibility handling:
+
+  - `max_completion_tokens` is translated to `max_tokens`
+  - unsupported reasoning options are removed before the request is sent
+  - strict tool schemas are sent without OpenAI's `strict` marker
+
+  ## Configuration
+
+      NEARAI_API_KEY=your-api-key
+
+  ## Examples
+
+      ReqLLM.generate_text("nearai:anthropic/claude-haiku-4-5", "Hello!")
+
+      ReqLLM.stream_text("nearai:openai/gpt-5.4-mini", "Tell me a story",
+        max_tokens: 512
+      )
+  """
+
+  use ReqLLM.Provider,
+    id: :nearai,
+    default_base_url: "https://cloud-api.near.ai/v1",
+    default_env_key: "NEARAI_API_KEY"
+
+  use ReqLLM.Provider.Defaults
+
+  @provider_schema [
+    max_completion_tokens: [
+      type: :pos_integer,
+      doc:
+        "Alias for max_tokens. NEAR AI Cloud expects the OpenAI Chat Completions max_tokens field."
+    ]
+  ]
+
+  @doc false
+  def display_name, do: "NEAR AI Cloud"
+
+  @impl ReqLLM.Provider
+  def translate_options(_operation, _model, opts) do
+    warnings = []
+
+    {max_completion_tokens, opts} = Keyword.pop(opts, :max_completion_tokens)
+    {opts, warnings} = translate_max_completion_tokens(max_completion_tokens, opts, warnings)
+    {opts, warnings} = drop_unsupported_reasoning_options(opts, warnings)
+
+    {opts, Enum.reverse(warnings)}
+  end
+
+  @impl ReqLLM.Provider
+  def build_body(request) do
+    request
+    |> ReqLLM.Provider.Defaults.default_build_body()
+    |> put_max_completion_alias(request.options)
+    |> strip_strict_from_tools()
+  end
+
+  defp translate_max_completion_tokens(nil, opts, warnings), do: {opts, warnings}
+
+  defp translate_max_completion_tokens(max_completion_tokens, opts, warnings) do
+    if Keyword.has_key?(opts, :max_tokens) do
+      {opts,
+       [
+         "NEAR AI Cloud expects max_tokens; ignored max_completion_tokens because max_tokens is set."
+         | warnings
+       ]}
+    else
+      {Keyword.put(opts, :max_tokens, max_completion_tokens),
+       [
+         "NEAR AI Cloud expects max_tokens; translated max_completion_tokens to max_tokens."
+         | warnings
+       ]}
+    end
+  end
+
+  defp drop_unsupported_reasoning_options(opts, warnings) do
+    {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
+    {reasoning_token_budget, opts} = Keyword.pop(opts, :reasoning_token_budget)
+
+    warnings =
+      if reasoning_effort && reasoning_effort != :default do
+        [
+          "NEAR AI Cloud does not support reasoning_effort; removed it from the request."
+          | warnings
+        ]
+      else
+        warnings
+      end
+
+    warnings =
+      if reasoning_token_budget do
+        [
+          "NEAR AI Cloud does not expose reasoning_token_budget on the OpenAI-compatible endpoint."
+          | warnings
+        ]
+      else
+        warnings
+      end
+
+    {opts, warnings}
+  end
+
+  defp put_max_completion_alias(body, options) do
+    cond do
+      Map.has_key?(body, :max_tokens) or Map.has_key?(body, "max_tokens") ->
+        body
+
+      options[:max_completion_tokens] ->
+        Map.put(body, :max_tokens, options[:max_completion_tokens])
+
+      true ->
+        body
+    end
+  end
+
+  defp strip_strict_from_tools(%{tools: tools} = body) when is_list(tools) do
+    %{body | tools: Enum.map(tools, &strip_tool_strict/1)}
+  end
+
+  defp strip_strict_from_tools(%{"tools" => tools} = body) when is_list(tools) do
+    %{body | "tools" => Enum.map(tools, &strip_tool_strict/1)}
+  end
+
+  defp strip_strict_from_tools(body), do: body
+
+  defp strip_tool_strict(%{"function" => function} = tool) when is_map(function) do
+    %{tool | "function" => Map.delete(function, "strict")}
+  end
+
+  defp strip_tool_strict(%{function: function} = tool) when is_map(function) do
+    %{tool | function: function |> Map.delete(:strict) |> Map.delete("strict")}
+  end
+
+  defp strip_tool_strict(tool), do: tool
+end

--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,7 @@ defmodule ReqLLM.MixProject do
           "guides/deepseek.md",
           "guides/fireworks_ai.md",
           "guides/meta.md",
+          "guides/nearai.md",
           "guides/zenmux.md",
           "guides/zai.md",
           "guides/zai_coder.md"
@@ -110,6 +111,7 @@ defmodule ReqLLM.MixProject do
             "guides/deepseek.md",
             "guides/fireworks_ai.md",
             "guides/meta.md",
+            "guides/nearai.md",
             "guides/zenmux.md",
             "guides/zai.md",
             "guides/zai_coder.md"

--- a/test/providers/nearai_test.exs
+++ b/test/providers/nearai_test.exs
@@ -1,0 +1,196 @@
+defmodule ReqLLM.Providers.NearAITest do
+  use ReqLLM.ProviderCase, provider: ReqLLM.Providers.NearAI
+
+  import ExUnit.CaptureIO
+
+  alias ReqLLM.Providers.NearAI
+
+  defp nearai_model(model_id \\ "anthropic/claude-haiku-4-5") do
+    %LLMDB.Model{
+      id: model_id,
+      model: model_id,
+      provider_model_id: model_id,
+      provider: :nearai,
+      name: model_id,
+      family: "nearai-openai-compatible",
+      capabilities: %{chat: true, tools: %{enabled: true}},
+      limits: %{context: 128_000, output: 4096},
+      extra: %{wire: %{protocol: "openai_chat"}}
+    }
+  end
+
+  describe "provider contract" do
+    test "provider identity and configuration" do
+      assert NearAI.provider_id() == :nearai
+      assert NearAI.base_url() == "https://cloud-api.near.ai/v1"
+      assert NearAI.default_env_key() == "NEARAI_API_KEY"
+      assert NearAI.display_name() == "NEAR AI Cloud"
+    end
+
+    test "provider schema exposes NEAR compatibility options" do
+      schema_keys = NearAI.provider_schema().schema |> Keyword.keys()
+
+      assert :max_completion_tokens in schema_keys
+    end
+
+    test "provider_extended_generation_schema includes all core keys" do
+      extended_schema = NearAI.provider_extended_generation_schema()
+      extended_keys = extended_schema.schema |> Keyword.keys()
+      core_keys = ReqLLM.Provider.Options.all_generation_keys()
+      core_without_meta = Enum.reject(core_keys, &(&1 == :provider_options))
+
+      for core_key <- core_without_meta do
+        assert core_key in extended_keys
+      end
+    end
+  end
+
+  describe "model fallback" do
+    test "resolves NEAR model strings before LLMDB catalog support" do
+      capture_io(:stderr, fn ->
+        assert {:ok, model} = ReqLLM.model("nearai:anthropic/claude-haiku-4-5")
+        assert model.provider == :nearai
+        assert model.id == "anthropic/claude-haiku-4-5"
+      end)
+    end
+  end
+
+  describe "request preparation" do
+    test "prepare_request for :chat creates /chat/completions request" do
+      {:ok, request} =
+        NearAI.prepare_request(:chat, nearai_model(), "Hello world", temperature: 0.7)
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/chat/completions"
+      assert request.method == :post
+      assert request.options[:base_url] == "https://cloud-api.near.ai/v1"
+    end
+  end
+
+  describe "authentication wiring" do
+    test "attach adds Bearer authorization header and pipeline steps" do
+      attached = NearAI.attach(Req.new(), nearai_model(), [])
+
+      auth_header = attached.headers["authorization"]
+      assert auth_header != nil
+      assert String.starts_with?(List.first(auth_header), "Bearer ")
+
+      assert :llm_encode_body in Keyword.keys(attached.request_steps)
+      assert :llm_decode_response in Keyword.keys(attached.response_steps)
+    end
+  end
+
+  describe "option translation and body encoding" do
+    test "translate_options maps max_completion_tokens and removes unsupported reasoning options" do
+      {translated, warnings} =
+        NearAI.translate_options(
+          :chat,
+          nearai_model(),
+          max_completion_tokens: 256,
+          reasoning_effort: :high,
+          reasoning_token_budget: 1000
+        )
+
+      assert translated[:max_tokens] == 256
+      refute Keyword.has_key?(translated, :max_completion_tokens)
+      refute Keyword.has_key?(translated, :reasoning_effort)
+      refute Keyword.has_key?(translated, :reasoning_token_budget)
+      assert length(warnings) == 3
+    end
+
+    test "translate_options preserves explicit max_tokens over max_completion_tokens" do
+      {translated, warnings} =
+        NearAI.translate_options(
+          :chat,
+          nearai_model(),
+          max_tokens: 128,
+          max_completion_tokens: 256
+        )
+
+      assert translated[:max_tokens] == 128
+      refute Keyword.has_key?(translated, :max_completion_tokens)
+      assert [warning] = warnings
+      assert warning =~ "ignored max_completion_tokens"
+    end
+
+    test "encode_body emits NEAR-compatible chat body" do
+      request = %Req.Request{
+        options: [
+          context: context_fixture(),
+          model: "anthropic/claude-haiku-4-5",
+          stream: false,
+          max_completion_tokens: 512,
+          reasoning_effort: :high
+        ]
+      }
+
+      encoded_request = NearAI.encode_body(request)
+      assert_no_duplicate_json_keys(encoded_request.body)
+      decoded = Jason.decode!(encoded_request.body)
+
+      assert decoded["model"] == "anthropic/claude-haiku-4-5"
+      assert decoded["max_tokens"] == 512
+      assert decoded["stream"] == false
+      refute Map.has_key?(decoded, "max_completion_tokens")
+      refute Map.has_key?(decoded, "reasoning_effort")
+      assert is_list(decoded["messages"])
+    end
+
+    test "encode_body strips strict markers from tools" do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Get the weather",
+          parameter_schema: [
+            location: [type: :string, required: true, doc: "City name"]
+          ],
+          callback: fn _ -> {:ok, "sunny"} end,
+          strict: true
+        )
+
+      request = %Req.Request{
+        options: [
+          context: context_fixture(),
+          model: "anthropic/claude-haiku-4-5",
+          stream: false,
+          tools: [tool]
+        ]
+      }
+
+      encoded_request = NearAI.encode_body(request)
+      decoded = Jason.decode!(encoded_request.body)
+      function = decoded["tools"] |> hd() |> Map.fetch!("function")
+
+      assert function["name"] == "get_weather"
+      refute Map.has_key?(function, "strict")
+    end
+  end
+
+  describe "response decoding" do
+    test "decode_response handles successful OpenAI-compatible responses" do
+      mock_resp = %Req.Response{
+        status: 200,
+        body:
+          openai_format_json_fixture(
+            model: "anthropic/claude-haiku-4-5",
+            content: "Hello from NEAR AI Cloud."
+          )
+      }
+
+      context = context_fixture()
+
+      mock_req = %Req.Request{
+        options: [context: context, stream: false, id: "nearai:anthropic/claude-haiku-4-5"],
+        private: %{req_llm_model: nearai_model()}
+      }
+
+      {req, resp} = NearAI.decode_response({mock_req, mock_resp})
+
+      assert req == mock_req
+      assert %ReqLLM.Response{} = resp.body
+      assert ReqLLM.Response.text(resp.body) == "Hello from NEAR AI Cloud."
+      assert resp.body.usage.input_tokens == 10
+      assert resp.body.usage.output_tokens == 8
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds NEAR AI Cloud as an OpenAI-compatible provider for TEE-backed inference. The provider uses `NEARAI_API_KEY`, the `https://cloud-api.near.ai/v1` base URL, and ReqLLM's shared Chat Completions request/response handling.

Implementation notes:

- Maps `max_completion_tokens` to `max_tokens` for NEAR AI Cloud compatibility.
- Removes unsupported reasoning options and strips OpenAI `strict` tool-schema markers before encoding requests.
- Adds provider documentation, README wiring, docs config, and provider-focused tests.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None.

## Testing

- [x] Targeted tests pass (`mix test test/providers/nearai_test.exs test/req_llm/providers_test.exs`)
- [x] Format check passes (`mix format --check-formatted`)
- [x] Compile check passes (`mix compile --warnings-as-errors`)
- [ ] Full test suite pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

None.
