### PR TITLE
feat(anthropic): honor explicit cache_control from ContentPart metadata

### DIFF
--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -217,8 +217,7 @@ defmodule ReqLLM.Providers.Anthropic.Context do
 
     case content_blocks do
       [] -> ""
-      # Simplify single text blocks
-      [%{type: "text", text: text}] -> text
+      [%{type: "text", text: text} = block] when map_size(block) == 2 -> text
       blocks -> blocks
     end
   end

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -196,7 +196,13 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   defp blank_system_content_block?(_block), do: false
 
   defp normalize_system_content([]), do: nil
-  defp normalize_system_content([%{type: "text", text: text}]), do: text
+  # Collapse a lone plain text block to a bare string — but only when it carries
+  # nothing else (e.g. no explicit `cache_control`), so an explicit cache
+  # breakpoint on a single system block is preserved.
+  defp normalize_system_content([%{type: "text", text: text} = block])
+       when map_size(block) == 2,
+       do: text
+
   defp normalize_system_content(blocks), do: blocks
 
   # Simple text content
@@ -217,13 +223,29 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     end
   end
 
-  defp encode_content_part(%ReqLLM.Message.ContentPart{type: :text, text: ""}), do: nil
+  # Encodes a content part, then applies any explicit Anthropic cache breakpoint
+  # declared via `ContentPart` metadata. This lets callers place multiple
+  # `cache_control` breakpoints with PER-BLOCK TTLs — e.g. a 1-hour system block
+  # followed by a 5-minute one — which the single `anthropic_prompt_cache_ttl`
+  # option cannot express. See the Anthropic prompt-caching "explicit cache
+  # breakpoints" docs. Declare it as
+  # `ContentPart.text(text, %{cache_control: %{type: "ephemeral", ttl: "1h"}})`.
+  defp encode_content_part(%ReqLLM.Message.ContentPart{metadata: metadata} = part) do
+    case do_encode_content_part(part) do
+      block when is_map(block) -> maybe_put_cache_control(block, metadata)
+      other -> other
+    end
+  end
 
-  defp encode_content_part(%ReqLLM.Message.ContentPart{type: :text, text: text}) do
+  defp encode_content_part(_), do: nil
+
+  defp do_encode_content_part(%ReqLLM.Message.ContentPart{type: :text, text: ""}), do: nil
+
+  defp do_encode_content_part(%ReqLLM.Message.ContentPart{type: :text, text: text}) do
     %{type: "text", text: text}
   end
 
-  defp encode_content_part(%ReqLLM.Message.ContentPart{
+  defp do_encode_content_part(%ReqLLM.Message.ContentPart{
          type: :image,
          data: data,
          media_type: media_type
@@ -240,7 +262,7 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     }
   end
 
-  defp encode_content_part(%ReqLLM.Message.ContentPart{type: :image_url, url: url}) do
+  defp do_encode_content_part(%ReqLLM.Message.ContentPart{type: :image_url, url: url}) do
     %{
       type: "image",
       source: %{
@@ -250,7 +272,7 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     }
   end
 
-  defp encode_content_part(%ReqLLM.Message.ContentPart{
+  defp do_encode_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
          file_id: file_id,
          media_type: media_type,
@@ -267,7 +289,7 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     |> maybe_add_document_file_metadata(metadata)
   end
 
-  defp encode_content_part(%ReqLLM.Message.ContentPart{
+  defp do_encode_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
          data: data,
          media_type: media_type,
@@ -286,7 +308,20 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     }
   end
 
-  defp encode_content_part(_), do: nil
+  defp do_encode_content_part(_), do: nil
+
+  # Honors an explicit cache breakpoint declared in ContentPart metadata as
+  # `%{cache_control: %{type: "ephemeral"}}` (or with `"ttl" => "1h"`). Accepts
+  # atom or string `cache_control` keys; leaves the block untouched when absent.
+  defp maybe_put_cache_control(block, %{cache_control: cache_control})
+       when is_map(cache_control),
+       do: Map.put(block, :cache_control, cache_control)
+
+  defp maybe_put_cache_control(block, %{"cache_control" => cache_control})
+       when is_map(cache_control),
+       do: Map.put(block, :cache_control, cache_control)
+
+  defp maybe_put_cache_control(block, _metadata), do: block
 
   defp file_block_type(media_type) when is_binary(media_type) do
     if String.starts_with?(media_type, "image/"), do: "image", else: "document"

--- a/test/req_llm/providers/anthropic_prompt_cache_test.exs
+++ b/test/req_llm/providers/anthropic_prompt_cache_test.exs
@@ -234,6 +234,81 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
     end
   end
 
+  describe "explicit per-block cache_control via ContentPart metadata" do
+    test "preserves cache_control declared on a content block, with its TTL" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          %ReqLLM.Message{
+            role: :system,
+            content: [
+              ReqLLM.Message.ContentPart.text("Style guide.", %{
+                cache_control: %{type: "ephemeral", ttl: "1h"}
+              })
+            ]
+          },
+          ReqLLM.Context.user("Hello!")
+        ])
+
+      # No `anthropic_prompt_cache` option — the breakpoint is declared explicitly.
+      {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
+      decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      [system_block] = decoded["system"]
+      assert system_block["text"] == "Style guide."
+      assert system_block["cache_control"] == %{"type" => "ephemeral", "ttl" => "1h"}
+    end
+
+    test "supports multiple breakpoints with distinct per-block TTLs" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          %ReqLLM.Message{
+            role: :system,
+            content: [
+              ReqLLM.Message.ContentPart.text("Stable style guide.", %{
+                cache_control: %{type: "ephemeral", ttl: "1h"}
+              }),
+              ReqLLM.Message.ContentPart.text("Per-run context.", %{
+                cache_control: %{type: "ephemeral"}
+              })
+            ]
+          },
+          ReqLLM.Context.user("Hello!")
+        ])
+
+      {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
+      decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      assert [first, second] = decoded["system"]
+      # Longer TTL (1h) must precede the shorter (5m default) per Anthropic's rule.
+      assert first["cache_control"] == %{"type" => "ephemeral", "ttl" => "1h"}
+      assert second["cache_control"] == %{"type" => "ephemeral"}
+    end
+
+    test "leaves blocks untouched when metadata has no cache_control" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          %ReqLLM.Message{
+            role: :system,
+            content: [ReqLLM.Message.ContentPart.text("Plain.", %{source: "test"})]
+          },
+          ReqLLM.Context.user("Hello!")
+        ])
+
+      {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
+      decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      # No cache_control and nothing else on the block, so it collapses to a
+      # bare system string, exactly as before this change.
+      assert decoded["system"] == "Plain."
+    end
+  end
+
   describe "combined prompt caching scenarios" do
     test "applies cache_control to both tools and system" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")

--- a/test/req_llm/providers/anthropic_prompt_cache_test.exs
+++ b/test/req_llm/providers/anthropic_prompt_cache_test.exs
@@ -251,13 +251,35 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
           ReqLLM.Context.user("Hello!")
         ])
 
-      # No `anthropic_prompt_cache` option — the breakpoint is declared explicitly.
       {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
       decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
       [system_block] = decoded["system"]
       assert system_block["text"] == "Style guide."
       assert system_block["cache_control"] == %{"type" => "ephemeral", "ttl" => "1h"}
+    end
+
+    test "preserves cache_control on a single message content block" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      context =
+        ReqLLM.Context.new([
+          %ReqLLM.Message{
+            role: :user,
+            content: [
+              ReqLLM.Message.ContentPart.text("Cached user context.", %{
+                "cache_control" => %{"type" => "ephemeral", "ttl" => "1h"}
+              })
+            ]
+          }
+        ])
+
+      {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
+      decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      [%{"content" => [content_block]}] = decoded["messages"]
+      assert content_block["text"] == "Cached user context."
+      assert content_block["cache_control"] == %{"type" => "ephemeral", "ttl" => "1h"}
     end
 
     test "supports multiple breakpoints with distinct per-block TTLs" do
@@ -283,7 +305,6 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
       decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
       assert [first, second] = decoded["system"]
-      # Longer TTL (1h) must precede the shorter (5m default) per Anthropic's rule.
       assert first["cache_control"] == %{"type" => "ephemeral", "ttl" => "1h"}
       assert second["cache_control"] == %{"type" => "ephemeral"}
     end
@@ -303,8 +324,6 @@ defmodule ReqLLM.Providers.AnthropicPromptCacheTest do
       {:ok, request} = Anthropic.prepare_request(:chat, model, context, [])
       decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
-      # No cache_control and nothing else on the block, so it collapses to a
-      # bare system string, exactly as before this change.
       assert decoded["system"] == "Plain."
     end
   end


### PR DESCRIPTION
## Summary

The Anthropic context encoder discards any `cache_control` set on a `ContentPart`, so prompt caching can only be driven by the `anthropic_prompt_cache` / `anthropic_prompt_cache_ttl` options. Those stamp a **single** TTL on the last block (system / tools / message), which cannot express Anthropic's [explicit cache breakpoints](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#explicit-cache-breakpoints) with **per-block TTLs** — e.g. a 1-hour system block followed by a 5-minute one.

This PR lets callers declare a cache breakpoint directly on a content block via its `metadata`, and the encoder carries it onto the emitted block:

```elixir
ReqLLM.Context.system([
  ContentPart.text(style_guide, %{cache_control: %{type: "ephemeral", ttl: "1h"}}),
  ContentPart.text(context,     %{cache_control: %{type: "ephemeral"}})  # 5m default
])
```

## Changes

- `encode_content_part/1` now applies a `cache_control` found in a ContentPart's `metadata` (atom **or** string key) onto the encoded block, for every block type (text/image/file/document). Implemented as a thin wrapper over the existing per-type encoders (renamed `do_encode_content_part/1`) — the shape logic is unchanged.
- `normalize_system_content/1` only collapses a lone text block to a bare string when it carries nothing else (`map_size == 2`), so an explicit cache breakpoint on a **single** system block is no longer silently stripped.

It composes with the existing auto-injection (`maybe_apply_prompt_caching/2` only adds `cache_control` to a block that lacks one), so there is **no behavior change** for current callers.

## Tests

Added a `describe "explicit per-block cache_control via ContentPart metadata"` block to `anthropic_prompt_cache_test.exs` covering: a single explicit breakpoint with a TTL, multiple breakpoints with distinct TTLs (1h before 5m), and the no-cache_control passthrough. Full suite green (`3340 tests, 0 failures`).

## Verification

Verified end-to-end against `claude-opus-4-6` on Google Vertex: the request is accepted with mixed TTLs, and the two breakpoints produce independent cache entries (the 1-hour block is read from cache while the trailing 5-minute block is rewritten when its content changes).