### PR TITLE
Emit signal when streamed tool args are lost

### DIFF
--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -45,6 +45,8 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   alias ReqLLM.Message.ContentPart
   alias ReqLLM.StreamChunk
 
+  require Logger
+
   @type tool_call_record :: %{
           id: String.t(),
           name: String.t(),
@@ -239,7 +241,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   defp response_tool_call(tool_call, fragments) do
     case Map.get(fragments, tool_call.index) do
       nil ->
-        Map.delete(tool_call, :index)
+        args_lost(tool_call, :missing_fragments)
 
       iodata ->
         json = IO.iodata_to_binary(iodata)
@@ -251,9 +253,40 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
             |> Map.delete(:index)
 
           {:error, _} ->
-            Map.delete(tool_call, :index)
+            args_lost(tool_call, :json_decode_error, json)
         end
     end
+  end
+
+  defp args_lost(tool_call, reason, json \\ nil) do
+    metadata = %{
+      tool_name: tool_call.name,
+      tool_call_id: tool_call.id,
+      reason: reason
+    }
+
+    :telemetry.execute([:req_llm, :tool_call_args_lost], %{count: 1}, metadata)
+    Logger.warning(args_lost_message(metadata, json), Map.to_list(metadata))
+
+    tool_call
+    |> Map.delete(:index)
+    |> Map.update(:metadata, %{error: {:args_lost, reason}}, fn existing ->
+      Map.put(existing, :error, {:args_lost, reason})
+    end)
+  end
+
+  defp args_lost_message(%{reason: reason, tool_name: tool_name, tool_call_id: tool_call_id}, nil) do
+    "req_llm tool_call args_lost reason=#{reason} tool_name=#{tool_name} tool_call_id=#{tool_call_id}"
+  end
+
+  defp args_lost_message(
+         %{reason: reason, tool_name: tool_name, tool_call_id: tool_call_id},
+         json
+       ) do
+    json_prefix = String.slice(json, 0, 80)
+
+    "req_llm tool_call args_lost reason=#{reason} tool_name=#{tool_name} " <>
+      "tool_call_id=#{tool_call_id} json_prefix=#{json_prefix}"
   end
 
   @doc """

--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -47,11 +47,33 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
 
   require Logger
 
+  @tool_call_control_metadata_keys [
+    :id,
+    "id",
+    :index,
+    "index",
+    :name,
+    "name",
+    :builtin?,
+    "builtin?",
+    :start,
+    "start",
+    :expects_arg_fragments,
+    "expects_arg_fragments",
+    :args_fragment_expected?,
+    "args_fragment_expected?",
+    :done_at_unix_nano,
+    "done_at_unix_nano"
+  ]
+
   @type tool_call_record :: %{
-          id: String.t(),
-          name: String.t(),
-          arguments: term(),
-          index: non_neg_integer()
+          required(:id) => String.t(),
+          required(:name) => String.t(),
+          required(:arguments) => term(),
+          required(:index) => non_neg_integer(),
+          optional(:builtin?) => true,
+          optional(:expects_arg_fragments) => true,
+          optional(:metadata) => map()
         }
 
   @type t :: %__MODULE__{
@@ -116,6 +138,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
           arguments: chunk.arguments || %{},
           index: index
         }
+        |> maybe_put_tool_call_metadata(metadata)
         |> maybe_mark_expects_arg_fragments(metadata)
         |> ToolCall.put_builtin_flag(ToolCall.flagged_builtin?(metadata))
 
@@ -188,6 +211,16 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
       {Map.get(args, :index, Map.get(args, "index", 0)), fragment}
     else
       _ -> nil
+    end
+  end
+
+  defp maybe_put_tool_call_metadata(tool_call, metadata) do
+    metadata = Map.drop(metadata, @tool_call_control_metadata_keys)
+
+    if map_size(metadata) > 0 do
+      Map.put(tool_call, :metadata, metadata)
+    else
+      tool_call
     end
   end
 

--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -116,6 +116,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
           arguments: chunk.arguments || %{},
           index: index
         }
+        |> maybe_mark_expects_arg_fragments(metadata)
         |> ToolCall.put_builtin_flag(ToolCall.flagged_builtin?(metadata))
 
       # Prepend (O(1)); finalizers reverse to restore arrival order.
@@ -190,6 +191,29 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
     end
   end
 
+  defp maybe_mark_expects_arg_fragments(tool_call, metadata) do
+    if expects_arg_fragments?(metadata) do
+      Map.put(tool_call, :expects_arg_fragments, true)
+    else
+      tool_call
+    end
+  end
+
+  defp expects_arg_fragments?(metadata) do
+    [
+      :expects_arg_fragments,
+      "expects_arg_fragments",
+      :args_fragment_expected?,
+      "args_fragment_expected?",
+      :start,
+      "start"
+    ]
+    |> Enum.any?(&truthy?(Map.get(metadata, &1)))
+  end
+
+  defp truthy?(true), do: true
+  defp truthy?(_), do: false
+
   @doc "Returns the concatenated text content as a binary."
   @spec finalize_text(t()) :: String.t()
   def finalize_text(%__MODULE__{text_content: iodata}), do: IO.iodata_to_binary(iodata)
@@ -241,7 +265,11 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   defp response_tool_call(tool_call, fragments) do
     case Map.get(fragments, tool_call.index) do
       nil ->
-        args_lost(tool_call, :missing_fragments)
+        if Map.get(tool_call, :expects_arg_fragments, false) do
+          args_lost(tool_call, :missing_fragments)
+        else
+          drop_accumulator_fields(tool_call)
+        end
 
       iodata ->
         json = IO.iodata_to_binary(iodata)
@@ -250,7 +278,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
           {:ok, args} ->
             tool_call
             |> Map.put(:arguments, args)
-            |> Map.delete(:index)
+            |> drop_accumulator_fields()
 
           {:error, _} ->
             args_lost(tool_call, :json_decode_error, json)
@@ -269,10 +297,16 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
     Logger.warning(args_lost_message(metadata, json), Map.to_list(metadata))
 
     tool_call
-    |> Map.delete(:index)
+    |> drop_accumulator_fields()
     |> Map.update(:metadata, %{error: {:args_lost, reason}}, fn existing ->
       Map.put(existing, :error, {:args_lost, reason})
     end)
+  end
+
+  defp drop_accumulator_fields(tool_call) do
+    tool_call
+    |> Map.delete(:index)
+    |> Map.delete(:expects_arg_fragments)
   end
 
   defp args_lost_message(%{reason: reason, tool_name: tool_name, tool_call_id: tool_call_id}, nil) do

--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -350,10 +350,8 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
          %{reason: reason, tool_name: tool_name, tool_call_id: tool_call_id},
          json
        ) do
-    json_prefix = String.slice(json, 0, 80)
-
     "req_llm tool_call args_lost reason=#{reason} tool_name=#{tool_name} " <>
-      "tool_call_id=#{tool_call_id} json_prefix=#{json_prefix}"
+      "tool_call_id=#{tool_call_id} json_bytes=#{byte_size(json)}"
   end
 
   @doc """
@@ -397,15 +395,13 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   defp message_tool_call_struct(tool_call, fragments) do
     args = message_tool_call_args(tool_call, fragments)
 
-    # The accumulator stores tool calls as flat maps (no OpenAI `:function`
-    # nesting), so `flagged_builtin?/1` is the correct check — `builtin?/1`
-    # would also work but pays for the unwrap that can't match here.
     constructor =
       if ToolCall.flagged_builtin?(tool_call),
         do: &ToolCall.new_builtin/3,
         else: &ToolCall.new/3
 
     constructor.(tool_call.id, tool_call.name, encode_tool_call_args(args))
+    |> ToolCall.put_metadata(ToolCall.metadata(tool_call))
   end
 
   defp message_tool_call_args(%{index: index, arguments: arguments}, fragments) do

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1312,7 +1312,11 @@ defmodule ReqLLM.Provider.Defaults do
          "function" => %{"name" => name}
        })
        when is_binary(name) do
-    ReqLLM.StreamChunk.tool_call(name, %{}, %{id: id, index: index})
+    ReqLLM.StreamChunk.tool_call(name, %{}, %{
+      id: id,
+      index: index,
+      expects_arg_fragments: true
+    })
   end
 
   # Mistral API omits "type" field - add it and delegate (must come before partial handlers)

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -128,6 +128,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       if ToolCall.flagged_builtin?(m), do: &ToolCall.new_builtin/3, else: &ToolCall.new/3
 
     constructor.(id, name, encode_tool_args(args))
+    |> put_tool_call_metadata(m)
   end
 
   defp normalize_tool_call(%{"id" => id, "name" => name, "arguments" => args} = m) do
@@ -135,6 +136,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       if ToolCall.flagged_builtin?(m), do: &ToolCall.new_builtin/3, else: &ToolCall.new/3
 
     constructor.(id, name, encode_tool_args(args))
+    |> put_tool_call_metadata(m)
   end
 
   defp normalize_tool_call(other) when is_map(other) do
@@ -142,6 +144,11 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       if ToolCall.flagged_builtin?(other), do: &ToolCall.new_builtin/3, else: &ToolCall.new/3
 
     constructor.(other[:id], other[:name], encode_tool_args(other[:arguments]))
+    |> put_tool_call_metadata(other)
+  end
+
+  defp put_tool_call_metadata(%ToolCall{} = call, source) do
+    ToolCall.put_metadata(call, ToolCall.metadata(source))
   end
 
   defp encode_tool_args(args) when is_binary(args), do: args

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -2309,37 +2309,53 @@ defmodule ReqLLM.Providers.Google do
   # See: https://ai.google.dev/gemini-api/docs/thought-signatures
   @thought_sig_dummy Base.encode64("skip_thought_signature_validator")
 
-  defp convert_tool_call_to_function_call(%ReqLLM.ToolCall{
-         type: "function",
-         function: %{name: name, arguments: args}
-       }) do
+  defp convert_tool_call_to_function_call(
+         %ReqLLM.ToolCall{
+           type: "function",
+           function: %{name: name, arguments: args}
+         } = tool_call
+       ) do
     %{
       functionCall: %{name: name, args: Jason.decode!(args)},
-      thoughtSignature: @thought_sig_dummy
+      thoughtSignature: tool_call_thought_signature(tool_call)
     }
   end
 
-  defp convert_tool_call_to_function_call(%{
-         "type" => "function",
-         "function" => %{"name" => name, "arguments" => args}
-       }) do
+  defp convert_tool_call_to_function_call(
+         %{
+           "type" => "function",
+           "function" => %{"name" => name, "arguments" => args}
+         } = tool_call
+       ) do
     %{
       functionCall: %{name: name, args: Jason.decode!(args)},
-      thoughtSignature: @thought_sig_dummy
+      thoughtSignature: tool_call_thought_signature(tool_call)
     }
   end
 
-  defp convert_tool_call_to_function_call(%{
-         type: "function",
-         function: %{name: name, arguments: args}
-       }) do
+  defp convert_tool_call_to_function_call(
+         %{
+           type: "function",
+           function: %{name: name, arguments: args}
+         } = tool_call
+       ) do
     %{
       functionCall: %{name: name, args: Jason.decode!(args)},
-      thoughtSignature: @thought_sig_dummy
+      thoughtSignature: tool_call_thought_signature(tool_call)
     }
   end
 
   defp convert_tool_call_to_function_call(_), do: nil
+
+  defp tool_call_thought_signature(tool_call) do
+    metadata = ReqLLM.ToolCall.metadata(tool_call)
+
+    Map.get(metadata, :thought_signature) ||
+      Map.get(metadata, "thought_signature") ||
+      Map.get(tool_call, :thought_signature) ||
+      Map.get(tool_call, "thought_signature") ||
+      @thought_sig_dummy
+  end
 
   defp extract_content_text(content) when is_binary(content), do: content
 

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1005,7 +1005,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     chunks =
       case delta["name"] do
         name when is_binary(name) and name != "" ->
-          [ReqLLM.StreamChunk.tool_call(name, %{}, %{id: call_id, index: index})]
+          [
+            ReqLLM.StreamChunk.tool_call(name, %{}, %{
+              id: call_id,
+              index: index,
+              expects_arg_fragments: true
+            })
+          ]
 
         _ ->
           chunks
@@ -1074,7 +1080,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     index = data["output_index"] || data["index"] || 0
     call_id = data["call_id"] || data["id"] || "call_#{:erlang.unique_integer([:positive])}"
 
-    [ReqLLM.StreamChunk.tool_call(name, %{}, %{id: call_id, index: index})]
+    [
+      ReqLLM.StreamChunk.tool_call(name, %{}, %{
+        id: call_id,
+        index: index,
+        expects_arg_fragments: true
+      })
+    ]
   end
 
   defp handle_function_call_name_delta(_), do: []
@@ -1098,7 +1110,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
         name = item["name"] || item[:name]
 
         if name && name != "" do
-          [ReqLLM.StreamChunk.tool_call(name, %{}, %{id: call_id, index: index})]
+          [
+            ReqLLM.StreamChunk.tool_call(name, %{}, %{
+              id: call_id,
+              index: index,
+              expects_arg_fragments: true
+            })
+          ]
         else
           []
         end
@@ -1198,7 +1216,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
     chunks =
       if is_binary(name) and name != "" and not tool_call_emitted?(state, index) do
-        [ReqLLM.StreamChunk.tool_call(name, %{}, %{id: call_id, index: index})]
+        [
+          ReqLLM.StreamChunk.tool_call(name, %{}, %{
+            id: call_id,
+            index: index,
+            expects_arg_fragments: true
+          })
+        ]
       else
         []
       end

--- a/lib/req_llm/tool_call.ex
+++ b/lib/req_llm/tool_call.ex
@@ -168,7 +168,13 @@ defmodule ReqLLM.ToolCall do
   @spec put_metadata(t(), map()) :: t()
   def put_metadata(%__MODULE__{} = call, metadata)
       when is_map(metadata) and map_size(metadata) > 0 do
-    %{call | function: Map.put(call.function, :metadata, metadata)}
+    function =
+      Map.update(call.function, :metadata, metadata, fn
+        existing when is_map(existing) -> Map.merge(existing, metadata)
+        _existing -> metadata
+      end)
+
+    %{call | function: function}
   end
 
   def put_metadata(%__MODULE__{} = call, _metadata), do: call

--- a/lib/req_llm/tool_call.ex
+++ b/lib/req_llm/tool_call.ex
@@ -151,6 +151,28 @@ defmodule ReqLLM.ToolCall do
   def put_builtin_flag(map, true), do: Map.put(map, :builtin?, true)
   def put_builtin_flag(map, _), do: map
 
+  @doc """
+  Returns metadata attached to a tool call or tool-call-shaped map.
+  """
+  @spec metadata(term()) :: map()
+  def metadata(%__MODULE__{function: function}) when is_map(function), do: metadata(function)
+  def metadata(%{metadata: metadata}) when is_map(metadata), do: metadata
+  def metadata(%{"metadata" => metadata}) when is_map(metadata), do: metadata
+  def metadata(%{function: function}) when is_map(function), do: metadata(function)
+  def metadata(%{"function" => function}) when is_map(function), do: metadata(function)
+  def metadata(_), do: %{}
+
+  @doc """
+  Attaches metadata to a ToolCall without changing provider wire encoding.
+  """
+  @spec put_metadata(t(), map()) :: t()
+  def put_metadata(%__MODULE__{} = call, metadata)
+      when is_map(metadata) and map_size(metadata) > 0 do
+    %{call | function: Map.put(call.function, :metadata, metadata)}
+  end
+
+  def put_metadata(%__MODULE__{} = call, _metadata), do: call
+
   defp generate_id do
     "call_#{Uniq.UUID.uuid7()}"
   end
@@ -202,6 +224,7 @@ defmodule ReqLLM.ToolCall do
       name: name,
       arguments: args_map(tc, opts) || %{}
     }
+    |> maybe_put_metadata(metadata(tc))
   end
 
   @doc """
@@ -230,6 +253,7 @@ defmodule ReqLLM.ToolCall do
       name: map["name"],
       arguments: parse_arguments(map["arguments"] || %{}, opts)
     }
+    |> maybe_put_metadata(metadata(map))
   end
 
   def from_map(map, opts) when is_map(map) do
@@ -238,7 +262,14 @@ defmodule ReqLLM.ToolCall do
       name: map[:name],
       arguments: parse_arguments(map[:arguments] || %{}, opts)
     }
+    |> maybe_put_metadata(metadata(map))
   end
+
+  defp maybe_put_metadata(map, metadata) when is_map(metadata) and map_size(metadata) > 0 do
+    Map.put(map, :metadata, metadata)
+  end
+
+  defp maybe_put_metadata(map, _metadata), do: map
 
   defp parse_arguments(args, opts) when is_binary(args) do
     case ReqLLM.JSON.decode(args, opts) do

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -616,6 +616,40 @@ defmodule ReqLLM.Providers.GoogleTest do
              "functionCall must not include 'id' — Google API rejects unknown fields"
     end
 
+    test "encode_body uses preserved tool call thought signature metadata" do
+      {:ok, model} = ReqLLM.model("google:gemini-2.5-flash")
+
+      tool_call =
+        "call_1"
+        |> ReqLLM.ToolCall.new("get_weather", ~s({"location":"SF"}))
+        |> ReqLLM.ToolCall.put_metadata(%{thought_signature: "real_signature_123"})
+
+      context =
+        Context.new([
+          Context.user("What's the weather?"),
+          Context.assistant("", tool_calls: [tool_call])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = Jason.decode!(updated_request.body)
+
+      [function_call_part] =
+        decoded["contents"]
+        |> Enum.flat_map(& &1["parts"])
+        |> Enum.filter(&Map.has_key?(&1, "functionCall"))
+
+      assert function_call_part["thoughtSignature"] == "real_signature_123"
+    end
+
     test "encode_body with Google-specific options" do
       {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
       context = context_fixture()

--- a/test/req_llm/provider/chunk_accumulator_test.exs
+++ b/test/req_llm/provider/chunk_accumulator_test.exs
@@ -162,13 +162,15 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
     end
 
     test "falls back to raw arguments when fragments fail to decode" do
+      attach_args_lost_handler("call_invalid_json")
+
       acc =
         ChunkAccumulator.new()
         |> ChunkAccumulator.push(%StreamChunk{
           type: :tool_call,
           name: "get_weather",
           arguments: %{"raw" => "args"},
-          metadata: %{id: "call_1", index: 0}
+          metadata: %{id: "call_invalid_json", index: 0}
         })
         |> ChunkAccumulator.push(%StreamChunk{
           type: :meta,
@@ -182,36 +184,79 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
                }
              ] =
                ChunkAccumulator.finalize_tool_calls_for_response(acc)
+
+      assert_receive {:args_lost, "call_invalid_json", %{count: 1}, %{reason: :json_decode_error}}
     end
 
     test "does not mark direct arguments as missing fragments" do
+      attach_args_lost_handler("call_direct_args")
+
       acc =
         ChunkAccumulator.new()
         |> ChunkAccumulator.push(%StreamChunk{
           type: :tool_call,
           name: "get_weather",
           arguments: %{"city" => "NYC"},
-          metadata: %{id: "call_1", index: 0}
+          metadata: %{id: "call_direct_args", index: 0}
         })
 
       assert [%{arguments: %{"city" => "NYC"}} = tool_call] =
                ChunkAccumulator.finalize_tool_calls_for_response(acc)
 
       refute Map.has_key?(tool_call, :metadata)
+      refute_receive {:args_lost, "call_direct_args", _, _}
+    end
+
+    test "preserves non-control tool metadata" do
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :tool_call,
+          name: "search",
+          arguments: %{"query" => "docs"},
+          metadata: %{
+            id: "call_meta",
+            index: 0,
+            builtin?: true,
+            done_at_unix_nano: 123,
+            thought_signature: "sig_123",
+            raw_arguments: ~s({"query":"docs"})
+          }
+        })
+
+      assert [
+               %{
+                 builtin?: true,
+                 metadata: %{
+                   thought_signature: "sig_123",
+                   raw_arguments: ~s({"query":"docs"})
+                 }
+               } = tool_call
+             ] = ChunkAccumulator.finalize_tool_calls_for_response(acc)
+
+      refute Map.has_key?(tool_call.metadata, :id)
+      refute Map.has_key?(tool_call.metadata, :index)
+      refute Map.has_key?(tool_call.metadata, :builtin?)
+      refute Map.has_key?(tool_call.metadata, :done_at_unix_nano)
     end
 
     test "marks missing expected argument fragments" do
+      attach_args_lost_handler("call_missing_fragments")
+
       acc =
         ChunkAccumulator.new()
         |> ChunkAccumulator.push(%StreamChunk{
           type: :tool_call,
           name: "get_weather",
           arguments: %{},
-          metadata: %{id: "call_1", index: 0, start: true}
+          metadata: %{id: "call_missing_fragments", index: 0, start: true}
         })
 
       assert [%{metadata: %{error: {:args_lost, :missing_fragments}}}] =
                ChunkAccumulator.finalize_tool_calls_for_response(acc)
+
+      assert_receive {:args_lost, "call_missing_fragments", %{count: 1},
+                      %{reason: :missing_fragments}}
     end
 
     test "returns [] for empty accumulator" do
@@ -444,5 +489,24 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
 
       assert ChunkAccumulator.finalize_logprobs(acc) == tokens
     end
+  end
+
+  defp attach_args_lost_handler(call_id) do
+    test_pid = self()
+    handler_id = {__MODULE__, test_pid, call_id}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:req_llm, :tool_call_args_lost],
+        fn _event, measurements, metadata, {pid, expected_call_id} ->
+          if metadata.tool_call_id == expected_call_id do
+            send(pid, {:args_lost, expected_call_id, measurements, metadata})
+          end
+        end,
+        {test_pid, call_id}
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
   end
 end

--- a/test/req_llm/provider/chunk_accumulator_test.exs
+++ b/test/req_llm/provider/chunk_accumulator_test.exs
@@ -175,7 +175,42 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
           metadata: %{tool_call_args: %{index: 0, fragment: "not-json"}}
         })
 
-      assert [%{arguments: %{"raw" => "args"}}] =
+      assert [
+               %{
+                 arguments: %{"raw" => "args"},
+                 metadata: %{error: {:args_lost, :json_decode_error}}
+               }
+             ] =
+               ChunkAccumulator.finalize_tool_calls_for_response(acc)
+    end
+
+    test "does not mark direct arguments as missing fragments" do
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :tool_call,
+          name: "get_weather",
+          arguments: %{"city" => "NYC"},
+          metadata: %{id: "call_1", index: 0}
+        })
+
+      assert [%{arguments: %{"city" => "NYC"}} = tool_call] =
+               ChunkAccumulator.finalize_tool_calls_for_response(acc)
+
+      refute Map.has_key?(tool_call, :metadata)
+    end
+
+    test "marks missing expected argument fragments" do
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :tool_call,
+          name: "get_weather",
+          arguments: %{},
+          metadata: %{id: "call_1", index: 0, start: true}
+        })
+
+      assert [%{metadata: %{error: {:args_lost, :missing_fragments}}}] =
                ChunkAccumulator.finalize_tool_calls_for_response(acc)
     end
 

--- a/test/req_llm/provider/chunk_accumulator_test.exs
+++ b/test/req_llm/provider/chunk_accumulator_test.exs
@@ -1,6 +1,8 @@
 defmodule ReqLLM.Provider.ChunkAccumulatorTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias ReqLLM.{Message, StreamChunk, ToolCall}
   alias ReqLLM.Message.ContentPart
   alias ReqLLM.Provider.ChunkAccumulator
@@ -188,6 +190,31 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
       assert_receive {:args_lost, "call_invalid_json", %{count: 1}, %{reason: :json_decode_error}}
     end
 
+    test "does not log raw argument fragment content when JSON decode fails" do
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :tool_call,
+          name: "get_secret",
+          arguments: %{},
+          metadata: %{id: "call_secret", index: 0}
+        })
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :meta,
+          metadata: %{tool_call_args: %{index: 0, fragment: ~s({"token":"secret-value")}}
+        })
+
+      log =
+        capture_log(fn ->
+          ChunkAccumulator.finalize_tool_calls_for_response(acc)
+        end)
+
+      assert log =~ "reason=json_decode_error"
+      assert log =~ "tool_call_id=call_secret"
+      assert log =~ "json_bytes="
+      refute log =~ "secret-value"
+    end
+
     test "does not mark direct arguments as missing fragments" do
       attach_args_lost_handler("call_direct_args")
 
@@ -317,6 +344,27 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
 
       assert %Message{tool_calls: [tool_call]} = ChunkAccumulator.finalize_message(acc)
       assert ToolCall.builtin?(tool_call)
+    end
+
+    test "preserves non-control metadata on emitted ToolCall struct" do
+      acc =
+        ChunkAccumulator.push(
+          ChunkAccumulator.new(),
+          %StreamChunk{
+            type: :tool_call,
+            name: "search",
+            arguments: %{"query" => "docs"},
+            metadata: %{
+              id: "call_meta",
+              index: 0,
+              thought_signature: "sig_123",
+              done_at_unix_nano: 123
+            }
+          }
+        )
+
+      assert %Message{tool_calls: [tool_call]} = ChunkAccumulator.finalize_message(acc)
+      assert ToolCall.metadata(tool_call) == %{thought_signature: "sig_123"}
     end
   end
 

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -948,6 +948,24 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert tool_call.function.metadata.error == {:args_lost, :json_decode_error}
       assert ReqLLM.ToolCall.to_map(tool_call).metadata.error == {:args_lost, :json_decode_error}
     end
+
+    test "preserves non-error tool metadata while normalizing", %{model: model, context: context} do
+      chunks = [
+        StreamChunk.tool_call("search", %{"query" => "docs"}, %{
+          id: "call_meta",
+          index: 0,
+          thought_signature: "sig_123",
+          done_at_unix_nano: 123
+        })
+      ]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{}, model: model, context: context)
+
+      assert [tool_call] = response.message.tool_calls
+      assert tool_call.function.metadata == %{thought_signature: "sig_123"}
+      assert ReqLLM.ToolCall.to_map(tool_call).metadata == %{thought_signature: "sig_123"}
+    end
   end
 
   describe "ResponseBuilder logprobs accumulation" do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -934,6 +934,20 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert response.message.reasoning_details == reasoning_details
       assert length(response.message.tool_calls) == 1
     end
+
+    test "preserves tool call metadata while normalizing", %{model: model, context: context} do
+      chunks = [
+        StreamChunk.tool_call("get_weather", %{}, %{id: "call_123", index: 0}),
+        StreamChunk.meta(%{tool_call_args: %{index: 0, fragment: "{not-json"}})
+      ]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{}, model: model, context: context)
+
+      assert [tool_call] = response.message.tool_calls
+      assert tool_call.function.metadata.error == {:args_lost, :json_decode_error}
+      assert ReqLLM.ToolCall.to_map(tool_call).metadata.error == {:args_lost, :json_decode_error}
+    end
   end
 
   describe "ResponseBuilder logprobs accumulation" do

--- a/test/req_llm/response/stream_test.exs
+++ b/test/req_llm/response/stream_test.exs
@@ -215,6 +215,7 @@ defmodule ReqLLM.Response.StreamTest do
 
       assert length(summary.tool_calls) == 1
       assert hd(summary.tool_calls).arguments == %{preset: "value"}
+      refute Map.has_key?(hd(summary.tool_calls), :metadata)
     end
 
     test "generates unique id when not provided" do

--- a/test/req_llm/tool_call_test.exs
+++ b/test/req_llm/tool_call_test.exs
@@ -127,6 +127,21 @@ defmodule ReqLLM.ToolCallTest do
     end
   end
 
+  describe "put_metadata/2" do
+    test "merges metadata into existing metadata" do
+      tool_call =
+        "call_123"
+        |> ToolCall.new("search", "{}")
+        |> ToolCall.put_metadata(%{thought_signature: "sig_123"})
+        |> ToolCall.put_metadata(%{raw_arguments: "{}"})
+
+      assert ToolCall.metadata(tool_call) == %{
+               thought_signature: "sig_123",
+               raw_arguments: "{}"
+             }
+    end
+  end
+
   describe "args_map/1" do
     test "decodes valid JSON arguments to map" do
       args = ~s({"location":"Paris","unit":"celsius"})

--- a/test/req_llm/tool_call_test.exs
+++ b/test/req_llm/tool_call_test.exs
@@ -111,6 +111,20 @@ defmodule ReqLLM.ToolCallTest do
 
       assert result == %{id: "call_456", name: "no_args", arguments: %{}}
     end
+
+    test "includes attached metadata" do
+      tool_call =
+        "call_123"
+        |> ToolCall.new("search", ~s({"query":"docs"}))
+        |> ToolCall.put_metadata(%{thought_signature: "sig_123"})
+
+      assert ToolCall.to_map(tool_call) == %{
+               id: "call_123",
+               name: "search",
+               arguments: %{"query" => "docs"},
+               metadata: %{thought_signature: "sig_123"}
+             }
+    end
   end
 
   describe "args_map/1" do
@@ -265,6 +279,17 @@ defmodule ReqLLM.ToolCallTest do
       assert decoded["function"]["builtin?"] == true
       assert ToolCall.builtin?(decoded)
     end
+
+    test "does not encode local metadata" do
+      decoded =
+        "call_123"
+        |> ToolCall.new("search", ~s({"query":"docs"}))
+        |> ToolCall.put_metadata(%{thought_signature: "sig_123"})
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      refute Map.has_key?(decoded["function"], "metadata")
+    end
   end
 
   describe "from_map/1" do
@@ -317,6 +342,22 @@ defmodule ReqLLM.ToolCallTest do
       result = ToolCall.from_map(map)
 
       assert result == %{id: "call_bad", name: "broken", arguments: %{}}
+    end
+
+    test "preserves map metadata" do
+      map = %{
+        id: "call_meta",
+        name: "search",
+        arguments: %{"query" => "docs"},
+        metadata: %{thought_signature: "sig_123"}
+      }
+
+      assert ToolCall.from_map(map) == %{
+               id: "call_meta",
+               name: "search",
+               arguments: %{"query" => "docs"},
+               metadata: %{thought_signature: "sig_123"}
+             }
     end
   end
 


### PR DESCRIPTION
## Summary

- emit telemetry and warnings when streamed tool-call argument fragments are missing or invalid JSON
- tag returned tool-call metadata with an args-lost marker for downstream handling
- keep successful argument reconstruction unchanged

## Notes

This mirrors the loud-contract patch being carried temporarily in ChapterSpot/builder while diagnosing dropped Anthropic input_json_delta fragments.
