### PR TITLE
fix: preserve xAI model metadata in Responses API lookup

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1351,27 +1351,47 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   defp ensure_deep_research_tools(tools, request) do
+    case request_model(request) || lookup_request_model(request) do
+      %LLMDB.Model{} = model ->
+        maybe_ensure_deep_research_tools(tools, model)
+
+      _ ->
+        tools
+    end
+  end
+
+  defp request_model(%Req.Request{} = request) do
+    Req.Request.get_private(request, :req_llm_model) || request.options[:req_llm_model]
+  end
+
+  defp request_model(%{options: options}) do
+    options[:req_llm_model]
+  end
+
+  defp request_model(_), do: nil
+
+  defp lookup_request_model(request) do
     model_name = request.options[:model] || request.options[:id]
-    provider = request.options[:provider] || "openai"
 
     if is_binary(model_name) and model_name != "" do
-      case ReqLLM.model("#{provider}:#{model_name}") do
-        {:ok, model} ->
-          category = get_in(model, [Access.key(:extra, %{}), :category])
-
-          case category do
-            "deep_research" ->
-              ensure_deep_research_tool_present(tools)
-
-            _ ->
-              tools
-          end
-
-        _ ->
-          tools
+      case ReqLLM.model("openai:#{model_name}") do
+        {:ok, model} -> model
+        _ -> nil
       end
     else
-      tools
+      nil
+    end
+  end
+
+  defp maybe_ensure_deep_research_tools(tools, model) do
+    category = get_in(model, [Access.key(:extra, %{}), :category])
+
+    case category do
+      "deep_research" ->
+        ensure_deep_research_tool_present(tools)
+
+      _ ->
+        tools
     end
   end
 

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1352,9 +1352,10 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp ensure_deep_research_tools(tools, request) do
     model_name = request.options[:model] || request.options[:id]
+    provider = request.options[:provider] || "openai"
 
     if is_binary(model_name) and model_name != "" do
-      case ReqLLM.model("openai:#{model_name}") do
+      case ReqLLM.model("#{provider}:#{model_name}") do
         {:ok, model} ->
           category = get_in(model, [Access.key(:extra, %{}), :category])
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -282,7 +282,7 @@ defmodule ReqLLM.Providers.XAI do
 
       req_keys =
         supported_provider_options() ++
-          [:context, :operation, :text, :stream, :model, :provider_options, :xai_api_type]
+          [:context, :operation, :text, :stream, :model, :provider, :provider_options, :xai_api_type]
 
       path = if use_responses, do: "/responses", else: "/chat/completions"
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -282,7 +282,16 @@ defmodule ReqLLM.Providers.XAI do
 
       req_keys =
         supported_provider_options() ++
-          [:context, :operation, :text, :stream, :model, :provider, :provider_options, :xai_api_type]
+          [
+            :context,
+            :operation,
+            :text,
+            :stream,
+            :model,
+            :provider,
+            :provider_options,
+            :xai_api_type
+          ]
 
       path = if use_responses, do: "/responses", else: "/chat/completions"
 

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -288,7 +288,6 @@ defmodule ReqLLM.Providers.XAI do
             :text,
             :stream,
             :model,
-            :provider,
             :provider_options,
             :xai_api_type
           ]
@@ -308,12 +307,12 @@ defmodule ReqLLM.Providers.XAI do
           Keyword.take(processed_opts, req_keys) ++
             [
               model: model.id,
-              provider: "xai",
               base_url: Keyword.get(processed_opts, :base_url, default_base_url()),
               xai_api_type: if(use_responses, do: :responses, else: :chat)
             ]
         )
         |> attach(model, processed_opts)
+        |> Req.Request.put_private(:req_llm_model, model)
 
       {:ok, request}
     end
@@ -721,7 +720,12 @@ defmodule ReqLLM.Providers.XAI do
       )
 
     base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
-    opts_with_base_url = Keyword.put(processed_opts, :base_url, base_url)
+
+    opts_with_base_url =
+      processed_opts
+      |> Keyword.put(:base_url, base_url)
+      |> Keyword.put(:req_llm_model, model)
+
     use_responses = use_responses_api?(opts_with_base_url)
 
     opts_with_base_url =

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -299,6 +299,7 @@ defmodule ReqLLM.Providers.XAI do
           Keyword.take(processed_opts, req_keys) ++
             [
               model: model.id,
+              provider: "xai",
               base_url: Keyword.get(processed_opts, :base_url, default_base_url()),
               xai_api_type: if(use_responses, do: :responses, else: :chat)
             ]

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -241,6 +241,51 @@ defmodule ReqLLM.Providers.XAITest do
       assert req.options[:xai_api_type] == :responses
       assert req.url.path == "/responses"
     end
+
+    test "non-streaming Responses API lookup uses xAI model metadata" do
+      warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          {:ok, req} =
+            XAI.prepare_request(:chat, "xai:grok-4-fast-reasoning", "hi",
+              max_completion_tokens: 1024,
+              xai_tools: [%{type: "web_search"}]
+            )
+
+          encoded_req = XAI.encode_body(req)
+          decoded = Jason.decode!(encoded_req.body)
+
+          assert Enum.any?(decoded["tools"], fn tool -> tool["type"] == "web_search" end)
+        end)
+
+      refute warning =~ "Using unverified model"
+      refute warning =~ "openai:grok-4-fast-reasoning"
+    end
+
+    test "streaming Responses API lookup uses xAI model metadata" do
+      warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          {:ok, model} = ReqLLM.model("xai:grok-4-fast-reasoning")
+          context = Context.new([Context.user("hi")])
+
+          {:ok, request} =
+            XAI.attach_stream(
+              model,
+              context,
+              [
+                max_completion_tokens: 1024,
+                xai_tools: [%{type: "web_search"}]
+              ],
+              ReqLLM.Finch
+            )
+
+          decoded = Jason.decode!(request.body)
+
+          assert Enum.any?(decoded["tools"], fn tool -> tool["type"] == "web_search" end)
+        end)
+
+      refute warning =~ "Using unverified model"
+      refute warning =~ "openai:grok-4-fast-reasoning"
+    end
   end
 
   describe "mode selection - response_format forcing" do


### PR DESCRIPTION
## Summary
- carry resolved model metadata into the shared Responses API deep-research tool lookup
- preserve xAI model metadata for both non-streaming and streaming Responses API requests
- add xAI regressions that assert the OpenAI fallback warning does not return

## Validation
- mix test test/providers/xai_test.exs
- mix test test/provider/openai/responses_api_unit_test.exs
- mix quality

Supersedes #714, which could not be pushed to the contributor fork from this environment.