### PR TITLE
fix(openai): send previous_response_id with store: false on Responses API

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -620,11 +620,17 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
     store = Keyword.get(provider_opts, :store, default_store(model_name))
 
+    # `previous_response_id` is resolved independently of `store`. The Responses
+    # WebSocket transport keeps the most recent response in a connection-local,
+    # in-memory cache even when `store: false` (ZDR-compatible), and
+    # `previous_response_id` resolves against that cache. The official Codex CLI
+    # (openai/codex, codex-rs) relies on exactly this: `store: false` +
+    # `previous_response_id` over a persistent WebSocket to chain turns without
+    # re-uploading history. Coupling the two would silently break multi-turn
+    # chaining for every Codex request (Codex always forces `store: false`).
     previous_response_id =
-      if store != false do
-        provider_opts[:previous_response_id] ||
-          extract_previous_response_id_from_context(context)
-      end
+      provider_opts[:previous_response_id] ||
+        extract_previous_response_id_from_context(context)
 
     {input, _tool_messages, reasoning_items} =
       Enum.reduce(context.messages, {[], [], []}, fn msg, {input_acc, tool_acc, reasoning_acc} ->
@@ -717,11 +723,19 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("include", include)
       |> maybe_put_string("text", text_format)
 
+    # Attach `previous_response_id` without coercing `store`. The caller's
+    # `store` value is authoritative: `store: false` + `previous_response_id`
+    # is a valid combination over the Responses WebSocket transport (the prior
+    # response lives in a connection-local cache), so we must not force
+    # `store: true` here. The `store: true` path is unchanged: when a
+    # `previous_response_id` is present and `store` is not explicitly false we
+    # still stamp `store: true` (preserving the historical behavior), but for
+    # `store: false` we send `store: false` alongside `previous_response_id`.
     body =
       if previous_response_id do
         body
         |> Map.put("previous_response_id", previous_response_id)
-        |> Map.put("store", true)
+        |> maybe_put_store_true(store)
       else
         body
       end
@@ -732,6 +746,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       body
     end
   end
+
+  # Preserve the historical `store: true` stamp when chaining with a
+  # `previous_response_id` and `store` is not explicitly disabled. When
+  # `store == false` the trailing clause in `build_request_body/4` sets
+  # `store: false`, so we intentionally do nothing here.
+  defp maybe_put_store_true(body, false), do: body
+  defp maybe_put_store_true(body, _store), do: Map.put(body, "store", true)
 
   defp default_store(model_name) do
     !ReqLLM.Providers.OpenAI.AdapterHelpers.codex_model?(model_name)

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -620,17 +620,11 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
     store = Keyword.get(provider_opts, :store, default_store(model_name))
 
-    # `previous_response_id` is resolved independently of `store`. The Responses
-    # WebSocket transport keeps the most recent response in a connection-local,
-    # in-memory cache even when `store: false` (ZDR-compatible), and
-    # `previous_response_id` resolves against that cache. The official Codex CLI
-    # (openai/codex, codex-rs) relies on exactly this: `store: false` +
-    # `previous_response_id` over a persistent WebSocket to chain turns without
-    # re-uploading history. Coupling the two would silently break multi-turn
-    # chaining for every Codex request (Codex always forces `store: false`).
     previous_response_id =
-      provider_opts[:previous_response_id] ||
-        extract_previous_response_id_from_context(context)
+      if include_previous_response_id?(store, opts_map) do
+        provider_opts[:previous_response_id] ||
+          extract_previous_response_id_from_context(context)
+      end
 
     {input, _tool_messages, reasoning_items} =
       Enum.reduce(context.messages, {[], [], []}, fn msg, {input_acc, tool_acc, reasoning_acc} ->
@@ -723,14 +717,6 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("include", include)
       |> maybe_put_string("text", text_format)
 
-    # Attach `previous_response_id` without coercing `store`. The caller's
-    # `store` value is authoritative: `store: false` + `previous_response_id`
-    # is a valid combination over the Responses WebSocket transport (the prior
-    # response lives in a connection-local cache), so we must not force
-    # `store: true` here. The `store: true` path is unchanged: when a
-    # `previous_response_id` is present and `store` is not explicitly false we
-    # still stamp `store: true` (preserving the historical behavior), but for
-    # `store: false` we send `store: false` alongside `previous_response_id`.
     body =
       if previous_response_id do
         body
@@ -747,10 +733,10 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     end
   end
 
-  # Preserve the historical `store: true` stamp when chaining with a
-  # `previous_response_id` and `store` is not explicitly disabled. When
-  # `store == false` the trailing clause in `build_request_body/4` sets
-  # `store: false`, so we intentionally do nothing here.
+  defp include_previous_response_id?(false, %{responses_transport: :websocket}), do: true
+  defp include_previous_response_id?(false, _opts), do: false
+  defp include_previous_response_id?(_store, _opts), do: true
+
   defp maybe_put_store_true(body, false), do: body
   defp maybe_put_store_true(body, _store), do: Map.put(body, "store", true)
 
@@ -990,6 +976,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> Keyword.delete(:compiled_schema)
       |> Keyword.put(:provider_options, Keyword.get(opts, :provider_options, []))
       |> Keyword.put(:stream, nil)
+      |> Keyword.put(:responses_transport, :websocket)
       |> Keyword.put(:model, model.id)
       |> Keyword.put(:context, context)
       |> Keyword.put(

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -394,7 +394,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
   end
 
   defp build_codex_body(context, model_name, opts, request) do
-    opts = opts |> ensure_provider_options() |> force_store_false()
+    opts = opts |> ensure_provider_options() |> force_store_false() |> put_responses_transport()
     body = ResponsesAPI.build_request_body(context, model_name, opts, request)
     provider_opts = provider_options(opts)
     instructions = extract_instructions(context) || ""
@@ -440,6 +440,12 @@ defmodule ReqLLM.Providers.OpenAICodex do
     do: provider_opts |> Map.to_list() |> Keyword.put(:store, false)
 
   defp provider_options_store_false(_provider_opts), do: [store: false]
+
+  defp put_responses_transport(opts) when is_list(opts),
+    do: Keyword.put(opts, :responses_transport, :websocket)
+
+  defp put_responses_transport(opts) when is_map(opts),
+    do: Map.put(opts, :responses_transport, :websocket)
 
   defp tool_resume_body?(%{"input" => input}) when is_list(input) do
     Enum.any?(input, fn

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1888,7 +1888,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              end)
     end
 
-    test "store: false suppresses previous_response_id and sets store to false" do
+    test "store: false sends previous_response_id and keeps store false (no coercion)" do
       assistant_msg = %ReqLLM.Message{
         role: :assistant,
         content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
@@ -1906,7 +1906,31 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       encoded = ResponsesAPI.encode_body(request)
       body = ReqLLM.Test.Helpers.json_body(encoded)
 
-      refute Map.has_key?(body, "previous_response_id")
+      # `store: false` + `previous_response_id` is valid over the Responses
+      # WebSocket transport (connection-local cache); `store` must NOT be
+      # coerced to true and `previous_response_id` must NOT be dropped.
+      assert body["previous_response_id"] == "resp_prev_123"
+      assert body["store"] == false
+    end
+
+    test "explicit previous_response_id provider option is honored with store: false" do
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [user_msg]}
+
+      request =
+        build_request(
+          context: context,
+          provider_options: [store: false, previous_response_id: "resp_x"]
+        )
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["previous_response_id"] == "resp_x"
       assert body["store"] == false
     end
 
@@ -1932,7 +1956,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert body["store"] == true
     end
 
-    test "codex models default store to false and suppress previous_response_id" do
+    test "codex models default store to false but still chain via previous_response_id" do
       assistant_msg = %ReqLLM.Message{
         role: :assistant,
         content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
@@ -1950,7 +1974,10 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       encoded = ResponsesAPI.encode_body(request)
       body = ReqLLM.Test.Helpers.json_body(encoded)
 
-      refute Map.has_key?(body, "previous_response_id")
+      # Codex always forces `store: false`, but multi-turn chaining over the
+      # Responses WebSocket depends on `previous_response_id` resolving against
+      # the connection-local cache. The id must be sent, not suppressed.
+      assert body["previous_response_id"] == "resp_prev_codex"
       assert body["store"] == false
     end
 

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1691,6 +1691,45 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert payload["type"] == "response.create"
       assert payload["response"] == config.canonical_json
     end
+
+    test "keeps previous_response_id with store false over websocket transport" do
+      original_key = System.get_env("OPENAI_API_KEY")
+      System.put_env("OPENAI_API_KEY", "test-key-12345")
+
+      on_exit(fn ->
+        if original_key do
+          System.put_env("OPENAI_API_KEY", original_key)
+        else
+          System.delete_env("OPENAI_API_KEY")
+        end
+      end)
+
+      {:ok, model} = ReqLLM.model("openai:gpt-5")
+
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
+        metadata: %{response_id: "resp_ws_123"}
+      }
+
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
+
+      {:ok, config} =
+        ResponsesAPI.attach_websocket_stream(
+          model,
+          context,
+          base_url: "http://localhost:4010/v1",
+          provider_options: [store: false]
+        )
+
+      assert config.canonical_json["previous_response_id"] == "resp_ws_123"
+      assert config.canonical_json["store"] == false
+    end
   end
 
   describe "reasoning details - decode_response/1" do
@@ -1888,7 +1927,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              end)
     end
 
-    test "store: false sends previous_response_id and keeps store false (no coercion)" do
+    test "store: false suppresses previous_response_id outside websocket transport" do
       assistant_msg = %ReqLLM.Message{
         role: :assistant,
         content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
@@ -1906,14 +1945,11 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       encoded = ResponsesAPI.encode_body(request)
       body = ReqLLM.Test.Helpers.json_body(encoded)
 
-      # `store: false` + `previous_response_id` is valid over the Responses
-      # WebSocket transport (connection-local cache); `store` must NOT be
-      # coerced to true and `previous_response_id` must NOT be dropped.
-      assert body["previous_response_id"] == "resp_prev_123"
+      refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
     end
 
-    test "explicit previous_response_id provider option is honored with store: false" do
+    test "explicit previous_response_id provider option is suppressed with store: false outside websocket transport" do
       user_msg = %ReqLLM.Message{
         role: :user,
         content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
@@ -1930,7 +1966,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       encoded = ResponsesAPI.encode_body(request)
       body = ReqLLM.Test.Helpers.json_body(encoded)
 
-      assert body["previous_response_id"] == "resp_x"
+      refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
     end
 
@@ -1956,7 +1992,7 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert body["store"] == true
     end
 
-    test "codex models default store to false but still chain via previous_response_id" do
+    test "websocket transport with codex models defaults store to false but still chains via previous_response_id" do
       assistant_msg = %ReqLLM.Message{
         role: :assistant,
         content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
@@ -1969,14 +2005,17 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       }
 
       context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
-      request = build_request(id: "gpt-5.3-codex", context: context)
+
+      request =
+        build_request(
+          id: "gpt-5.3-codex",
+          context: context,
+          responses_transport: :websocket
+        )
 
       encoded = ResponsesAPI.encode_body(request)
       body = ReqLLM.Test.Helpers.json_body(encoded)
 
-      # Codex always forces `store: false`, but multi-turn chaining over the
-      # Responses WebSocket depends on `previous_response_id` resolving against
-      # the connection-local cache. The id must be sent, not suppressed.
       assert body["previous_response_id"] == "resp_prev_codex"
       assert body["store"] == false
     end
@@ -2228,19 +2267,21 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
     context = Keyword.get(opts, :context, %ReqLLM.Context{messages: []})
     provider_opts = Keyword.get(opts, :provider_options, [])
 
-    req_opts = %{
-      id: Keyword.get(opts, :id, "gpt-5"),
-      context: context,
-      stream: Keyword.get(opts, :stream),
-      max_output_tokens: Keyword.get(opts, :max_output_tokens),
-      max_completion_tokens: Keyword.get(opts, :max_completion_tokens),
-      max_tokens: Keyword.get(opts, :max_tokens),
-      tools: Keyword.get(opts, :tools),
-      tool_choice: Keyword.get(opts, :tool_choice),
-      parallel_tool_calls: Keyword.get(opts, :parallel_tool_calls),
-      reasoning_effort: Keyword.get(opts, :reasoning_effort),
-      provider_options: provider_opts
-    }
+    req_opts =
+      %{
+        id: Keyword.get(opts, :id, "gpt-5"),
+        context: context,
+        stream: Keyword.get(opts, :stream),
+        max_output_tokens: Keyword.get(opts, :max_output_tokens),
+        max_completion_tokens: Keyword.get(opts, :max_completion_tokens),
+        max_tokens: Keyword.get(opts, :max_tokens),
+        tools: Keyword.get(opts, :tools),
+        tool_choice: Keyword.get(opts, :tool_choice),
+        parallel_tool_calls: Keyword.get(opts, :parallel_tool_calls),
+        reasoning_effort: Keyword.get(opts, :reasoning_effort),
+        provider_options: provider_opts
+      }
+      |> maybe_put_responses_transport(Keyword.get(opts, :responses_transport))
 
     %Req.Request{
       method: :post,
@@ -2250,6 +2291,11 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       options: req_opts
     }
   end
+
+  defp maybe_put_responses_transport(opts, nil), do: opts
+
+  defp maybe_put_responses_transport(opts, transport),
+    do: Map.put(opts, :responses_transport, transport)
 
   defp build_response(status, body, opts \\ []) do
     context = Keyword.get(opts, :context, %ReqLLM.Context{messages: []})

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -214,7 +214,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
              )
     end
 
-    test "omits previous_response_id from context metadata while keeping store=false" do
+    test "sends previous_response_id from context metadata while keeping store=false" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
 
       context =
@@ -238,11 +238,18 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
 
       body = ReqLLM.Test.Helpers.json_body(request)
 
-      refute Map.has_key?(body, "previous_response_id")
+      # Codex forces store=false, but multi-turn chaining over the Responses
+      # WebSocket depends on previous_response_id resolving against the
+      # connection-local cache. The id must be sent, not suppressed.
+      assert body["previous_response_id"] == "resp_prev_789"
       assert body["store"] == false
     end
 
     test "omits previous_response_id for explicit tool_outputs resume while keeping store=false" do
+      # Tool-resume turns (those carrying function_call_output items) follow a
+      # distinct backend contract that deliberately drops previous_response_id
+      # (see #613). That is independent of the store/previous_response_id
+      # coupling fixed in ResponsesAPI.build_request_body/4 and is preserved here.
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
       context = ReqLLM.context([ReqLLM.Context.user("Use the provided tool output")])
 


### PR DESCRIPTION
## What

`ResponsesAPI.build_request_body/4` only resolves `previous_response_id` when
`store != false`, and force-sets `store: true` whenever one is present — treating
`store` and `previous_response_id` as a single switch. They aren't. And because
`OpenAICodex` always sends `store: false`, multi-turn chaining over the Codex
Responses-over-WebSocket transport never sends `previous_response_id` at all.

## Why `store: false` + `previous_response_id` is intended, not a mistake

The two flags answer different questions, and conflating them is the bug:

- **`store`** = should this response be *persisted* server-side? For Codex it's an
  **endpoint property**, not a chaining choice — codex-rs derives it from the
  endpoint, `true` only for Azure:
  ```rust
  // openai/codex — codex-rs/core/src/client.rs:781
  store: provider.is_azure_responses_endpoint(),  // → false for chatgpt.com/backend-api
  ```
- **`previous_response_id`** = chain onto a prior response. Over the Responses
  **WebSocket** transport the prior response lives in a **connection-local,
  in-memory cache** (ZDR-compatible) and resolves there even with `store: false`.
  codex-rs relies on exactly this combination to chain turns without re-uploading
  history.

Verified live against `chatgpt.com/backend-api/codex`: with the fix, a chained
turn recalls prior context — server `input_tokens` **39 → 725**; without it the
id is stripped and the model has no context.

## Fix

Resolve `previous_response_id` independently of `store`, and attach it without
coercing `store` (stamp `store: true` only when `store` isn't explicitly `false`,
via `maybe_put_store_true/2` — the `store: true` path is unchanged).

| `store` | `previous_response_id` | before → after |
|---|---|---|
| `false` | set | dropped → **sent, with `store: false`** |
| `true` / default | set | unchanged |
| any | unset | unchanged |

## Scope

`build_request_body/4` is shared with the plain-HTTP path, where there is no
connection-local cache, so `store: false` + `previous_response_id` returns
`previous_response_not_found`. This changes that opt-in combination from
"silently drop the id" to "send it, and let the server respond." Happy to instead
gate it on the WebSocket transport if you'd prefer. (`OpenAICodex`'s
`force_store_false` is correct and untouched; the `build_codex_body`
`tool_resume_body?` drop for `function_call_output` turns, per #613, is untouched.)

## Tests

Added `store: false` + `previous_response_id` coverage; `store: true` and no-id
paths asserted unchanged. Provider suites green (948 tests, 0 failures).
