### PR TITLE
fix(openai): preserve Responses file_id inputs

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -867,6 +867,18 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   defp encode_input_content_part(
+         %ReqLLM.Message.ContentPart{type: :file, file_id: file_id, filename: filename},
+         _type
+       )
+       when is_binary(file_id) and file_id != "" do
+    file =
+      %{"type" => "input_file", "file_id" => file_id}
+      |> maybe_put_string("filename", filename)
+
+    [file]
+  end
+
+  defp encode_input_content_part(
          %ReqLLM.Message.ContentPart{
            type: :file,
            data: data,

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -144,6 +144,37 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert warning == ""
     end
 
+    test "encodes file_id content parts as input_file items" do
+      file_part = ReqLLM.Message.ContentPart.file_id("file-6F2ksmvXxt4VdoqmHRw6kL")
+
+      context = %ReqLLM.Context{
+        messages: [
+          %ReqLLM.Message{
+            role: :user,
+            content: [
+              ReqLLM.Message.ContentPart.text("Summarize this file"),
+              file_part
+            ]
+          }
+        ]
+      }
+
+      request = build_request(context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert [
+               %{
+                 "role" => "user",
+                 "content" => [
+                   %{"type" => "input_text", "text" => "Summarize this file"},
+                   %{"type" => "input_file", "file_id" => "file-6F2ksmvXxt4VdoqmHRw6kL"}
+                 ]
+               }
+             ] = body["input"]
+    end
+
     test "omits tools when empty list" do
       request = build_request(tools: [])
 


### PR DESCRIPTION
## Summary
- encode OpenAI Responses file-id-only ContentPart values as input_file items
- keep binary file data handling unchanged
- add regression coverage for ContentPart.file_id/1 request body encoding

Closes #739

## Tests
- mix test test/provider/openai/responses_api_unit_test.exs
- mix test test/providers/openai_test.exs
- mix compile --warnings-as-errors
- git diff --check
- mix test