### PR TITLE
feat: leave JSON encoding to Req's native :encode step

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -584,7 +584,7 @@ defmodule ReqLLM.Provider.Defaults do
     )
     |> ReqLLM.Step.Retry.attach()
     |> ReqLLM.Step.Error.attach()
-    |> Req.Request.append_request_steps(llm_encode_body: &provider_mod.encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &provider_mod.encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &provider_mod.decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, user_opts)
@@ -684,14 +684,9 @@ defmodule ReqLLM.Provider.Defaults do
   """
   @spec encode_body_from_map(Req.Request.t(), map()) :: Req.Request.t()
   def encode_body_from_map(request, body) do
-    encoded_body =
-      body
-      |> ReqLLM.Schema.apply_property_ordering()
-      |> Jason.encode!()
-
     request
     |> Req.Request.put_header("content-type", "application/json")
-    |> Map.put(:body, encoded_body)
+    |> put_in([Access.key!(:options), :json], ReqLLM.Schema.apply_property_ordering(body))
   rescue
     error ->
       reraise error, __STACKTRACE__
@@ -1833,12 +1828,15 @@ defmodule ReqLLM.Provider.Defaults do
       method: :post,
       url: URI.parse("https://example.com/temp"),
       headers: %{},
-      body: {:json, %{}},
+      body: nil,
       options: Map.new(req_opts)
     }
 
     # Use provider's encode_body to build the JSON
-    encoded_request = provider_mod.encode_body(temp_request)
+    encoded_request =
+      temp_request
+      |> provider_mod.encode_body()
+      |> Req.Steps.encode_body()
 
     # Return the encoded body (should be JSON string)
     encoded_request.body

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -365,7 +365,7 @@ defmodule ReqLLM.Providers.Anthropic do
     )
     |> ReqLLM.Step.Error.attach()
     |> ReqLLM.Step.Retry.attach(user_opts)
-    |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, user_opts)
@@ -396,9 +396,8 @@ defmodule ReqLLM.Providers.Anthropic do
       |> build_request_body(model_name, opts)
       |> shape_subscription_body(request)
 
-    json_body = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
-
-    %{request | body: json_body}
+    request
+    |> put_in([Access.key!(:options), :json], ReqLLM.Schema.apply_property_ordering(body))
   end
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/cohere.ex
+++ b/lib/req_llm/providers/cohere.ex
@@ -87,7 +87,7 @@ defmodule ReqLLM.Providers.Cohere do
     )
     |> ReqLLM.Step.Retry.attach()
     |> ReqLLM.Step.Error.attach()
-    |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, user_opts)

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -590,7 +590,7 @@ defmodule ReqLLM.Providers.Google do
     |> Req.Request.merge_options([model: model.id, params: [key: api_key]] ++ req_opts)
     |> ReqLLM.Step.Error.attach()
     |> ReqLLM.Step.Retry.attach(user_opts)
-    |> Req.Request.append_request_steps(llm_encode_body: &__MODULE__.encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &__MODULE__.encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &__MODULE__.decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, user_opts)
@@ -925,16 +925,8 @@ defmodule ReqLLM.Providers.Google do
           encode_chat_body(request)
       end
 
-    try do
-      encoded_body = Jason.encode!(body)
-
-      request
-      |> Req.Request.put_header("content-type", "application/json")
-      |> Map.put(:body, encoded_body)
-    rescue
-      error ->
-        reraise error, __STACKTRACE__
-    end
+    request
+    |> put_in([Access.key!(:options), :json], ReqLLM.Schema.apply_property_ordering(body))
   end
 
   defp encode_image_body(request) do
@@ -2011,11 +2003,11 @@ defmodule ReqLLM.Providers.Google do
 
     temp_request =
       Req.new(method: :post, url: URI.parse("https://example.com/temp"))
-      |> Map.put(:body, {:json, %{}})
       |> Map.put(:options, Map.new(all_options))
 
-    encoded_request = encode_body(temp_request)
-    encoded_request.body
+    request_with_json = encode_body(temp_request)
+    json_body = request_with_json.options[:json] || %{}
+    Jason.encode_to_iodata!(json_body)
   end
 
   @impl ReqLLM.Provider

--- a/lib/req_llm/providers/google_vertex/gemini.ex
+++ b/lib/req_llm/providers/google_vertex/gemini.ex
@@ -43,10 +43,12 @@ defmodule ReqLLM.Providers.GoogleVertex.Gemini do
 
     temp_request =
       Req.new(method: :post, url: URI.parse("https://example.com/temp"))
-      |> Map.put(:body, {:json, %{}})
       |> Map.put(:options, opts_map)
 
-    %Req.Request{body: encoded_body} = Google.encode_body(temp_request)
+    %Req.Request{body: encoded_body} =
+      temp_request
+      |> Google.encode_body()
+      |> Req.Steps.encode_body()
 
     body = Jason.decode!(encoded_body)
 

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -698,7 +698,7 @@ defmodule ReqLLM.Providers.OpenAI do
     )
     |> ReqLLM.Step.Retry.attach()
     |> ReqLLM.Step.Error.attach()
-    |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, user_opts)

--- a/lib/req_llm/providers/openai/images_api.ex
+++ b/lib/req_llm/providers/openai/images_api.ex
@@ -37,7 +37,7 @@ defmodule ReqLLM.Providers.OpenAI.ImagesAPI do
       |> maybe_put_string("negative_prompt", opts[:negative_prompt])
 
     request
-    |> Map.put(:body, Jason.encode!(body))
+    |> put_in([Access.key!(:options), :json], body)
   end
 
   @impl true

--- a/lib/req_llm/providers/xai/images_api.ex
+++ b/lib/req_llm/providers/xai/images_api.ex
@@ -31,7 +31,7 @@ defmodule ReqLLM.Providers.XAI.ImagesAPI do
       |> maybe_put_string("aspect_ratio", opts[:aspect_ratio])
 
     request
-    |> Map.put(:body, Jason.encode!(body))
+    |> put_in([Access.key!(:options), :json], body)
   end
 
   @impl true

--- a/lib/req_llm/telemetry.ex
+++ b/lib/req_llm/telemetry.ex
@@ -1132,6 +1132,14 @@ defmodule ReqLLM.Telemetry do
     end
   end
 
+  defp decode_json_body(body) when is_list(body) do
+    body
+    |> IO.iodata_to_binary()
+    |> decode_json_body()
+  rescue
+    ArgumentError -> body
+  end
+
   defp decode_json_body(body), do: body
 
   defp normalize_requested_reasoning(contract, opts) do

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -14,7 +14,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(max_output_tokens: 1000)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["max_output_tokens"] == 1000
       assert body["model"] == "gpt-5"
@@ -25,7 +25,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(max_completion_tokens: 2048)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["max_output_tokens"] == 2048
     end
@@ -34,7 +34,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(max_tokens: 512)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["max_output_tokens"] == 512
     end
@@ -48,7 +48,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
         )
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["max_output_tokens"] == 1000
     end
@@ -57,7 +57,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(stream: true)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["stream"] == true
     end
@@ -76,7 +76,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tools: [tool])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert [encoded_tool] = body["tools"]
       assert encoded_tool["type"] == "function"
@@ -100,7 +100,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tools: [tool])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert [encoded_tool] = body["tools"]
       assert encoded_tool["strict"] == false
@@ -123,7 +123,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tools: [tool])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert [encoded_tool] = body["tools"]
       assert encoded_tool["strict"] == true
@@ -136,7 +136,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
           request = build_request([])
 
           encoded = ResponsesAPI.encode_body(request)
-          body = Jason.decode!(encoded.body)
+          body = ReqLLM.Test.Helpers.json_body(encoded)
 
           assert body["model"] == "gpt-5"
         end)
@@ -148,7 +148,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tools: [])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "tools")
     end
@@ -157,7 +157,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tool_choice: :auto)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["tool_choice"] == "auto"
     end
@@ -166,7 +166,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tool_choice: :none)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["tool_choice"] == "none"
     end
@@ -175,7 +175,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(tool_choice: :required)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["tool_choice"] == "required"
     end
@@ -204,7 +204,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       tool_output =
         Enum.find(body["input"], fn item ->
@@ -280,7 +280,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       tool_output =
         Enum.find(body["input"], fn item ->
@@ -323,7 +323,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       tool_output =
         Enum.find(body["input"], fn item ->
@@ -349,7 +349,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
         build_request(tool_choice: %{type: "function", function: %{name: "get_weather"}})
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["tool_choice"] == %{"type" => "function", "name" => "get_weather"}
     end
@@ -359,7 +359,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
         build_request(tool_choice: %{"type" => "function", "function" => %{"name" => "search"}})
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["tool_choice"] == %{"type" => "function", "name" => "search"}
     end
@@ -368,7 +368,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(parallel_tool_calls: true)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["parallel_tool_calls"] == true
     end
@@ -377,7 +377,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(parallel_tool_calls: false)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["parallel_tool_calls"] == false
     end
@@ -386,7 +386,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request([])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "parallel_tool_calls")
     end
@@ -395,7 +395,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(reasoning_effort: :medium)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["reasoning"] == %{"effort" => "medium"}
     end
@@ -404,7 +404,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(reasoning_effort: "high")
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["reasoning"] == %{"effort" => "high"}
     end
@@ -413,7 +413,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(reasoning_effort: :none)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["reasoning"] == %{"effort" => "none"}
     end
@@ -422,7 +422,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(reasoning_effort: :minimal)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["reasoning"] == %{"effort" => "minimal"}
     end
@@ -431,7 +431,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(reasoning_effort: :xhigh)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["reasoning"] == %{"effort" => "xhigh"}
     end
@@ -440,7 +440,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "reasoning")
     end
@@ -497,7 +497,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert [input1, input2] = body["input"]
       assert input1["role"] == "user"
@@ -524,7 +524,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [response_format: response_format])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["text"]["format"]["type"] == "json_schema"
       assert body["text"]["format"]["name"] == "person_schema"
@@ -539,7 +539,8 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       refute Map.has_key?(body["text"]["format"]["schema"], "propertyOrdering")
 
       # Verify the actual JSON wire order of properties
-      assert encoded.body =~ ~r/"properties"\s*:\s*\{\s*"name".*"age"/s
+      assert IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(encoded)) =~
+               ~r/"properties"\s*:\s*\{\s*"name".*"age"/s
     end
 
     test "encodes response_format with direct JSON schema (pass-through)" do
@@ -565,7 +566,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [response_format: response_format])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["text"]["format"]["type"] == "json_schema"
       assert body["text"]["format"]["name"] == "weather_schema"
@@ -593,7 +594,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [response_format: response_format])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["text"]["format"]["type"] == "json_schema"
       assert body["text"]["format"]["name"] == "search_schema"
@@ -605,7 +606,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [verbosity: :low])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["text"]["verbosity"] == "low"
     end
@@ -614,7 +615,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [verbosity: "high"])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["text"]["verbosity"] == "high"
     end
@@ -623,7 +624,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(provider_options: [])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "text")
     end
@@ -648,7 +649,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
         build_request(provider_options: [response_format: response_format, verbosity: :medium])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["text"]["format"]["type"] == "json_schema"
       assert body["text"]["format"]["name"] == "test_schema"
@@ -1843,7 +1844,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert [reasoning_input | _rest] = body["input"]
       assert reasoning_input["type"] == "reasoning"
@@ -1878,7 +1879,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["previous_response_id"] == "resp_prev_123"
 
@@ -1903,7 +1904,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context, provider_options: [store: false])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
@@ -1925,7 +1926,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["previous_response_id"] == "resp_prev_456"
       assert body["store"] == true
@@ -1947,7 +1948,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(id: "gpt-5.3-codex", context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
@@ -1963,7 +1964,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context, provider_options: [store: false])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
@@ -1999,7 +2000,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       log =
         capture_log(fn ->
           encoded = ResponsesAPI.encode_body(request)
-          body = Jason.decode!(encoded.body)
+          body = ReqLLM.Test.Helpers.json_body(encoded)
 
           refute Enum.any?(body["input"], fn item ->
                    item["type"] == "reasoning"
@@ -2035,7 +2036,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       [reasoning_input | _] = body["input"]
       assert reasoning_input["type"] == "reasoning"
@@ -2071,7 +2072,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context)
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert [reasoning_input | _rest] = body["input"]
       assert reasoning_input["type"] == "reasoning"
@@ -2097,7 +2098,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context, provider_options: [store: false])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert Enum.at(body["input"], 0) == %{
                "role" => "assistant",
@@ -2138,7 +2139,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       request = build_request(context: context, provider_options: [store: false])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert Enum.take(body["input"], 2) == [
                %{
@@ -2179,7 +2180,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
         build_request(context: decoded_resp.body.context, provider_options: [store: false])
 
       encoded = ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["input"] == [
                %{

--- a/test/providers/alibaba_cn_test.exs
+++ b/test/providers/alibaba_cn_test.exs
@@ -134,7 +134,7 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
              }
 
       encoded_request = AlibabaCN.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["enable_search"] == true
       assert decoded["enable_thinking"] == true
@@ -155,7 +155,7 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
         )
 
       encoded_request = AlibabaCN.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["response_format"]["type"] == "json_schema"
       assert decoded["response_format"]["json_schema"]["name"] == "person_schema"
@@ -289,8 +289,8 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       }
 
       updated_request = AlibabaCN.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "qwen-plus"
       assert is_list(decoded["messages"])
@@ -316,8 +316,8 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       }
 
       updated_request = AlibabaCN.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["enable_search"] == true
       assert Map.has_key?(decoded, "search_options")
@@ -343,8 +343,8 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       }
 
       updated_request = AlibabaCN.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["enable_thinking"] == true
       assert decoded["thinking_budget"] == 8192
@@ -364,8 +364,8 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       }
 
       updated_request = AlibabaCN.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["top_k"] == 50
     end
@@ -394,8 +394,8 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       }
 
       updated_request = AlibabaCN.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -427,7 +427,7 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
       }
 
       updated_request = AlibabaCN.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert decoded["enable_search"] == true
@@ -453,7 +453,7 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
           ReqLLM.Finch
         )
 
-      decoded = Jason.decode!(request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(request)
 
       assert decoded["enable_search"] == true
       assert decoded["enable_thinking"] == true
@@ -481,7 +481,7 @@ defmodule ReqLLM.Providers.AlibabaCNTest do
           ReqLLM.Finch
         )
 
-      decoded = Jason.decode!(request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(request)
 
       assert decoded["enable_search"] == true
       assert decoded["enable_thinking"] == true

--- a/test/providers/alibaba_test.exs
+++ b/test/providers/alibaba_test.exs
@@ -134,7 +134,7 @@ defmodule ReqLLM.Providers.AlibabaTest do
              }
 
       encoded_request = Alibaba.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["enable_search"] == true
       assert decoded["enable_thinking"] == true
@@ -155,7 +155,7 @@ defmodule ReqLLM.Providers.AlibabaTest do
         )
 
       encoded_request = Alibaba.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["response_format"]["type"] == "json_schema"
       assert decoded["response_format"]["json_schema"]["name"] == "person_schema"
@@ -289,8 +289,8 @@ defmodule ReqLLM.Providers.AlibabaTest do
       }
 
       updated_request = Alibaba.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "qwen-plus"
       assert is_list(decoded["messages"])
@@ -316,8 +316,8 @@ defmodule ReqLLM.Providers.AlibabaTest do
       }
 
       updated_request = Alibaba.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["enable_search"] == true
       assert Map.has_key?(decoded, "search_options")
@@ -343,8 +343,8 @@ defmodule ReqLLM.Providers.AlibabaTest do
       }
 
       updated_request = Alibaba.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["enable_thinking"] == true
       assert decoded["thinking_budget"] == 4096
@@ -364,8 +364,8 @@ defmodule ReqLLM.Providers.AlibabaTest do
       }
 
       updated_request = Alibaba.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["top_k"] == 50
     end
@@ -394,8 +394,8 @@ defmodule ReqLLM.Providers.AlibabaTest do
       }
 
       updated_request = Alibaba.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -427,7 +427,7 @@ defmodule ReqLLM.Providers.AlibabaTest do
       }
 
       updated_request = Alibaba.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert decoded["enable_search"] == true
@@ -453,7 +453,7 @@ defmodule ReqLLM.Providers.AlibabaTest do
           ReqLLM.Finch
         )
 
-      decoded = Jason.decode!(request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(request)
 
       assert decoded["enable_search"] == true
       assert decoded["enable_thinking"] == true
@@ -481,7 +481,7 @@ defmodule ReqLLM.Providers.AlibabaTest do
           ReqLLM.Finch
         )
 
-      decoded = Jason.decode!(request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(request)
 
       assert decoded["enable_search"] == true
       assert decoded["enable_thinking"] == true

--- a/test/providers/amazon_bedrock_provider_test.exs
+++ b/test/providers/amazon_bedrock_provider_test.exs
@@ -89,7 +89,7 @@ defmodule ReqLLM.Providers.AmazonBedrockProviderTest do
       assert request.method == :post
 
       # Check that body contains proper Anthropic format
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["anthropic_version"] == "bedrock-2023-05-31"
       assert body["max_tokens"] == 100
       assert body["temperature"] == 0.7

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -146,7 +146,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
         |> Req.Request.put_private(:req_llm_claude_subscription?, true)
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [billing_block, identity_block, original_system_block] = decoded["system"]
 
@@ -280,7 +280,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert "oauth-2025-04-20" in features
       assert "interleaved-thinking-2025-05-14" in features
 
-      decoded = request |> Anthropic.encode_body() |> Map.fetch!(:body) |> Jason.decode!()
+      decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
       assert decoded["model"] == "claude-sonnet-4-5-20250929"
       assert decoded["max_tokens"] == 64
@@ -406,7 +406,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
       {:ok, request} = Anthropic.prepare_request(:object, model, context, compiled_schema: schema)
 
-      body = request |> Anthropic.encode_body() |> Map.fetch!(:body) |> Jason.decode!()
+      body = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
       assert body["max_tokens"] == model.limits.output
     end
 
@@ -462,7 +462,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded["messages"]
 
@@ -510,7 +510,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_result_msg = List.last(decoded["messages"])
       [tool_result_block] = tool_result_msg["content"]
@@ -554,7 +554,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_message] = decoded["messages"]
       [_text_block, document_block, image_block] = user_message["content"]
@@ -595,8 +595,8 @@ defmodule ReqLLM.Providers.AnthropicTest do
       # Test the encode_body function directly
       updated_request = Anthropic.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "claude-sonnet-4-5-20250929"
       assert is_list(decoded["messages"])
@@ -640,7 +640,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -675,7 +675,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # :required should be normalized to %{type: "any"} for Anthropic
       assert decoded["tool_choice"] == %{"type" => "any"}
@@ -704,7 +704,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # :auto should be normalized to %{type: "auto"} for Anthropic
       assert decoded["tool_choice"] == %{"type" => "auto"}
@@ -733,7 +733,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # {:tool, name} should be normalized to %{type: "tool", name: "..."} for Anthropic
       assert decoded["tool_choice"] == %{"type" => "tool", "name" => "test_tool"}
@@ -774,7 +774,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_result_msg = List.last(decoded["messages"])
       [tool_result_block] = tool_result_msg["content"]
@@ -825,7 +825,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_result_msg = List.last(decoded["messages"])
       [tool_result_block] = tool_result_msg["content"]
@@ -869,7 +869,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_result_msg = List.last(decoded["messages"])
       [tool_result_block] = tool_result_msg["content"]
@@ -988,7 +988,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
       messages = decoded["messages"]
 
       assistant_block =
@@ -1030,7 +1030,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
       messages = decoded["messages"]
 
       tool_use_block =
@@ -1469,7 +1469,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [encoded_tool] = decoded["tools"]
       assert encoded_tool["defer_loading"] == true
@@ -1497,7 +1497,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -1528,7 +1528,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [web_fetch_tool] = decoded["tools"]
       assert web_fetch_tool["max_content_tokens"] == 50_000
@@ -1551,7 +1551,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [web_fetch_tool] = decoded["tools"]
       assert web_fetch_tool["type"] == "web_fetch_20260209"
@@ -1584,7 +1584,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert length(decoded["tools"]) == 2
       [regular_tool, web_fetch_tool] = decoded["tools"]
@@ -1611,7 +1611,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert length(decoded["tools"]) == 2
       tool_types = Enum.map(decoded["tools"], & &1["type"])
@@ -1737,7 +1737,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -1776,7 +1776,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [web_search_tool] = decoded["tools"]
       assert web_search_tool["type"] == "web_search_20250305"
@@ -1807,7 +1807,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [web_search_tool] = decoded["tools"]
       assert web_search_tool["type"] == "web_search_20250305"
@@ -1842,7 +1842,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       }
 
       updated_request = Anthropic.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 2

--- a/test/providers/cerebras_test.exs
+++ b/test/providers/cerebras_test.exs
@@ -34,8 +34,8 @@ defmodule ReqLLM.Providers.CerebrasTest do
         }
 
         updated_request = Cerebras.encode_body(mock_request)
-        assert_no_duplicate_json_keys(updated_request.body)
-        decoded = Jason.decode!(updated_request.body)
+        assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
         assert is_list(decoded["tools"])
         assert decoded["tool_choice"] == to_string(tool_choice)
@@ -67,8 +67,8 @@ defmodule ReqLLM.Providers.CerebrasTest do
       }
 
       updated_request = Cerebras.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["tool_choice"] == %{
                "type" => "function",
@@ -101,8 +101,8 @@ defmodule ReqLLM.Providers.CerebrasTest do
       }
 
       updated_request = Cerebras.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["parallel_tool_calls"] == false
     end

--- a/test/providers/cohere_test.exs
+++ b/test/providers/cohere_test.exs
@@ -80,7 +80,7 @@ defmodule ReqLLM.Providers.CohereTest do
         )
 
       encoded = Cohere.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body == %{
                "model" => "rerank-v3.5",

--- a/test/providers/deepseek_test.exs
+++ b/test/providers/deepseek_test.exs
@@ -133,8 +133,8 @@ defmodule ReqLLM.Providers.DeepseekTest do
 
       updated_request = Deepseek.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "deepseek-chat"
       assert is_list(decoded["messages"])
@@ -165,7 +165,7 @@ defmodule ReqLLM.Providers.DeepseekTest do
       }
 
       updated_request = Deepseek.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1

--- a/test/providers/fireworks_ai_test.exs
+++ b/test/providers/fireworks_ai_test.exs
@@ -90,7 +90,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
         )
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["model"] == "accounts/fireworks/models/kimi-k2-instruct"
       assert is_list(body["messages"])
@@ -111,7 +111,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
       {:ok, request} = FireworksAI.prepare_request(:chat, model, "Hello", temperature: 0.0)
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "min_p")
       refute Map.has_key?(body, "reasoning_effort")
@@ -151,7 +151,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
       }
 
       {:ok, request} = FireworksAI.prepare_request(:chat, model, context, temperature: 0.0)
-      body = Jason.decode!(FireworksAI.encode_body(request).body)
+      body = ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(request))
 
       for msg <- body["messages"] do
         refute Map.has_key?(msg, "metadata"),
@@ -182,7 +182,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
       {:ok, request} = FireworksAI.prepare_request(:chat, model, "Hi", tools: [tool])
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert is_list(body["tools"])
       assert hd(body["tools"])["function"]["name"] == "get_weather"
@@ -246,7 +246,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
           FireworksAI.prepare_request(:chat, model, "Hi", reasoning_effort: atom_value)
 
         encoded = FireworksAI.encode_body(request)
-        body = Jason.decode!(encoded.body)
+        body = ReqLLM.Test.Helpers.json_body(encoded)
         assert body["reasoning_effort"] == expected
       end
     end
@@ -261,7 +261,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
         )
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
       assert body["reasoning_effort"] == "max"
     end
 
@@ -273,7 +273,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
         FireworksAI.prepare_request(:chat, model, "Hi", reasoning_effort: :default)
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
       refute Map.has_key?(body, "reasoning_effort")
     end
   end
@@ -298,7 +298,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
         )
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["tool_choice"] == %{"type" => "function", "function" => %{"name" => "add"}}
     end
@@ -316,7 +316,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
         )
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["parallel_tool_calls"] == true
       assert body["max_completion_tokens"] == 500
@@ -332,8 +332,10 @@ defmodule ReqLLM.Providers.FireworksAITest do
       {:ok, nested_request} =
         FireworksAI.prepare_request(:chat, model, "Hi", provider_options: [top_k: 41])
 
-      assert Jason.decode!(FireworksAI.encode_body(top_level_request).body)["top_k"] == 40
-      assert Jason.decode!(FireworksAI.encode_body(nested_request).body)["top_k"] == 41
+      assert ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(top_level_request))["top_k"] ==
+               40
+
+      assert ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(nested_request))["top_k"] == 41
     end
 
     test "tool.strict flag is preserved in the encoded tool schema" do
@@ -352,7 +354,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
       {:ok, request} = FireworksAI.prepare_request(:chat, model, "Hi", tools: [tool])
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert hd(body["tools"])["function"]["strict"] == true
     end
@@ -380,7 +382,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
           temperature: 0.0
         )
 
-      body = Jason.decode!(FireworksAI.encode_body(request).body)
+      body = ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(request))
       refute Map.has_key?(body, "tools")
 
       assert %{
@@ -410,7 +412,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
           fireworks_json_schema_strict: false
         )
 
-      body = Jason.decode!(FireworksAI.encode_body(request).body)
+      body = ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(request))
 
       assert body["response_format"]["json_schema"]["strict"] == false
     end
@@ -426,7 +428,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
           provider_options: [fireworks_json_schema_strict: false]
         )
 
-      body = Jason.decode!(FireworksAI.encode_body(request).body)
+      body = ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(request))
 
       assert body["response_format"]["json_schema"]["strict"] == false
     end
@@ -439,7 +441,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
           fireworks_structured_output_mode: :tool
         )
 
-      body = Jason.decode!(FireworksAI.encode_body(request).body)
+      body = ReqLLM.Test.Helpers.json_body(FireworksAI.encode_body(request))
 
       refute Map.has_key?(body, "response_format")
       assert hd(body["tools"])["function"]["name"] == "structured_output"
@@ -457,7 +459,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
       {:ok, request} = FireworksAI.prepare_request(:chat, model, "Hi", stream: true)
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["stream"] == true
       assert body["stream_options"] == %{"include_usage" => true}
@@ -470,7 +472,7 @@ defmodule ReqLLM.Providers.FireworksAITest do
       {:ok, request} = FireworksAI.prepare_request(:chat, model, "Hi", stream: false)
 
       encoded = FireworksAI.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       refute Map.has_key?(body, "stream_options")
     end

--- a/test/providers/google_images_test.exs
+++ b/test/providers/google_images_test.exs
@@ -35,7 +35,7 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
       )
 
     encoded = Google.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert get_in(body, ["generationConfig", "responseModalities"]) == nil
     assert get_in(body, ["generationConfig", "imageConfig", "aspectRatio"]) == "1:1"
@@ -64,7 +64,7 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
     assert request.url.path == "/models/imagen-4.0-generate-001:predict"
 
     encoded = Google.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert body["instances"] == [%{"prompt" => "A cat in space"}]
     assert get_in(body, ["parameters", "sampleCount"]) == 2
@@ -106,7 +106,7 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
       )
 
     encoded = Google.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert is_nil(body["generationConfig"])
   end
@@ -123,7 +123,7 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
       )
 
     encoded = Google.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert request.options[:response_modalities] == ["IMAGE"]
     assert get_in(body, ["generationConfig", "responseModalities"]) == ["IMAGE"]
@@ -141,7 +141,7 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
       )
 
     encoded = Google.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert request.options[:response_modalities] == ["TEXT", "IMAGE"]
     assert get_in(body, ["generationConfig", "responseModalities"]) == ["TEXT", "IMAGE"]

--- a/test/providers/google_role_fix_test.exs
+++ b/test/providers/google_role_fix_test.exs
@@ -25,7 +25,7 @@ defmodule ReqLLM.Providers.GoogleRoleFixTest do
 
       # Call the encode_body function to get the Gemini-formatted body
       updated_request = Google.encode_body(request)
-      body = Jason.decode!(updated_request.body)
+      body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Check that the contents have the correct roles
       contents = body["contents"]
@@ -65,7 +65,7 @@ defmodule ReqLLM.Providers.GoogleRoleFixTest do
       }
 
       updated_request = Google.encode_body(request)
-      body = Jason.decode!(updated_request.body)
+      body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # System instruction should be separate
       assert body["systemInstruction"]["parts"] == [%{"text" => "You are a helpful assistant"}]
@@ -94,7 +94,7 @@ defmodule ReqLLM.Providers.GoogleRoleFixTest do
       }
 
       updated_request = Google.encode_body(request)
-      body = Jason.decode!(updated_request.body)
+      body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       contents = body["contents"]
 

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -241,8 +241,8 @@ defmodule ReqLLM.Providers.GoogleTest do
       # Test the encode_body function directly
       updated_request = Google.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Should have Google's structure
       assert is_list(decoded["contents"])
@@ -289,7 +289,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -343,7 +343,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
       [tool_def] = decoded["tools"]
       [function_def] = tool_def["functionDeclarations"]
       parameters = function_def["parameters"]
@@ -373,7 +373,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Ensure both tools and toolConfig are completely omitted when tools is empty
       refute Map.has_key?(decoded, "tools"), "tools array should be omitted"
@@ -417,7 +417,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_parts =
         decoded["contents"]
@@ -471,7 +471,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_user_msg =
         decoded["contents"]
@@ -550,7 +550,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_user_msg =
         decoded["contents"]
@@ -612,7 +612,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       tool_user_msg =
         decoded["contents"]
@@ -657,7 +657,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       function_call_parts =
         decoded["contents"]
@@ -696,7 +696,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [function_call_part] =
         decoded["contents"]
@@ -730,7 +730,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Check safety settings
       assert decoded["safetySettings"] == safety_settings
@@ -755,7 +755,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       thinking_config = decoded["generationConfig"]["thinkingConfig"]
       assert thinking_config["thinkingLevel"] == "medium"
@@ -776,7 +776,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       thinking_config = decoded["generationConfig"]["thinkingConfig"]
       assert thinking_config["thinkingBudget"] == 8_192
@@ -813,7 +813,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Check embedding-specific structure
       assert decoded["model"] == "models/gemini-embedding-001"
@@ -839,7 +839,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # labels must be top-level, not nested in generationConfig
       assert decoded["labels"] == labels
@@ -859,7 +859,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       refute Map.has_key?(decoded, "labels")
     end
@@ -883,7 +883,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["labels"] == labels
     end
@@ -904,7 +904,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -927,7 +927,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -962,7 +962,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 2
@@ -987,7 +987,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 2
@@ -1866,7 +1866,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["generationConfig"]["responseMimeType"] == "application/json"
       assert decoded["generationConfig"]["candidateCount"] == 1
@@ -1894,7 +1894,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       response_schema = decoded["generationConfig"]["responseSchema"]
       assert response_schema["type"] == "OBJECT"
@@ -1923,7 +1923,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       response_json_schema = decoded["generationConfig"]["responseJsonSchema"]
       assert response_json_schema["type"] == "object"
@@ -1950,7 +1950,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       response_json_schema = decoded["generationConfig"]["responseJsonSchema"]
       assert response_json_schema["type"] == "object"
@@ -2033,7 +2033,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       parts = user_msg["parts"]
@@ -2071,7 +2071,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2106,7 +2106,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2139,7 +2139,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2170,7 +2170,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2200,7 +2200,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [_text_part, part] = user_msg["parts"]
@@ -2231,7 +2231,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2274,7 +2274,7 @@ defmodule ReqLLM.Providers.GoogleTest do
         }
 
         updated_request = Google.encode_body(mock_request)
-        decoded = Jason.decode!(updated_request.body)
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
         [user_msg] = decoded["contents"]
         [part] = user_msg["parts"]
@@ -2296,7 +2296,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2319,7 +2319,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2351,7 +2351,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2383,7 +2383,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2415,7 +2415,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2447,7 +2447,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["contents"]
       [part] = user_msg["parts"]
@@ -2586,7 +2586,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["contents"])
       assert length(decoded["contents"]) == 2
@@ -2640,7 +2640,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       log =
         capture_log(fn ->
           updated_request = Google.encode_body(mock_request)
-          decoded = Jason.decode!(updated_request.body)
+          decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
           [model_msg] = decoded["contents"]
           parts = model_msg["parts"]
@@ -2761,7 +2761,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
       contents = decoded["contents"]
 
       tool_result_entries =
@@ -2800,7 +2800,7 @@ defmodule ReqLLM.Providers.GoogleTest do
       }
 
       updated_request = Google.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
       contents = decoded["contents"]
 
       user_entries = Enum.filter(contents, &(&1["role"] == "user"))

--- a/test/providers/groq_test.exs
+++ b/test/providers/groq_test.exs
@@ -129,9 +129,9 @@ defmodule ReqLLM.Providers.GroqTest do
       # Test the encode_body function directly
       updated_request = Groq.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "llama-3.1-8b-instant"
       assert is_list(decoded["messages"])
@@ -168,8 +168,8 @@ defmodule ReqLLM.Providers.GroqTest do
       }
 
       updated_request = Groq.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -206,8 +206,8 @@ defmodule ReqLLM.Providers.GroqTest do
       }
 
       updated_request = Groq.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
 
@@ -243,8 +243,8 @@ defmodule ReqLLM.Providers.GroqTest do
         }
 
         updated_request = Groq.encode_body(mock_request)
-        assert_no_duplicate_json_keys(updated_request.body)
-        decoded = Jason.decode!(updated_request.body)
+        assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
         assert is_list(decoded["tools"])
         assert decoded["tool_choice"] == to_string(tool_choice)
@@ -267,7 +267,7 @@ defmodule ReqLLM.Providers.GroqTest do
       }
 
       updated_request = Groq.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["response_format"] == %{"type" => "json_object"}
     end
@@ -296,7 +296,7 @@ defmodule ReqLLM.Providers.GroqTest do
         options = [context: context, model: model.model, stream: false] ++ provider_opts
         mock_request = %Req.Request{options: options}
         updated_request = Groq.encode_body(mock_request)
-        decoded = Jason.decode!(updated_request.body)
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
         assertion.(decoded)
       end
     end
@@ -327,7 +327,7 @@ defmodule ReqLLM.Providers.GroqTest do
         full_options = [context: context, model: model.model, stream: false] ++ options
         mock_request = %Req.Request{options: full_options}
         updated_request = Groq.encode_body(mock_request)
-        decoded = Jason.decode!(updated_request.body)
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
         assertion.(decoded)
       end
     end

--- a/test/providers/minimax_test.exs
+++ b/test/providers/minimax_test.exs
@@ -129,7 +129,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
       }
 
       encoded_request = Minimax.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["model"] == "MiniMax-M2.7"
       assert decoded["max_completion_tokens"] == 256
@@ -149,7 +149,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
       }
 
       encoded_request = Minimax.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["reasoning_split"] == false
     end
@@ -186,7 +186,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
       }
 
       encoded_request = Minimax.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
       assistant = Enum.at(decoded["messages"], 1)
 
       assert [

--- a/test/providers/mistral_test.exs
+++ b/test/providers/mistral_test.exs
@@ -103,7 +103,7 @@ defmodule ReqLLM.Providers.MistralTest do
       }
 
       updated_request = Mistral.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["random_seed"] == 7
       assert decoded["parallel_tool_calls"] == false
@@ -130,7 +130,7 @@ defmodule ReqLLM.Providers.MistralTest do
       }
 
       updated_request = Mistral.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "mistral-embed"
       assert decoded["input"] == ["hello world"]

--- a/test/providers/nearai_test.exs
+++ b/test/providers/nearai_test.exs
@@ -125,8 +125,8 @@ defmodule ReqLLM.Providers.NearAITest do
       }
 
       encoded_request = NearAI.encode_body(request)
-      assert_no_duplicate_json_keys(encoded_request.body)
-      decoded = Jason.decode!(encoded_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(encoded_request))
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert decoded["model"] == "anthropic/claude-haiku-4-5"
       assert decoded["max_tokens"] == 512
@@ -158,7 +158,7 @@ defmodule ReqLLM.Providers.NearAITest do
       }
 
       encoded_request = NearAI.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
       function = decoded["tools"] |> hd() |> Map.fetch!("function")
 
       assert function["name"] == "get_weather"

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -103,7 +103,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert {"accept", "text/event-stream"} in request.headers
       assert {"openai-beta", "responses=experimental"} in request.headers
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
 
       assert body["instructions"] == "You are a mining analyst.\n\nUse bullet points."
       assert body["model"] == "gpt-5.3-codex-spark"
@@ -203,7 +203,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
           nil
         )
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
 
       refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
@@ -236,7 +236,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
           nil
         )
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
 
       refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
@@ -261,7 +261,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
           nil
         )
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
 
       refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false

--- a/test/providers/openai_images_test.exs
+++ b/test/providers/openai_images_test.exs
@@ -28,7 +28,7 @@ defmodule ReqLLM.Providers.OpenAIImagesTest do
       )
 
     encoded = ImagesAPI.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert body["model"] == "gpt-image-1"
     assert body["prompt"] == "A lighthouse in a storm"
@@ -50,7 +50,7 @@ defmodule ReqLLM.Providers.OpenAIImagesTest do
       )
 
     encoded = ImagesAPI.encode_body(request)
-    body = Jason.decode!(encoded.body)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
 
     assert body["model"] == "dall-e-3"
     assert body["response_format"] == "b64_json"

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -113,7 +113,7 @@ defmodule ReqLLM.Providers.OpenAITest do
 
       {:ok, request} = OpenAI.attach_stream(model, context, [api_key: "test-key"], nil)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["max_tokens"] == model.limits.output
     end
 
@@ -124,7 +124,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       {:ok, request} =
         OpenAI.attach_stream(model, context, [api_key: "test-key", max_tokens: 123], nil)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["max_tokens"] == 123
     end
 
@@ -134,7 +134,7 @@ defmodule ReqLLM.Providers.OpenAITest do
 
       {:ok, request} = OpenAI.attach_stream(model, context, [api_key: "test-key"], nil)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["max_output_tokens"] == model.limits.output
     end
 
@@ -150,7 +150,7 @@ defmodule ReqLLM.Providers.OpenAITest do
           nil
         )
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["max_output_tokens"] == 456
     end
 
@@ -161,7 +161,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       {:ok, request} =
         OpenAI.attach_stream(model, context, [api_key: "test-key", max_output_tokens: 789], nil)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["max_output_tokens"] == 789
     end
 
@@ -172,7 +172,7 @@ defmodule ReqLLM.Providers.OpenAITest do
 
       {:ok, request} = OpenAI.prepare_request(:object, model, context, compiled_schema: schema)
 
-      body = request |> OpenAI.encode_body() |> Map.fetch!(:body) |> Jason.decode!()
+      body = request |> OpenAI.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
       token_limit =
         body["max_tokens"] || body["max_completion_tokens"] || body["max_output_tokens"]
@@ -350,8 +350,8 @@ defmodule ReqLLM.Providers.OpenAITest do
       # Test the encode_body function directly
       updated_request = OpenAI.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "gpt-4o"
       assert is_list(decoded["messages"])
@@ -388,7 +388,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -425,7 +425,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
 
@@ -460,7 +460,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
 
@@ -492,7 +492,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
 
@@ -522,7 +522,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
       messages = decoded["messages"]
 
       assistant_message = Enum.find(messages, &(&1["role"] == "assistant"))
@@ -546,7 +546,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "o1-mini"
       assert decoded["max_completion_tokens"] == 1000
@@ -568,7 +568,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "o3-mini"
       assert decoded["max_completion_tokens"] == 2000
@@ -591,7 +591,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "gpt-5"
       assert decoded["max_completion_tokens"] == 2500
@@ -613,7 +613,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "o4-mini"
       assert decoded["max_completion_tokens"] == 3000
@@ -636,7 +636,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "gpt-4o"
       assert decoded["max_tokens"] == 1500
@@ -658,7 +658,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "text-embedding-3-small"
       assert decoded["input"] == "Hello, world!"
@@ -678,7 +678,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["service_tier"] == "auto"
     end
@@ -696,7 +696,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["service_tier"] == "flex"
     end
@@ -714,7 +714,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["verbosity"] == "low"
     end
@@ -732,7 +732,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["verbosity"] == "high"
     end
@@ -749,7 +749,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       refute Map.has_key?(decoded, "verbosity")
     end
@@ -1114,7 +1114,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "text-embedding-3-large"
       assert decoded["input"] == "Test embedding text"
@@ -1239,7 +1239,7 @@ defmodule ReqLLM.Providers.OpenAITest do
 
       # Test encode_body
       encoded_request = ReqLLM.Providers.OpenAI.ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded_request.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       # Verify text parameter exists with correct structure
       # OpenAI ResponsesAPI expects name at text.format.name level, not text.format.json_schema.name
@@ -1428,7 +1428,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["logprobs"] == true
       refute Map.has_key?(decoded, "top_logprobs")
@@ -1448,7 +1448,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["logprobs"] == true
       assert decoded["top_logprobs"] == 5
@@ -1467,7 +1467,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       updated_request = OpenAI.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       refute Map.has_key?(decoded, "logprobs")
       refute Map.has_key?(decoded, "top_logprobs")
@@ -1584,7 +1584,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       }
 
       encoded_request = ReqLLM.Providers.OpenAI.ResponsesAPI.encode_body(request)
-      body = Jason.decode!(encoded_request.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       assert Enum.any?(body["tools"], fn tool -> tool["type"] == "web_search" end)
     end

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -130,9 +130,9 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       # Test the encode_body function directly
       updated_request = OpenRouter.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "openai/gpt-4"
       assert is_list(decoded["messages"])
@@ -169,8 +169,8 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -207,8 +207,8 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
 
@@ -244,7 +244,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
         }
 
         updated_request = OpenRouter.encode_body(mock_request)
-        decoded = Jason.decode!(updated_request.body)
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
         assert is_list(decoded["tools"])
 
@@ -266,8 +266,8 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["stream"] == true
       assert decoded["stream_options"] == %{"include_usage" => true}
@@ -287,7 +287,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["usage"] == %{"include" => true}
     end
@@ -306,7 +306,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["plugins"] == [%{"id" => "web"}]
     end
@@ -325,7 +325,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["plugins"] == [%{"id" => "web"}, %{"id" => "code"}]
     end
@@ -352,7 +352,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [message] = decoded["messages"]
       [text_part, file_part] = message["content"]
@@ -389,7 +389,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [message] = decoded["messages"]
       [_, file_part] = message["content"]
@@ -453,7 +453,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["response_format"] == %{"type" => "json_object"}
     end
@@ -488,7 +488,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
         }
 
         updated_request = OpenRouter.encode_body(mock_request)
-        decoded = Jason.decode!(updated_request.body)
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
         assertion.(decoded)
       end
     end
@@ -930,7 +930,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "openai/text-embedding-3-small"
       assert decoded["input"] == "Hello"
@@ -975,7 +975,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["models"] == ["openai/gpt-4", "anthropic/claude-3-haiku"]
       assert decoded["route"] == "fallback"
@@ -997,7 +997,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["transforms"] == transforms
     end
@@ -1023,7 +1023,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["top_k"] == 40
       assert decoded["repetition_penalty"] == 1.05
@@ -1159,7 +1159,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded_body = Jason.decode!(updated_request.body)
+      decoded_body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded_body["messages"]
       assistant_message = Enum.find(messages, fn msg -> msg["role"] == "assistant" end)
@@ -1223,7 +1223,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded_body = Jason.decode!(updated_request.body)
+      decoded_body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Step 4: Verify reasoning_details was preserved exactly
       messages = decoded_body["messages"]
@@ -1259,7 +1259,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded_body = Jason.decode!(updated_request.body)
+      decoded_body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Empty array should not be included (cleaner)
       assistant_message = List.first(decoded_body["messages"])
@@ -1372,7 +1372,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       log =
         capture_log(fn ->
           updated_request = OpenRouter.encode_body(mock_request)
-          decoded_body = Jason.decode!(updated_request.body)
+          decoded_body = ReqLLM.Test.Helpers.json_body(updated_request)
 
           assistant_message =
             Enum.find(decoded_body["messages"], fn msg -> msg["role"] == "assistant" end)
@@ -1416,7 +1416,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       }
 
       updated_request = OpenRouter.encode_body(mock_request)
-      decoded_body = Jason.decode!(updated_request.body)
+      decoded_body = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assistant_message =
         Enum.find(decoded_body["messages"], fn msg -> msg["role"] == "assistant" end)

--- a/test/providers/venice_test.exs
+++ b/test/providers/venice_test.exs
@@ -240,8 +240,8 @@ defmodule ReqLLM.Providers.VeniceTest do
       }
 
       updated_request = Venice.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "venice-uncensored"
       assert is_list(decoded["messages"])
@@ -266,8 +266,8 @@ defmodule ReqLLM.Providers.VeniceTest do
       }
 
       updated_request = Venice.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert Map.has_key?(decoded, "venice_parameters")
       venice_params = decoded["venice_parameters"]
@@ -293,8 +293,8 @@ defmodule ReqLLM.Providers.VeniceTest do
       }
 
       updated_request = Venice.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       venice_params = decoded["venice_parameters"]
       assert venice_params["strip_thinking_response"] == true
@@ -326,8 +326,8 @@ defmodule ReqLLM.Providers.VeniceTest do
       }
 
       updated_request = Venice.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -359,7 +359,7 @@ defmodule ReqLLM.Providers.VeniceTest do
       }
 
       updated_request = Venice.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert Map.has_key?(decoded, "venice_parameters")

--- a/test/providers/vllm_test.exs
+++ b/test/providers/vllm_test.exs
@@ -145,8 +145,8 @@ defmodule ReqLLM.Providers.VLLMTest do
 
       updated_request = VLLM.encode_body(mock_request)
 
-      assert is_binary(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert is_binary(IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(updated_request)))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "test-model"
       assert is_list(decoded["messages"])
@@ -177,7 +177,7 @@ defmodule ReqLLM.Providers.VLLMTest do
       }
 
       updated_request = VLLM.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -589,8 +589,8 @@ defmodule ReqLLM.Providers.XAITest do
       }
 
       updated_request = XAI.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "grok-3"
       assert is_list(decoded["messages"])
@@ -621,8 +621,8 @@ defmodule ReqLLM.Providers.XAITest do
       }
 
       updated_request = XAI.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert decoded["tool_choice"]["function"]["name"] == "test_tool"
@@ -642,8 +642,8 @@ defmodule ReqLLM.Providers.XAITest do
       }
 
       updated_request = XAI.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["response_format"] == %{"type" => "json_object"}
     end
@@ -664,8 +664,8 @@ defmodule ReqLLM.Providers.XAITest do
       }
 
       updated_request = XAI.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["parallel_tool_calls"] == false
       assert decoded["max_completion_tokens"] == 1024

--- a/test/providers/zai_test.exs
+++ b/test/providers/zai_test.exs
@@ -23,7 +23,7 @@ defmodule ReqLLM.Providers.ZaiTest do
       request = %Req.Request{options: [context: context, model: model.model, stream: false]}
 
       encoded_request = Zai.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       [_user_msg, assistant_msg, _followup_msg] = decoded["messages"]
 
@@ -46,7 +46,7 @@ defmodule ReqLLM.Providers.ZaiTest do
       request = %Req.Request{options: [context: context, model: model.model, stream: false]}
 
       encoded_request = Zai.encode_body(request)
-      decoded = Jason.decode!(encoded_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
 
       [assistant_msg, user_msg] = decoded["messages"]
 

--- a/test/providers/zenmux_test.exs
+++ b/test/providers/zenmux_test.exs
@@ -81,8 +81,8 @@ defmodule ReqLLM.Providers.ZenmuxTest do
       }
 
       updated_request = Zenmux.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["model"] == "xiaomi/mimo-v2-flash"
       assert is_list(decoded["messages"])
@@ -140,8 +140,8 @@ defmodule ReqLLM.Providers.ZenmuxTest do
       }
 
       updated_request = Zenmux.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["provider"] == %{"routing" => %{"type" => "priority"}}
       assert decoded["model_routing_config"] == %{"preference" => "fastest"}
@@ -161,8 +161,8 @@ defmodule ReqLLM.Providers.ZenmuxTest do
       }
 
       updated_request = Zenmux.encode_body(mock_request)
-      assert_no_duplicate_json_keys(updated_request.body)
-      decoded = Jason.decode!(updated_request.body)
+      assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["stream_options"] == %{"include_usage" => true}
     end
@@ -187,7 +187,7 @@ defmodule ReqLLM.Providers.ZenmuxTest do
       }
 
       updated_request = Zenmux.encode_body(mock_request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["tool_choice"] == %{
                "type" => "function",
@@ -221,8 +221,8 @@ defmodule ReqLLM.Providers.ZenmuxTest do
         }
 
         updated_request = Zenmux.encode_body(mock_request)
-        assert_no_duplicate_json_keys(updated_request.body)
-        decoded = Jason.decode!(updated_request.body)
+        assert_no_duplicate_json_keys(ReqLLM.Test.Helpers.json_iodata(updated_request))
+        decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
         assert is_list(decoded["tools"])
         assert decoded["tool_choice"] == to_string(tool_choice)

--- a/test/req_llm/property_ordering_wire_test.exs
+++ b/test/req_llm/property_ordering_wire_test.exs
@@ -38,10 +38,11 @@ defmodule ReqLLM.PropertyOrderingWireTest do
 
       request = build_responses_request(provider_options: [response_format: response_format])
       encoded = ResponsesAPI.encode_body(request)
+      json = ReqLLM.Test.Helpers.json_iodata(encoded)
 
-      assert_no_property_ordering(encoded.body)
+      assert_no_property_ordering(json)
 
-      assert ordered_prop_keys(encoded.body, ["text", "format", "schema", "properties"]) ==
+      assert ordered_prop_keys(json, ["text", "format", "schema", "properties"]) ==
                @expected_order
     end
   end
@@ -78,11 +79,12 @@ defmodule ReqLLM.PropertyOrderingWireTest do
       }
 
       encoded = ChatAPI.encode_body(request)
+      json = ReqLLM.Test.Helpers.json_iodata(encoded)
 
-      assert_no_property_ordering(encoded.body)
+      assert_no_property_ordering(json)
 
       assert ordered_prop_keys(
-               encoded.body,
+               json,
                ["response_format", "json_schema", "schema", "properties"]
              ) == @expected_order
     end
@@ -114,10 +116,11 @@ defmodule ReqLLM.PropertyOrderingWireTest do
       }
 
       updated = Anthropic.encode_body(mock_request)
+      json = ReqLLM.Test.Helpers.json_iodata(updated)
 
-      assert_no_property_ordering(updated.body)
+      assert_no_property_ordering(json)
 
-      assert ordered_prop_keys(updated.body, ["output_format", "schema", "properties"]) ==
+      assert ordered_prop_keys(json, ["output_format", "schema", "properties"]) ==
                @expected_order
     end
   end
@@ -146,11 +149,12 @@ defmodule ReqLLM.PropertyOrderingWireTest do
       }
 
       encoded = ReqLLM.Provider.Defaults.encode_body_from_map(request, body)
+      json = ReqLLM.Test.Helpers.json_iodata(encoded)
 
-      assert_no_property_ordering(encoded.body)
+      assert_no_property_ordering(json)
 
       assert ordered_prop_keys(
-               encoded.body,
+               json,
                ["response_format", "json_schema", "schema", "properties"]
              ) == @expected_order
     end
@@ -184,11 +188,12 @@ defmodule ReqLLM.PropertyOrderingWireTest do
       }
 
       encoded = ReqLLM.Provider.Defaults.encode_body_from_map(request, body)
+      json = ReqLLM.Test.Helpers.json_iodata(encoded)
 
-      assert_no_property_ordering(encoded.body)
+      assert_no_property_ordering(json)
 
       assert ordered_prop_keys(
-               encoded.body,
+               json,
                ["response_format", "json_schema", "schema", "properties"]
              ) == @expected_order
     end

--- a/test/req_llm/providers/amazon_bedrock/additional_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/additional_test.exs
@@ -68,7 +68,8 @@ defmodule ReqLLM.Providers.AmazonBedrock.AdditionalTest do
         assert {:ok, request} =
                  AmazonBedrock.attach_stream(model, context, opts, __MODULE__.TestFinch)
 
-        assert request.body =~ "anthropic_version"
+        assert IO.iodata_to_binary(ReqLLM.Test.Helpers.json_iodata(request)) =~
+                 "anthropic_version"
       end
     end
 
@@ -193,7 +194,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.AdditionalTest do
 
       {:ok, request} = AmazonBedrock.attach_stream(model, context, opts, __MODULE__.TestFinch)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["anthropic_version"] == "bedrock-2023-05-31"
       assert body["max_tokens"] == 500
       assert body["temperature"] == 0.7

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -152,7 +152,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert request.url.path =~ "/converse"
 
       # Verify the body is properly encoded
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
 
       # Verify system instruction
       assert body["system"] == [%{"text" => "You are a calculator"}]
@@ -231,7 +231,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       refute request.url.path =~ "/converse"
 
       # Verify the body uses native Anthropic format (via delegation)
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
 
       # Native Anthropic format has different structure than Converse
       assert body["anthropic_version"] == "bedrock-2023-05-31"
@@ -575,7 +575,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:embedding, model, text, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["texts"] == ["Test embedding text"]
       assert body["input_type"] == "search_document"
       assert body["embedding_types"] == ["float"]
@@ -592,7 +592,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:embedding, model, texts, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["texts"] == ["First text", "Second text", "Third text"]
     end
 
@@ -608,7 +608,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:embedding, model, text, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["input_type"] == "search_query"
     end
 
@@ -624,7 +624,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:embedding, model, text, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["embedding_types"] == ["float", "int8"]
     end
 
@@ -640,7 +640,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:embedding, model, text, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["truncate"] == "RIGHT"
     end
   end
@@ -818,7 +818,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
       assert %Req.Request{} = request
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["service_tier"] == "priority"
     end
 
@@ -839,7 +839,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["service_tier"] == "flex"
     end
 
@@ -860,7 +860,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       refute Map.has_key?(body, "service_tier")
     end
 
@@ -880,7 +880,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       refute Map.has_key?(body, "service_tier")
     end
   end
@@ -904,7 +904,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["anthropic_beta"] == ["output-128k-2025-02-19"]
     end
 
@@ -919,7 +919,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       refute Map.has_key?(body, "anthropic_beta")
     end
 
@@ -935,7 +935,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["anthropic_beta"] == ["output-128k-2025-02-19", "another-beta-flag"]
     end
 
@@ -951,7 +951,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["anthropic_beta"] == ["output-128k-2025-02-19"]
     end
   end

--- a/test/req_llm/providers/anthropic_prompt_cache_test.exs
+++ b/test/req_llm/providers/anthropic_prompt_cache_test.exs
@@ -71,7 +71,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       assert length(decoded["tools"]) == 1
@@ -102,7 +102,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       [encoded_tool] = decoded["tools"]
@@ -133,7 +133,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert length(decoded["tools"]) == 5
 
@@ -164,7 +164,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
       {:ok, request} = Anthropic.prepare_request(:chat, model, context, tools: [tool])
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       [encoded_tool] = decoded["tools"]
@@ -181,7 +181,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         Anthropic.prepare_request(:chat, model, context, anthropic_prompt_cache: true)
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["system"])
       [system_block] = decoded["system"]
@@ -209,7 +209,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         Anthropic.prepare_request(:chat, model, context, anthropic_prompt_cache: true)
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["system"])
       assert length(decoded["system"]) == 2
@@ -228,7 +228,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
       {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["system"] == "You are a helpful assistant."
     end
@@ -257,7 +257,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [system_block] = decoded["system"]
       assert system_block["cache_control"] == %{"type" => "ephemeral", "ttl" => "2h"}
@@ -288,7 +288,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert is_list(decoded["tools"])
       [encoded_tool] = decoded["tools"]
@@ -315,7 +315,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded["messages"]
       assert length(messages) == 3
@@ -353,7 +353,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [user_msg] = decoded["messages"]
       assert length(user_msg["content"]) == 2
@@ -376,7 +376,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       last_msg = List.last(decoded["messages"])
       [content_block] = last_msg["content"]
@@ -394,7 +394,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       last_msg = List.last(decoded["messages"])
       refute has_cache_control?(last_msg)
@@ -411,7 +411,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       last_msg = List.last(decoded["messages"])
       refute has_cache_control?(last_msg)
@@ -431,7 +431,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
 
       # Should not crash
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # Should have empty messages array
       assert decoded["messages"] == []
@@ -459,7 +459,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # System should be cached
       [system_block] = decoded["system"]
@@ -524,7 +524,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded["messages"]
       assert length(messages) == 3
@@ -555,7 +555,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded["messages"]
       [first_msg, second_msg, third_msg] = messages
@@ -584,7 +584,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded["messages"]
       [first_msg, second_msg, third_msg] = messages
@@ -613,7 +613,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       messages = decoded["messages"]
       [first_msg, second_msg, third_msg] = messages
@@ -635,7 +635,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # No message should have cache_control
       for msg <- decoded["messages"] do
@@ -654,7 +654,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # No message should have cache_control
       for msg <- decoded["messages"] do
@@ -679,7 +679,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # -1 = last message, so the only message gets cached
       [only_msg] = decoded["messages"]
@@ -702,7 +702,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       [only_msg] = decoded["messages"]
       assert has_cache_control?(only_msg)
@@ -724,7 +724,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # -2 on single message is out of bounds
       [only_msg] = decoded["messages"]
@@ -744,7 +744,7 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
         )
 
       updated_request = Anthropic.encode_body(request)
-      decoded = Jason.decode!(updated_request.body)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       # No messages to cache
       assert decoded["messages"] == []

--- a/test/req_llm/providers/elevenlabs_test.exs
+++ b/test/req_llm/providers/elevenlabs_test.exs
@@ -116,7 +116,7 @@ defmodule ReqLLM.Providers.ElevenLabsTest do
       assert {:ok, request} =
                ElevenLabs.prepare_request(:speech, model, "Hello world", [])
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["text"] == "Hello world"
       assert body["model_id"] == "eleven_multilingual_v2"
     end
@@ -127,7 +127,7 @@ defmodule ReqLLM.Providers.ElevenLabsTest do
       assert {:ok, request} =
                ElevenLabs.prepare_request(:speech, model, "Hola", language: "es")
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["language_code"] == "es"
     end
 
@@ -139,7 +139,7 @@ defmodule ReqLLM.Providers.ElevenLabsTest do
                  provider_options: [stability: 0.5, similarity_boost: 0.8]
                )
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       assert body["voice_settings"]["stability"] == 0.5
       assert body["voice_settings"]["similarity_boost"] == 0.8
     end
@@ -150,7 +150,7 @@ defmodule ReqLLM.Providers.ElevenLabsTest do
       assert {:ok, request} =
                ElevenLabs.prepare_request(:speech, model, "Hello", [])
 
-      body = Jason.decode!(request.body)
+      body = ReqLLM.Test.Helpers.json_body(request)
       refute Map.has_key?(body, "voice_settings")
     end
 

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -80,7 +80,7 @@ defmodule ReqLLM.Providers.OllamaTest do
         )
 
       encoded = Ollama.encode_body(request)
-      body = Jason.decode!(encoded.body)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
 
       assert body["response_format"]["type"] == "json_schema"
       assert body["response_format"]["json_schema"]["name"] == "structured_output"

--- a/test/req_llm/telemetry_provider_test.exs
+++ b/test/req_llm/telemetry_provider_test.exs
@@ -333,7 +333,9 @@ defmodule ReqLLM.TelemetryProviderTest do
         end
 
       encode_step ->
-        encode_step.(request)
+        request
+        |> encode_step.()
+        |> Req.Steps.encode_body()
     end
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -64,6 +64,35 @@ defmodule ReqLLM.Test.Helpers do
   def pricing_from_cost(_), do: %{components: []}
 
   @doc """
+  Returns a decoded JSON body from a request-like struct.
+
+  Req keeps `options[:json]` unencoded until its native encode step runs, while
+  some lower-level tests still inspect provider body builders directly.
+  """
+  def json_body(request_or_body) do
+    request_or_body
+    |> json_iodata()
+    |> Jason.decode!()
+  end
+
+  @doc """
+  Returns JSON iodata from either a materialized body or pending `options[:json]`.
+  """
+  def json_iodata(%Req.Request{options: options, body: body}) do
+    case options[:json] do
+      nil -> json_iodata(body)
+      json -> json |> Jason.encode_to_iodata!() |> IO.iodata_to_binary()
+    end
+  end
+
+  def json_iodata(%{body: body}), do: json_iodata(body)
+  def json_iodata({:json, body}), do: body |> Jason.encode_to_iodata!() |> IO.iodata_to_binary()
+
+  def json_iodata(body) when is_binary(body) or is_list(body) do
+    IO.iodata_to_binary(body)
+  end
+
+  @doc """
   Calculate cost using ReqLLM.Billing from a raw usage map.
   """
   def billing_cost(model, usage) do


### PR DESCRIPTION
## Summary
This PR implements the improvement proposed in #728.

ReqLLM now delegates JSON encoding to Req's built-in `:encode` request step (powered by `Jason.encode_to_iodata/1`) instead of manually encoding request bodies and setting `request.body`.

### Changes
- Updated the central helper `ReqLLM.Provider.Defaults.encode_body_from_map/2` to set `options[:json]`
- Refactored provider request steps that use pending JSON bodies to run before Req's native encode step
- Refactored the **Anthropic** provider and **Google** provider, including streaming/Vertex helper paths that materialize Finch bodies
- Refactored **OpenAI Images API** and **xAI Images API**
- Updated request-body tests to inspect pending `options[:json]` through shared helpers

All other providers that delegate to the central helper benefit automatically.

### Benefits
- More efficient final wire encoding via `Jason.encode_to_iodata`
- Enables better composability with other Req request steps (e.g. PostHog analytics, custom middleware) that need to inspect or modify the body *before* it is encoded
- Reduces custom encoding logic across providers
- Aligns ReqLLM more closely with Req's plugin architecture

### Scope of this PR
- Core JSON staging change + providers and tests affected by that central path

Remaining fully custom providers (for example OpenAI Chat/Responses, Bedrock, Cohere-specific manual bodies, etc.) can be migrated further in follow-up PRs where needed.

### Testing
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors --no-verification --no-protocol-consolidation`
- `mix test --no-compile` (2986 tests, 0 failures, 11 skipped; integration/coverage excluded by project defaults)

Closes #728
