### PR TITLE
fix(streaming): handle iodata request bodies

### DIFF
--- a/lib/req_llm/streaming/finch_client.ex
+++ b/lib/req_llm/streaming/finch_client.ex
@@ -288,7 +288,7 @@ defmodule ReqLLM.Streaming.FinchClient do
   # Validate that HTTP/2 pools won't fail with large request bodies
   # See: https://github.com/sneako/finch/issues/265
   defp validate_http2_body_size(finch_request, finch_name) do
-    body_size = byte_size(finch_request.body || "")
+    body_size = request_body_size(finch_request.body)
 
     # Only check if body is potentially problematic (>64KB threshold from Finch #265)
     if body_size > 65_535 do
@@ -323,4 +323,8 @@ defmodule ReqLLM.Streaming.FinchClient do
   rescue
     _ -> {:error, :config_error}
   end
+
+  defp request_body_size(nil), do: 0
+  defp request_body_size({:stream, _}), do: 0
+  defp request_body_size(body), do: IO.iodata_length(body)
 end

--- a/lib/req_llm/streaming/fixtures.ex
+++ b/lib/req_llm/streaming/fixtures.ex
@@ -135,18 +135,27 @@ defmodule ReqLLM.Streaming.Fixtures do
         %{}
 
       binary when is_binary(binary) ->
-        case Jason.decode(binary) do
-          {:ok, json} -> json
-          {:error, _} -> %{raw_body: binary}
-        end
+        decode_json_body(binary)
 
       {:stream, _} ->
         %{streaming_body: true}
+
+      iodata when is_list(iodata) ->
+        iodata
+        |> IO.iodata_to_binary()
+        |> decode_json_body()
 
       other ->
         %{unknown_body: inspect(other)}
     end
   rescue
     _ -> %{}
+  end
+
+  defp decode_json_body(binary) do
+    case Jason.decode(binary) do
+      {:ok, json} -> json
+      {:error, _} -> %{raw_body: binary}
+    end
   end
 end

--- a/test/req_llm/streaming/finch_client_test.exs
+++ b/test/req_llm/streaming/finch_client_test.exs
@@ -231,6 +231,24 @@ defmodule ReqLLM.Streaming.FinchClientTest do
       end
     end
 
+    defmodule IodataBodyProvider do
+      def attach_stream(_model, _context, _opts, _finch_name) do
+        body =
+          Jason.encode_to_iodata!(%{
+            messages: [%{role: "user", content: "Test"}],
+            stream: true
+          })
+
+        {:ok,
+         Finch.build(
+           :post,
+           "https://example.com/stream",
+           [{"content-type", "application/json"}],
+           body
+         )}
+      end
+    end
+
     defmodule LiveStreamProvider do
       def attach_stream(_model, _context, opts, _finch_name) do
         body =
@@ -287,6 +305,26 @@ defmodule ReqLLM.Streaming.FinchClientTest do
       assert String.ends_with?(http_context.url, "/chat/completions")
       assert http_context.method == :post
       assert is_map(http_context.req_headers)
+    end
+
+    test "accepts iodata request bodies from provider attach_stream" do
+      {:ok, stream_server} = MockStreamServer.start_link()
+      {:ok, context} = Context.normalize("Test")
+
+      assert {:ok, task_pid, http_context, canonical_json} =
+               FinchClient.start_stream(
+                 IodataBodyProvider,
+                 %LLMDB.Model{provider: :test, id: "test"},
+                 context,
+                 [receive_timeout: 10, max_retries: 0],
+                 stream_server,
+                 ReqLLM.MissingFinch
+               )
+
+      assert is_pid(task_pid)
+      assert %HTTPContext{} = http_context
+      assert canonical_json["stream"] == true
+      assert canonical_json["messages"] == [%{"role" => "user", "content" => "Test"}]
     end
 
     test "returns provider_build_failed when provider attach_stream returns an error" do

--- a/test/req_llm/streaming/fixtures_test.exs
+++ b/test/req_llm/streaming/fixtures_test.exs
@@ -90,6 +90,11 @@ defmodule ReqLLM.Streaming.FixturesTest do
 
       assert Fixtures.canonical_json_from_finch_request(
                Finch.build(:post, "https://api.example.com")
+               |> Map.put(:body, Jason.encode_to_iodata!(%{stream: true}))
+             ) == %{"stream" => true}
+
+      assert Fixtures.canonical_json_from_finch_request(
+               Finch.build(:post, "https://api.example.com")
                |> Map.put(:body, {:stream, Stream.iterate(0, &(&1 + 1))})
              ) == %{streaming_body: true}
 


### PR DESCRIPTION
## Summary
- handle Finch streaming request bodies as iodata during HTTP/2 body-size validation
- decode fixture/telemetry canonical JSON from iodata request bodies
- add regression coverage for providers returning `Jason.encode_to_iodata!/1` bodies

## Root Cause
ReqLLM 1.13 moved OpenAI-compatible request body encoding through Req's native JSON encoder. That path can leave the Finch request body as JSON iodata. The streaming transport still called `byte_size/1` on `finch_request.body`, which raises `ArgumentError` when the body is a list.

This reproduces the reported OpenRouter failure before any network traffic:

```elixir
ReqLLM.Generation.stream_text("openrouter:openai/gpt-oss-120b:free", "hello", api_key: "sk-test")
```

## Validation
- `mix test test/req_llm/streaming/finch_client_test.exs test/req_llm/streaming/fixtures_test.exs test/req_llm/streaming/http2_validation_test.exs`
- `mix test test/providers/openrouter_test.exs`
- `mix compile --warnings-as-errors`
- direct reproduction now returns `{:ok, %ReqLLM.StreamResponse{}}` instead of `{:http_streaming_failed, {:build_request_failed, %ArgumentError{...}}}`
