### PR TITLE
fix: use actual provider prefix in ensure_deep_research_tools LLMDB lookup

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1352,9 +1352,10 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp ensure_deep_research_tools(tools, request) do
     model_name = request.options[:model] || request.options[:id]
+    provider = request.options[:provider] || "openai"
 
     if is_binary(model_name) and model_name != "" do
-      case ReqLLM.model("openai:#{model_name}") do
+      case ReqLLM.model("#{provider}:#{model_name}") do
         {:ok, model} ->
           category = get_in(model, [Access.key(:extra, %{}), :category])
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -282,7 +282,7 @@ defmodule ReqLLM.Providers.XAI do
 
       req_keys =
         supported_provider_options() ++
-          [:context, :operation, :text, :stream, :model, :provider_options, :xai_api_type]
+          [:context, :operation, :text, :stream, :model, :provider, :provider_options, :xai_api_type]
 
       path = if use_responses, do: "/responses", else: "/chat/completions"
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -282,7 +282,16 @@ defmodule ReqLLM.Providers.XAI do
 
       req_keys =
         supported_provider_options() ++
-          [:context, :operation, :text, :stream, :model, :provider, :provider_options, :xai_api_type]
+          [
+            :context,
+            :operation,
+            :text,
+            :stream,
+            :model,
+            :provider,
+            :provider_options,
+            :xai_api_type
+          ]
 
       path = if use_responses, do: "/responses", else: "/chat/completions"
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -299,6 +299,7 @@ defmodule ReqLLM.Providers.XAI do
           Keyword.take(processed_opts, req_keys) ++
             [
               model: model.id,
+              provider: "xai",
               base_url: Keyword.get(processed_opts, :base_url, default_base_url()),
               xai_api_type: if(use_responses, do: :responses, else: :chat)
             ]


### PR DESCRIPTION
## Summary

- `ensure_deep_research_tools/2` in `ResponsesAPI` hardcoded `"openai:"` when looking up a model in LLMDB, even when the request was routed through a different provider (e.g. xAI)
- xAI Live Search routes through `ResponsesAPI.encode_body/1` — so a model like `xai:grok-4-fast` triggered a lookup for `openai:grok-4-fast`, which is not in the LLMDB catalog, emitting a spurious `"Using unverified model"` warning
- Added `provider: "xai"` to xAI request options so the lookup uses the correct catalog entry
- `ensure_deep_research_tools` now uses `request.options[:provider] || "openai"` — OpenAI requests are unaffected

## Root cause

```
xAI.prepare_chat_request → stores model: "grok-4-fast" (bare id, no provider)
xAI.encode_responses_body → ResponsesAPI.encode_body
ResponsesAPI.ensure_deep_research_tools → ReqLLM.model("openai:grok-4-fast")  ← wrong prefix
LLMDB lookup fails → "Using unverified model" warning
```

## Test plan

- [ ] xAI Responses API call with `xai_tools: [%{type: "web_search"}]` no longer emits `"Using unverified model: openai:grok-4-fast"`
- [ ] OpenAI Responses API calls continue to resolve models correctly (fallback to `"openai"` prefix)
- [ ] Deep-research model auto-injection still works for OpenAI deep-research models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### PS: @mikehostetler Unsure this is a proper fix at all, in the sense that it feels wrong to have a provider key inside the xai provider :)