### PR TITLE
fix(anthropic): Return thinking text for Opus 4.7, Opus 4.8, and Mythos Preview

### DIFF
--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1418,11 +1418,15 @@ defmodule ReqLLM.Providers.Anthropic do
           |> put_output_effort(effort_from_thinking(thinking, model))
           |> remove_adaptive_thinking_sampling_params()
 
-        %{type: "adaptive"} ->
-          remove_adaptive_thinking_sampling_params(opts)
+        %{type: "adaptive"} = thinking ->
+          opts
+          |> Keyword.put(:thinking, put_default_adaptive_thinking_display(thinking))
+          |> remove_adaptive_thinking_sampling_params()
 
-        %{"type" => "adaptive"} ->
-          remove_adaptive_thinking_sampling_params(opts)
+        %{"type" => "adaptive"} = thinking ->
+          opts
+          |> Keyword.put(:thinking, put_default_adaptive_thinking_display(thinking))
+          |> remove_adaptive_thinking_sampling_params()
 
         _ ->
           opts
@@ -1431,6 +1435,15 @@ defmodule ReqLLM.Providers.Anthropic do
       opts
     end
   end
+
+  defp put_default_adaptive_thinking_display(%{display: _} = thinking), do: thinking
+  defp put_default_adaptive_thinking_display(%{"display" => _} = thinking), do: thinking
+
+  defp put_default_adaptive_thinking_display(%{"type" => _} = thinking),
+    do: Map.put(thinking, "display", "summarized")
+
+  defp put_default_adaptive_thinking_display(thinking),
+    do: Map.put(thinking, :display, "summarized")
 
   defp put_output_effort(opts, effort) do
     Keyword.update(opts, :output_config, %{effort: effort}, fn

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1377,7 +1377,7 @@ defmodule ReqLLM.Providers.Anthropic do
   defp put_reasoning_effort(opts, model, effort, reasoning_budget) do
     if adaptive_thinking_required?(model) do
       opts
-      |> Keyword.put(:thinking, %{type: "adaptive"})
+      |> Keyword.put(:thinking, %{type: "adaptive", display: "summarized"})
       |> put_output_effort(adaptive_effort(effort, model))
       |> remove_adaptive_thinking_sampling_params()
     else
@@ -1393,7 +1393,7 @@ defmodule ReqLLM.Providers.Anthropic do
   defp put_default_reasoning_effort(opts, model) do
     if adaptive_thinking_required?(model) do
       opts
-      |> Keyword.put(:thinking, %{type: "adaptive"})
+      |> Keyword.put(:thinking, %{type: "adaptive", display: "summarized"})
       |> put_output_effort(adaptive_effort(:default, model))
       |> remove_adaptive_thinking_sampling_params()
     else
@@ -1408,13 +1408,13 @@ defmodule ReqLLM.Providers.Anthropic do
       case Keyword.get(opts, :thinking) do
         %{type: "enabled"} = thinking ->
           opts
-          |> Keyword.put(:thinking, %{type: "adaptive"})
+          |> Keyword.put(:thinking, %{type: "adaptive", display: "summarized"})
           |> put_output_effort(effort_from_thinking(thinking, model))
           |> remove_adaptive_thinking_sampling_params()
 
         %{"type" => "enabled"} = thinking ->
           opts
-          |> Keyword.put(:thinking, %{type: "adaptive"})
+          |> Keyword.put(:thinking, %{type: "adaptive", display: "summarized"})
           |> put_output_effort(effort_from_thinking(thinking, model))
           |> remove_adaptive_thinking_sampling_params()
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -1373,6 +1373,27 @@ defmodule ReqLLM.Providers.AnthropicTest do
       refute Keyword.has_key?(translated_opts, :temperature)
     end
 
+    test "translate_options defaults direct adaptive thinking display to summarized" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
+
+      cases = [
+        {%{type: "adaptive"}, %{type: "adaptive", display: "summarized"}},
+        {%{"type" => "adaptive"}, %{"type" => "adaptive", "display" => "summarized"}}
+      ]
+
+      for {thinking, expected} <- cases do
+        {translated_opts, []} =
+          Anthropic.translate_options(:chat, model,
+            thinking: thinking,
+            temperature: 0.0,
+            max_tokens: 100
+          )
+
+        assert Keyword.get(translated_opts, :thinking) == expected
+        refute Keyword.has_key?(translated_opts, :temperature)
+      end
+    end
+
     test "translate_options removes Claude Opus 4.8 sampling params without reasoning" do
       {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -66,7 +66,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
       assert decoded["model"] == "claude-opus-4-8"
-      assert decoded["thinking"] == %{"type" => "adaptive"}
+      assert decoded["thinking"] == %{"type" => "adaptive", "display" => "summarized"}
       assert decoded["output_config"] == %{"effort" => "low"}
       refute Map.has_key?(decoded, "temperature")
       refute Map.has_key?(request.headers, "anthropic-beta")
@@ -1367,7 +1367,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
           max_tokens: 100
         )
 
-      assert Keyword.get(translated_opts, :thinking) == %{type: "adaptive"}
+      assert Keyword.get(translated_opts, :thinking) == %{type: "adaptive", display: "summarized"}
       assert Keyword.get(translated_opts, :output_config) == %{effort: "max"}
       refute Keyword.has_key?(translated_opts, :top_p)
       refute Keyword.has_key?(translated_opts, :temperature)

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -365,7 +365,7 @@ defmodule ReqLLM.Provider.OptionsTest do
       refute Keyword.has_key?(processed, :retry)
     end
 
-    test "process_stream preserves map-shaped thinking options" do
+    test "process_stream defaults direct adaptive thinking display to summarized" do
       {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
@@ -381,7 +381,7 @@ defmodule ReqLLM.Provider.OptionsTest do
           temperature: 0.0
         )
 
-      assert processed[:thinking] == %{type: "adaptive"}
+      assert processed[:thinking] == %{type: "adaptive", display: "summarized"}
       assert processed[:output_config] == %{effort: "low"}
       assert processed[:stream] == true
       refute Keyword.has_key?(processed, :top_p)


### PR DESCRIPTION
## Description

#732 added support for Claude models which only support `type: "adaptive"` thinking, such as Opus 4.7 and Opus 4.8. However, these new models default to `display: "omitted"` instead of `display: "summarized"` for thinking content, [as described in the documentation](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#summarized-thinking).

This PR forces `display: "summarized"` to continue returning thinking text content in the response from these models.

Previously the following code would return an empty string, even though the model did perform reasoning:

```elixir
{:ok, response} = ReqLLM.generate_text("anthropic:claude-opus-4-8", ["How would you build a pyramid? This task involves multi-step reasoning. Think carefully through the problem before responding."], api_key: api_key, reasoning_effort: :xhigh)

ReqLLM.Response.thinking(response)
```

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

N/A

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

#732 