### PR TITLE
feat(providers): add built-in Ollama provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ LLM APIs are inconsistent. ReqLLM provides a unified, idiomatic Elixir interface
 - **High-level API** – Vercel AI SDK-inspired functions (`generate_text/3`, `stream_text/3`, `generate_object/4` and more) that work uniformly across providers. Standard features, minimal configuration.
 - **Low-level API** – Direct Req plugin access for full HTTP control. Built around OpenAI Chat Completions baseline with provider-specific callbacks for non-compatible APIs (e.g., Anthropic).
 
-**21 Supported Providers:**
+**22 Supported Providers:**
 
 | Provider | ID | Guide |
 |---|---|---|
@@ -44,8 +44,9 @@ LLM APIs are inconsistent. ReqLLM provides a unified, idiomatic Elixir interface
 | [Z.AI](https://z.ai) | `zai` | [Guide](guides/zai.md) |
 | [Z.AI Coder](https://z.ai) | `zai_coder` | [Guide](guides/zai_coder.md) |
 | [Zenmux](https://zenmux.ai) | `zenmux` | [Guide](guides/zenmux.md) |
+| [Ollama](https://ollama.ai) | `ollama` | [Guide](guides/ollama.md) |
 | [Venice](https://venice.ai) | `venice` | — |
-| [vLLM](https://docs.vllm.ai) | `vllm` | [Ollama](guides/ollama.md) |
+| [vLLM](https://docs.vllm.ai) | `vllm` | — |
 
 \* _Streaming uses Finch directly due to known Req limitations with SSE responses._
 
@@ -465,7 +466,7 @@ This approach gives you full control over the Req pipeline, allowing you to add 
 - [Mix Tasks](guides/mix-tasks.md) – model sync, compatibility testing, code generation
 - [Fixture Testing](guides/fixture-testing.md) – model validation and supported models
 - [Adding a Provider](guides/adding_a_provider.md) – extend with new providers
-- Provider Guides: [Anthropic](guides/anthropic.md), [OpenAI](guides/openai.md), [Google](guides/google.md), [Google Vertex](guides/google_vertex.md), [xAI](guides/xai.md), [Groq](guides/groq.md), [OpenRouter](guides/openrouter.md), [Amazon Bedrock](guides/amazon_bedrock.md), [Azure](guides/azure.md), [Cerebras](guides/cerebras.md), [Meta](guides/meta.md), [NEAR AI Cloud](guides/nearai.md), [Z.AI](guides/zai.md), [Z.AI Coder](guides/zai_coder.md), [Zenmux](guides/zenmux.md), [Ollama/vLLM](guides/ollama.md)
+- Provider Guides: [Anthropic](guides/anthropic.md), [OpenAI](guides/openai.md), [Google](guides/google.md), [Google Vertex](guides/google_vertex.md), [xAI](guides/xai.md), [Groq](guides/groq.md), [OpenRouter](guides/openrouter.md), [Amazon Bedrock](guides/amazon_bedrock.md), [Azure](guides/azure.md), [Cerebras](guides/cerebras.md), [Meta](guides/meta.md), [NEAR AI Cloud](guides/nearai.md), [Ollama](guides/ollama.md), [Z.AI](guides/zai.md), [Z.AI Coder](guides/zai_coder.md), [Zenmux](guides/zenmux.md)
 
 ## Roadmap & Status
 

--- a/guides/ollama.md
+++ b/guides/ollama.md
@@ -14,6 +14,33 @@ For the full model-spec workflow, see [Model Specs](model-specs.md).
 
 Ollama is a good example of the full explicit model specification path: the model may not exist in LLMDB, but ReqLLM can still use it as long as the model spec includes `provider`, `id`, and `base_url`.
 
+## Native Provider (recommended)
+
+As of req_llm 1.11, Ollama ships as a built-in provider. Use the `ollama:` prefix
+directly — no custom provider setup required:
+
+```elixir
+ReqLLM.generate_text("ollama:llama3", "Hello!")
+
+# With Ollama-specific options
+ReqLLM.generate_text("ollama:gemma4:27b", "Hello",
+  provider_options: [num_ctx: 16_384, keep_alive: "30m"]
+)
+
+# generate_object works out of the box
+{:ok, compiled} = ReqLLM.Schema.compile(%{type: "object", properties: %{answer: %{type: "string"}}})
+ReqLLM.generate_object("ollama:gemma4:27b", "What is 2+2?", compiled_schema: compiled)
+```
+
+For jido_ai users, set a model alias in config and it resolves automatically:
+
+```elixir
+config :jido_ai, model_aliases: [default: "ollama:gemma4:27b"]
+```
+
+The existing model-struct approach (`provider: :openai, base_url: "..."`) continues to
+work unchanged.
+
 ## Usage
 
 Ollama exposes an OpenAI-compatible API, so use the `:openai` provider with a custom `base_url`:

--- a/guides/ollama.md
+++ b/guides/ollama.md
@@ -28,8 +28,8 @@ ReqLLM.generate_text("ollama:gemma4:27b", "Hello",
 )
 
 # generate_object works out of the box
-{:ok, compiled} = ReqLLM.Schema.compile(%{type: "object", properties: %{answer: %{type: "string"}}})
-ReqLLM.generate_object("ollama:gemma4:27b", "What is 2+2?", compiled_schema: compiled)
+schema = [answer: [type: :string, required: true]]
+ReqLLM.generate_object("ollama:llama3", "What is 2+2?", schema)
 ```
 
 For jido_ai users, set a model alias in config and it resolves automatically:

--- a/lib/req_llm/providers/ollama.ex
+++ b/lib/req_llm/providers/ollama.ex
@@ -1,0 +1,92 @@
+defmodule ReqLLM.Providers.Ollama do
+  @moduledoc """
+  Ollama provider — local LLM inference via Ollama's OpenAI-compatible API.
+
+  Routes to Ollama's `/v1` endpoint (port 11434 by default). No API key required.
+
+  ## Usage
+
+      # In jido_ai model alias config
+      config :jido_ai, model_aliases: [default: "ollama:gemma4:27b"]
+
+      # Direct usage
+      ReqLLM.generate_text("ollama:llama3", "Hello!")
+      ReqLLM.generate_object("ollama:gemma4:27b", "Extract the name", compiled_schema: schema)
+
+  ## Configuration
+
+      # Optional — defaults to http://localhost:11434/v1
+      config :req_llm, :ollama, base_url: "http://my-ollama-host:11434/v1"
+
+  ## Ollama-Specific Options
+
+  Pass via `provider_options:` keyword:
+
+  - `num_ctx` — context window size in tokens (Ollama `options.num_ctx`)
+  - `keep_alive` — how long to keep model loaded, e.g. `"30m"` or `0` to unload immediately
+
+  ## Examples
+
+      ReqLLM.generate_text("ollama:gemma4:27b", "Hello",
+        provider_options: [num_ctx: 16_384, keep_alive: "30m"]
+      )
+  """
+
+  use ReqLLM.Provider,
+    id: :ollama,
+    default_base_url: "http://localhost:11434/v1"
+
+  use ReqLLM.Provider.Defaults
+
+  @provider_schema [
+    num_ctx: [
+      type: :non_neg_integer,
+      doc: "Context window size in tokens (passed as options.num_ctx in Ollama body)"
+    ],
+    keep_alive: [
+      type: {:or, [:string, :non_neg_integer]},
+      doc: "How long to keep model loaded (e.g. \"30m\", 0). Top-level body field."
+    ]
+  ]
+
+  @doc """
+  Attaches Ollama-specific pipeline steps.
+
+  Unlike OpenAI-compatible providers, Ollama does not require authentication.
+  This override skips the `Authorization: Bearer` header entirely so users
+  do not need to set any API key environment variable.
+  """
+  @impl ReqLLM.Provider
+  def attach(request, _model_input, user_opts) do
+    extra_keys = ReqLLM.Provider.Defaults.extra_option_keys(__MODULE__)
+
+    request
+    |> Req.Request.put_header("content-type", "application/json")
+    |> Req.Request.register_options(extra_keys)
+    |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request) ++ user_opts)
+    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Error.attach()
+    |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
+    |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
+  end
+
+  @doc """
+  Builds the Ollama request body.
+
+  Extends the standard OpenAI-compat body with two Ollama-specific fields:
+  - `options.num_ctx` — nested under the `options` map (Ollama model parameter)
+  - `keep_alive` — top-level field controlling how long the model stays loaded
+  """
+  @impl ReqLLM.Provider
+  def build_body(request) do
+    ReqLLM.Provider.Defaults.default_build_body(request)
+    |> maybe_add_num_ctx(request.options[:num_ctx])
+    |> maybe_add_keep_alive(request.options[:keep_alive])
+  end
+
+  defp maybe_add_num_ctx(body, nil), do: body
+  defp maybe_add_num_ctx(body, num_ctx), do: Map.put(body, :options, %{num_ctx: num_ctx})
+
+  defp maybe_add_keep_alive(body, nil), do: body
+  defp maybe_add_keep_alive(body, keep_alive), do: Map.put(body, :keep_alive, keep_alive)
+end

--- a/lib/req_llm/providers/ollama.ex
+++ b/lib/req_llm/providers/ollama.ex
@@ -11,7 +11,7 @@ defmodule ReqLLM.Providers.Ollama do
 
       # Direct usage
       ReqLLM.generate_text("ollama:llama3", "Hello!")
-      ReqLLM.generate_object("ollama:gemma4:27b", "Extract the name", compiled_schema: schema)
+      ReqLLM.generate_object("ollama:llama3", "Extract the name", schema)
 
   ## Configuration
 
@@ -46,8 +46,46 @@ defmodule ReqLLM.Providers.Ollama do
     keep_alive: [
       type: {:or, [:string, :non_neg_integer]},
       doc: "How long to keep model loaded (e.g. \"30m\", 0). Top-level body field."
+    ],
+    response_format: [
+      type: :map,
+      doc: "Response format configuration for Ollama's OpenAI-compatible API"
     ]
   ]
+
+  @impl ReqLLM.Provider
+  def prepare_request(:object, model_spec, prompt, opts) do
+    compiled_schema = Keyword.fetch!(opts, :compiled_schema)
+    schema_name = Map.get(compiled_schema, :name, "structured_output")
+
+    response_format = %{
+      type: "json_schema",
+      json_schema: %{
+        name: schema_name,
+        schema: ReqLLM.Schema.to_json(compiled_schema.schema)
+      }
+    }
+
+    opts_with_format =
+      opts
+      |> Keyword.update(:provider_options, [response_format: response_format], fn provider_opts ->
+        Keyword.put(provider_opts, :response_format, response_format)
+      end)
+      |> ReqLLM.Provider.Options.put_model_max_tokens_default(model_spec, fallback: 4096)
+      |> Keyword.put(:operation, :object)
+
+    ReqLLM.Provider.Defaults.prepare_request(
+      __MODULE__,
+      :chat,
+      model_spec,
+      prompt,
+      opts_with_format
+    )
+  end
+
+  def prepare_request(operation, model_spec, input, opts) do
+    ReqLLM.Provider.Defaults.prepare_request(__MODULE__, operation, model_spec, input, opts)
+  end
 
   @doc """
   Attaches Ollama-specific pipeline steps.
@@ -57,17 +95,53 @@ defmodule ReqLLM.Providers.Ollama do
   do not need to set any API key environment variable.
   """
   @impl ReqLLM.Provider
-  def attach(request, _model_input, user_opts) do
+  def attach(request, model_input, user_opts) do
+    {:ok, %LLMDB.Model{} = model} = ReqLLM.model(model_input)
+
+    if model.provider != provider_id() do
+      raise ReqLLM.Error.Invalid.Provider.exception(provider: model.provider)
+    end
+
     extra_keys = ReqLLM.Provider.Defaults.extra_option_keys(__MODULE__)
 
     request
     |> Req.Request.put_header("content-type", "application/json")
     |> Req.Request.register_options(extra_keys)
-    |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request) ++ user_opts)
+    |> Req.Request.merge_options(
+      ReqLLM.Provider.Defaults.finch_option(request) ++
+        [model: model.provider_model_id || model.id] ++ user_opts
+    )
     |> ReqLLM.Step.Retry.attach()
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
+    |> ReqLLM.Step.Usage.attach(model)
+    |> ReqLLM.Step.Telemetry.attach(model, user_opts)
+    |> ReqLLM.Step.Fixture.maybe_attach(model, user_opts)
+  end
+
+  @impl ReqLLM.Provider
+  def attach_stream(model, context, opts, _finch_name) do
+    operation = opts[:operation] || :chat
+
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(__MODULE__, operation, model, context, opts)
+
+    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
+    url = endpoint_url(base_url, "/chat/completions")
+    body = encode_stream_body(model, context, processed_opts)
+
+    headers =
+      [{"Content-Type", "application/json"}, {"Accept", "text/event-stream"}] ++
+        ReqLLM.Provider.Utils.extract_custom_headers(processed_opts[:req_http_options])
+
+    {:ok, Finch.build(:post, url, headers, body)}
+  rescue
+    error ->
+      {:error,
+       ReqLLM.Error.API.Request.exception(
+         reason: "Failed to build Ollama stream request: #{inspect(error)}"
+       )}
   end
 
   @doc """
@@ -89,4 +163,28 @@ defmodule ReqLLM.Providers.Ollama do
 
   defp maybe_add_keep_alive(body, nil), do: body
   defp maybe_add_keep_alive(body, keep_alive), do: Map.put(body, :keep_alive, keep_alive)
+
+  defp encode_stream_body(model, context, opts) do
+    req_opts =
+      opts
+      |> Keyword.delete(:finch_name)
+      |> Keyword.put(:model, model.provider_model_id || model.id)
+      |> Keyword.put(:context, context)
+      |> Keyword.put(:stream, true)
+
+    request =
+      Req.new(method: :post, url: "http://localhost")
+      |> Req.Request.register_options(
+        ReqLLM.Provider.Defaults.extra_option_keys(__MODULE__) ++ [:context, :operation]
+      )
+      |> Req.Request.merge_options(req_opts)
+
+    request
+    |> encode_body()
+    |> Map.fetch!(:body)
+  end
+
+  defp endpoint_url(base_url, path) do
+    String.trim_trailing(base_url, "/") <> path
+  end
 end

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -3,6 +3,16 @@ defmodule ReqLLM.Providers.OllamaTest do
 
   alias ReqLLM.Providers.Ollama
 
+  defp ollama_model do
+    %LLMDB.Model{
+      id: "qwen2.5-coder:14b",
+      model: "qwen2.5-coder:14b",
+      provider: :ollama,
+      capabilities: %{chat: true, tools: %{enabled: true}},
+      limits: %{context: 32_768, output: 4096}
+    }
+  end
+
   defp req_with_opts(opts) do
     %Req.Request{options: Map.new(opts)}
   end
@@ -41,8 +51,68 @@ defmodule ReqLLM.Providers.OllamaTest do
   describe "attach/3" do
     test "sets no authorization header" do
       request = Req.new(url: "http://localhost:11434/v1/chat/completions")
-      result = Ollama.attach(request, nil, [])
+      result = Ollama.attach(request, ollama_model(), [])
       refute Map.has_key?(result.headers, "authorization")
+    end
+
+    test "keeps standard response pipeline steps" do
+      result = Ollama.attach(Req.new(), ollama_model(), [])
+
+      request_steps = Keyword.keys(result.request_steps)
+      response_steps = Keyword.keys(result.response_steps)
+
+      assert :llm_encode_body in request_steps
+      assert :llm_decode_response in response_steps
+      assert :llm_usage in response_steps
+      assert :llm_telemetry_stop in response_steps
+      assert result.private[:req_llm_model].provider == :ollama
+    end
+  end
+
+  describe "prepare_request/4" do
+    test "object requests use Ollama json_schema response format" do
+      {:ok, compiled_schema} =
+        ReqLLM.Schema.compile(answer: [type: :string, required: true])
+
+      {:ok, request} =
+        Ollama.prepare_request(:object, ollama_model(), "Return ok",
+          compiled_schema: compiled_schema
+        )
+
+      encoded = Ollama.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      assert body["response_format"]["type"] == "json_schema"
+      assert body["response_format"]["json_schema"]["name"] == "structured_output"
+
+      assert body["response_format"]["json_schema"]["schema"]["properties"]["answer"]["type"] ==
+               "string"
+
+      refute Map.has_key?(body, "tools")
+      refute Map.has_key?(body, "tool_choice")
+    end
+  end
+
+  describe "attach_stream/4" do
+    test "builds auth-free streaming request without Ollama API key" do
+      original_key = System.get_env("OLLAMA_API_KEY")
+      System.delete_env("OLLAMA_API_KEY")
+
+      try do
+        assert {:ok, request} =
+                 Ollama.attach_stream(ollama_model(), simple_context(), [], ReqLLM.Finch)
+
+        headers = Map.new(request.headers)
+
+        assert request.method == "POST"
+        assert request.scheme == :http
+        assert request.host == "localhost"
+        assert request.path == "/v1/chat/completions"
+        assert headers["Accept"] == "text/event-stream"
+        refute Map.has_key?(headers, "Authorization")
+      after
+        if original_key, do: System.put_env("OLLAMA_API_KEY", original_key)
+      end
     end
   end
 end

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -1,0 +1,48 @@
+defmodule ReqLLM.Providers.OllamaTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.Ollama
+
+  defp req_with_opts(opts) do
+    %Req.Request{options: Map.new(opts)}
+  end
+
+  defp simple_context do
+    %ReqLLM.Context{
+      messages: [
+        %ReqLLM.Message{
+          role: :user,
+          content: [%ReqLLM.Message.ContentPart{type: :text, text: "hello"}]
+        }
+      ]
+    }
+  end
+
+  describe "build_body/1" do
+    test "omits :options key when no num_ctx given" do
+      request = req_with_opts(model: "llama3", context: simple_context())
+      body = Ollama.build_body(request)
+      refute Map.has_key?(body, :options)
+    end
+
+    test "injects options.num_ctx when num_ctx is given" do
+      request = req_with_opts(model: "llama3", context: simple_context(), num_ctx: 4096)
+      body = Ollama.build_body(request)
+      assert body.options == %{num_ctx: 4096}
+    end
+
+    test "injects keep_alive at body top-level when given" do
+      request = req_with_opts(model: "llama3", context: simple_context(), keep_alive: "30m")
+      body = Ollama.build_body(request)
+      assert body.keep_alive == "30m"
+    end
+  end
+
+  describe "attach/3" do
+    test "sets no authorization header" do
+      request = Req.new(url: "http://localhost:11434/v1/chat/completions")
+      result = Ollama.attach(request, nil, [])
+      refute Map.has_key?(result.headers, "authorization")
+    end
+  end
+end


### PR DESCRIPTION
Closes #724

## Summary

- Registers `:ollama` as a first-class provider prefix using Ollama's OpenAI-compatible `/v1` endpoint
- Inherits all behavior from `ReqLLM.Provider.Defaults`; overrides only what deviates from OpenAI-compat
- No API key required — `attach/3` skips the `Authorization: Bearer` header entirely
- Adds `num_ctx` and `keep_alive` as typed `provider_options` covering ~80% of real-world Ollama customization

## Motivation

See #724 for the full problem statement. Short version: `"ollama:model"` string specs fail in jido_ai's model alias system because `:ollama` is not a registered provider prefix. Every jido_ai app targeting Ollama must ship its own custom provider today.

## Design

Follows the same pattern as the existing `vllm` provider — a self-hosted OpenAI-compat provider with no llm_db model catalog. Two practical differences:

| | `vllm` | `ollama` (this PR) |
|---|---|---|
| Auth | Requires `OPENAI_API_KEY` (not validated, but must be set) | No key — `attach/3` skips header |
| Provider options | None | `num_ctx`, `keep_alive` |
| Default base URL | `http://localhost:8000/v1` | `http://localhost:11434/v1` |

`num_ctx` injects as `body.options.num_ctx` (Ollama model parameter map). `keep_alive` hoists to `body.keep_alive` (top-level Ollama field — putting it inside `options` causes Ollama to silently discard it with a `WARN invalid option provided` log line).

`translate_options/3` is intentionally not overridden — `Options.process/4` already flattens `provider_options` into top-level opts before `build_body/1` reads them, so no passthrough needed.

## What works after this PR

```elixir
# jido_ai model alias — was broken, now works
config :jido_ai, model_aliases: [default: "ollama:gemma4:27b"]

# All standard operations
ReqLLM.generate_text("ollama:llama3", "Hello!")
ReqLLM.stream_text("ollama:gemma4:27b", "Tell me a story")
ReqLLM.generate_object("ollama:gemma4:27b", "Extract name", compiled_schema: schema)

# Ollama-specific options
ReqLLM.generate_text("ollama:gemma4:27b", "Hello",
  provider_options: [num_ctx: 16_384, keep_alive: "30m"]
)

# Custom host
ReqLLM.generate_text("ollama:llama3", "Hello",
  base_url: "http://my-ollama-host:11434/v1"
)
```

## Non-goals

- Native `/api/chat` routing and NDJSON streaming — the OpenAI-compat endpoint is sufficient for text, streaming, tool use, and structured output. Separate PR if needed.
- `num_predict` — trivial follow-on addition to `@provider_schema`.

## Test plan

- [x] 4 unit tests in `test/req_llm/providers/ollama_test.exs` covering the two behavioral deviations from defaults (`build_body/1` options injection, `attach/3` no-auth)
- [x] Full test suite: `mix test` → **3258 tests, 0 failures** (3254 baseline + 4 new)
- [x] `mix quality` passes: 0 dialyzer errors, credo --strict clean
- `mix mc "ollama:*"` → "No models match spec" — expected, same as `vllm`; Ollama model names are user-defined and can't be centrally catalogued

## Files changed

| File | Change |
|---|---|
| `lib/req_llm/providers/ollama.ex` | New — provider module |
| `test/req_llm/providers/ollama_test.exs` | New — 4 unit tests |
| `guides/ollama.md` | Updated — native provider section added above legacy usage |
| `README.md` | Updated — Ollama added to provider table (21 → 22), vLLM guide link corrected |