### PR TITLE
fix: avoid record typespec conflict

### DIFF
--- a/lib/req_llm/open_telemetry/metrics.ex
+++ b/lib/req_llm/open_telemetry/metrics.ex
@@ -96,7 +96,7 @@ defmodule ReqLLM.OpenTelemetry.Metrics do
   @ttfc_metric "gen_ai.client.operation.time_to_first_chunk"
   @tpoc_metric "gen_ai.client.operation.time_per_output_chunk"
 
-  @type record :: %{
+  @type histogram_record :: %{
           name: String.t(),
           value: number(),
           unit: String.t(),
@@ -120,7 +120,7 @@ defmodule ReqLLM.OpenTelemetry.Metrics do
   unavailable — without a duration the per-request metric set isn't
   meaningful.
   """
-  @spec stop(map(), integer() | nil) :: [record()]
+  @spec stop(map(), integer() | nil) :: [histogram_record()]
   def stop(_metadata, nil), do: []
 
   def stop(metadata, duration) when is_integer(duration) do
@@ -138,7 +138,7 @@ defmodule ReqLLM.OpenTelemetry.Metrics do
   streaming histograms are intentionally skipped — usage and chunk timings
   are not reliable on exception. Returns `[]` when `duration` is unavailable.
   """
-  @spec exception(map(), integer() | nil) :: [record()]
+  @spec exception(map(), integer() | nil) :: [histogram_record()]
   def exception(_metadata, nil), do: []
 
   def exception(metadata, duration) when is_integer(duration) do

--- a/lib/req_llm/telemetry/open_telemetry.ex
+++ b/lib/req_llm/telemetry/open_telemetry.ex
@@ -37,7 +37,7 @@ defmodule ReqLLM.Telemetry.OpenTelemetry do
   @type content_mode :: :none | :attributes | :event
   @type span_status :: :ok | {:error, String.t()}
   @type otel_event :: %{name: String.t(), attributes: map()}
-  @type metric_record :: map()
+  @type metric_record :: Metrics.histogram_record()
 
   @type tool_span_stub :: %{
           name: String.t(),


### PR DESCRIPTION
## Summary
- rename OpenTelemetry metric `record` typespec to `histogram_record` to avoid the Elixir 1.19.5 / OTP 29 built-in type conflict
- keep telemetry metric stub typing pointed at the renamed histogram record type

Closes #716

## Tests
- `mix compile --force`
- `mix test test/req_llm/open_telemetry_test.exs test/req_llm/open_telemetry/translator_test.exs test/req_llm/telemetry_open_telemetry_test.exs`
- `mix test`