### PR TITLE
ReqLLM v2 architecture migration

### DIFF
--- a/guides/fixture-testing.md
+++ b/guides/fixture-testing.md
@@ -75,19 +75,29 @@ Each model entry includes:
 
 The `priv/supported_models.json` file tracks which models have passing fixtures. This file is auto-generated and should not be manually edited.
 
-### Comprehensive Test Macro
+### Scenario-Based Comprehensive Coverage
 
-Tests use the `ReqLLM.ProviderTest.Comprehensive` macro (in `test/support/provider_test/comprehensive.ex`), which generates up to 9 focused tests per model based on capabilities:
+Tests use the `ReqLLM.ProviderTest.Comprehensive` macro (in `test/support/provider_test/comprehensive.ex`), which generates tests from the scenario registry in `ReqLLM.Test.Scenarios`.
 
-1. **Basic generate_text** (non-streaming) - All models
-2. **Streaming** with system context + creative params - Models with streaming support
-3. **Token limit constraints** - All models
-4. **Usage metrics and cost calculations** - All models
-5. **Tool calling - multi-tool selection** - Models with `:tool_call` capability
-6. **Tool calling - no tool when inappropriate** - Models with `:tool_call` capability
-7. **Object generation (non-streaming)** - Models with object generation support
-8. **Object generation (streaming)** - Models with object generation support
-9. **Reasoning/thinking tokens** - Models with `:reasoning` capability
+Scenario modules live in `test/support/scenarios/` and own:
+- `id/0`, `name/0`, and `description/0`
+- fixture names via `fixtures/1`
+- model capability applicability via `applies?/1`
+- the replay/record request behavior in `run/3`
+
+Current comprehensive scenarios:
+
+1. **basic** - Basic `generate_text` (non-streaming)
+2. **streaming** - Streaming with system context
+3. **token_limit** - Token limit constraints
+4. **usage** - Usage metrics and cost calculations
+5. **context_append** - Multi-turn context advancement
+6. **tool_multi** - Tool calling with multiple tools
+7. **tool_round_trip** - Tool execution and follow-up response
+8. **tool_none** - Text response when tools are available but inappropriate
+9. **object_basic** - Object generation (non-streaming)
+10. **object_streaming** - Object generation (streaming)
+11. **reasoning** - Reasoning/thinking tokens for non-streaming and streaming
 
 ### Test Organization
 
@@ -112,9 +122,19 @@ end
 
 The macro automatically:
 - Selects models from `ModelMatrix` based on provider and operation type
-- Generates tests for each model based on capabilities
+- Filters scenario modules for each model based on capabilities
 - Handles fixture recording and replay
 - Tags tests with provider, model, and scenario
+
+### Authoring Scenarios
+
+Add or change scenarios in `test/support/scenarios/`, then register them in `ReqLLM.Test.Scenarios`.
+
+Rules:
+- Keep fixture names stable when refactoring test structure.
+- Do not change prompts, request options, tool schemas, object schemas, or fixture names unless the work includes an explicit fixture-refresh task.
+- Add guardrail coverage in `test/req_llm/scenarios/fixture_guardrail_test.exs` for new scenario fixture names.
+- Prefer replay proof first. Live recording is only needed when the wire request or provider behavior is intentionally changing.
 
 ## How "Supported Models" is Defined
 
@@ -150,6 +170,7 @@ mix test --only "provider:anthropic"
 mix test --only "scenario:basic"
 mix test --only "scenario:streaming"
 mix test --only "scenario:tool_multi"
+mix test --only "scenario:tool_round_trip"
 
 # Specific model
 mix test --only "model:claude-3-5-haiku-20241022"
@@ -202,20 +223,43 @@ REQ_LLM_DEBUG=1 mix mc
 
 ### Fixture Storage
 
-Fixtures are stored next to test files:
+Fixtures are stored under `test/support/fixtures/<provider>/<model_slug>/<fixture>.json`:
 
 ```
-test/coverage/<provider>/fixtures/
+test/support/fixtures/openai/gpt_4o_mini/
 ├── basic.json
 ├── streaming.json
 ├── token_limit.json
 ├── usage.json
-├── tool_multi.json
+├── context_append_1.json
+├── context_append_2.json
+├── multi_tool.json
+├── tool_round_trip_1.json
+├── tool_round_trip_2.json
 ├── no_tool.json
 ├── object_basic.json
-├── object_streaming.json
-└── reasoning_basic.json
+└── object_streaming.json
 ```
+
+Fixture paths are derived by `ReqLLM.Test.FixturePath`; scenario modules only pass the fixture basename through `fixture_opts/2` or `fixture_opts/3`.
+
+### `model_compat` Scenario Routing
+
+`mix req_llm.model_compat` preserves scenario and capability filters:
+
+```bash
+mix req_llm.model_compat "openai:gpt-4o-mini" --scenario basic,usage
+mix req_llm.model_compat "openai:gpt-4o-mini" --capability core
+mix req_llm.model_compat "anthropic:*" --capability tools
+```
+
+Text capability groups are sourced from `ReqLLM.Test.Scenarios` when the test support registry is loaded. Specialty provider scenarios, such as Google grounding and xAI web search, still route to focused provider-specific files.
+
+### Live Verification Policy
+
+Routine broad coverage is replay-first and should not make live API calls. Use `REQ_LLM_FIXTURES_MODE=record` or `mix req_llm.model_compat --record` only when intentionally creating or refreshing fixtures.
+
+Sparse live provider-drift checks should be added as separate focused work. Do not expand routine replay suites into live CI just to prove scenario refactors.
 
 ### Fixture Format
 

--- a/guides/fixture-testing.md
+++ b/guides/fixture-testing.md
@@ -99,6 +99,9 @@ Current comprehensive scenarios:
 10. **object_streaming** - Object generation (streaming)
 11. **reasoning** - Reasoning/thinking tokens for non-streaming and streaming
 
+The broader ReqLLM v2 modality map, including focused non-text coverage and
+known gaps, is documented in `guides/modality-coverage.md`.
+
 ### Test Organization
 
 ```
@@ -253,7 +256,7 @@ mix req_llm.model_compat "openai:gpt-4o-mini" --capability core
 mix req_llm.model_compat "anthropic:*" --capability tools
 ```
 
-Text capability groups are sourced from `ReqLLM.Test.Scenarios` when the test support registry is loaded. Specialty provider scenarios, such as Google grounding and xAI web search, still route to focused provider-specific files.
+Text capability groups are sourced from `ReqLLM.Test.Scenarios` when the test support registry is loaded. Specialty provider scenarios, such as Google grounding, web search/fetch, multimodal tool results, and focused streaming structured output, still route to focused provider-specific files.
 
 ### Live Verification Policy
 

--- a/guides/modality-coverage.md
+++ b/guides/modality-coverage.md
@@ -1,0 +1,105 @@
+# Modality Coverage Map
+
+This guide documents the ReqLLM v2 scenario taxonomy across text and non-text
+modalities. It is a planning and guardrail document: it names the behavior
+surface that should stay protected while provider wire-format internals are
+refactored.
+
+Routine validation remains replay-first. Do not record live fixtures unless a
+scenario prompt, request shape, options, schema, media payload, or provider
+behavior intentionally changes.
+
+## Proof Levels
+
+- `fixture_backed` - covered by replay fixtures today.
+- `unit_guarded` - covered by unit or provider encoding/decoding tests, but not
+  yet represented by replay fixture scenarios.
+- `mixed_proof` - some fixture-backed coverage exists, but adjacent behavior is
+  still mostly provider/unit guarded.
+- `macro_available` - a provider coverage macro exists, but no focused coverage
+  file currently uses it.
+
+## Scenario Taxonomy
+
+| Area | Operation | Modality | Proof | Scenario IDs |
+| --- | --- | --- | --- | --- |
+| `core` | `text` | text | `fixture_backed` | `basic`, `usage`, `token_limit` |
+| `conversation` | `text` | text | `fixture_backed` | `context_append` |
+| `streaming` | `text` | text | `fixture_backed` | `streaming` |
+| `tools` | `text` | tool | `fixture_backed` | `tool_none`, `tool_multi`, `tool_round_trip` |
+| `objects` | `text` | structured output | `fixture_backed` | `object_basic`, `object_streaming` |
+| `reasoning` | `text` | reasoning | `fixture_backed` | `reasoning` |
+| `embedding` | `embedding` | embedding vectors | `fixture_backed` | `embed_basic`, `embed_usage`, `embed_batch` |
+| `image` | `image` | image output | `fixture_backed` | `image_basic` |
+| `transcription` | `transcription` | audio input | `fixture_backed` | `transcription_basic` |
+| `speech` | `speech` | audio output | `fixture_backed` | `speech_basic` |
+| `rerank` | `rerank` | ranking | `fixture_backed` | `rerank_basic` |
+| `ocr` | `ocr` | document input | `macro_available` | `ocr_basic` |
+| `grounding` | `text` | web tool | `fixture_backed` | `grounding_basic`, `grounding_with_context`, `grounding_streaming` |
+| `grounding_legacy` | `text` | web tool | `fixture_backed` | `grounding_legacy` |
+| `multimodal_tool_result` | `text` | document input | `fixture_backed` | `multimodal_tool_result` |
+| `web_search` | `text` | web tool | `fixture_backed` | `web_search_basic`, `web_search_streaming`, `x_search_streaming` |
+| `web_fetch` | `text` | web tool | `fixture_backed` | `web_fetch_basic` |
+| `streaming_structured_output` | `text` | structured output | `fixture_backed` | `object_streaming_json_schema`, `object_streaming_tool_strict`, `object_streaming_auto`, `streaming_error_handling` |
+| `vision_input` | `text` | vision input | `unit_guarded` | none |
+| `file_input` | `text` | document input | `mixed_proof` | none |
+| `media_url_content` | `text` | media URL | `unit_guarded` | none |
+| `audio_output_chat` | `text` | audio output | `unit_guarded` | none |
+
+The machine-checkable source for this table is
+`ReqLLM.Test.Scenarios.ModalityTaxonomy` in
+`test/support/scenarios/modality_taxonomy.ex`.
+
+## Current Fixture-Backed Providers
+
+Focused non-text and provider-specific coverage is routed through
+`mix req_llm.model_compat` when a matching capability or scenario is requested.
+
+| Area | Focused Coverage Files |
+| --- | --- |
+| `embedding` | `test/coverage/amazon_bedrock/embedding_test.exs`, `test/coverage/azure/embedding_test.exs`, `test/coverage/google/embedding_test.exs`, `test/coverage/google_vertex_gemini/embedding_test.exs`, `test/coverage/openai/embedding_test.exs`, `test/coverage/openrouter/embedding_test.exs` |
+| `image` | `test/coverage/google/image_generation_test.exs`, `test/coverage/openai/image_generation_test.exs`, `test/coverage/xai/image_generation_test.exs` |
+| `transcription` | `test/coverage/groq/transcription_test.exs`, `test/coverage/openai/transcription_test.exs` |
+| `speech` | `test/coverage/elevenlabs/speech_test.exs`, `test/coverage/openai/speech_test.exs` |
+| `rerank` | `test/coverage/cohere/rerank_test.exs` |
+| `grounding`, `grounding_legacy` | `test/coverage/google/grounding_test.exs` |
+| `multimodal_tool_result` | `test/coverage/google/multimodal_tool_result_test.exs` |
+| `web_search` | `test/coverage/anthropic/web_search_test.exs`, `test/coverage/openai/web_search_test.exs`, `test/coverage/xai/web_search_test.exs` |
+| `web_fetch` | `test/coverage/anthropic/web_fetch_test.exs` |
+| `streaming_structured_output` | `test/coverage/anthropic/streaming_structured_output_test.exs`, `test/coverage/azure/streaming_structured_output_test.exs`, `test/coverage/xai/streaming_structured_output_test.exs` |
+
+## Known Gaps
+
+These are intentional visibility gaps, not failures in the current suite.
+
+- `ocr_basic` has a provider coverage macro but no focused coverage file.
+- Vision input is mostly protected by provider/unit tests for image binary,
+  image URL, and mixed text/image encoding.
+- File input has focused Google multimodal-tool-result coverage, but broader
+  PDF/file-id/provider rejection behavior is still provider/unit guarded.
+- Video URL and media URL content parts are tested at message/context/provider
+  encoding boundaries, not as live replay scenarios.
+- Audio-output chat behavior is provider/unit guarded; speech generation itself
+  is fixture-backed through `speech_basic`.
+- Image edit, source image, and mask options are unit-guarded; `image_basic`
+  currently proves only basic image generation.
+
+## Brainstormed Next Epics
+
+This list is brainstormed and subject to change. Items should be promoted into
+separate Beadwork epics before implementation.
+
+- Promote OCR into focused fixture-backed coverage once a stable provider/model
+  target is selected.
+- Add vision-input replay scenarios for image binary, image URL, and mixed
+  text/image messages.
+- Add document-input replay scenarios for file IDs, inline PDFs, OpenRouter
+  file-parser behavior, and OpenAI Responses file handling.
+- Split image generation into basic generation, edit/source image, mask, and
+  provider option scenarios.
+- Add audio-output chat scenarios for models that return text plus audio
+  metadata or transcripts.
+- Add video/media URL replay coverage where providers support it, and explicit
+  rejection scenarios where they do not.
+- Convert focused non-text provider macros into reusable scenario modules once
+  the taxonomy is stable.

--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -92,17 +92,40 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     "grounding_legacy" => ~w(grounding_legacy),
     "multimodal_tool_result" => ~w(multimodal_tool_result),
     "web_search" => ~w(web_search_basic web_search_streaming x_search_streaming),
+    "web_fetch" => ~w(web_fetch_basic),
     "streaming_structured_output" =>
       ~w(object_streaming_json_schema object_streaming_tool_strict object_streaming_auto streaming_error_handling)
   }
 
   @scenario_test_files %{
+    anthropic: %{
+      "web_fetch_basic" => "test/coverage/anthropic/web_fetch_test.exs",
+      "web_search_basic" => "test/coverage/anthropic/web_search_test.exs",
+      "object_streaming_json_schema" =>
+        "test/coverage/anthropic/streaming_structured_output_test.exs",
+      "object_streaming_tool_strict" =>
+        "test/coverage/anthropic/streaming_structured_output_test.exs",
+      "object_streaming_auto" => "test/coverage/anthropic/streaming_structured_output_test.exs",
+      "streaming_error_handling" => "test/coverage/anthropic/streaming_structured_output_test.exs"
+    },
+    azure: %{
+      "object_streaming_json_schema" =>
+        "test/coverage/azure/streaming_structured_output_test.exs",
+      "object_streaming_tool_strict" =>
+        "test/coverage/azure/streaming_structured_output_test.exs",
+      "object_streaming_auto" => "test/coverage/azure/streaming_structured_output_test.exs",
+      "streaming_error_handling" => "test/coverage/azure/streaming_structured_output_test.exs"
+    },
     google: %{
       "grounding_basic" => "test/coverage/google/grounding_test.exs",
       "grounding_with_context" => "test/coverage/google/grounding_test.exs",
       "grounding_streaming" => "test/coverage/google/grounding_test.exs",
       "grounding_legacy" => "test/coverage/google/grounding_test.exs",
       "multimodal_tool_result" => "test/coverage/google/multimodal_tool_result_test.exs"
+    },
+    openai: %{
+      "web_search_basic" => "test/coverage/openai/web_search_test.exs",
+      "web_search_streaming" => "test/coverage/openai/web_search_test.exs"
     },
     xai: %{
       "web_search_basic" => "test/coverage/xai/web_search_test.exs",
@@ -587,36 +610,39 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   defp normalize_provider(provider) when is_binary(provider), do: String.to_atom(provider)
 
   defp base_test_args(provider, :all) do
-    ["test", "test/coverage/#{provider}"]
+    ["test", "test/coverage/#{coverage_dir(provider)}"]
   end
 
   defp base_test_args(provider, :embedding) do
-    ["test", "test/coverage/#{provider}/embedding_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/embedding_test.exs"]
   end
 
   defp base_test_args(provider, :image) do
-    ["test", "test/coverage/#{provider}/image_generation_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/image_generation_test.exs"]
   end
 
   defp base_test_args(provider, :speech) do
-    ["test", "test/coverage/#{provider}/speech_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/speech_test.exs"]
   end
 
   defp base_test_args(provider, :transcription) do
-    ["test", "test/coverage/#{provider}/transcription_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/transcription_test.exs"]
   end
 
   defp base_test_args(provider, :rerank) do
-    ["test", "test/coverage/#{provider}/rerank_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/rerank_test.exs"]
   end
 
   defp base_test_args(provider, :ocr) do
-    ["test", "test/coverage/#{provider}/ocr_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/ocr_test.exs"]
   end
 
   defp base_test_args(provider, :text) do
-    ["test", "test/coverage/#{provider}/comprehensive_test.exs"]
+    ["test", "test/coverage/#{coverage_dir(provider)}/comprehensive_test.exs"]
   end
+
+  defp coverage_dir(:google_vertex), do: "google_vertex_gemini"
+  defp coverage_dir(provider), do: to_string(provider)
 
   defp parse_test_result(provider, model_id, output, exit_code, scenario) do
     {passed, failed, total} = parse_exunit_summary(output)

--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -169,8 +169,10 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
   @doc false
   def capability_scenarios!(capability) when is_binary(capability) do
-    case Map.fetch(@capability_scenarios, capability) do
+    case scenario_registry_capability_scenarios(capability) ||
+           Map.fetch(@capability_scenarios, capability) do
       {:ok, scenarios} -> scenarios
+      scenarios when is_list(scenarios) -> scenarios
       :error -> Mix.raise("Unknown capability group: #{capability}")
     end
   end
@@ -542,6 +544,31 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
   defp build_test_args(provider, _category, operation, scenario) do
     test_args_for(provider, operation, scenario)
+  end
+
+  defp scenario_registry_capability_scenarios(capability) do
+    registry = Module.concat([ReqLLM, Test, Scenarios])
+
+    with true <- Code.ensure_loaded?(registry),
+         true <- function_exported?(registry, :groups, 0),
+         true <- function_exported?(registry, :ids_for_group, 1),
+         group when not is_nil(group) <- scenario_registry_group(registry, capability) do
+      registry
+      |> apply(:ids_for_group, [group])
+      |> Enum.map(&Atom.to_string/1)
+    else
+      _ -> nil
+    end
+  end
+
+  defp scenario_registry_group(registry, capability) do
+    registry
+    |> apply(:groups, [])
+    |> Enum.find_value(fn {group, _ids} ->
+      if Atom.to_string(group) == capability do
+        group
+      end
+    end)
   end
 
   defp scenario_test_args(_provider, nil), do: nil

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -17,7 +17,7 @@ Three-tier testing architecture for reliability and comprehensive coverage.
 **FIXTURE-BASED API CALLS** - High-level integration testing
 - Only test high-level API (`ReqLLM.generate_text/3`, `ReqLLM.stream_text/3`, etc.)
 - Fixtures replayed by default, re-recorded with `REQ_LLM_FIXTURES_MODE=record`
-- Uses shared provider test macros (`ReqLLM.ProviderTest.Core`, `ReqLLM.ProviderTest.Streaming`)
+- Uses shared provider test macros and scenario modules (`ReqLLM.ProviderTest.Comprehensive`, `ReqLLM.Test.Scenarios`)
 
 ## Test Commands
 
@@ -78,36 +78,33 @@ REQ_LLM_FIXTURES_MODE=record mix test --only "model:claude-3-5-haiku-20241022" -
 
 ## Fixture System
 
+Comprehensive coverage tests are generated from scenario modules in `test/support/scenarios/`.
+Each scenario owns its fixture basenames, prompt/options, capability guard, and assertions.
+The provider macro only applies provider/model/scenario tags and executes applicable scenarios.
+
+Fixture names are a compatibility contract. Do not change a scenario prompt, request options, tool schema, object schema, or fixture basename without an explicit fixture-refresh task and replay proof.
+
 Coverage tests use shared provider test macros with automatic fixture handling:
 
 ```elixir
-defmodule ReqLLM.Coverage.Anthropic.CoreTest do
+defmodule ReqLLM.Coverage.Anthropic.ComprehensiveTest do
   @moduledoc """
-  Core Anthropic API feature coverage tests.
+  Comprehensive Anthropic API feature coverage tests.
   
   Run with REQ_LLM_FIXTURES_MODE=record to test against live API and record fixtures.
   Otherwise uses fixtures for fast, reliable testing.
   """
   
-  use ReqLLM.ProviderTest.Core, provider: :anthropic
-end
-
-defmodule ReqLLM.Coverage.Anthropic.StreamingTest do
-  @moduledoc """
-  Anthropic streaming API feature coverage tests.
-  
-  Run with REQ_LLM_FIXTURES_MODE=record to test against live API and capture fixtures.
-  Otherwise uses cached fixtures for fast, reliable testing.
-  """
-  
-  use ReqLLM.ProviderTest.Streaming, provider: :anthropic
+  use ReqLLM.ProviderTest.Comprehensive, provider: :anthropic
 end
 ```
 
 The macros automatically:
 - Generate tests for all models selected by `ModelMatrix` for the provider
 - Handle fixture creation and replay transparently
-- Support both streaming and non-streaming APIs
+- Support applicable text, streaming, tool, object, and reasoning scenarios
+
+`mix req_llm.model_compat --scenario ...` routes generic text scenarios to the comprehensive provider file. `--capability core|conversation|streaming|tools|objects|reasoning` expands from `ReqLLM.Test.Scenarios`; provider-specific scenarios still use focused files.
 
 ## Environment Variables
 
@@ -151,12 +148,18 @@ Tests are organized by Provider → Model → Scenario hierarchy.
   - `:streaming` - Streaming with system context
   - `:token_limit` - Token limit constraints
   - `:usage` - Usage metrics and costs
+  - `:context_append` - Context continuation
   - `:tool_multi` - Tool calling with multiple tools
+  - `:tool_round_trip` - Tool execution and follow-up response
   - `:tool_none` - Tool avoidance
   - `:object_basic` - Object generation (non-streaming)
   - `:object_streaming` - Object generation (streaming)
   - `:reasoning` - Reasoning/thinking tokens
 - `coverage` - Mark coverage tests with `coverage: true`
+
+## Live Verification Policy
+
+Broad coverage remains replay-first. Use live recording only for deliberate fixture creation or refresh work. Add sparse provider drift checks separately instead of turning routine replay suites into live CI.
 
 ## HTTP Mocking
 

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -155,6 +155,16 @@ Tests are organized by Provider → Model → Scenario hierarchy.
   - `:object_basic` - Object generation (non-streaming)
   - `:object_streaming` - Object generation (streaming)
   - `:reasoning` - Reasoning/thinking tokens
+  - `:embed_basic`, `:embed_usage`, `:embed_batch` - Embedding operation coverage
+  - `:image_basic` - Image generation coverage
+  - `:transcription_basic` - Audio transcription coverage
+  - `:speech_basic` - Speech generation coverage
+  - `:rerank_basic` - Rerank operation coverage
+  - `:ocr_basic` - OCR operation coverage
+  - `:grounding_basic`, `:grounding_with_context`, `:grounding_streaming`, `:grounding_legacy` - Google grounding coverage
+  - `:multimodal_tool_result` - Text plus file/PDF tool-result coverage
+  - `:web_search_basic`, `:web_search_streaming`, `:x_search_streaming`, `:web_fetch_basic` - Built-in web tool coverage
+  - `:object_streaming_json_schema`, `:object_streaming_tool_strict`, `:object_streaming_auto`, `:streaming_error_handling` - Focused streaming structured-output coverage
 - `coverage` - Mark coverage tests with `coverage: true`
 
 ## Live Verification Policy

--- a/test/req_llm/scenarios/capabilities_test.exs
+++ b/test/req_llm/scenarios/capabilities_test.exs
@@ -21,4 +21,30 @@ defmodule ReqLLM.Test.Scenarios.CapabilitiesTest do
     assert Capabilities.supports_reasoning?(model)
     refute Capabilities.supports_forced_tool_choice?(model)
   end
+
+  test "object generation can be supported through execution metadata" do
+    model = %LLMDB.Model{
+      provider: :openai,
+      id: "execution-object",
+      execution: %{"object" => %{"supported" => true}},
+      capabilities: %{}
+    }
+
+    assert Capabilities.supports_object_generation?(model)
+  end
+
+  test "anthropic structured output metadata can disable tool fallback object generation" do
+    model = %LLMDB.Model{
+      provider: :anthropic,
+      id: "anthropic-without-structured-output",
+      capabilities: %{"tools" => %{"enabled" => true}},
+      extra: %{
+        "provider_capabilities" => %{
+          "structured_outputs" => %{"supported" => false}
+        }
+      }
+    }
+
+    refute Capabilities.supports_object_generation?(model)
+  end
 end

--- a/test/req_llm/scenarios/capabilities_test.exs
+++ b/test/req_llm/scenarios/capabilities_test.exs
@@ -1,0 +1,24 @@
+defmodule ReqLLM.Test.Scenarios.CapabilitiesTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  test "capability predicates support string-keyed capability maps" do
+    model = %LLMDB.Model{
+      provider: :openai,
+      id: "string-capabilities",
+      capabilities: %{
+        "json" => %{"schema" => true},
+        "tools" => %{"enabled" => true, "forced_choice" => false},
+        "streaming" => %{"tool_calls" => true},
+        "reasoning" => %{"enabled" => true}
+      }
+    }
+
+    assert Capabilities.supports_object_generation?(model)
+    assert Capabilities.supports_streaming_object_generation?(model)
+    assert Capabilities.supports_tool_calling?(model)
+    assert Capabilities.supports_reasoning?(model)
+    refute Capabilities.supports_forced_tool_choice?(model)
+  end
+end

--- a/test/req_llm/scenarios/core_text_test.exs
+++ b/test/req_llm/scenarios/core_text_test.exs
@@ -35,6 +35,15 @@ defmodule ReqLLM.Test.Scenarios.CoreTextTest do
            ]
   end
 
+  test "registry exposes capability groups for model compatibility" do
+    assert Scenarios.ids_for_group(:core) == [:basic, :usage, :token_limit]
+    assert Scenarios.ids_for_group("conversation") == [:context_append]
+    assert Scenarios.ids_for_group(:streaming) == [:streaming]
+    assert Scenarios.ids_for_group(:tools) == [:tool_none, :tool_multi, :tool_round_trip]
+    assert Scenarios.ids_for_group(:objects) == [:object_basic, :object_streaming]
+    assert Scenarios.ids_for_group(:reasoning) == [:reasoning]
+  end
+
   test "core text scenarios apply to every selected text model" do
     model = %LLMDB.Model{provider: :openai, id: "gpt-4o-mini"}
 

--- a/test/req_llm/scenarios/core_text_test.exs
+++ b/test/req_llm/scenarios/core_text_test.exs
@@ -1,0 +1,36 @@
+defmodule ReqLLM.Test.Scenarios.CoreTextTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Test.Scenarios
+
+  @core [
+    ReqLLM.Test.Scenarios.Basic,
+    ReqLLM.Test.Scenarios.Streaming,
+    ReqLLM.Test.Scenarios.TokenLimit,
+    ReqLLM.Test.Scenarios.Usage,
+    ReqLLM.Test.Scenarios.ContextAppend
+  ]
+
+  test "registry includes extracted core text scenarios in stable order" do
+    assert Scenarios.all() == @core
+    assert Scenarios.ids() == [:basic, :streaming, :token_limit, :usage, :context_append]
+  end
+
+  test "core text scenarios preserve fixture names" do
+    assert ReqLLM.Test.Scenarios.Basic.fixtures(:model) == ["basic"]
+    assert ReqLLM.Test.Scenarios.Streaming.fixtures(:model) == ["streaming"]
+    assert ReqLLM.Test.Scenarios.TokenLimit.fixtures(:model) == ["token_limit"]
+    assert ReqLLM.Test.Scenarios.Usage.fixtures(:model) == ["usage"]
+
+    assert ReqLLM.Test.Scenarios.ContextAppend.fixtures(:model) == [
+             "context_append_1",
+             "context_append_2"
+           ]
+  end
+
+  test "core text scenarios apply to every selected text model" do
+    model = %LLMDB.Model{provider: :openai, id: "gpt-4o-mini"}
+
+    assert Scenarios.for_model(model) == @core
+  end
+end

--- a/test/req_llm/scenarios/core_text_test.exs
+++ b/test/req_llm/scenarios/core_text_test.exs
@@ -12,8 +12,15 @@ defmodule ReqLLM.Test.Scenarios.CoreTextTest do
   ]
 
   test "registry includes extracted core text scenarios in stable order" do
-    assert Scenarios.all() == @core
-    assert Scenarios.ids() == [:basic, :streaming, :token_limit, :usage, :context_append]
+    assert Enum.take(Scenarios.all(), 5) == @core
+
+    assert Enum.take(Scenarios.ids(), 5) == [
+             :basic,
+             :streaming,
+             :token_limit,
+             :usage,
+             :context_append
+           ]
   end
 
   test "core text scenarios preserve fixture names" do

--- a/test/req_llm/scenarios/fixture_guardrail_test.exs
+++ b/test/req_llm/scenarios/fixture_guardrail_test.exs
@@ -1,0 +1,114 @@
+defmodule ReqLLM.Test.Scenarios.FixtureGuardrailTest do
+  use ExUnit.Case, async: false
+
+  alias ReqLLM.Test.FixturePath
+  alias ReqLLM.Test.Fixtures
+  alias ReqLLM.Test.Scenarios
+
+  @expected_fixtures %{
+    basic: ["basic"],
+    streaming: ["streaming"],
+    token_limit: ["token_limit"],
+    usage: ["usage"],
+    context_append: ["context_append_1", "context_append_2"],
+    tool_multi: ["multi_tool"],
+    tool_round_trip: ["tool_round_trip_1", "tool_round_trip_2"],
+    tool_none: ["no_tool"],
+    object_basic: ["object_basic"],
+    object_streaming: ["object_streaming"],
+    reasoning: ["reasoning_basic", "reasoning_streaming"]
+  }
+
+  @scenario_specs %{
+    basic: "openai:gpt-4o-mini",
+    streaming: "openai:gpt-4o-mini",
+    token_limit: "openai:gpt-4o-mini",
+    usage: "openai:gpt-4o-mini",
+    context_append: "openai:gpt-4o-mini",
+    tool_multi: "openai:gpt-4o-mini",
+    tool_round_trip: "openai:gpt-4o-mini",
+    tool_none: "openai:gpt-4o-mini",
+    object_basic: "openai:gpt-4o-mini",
+    object_streaming: "openai:gpt-4o-mini",
+    reasoning: "anthropic:claude-haiku-4-5-20251001"
+  }
+
+  @provider_slices [
+    {"anthropic:claude-haiku-4-5-20251001", [:object_basic, :object_streaming, :reasoning]},
+    {"google:gemini-2.5-flash", [:object_streaming, :reasoning]},
+    {"xai:grok-4.3", [:object_basic, :object_streaming, :reasoning]}
+  ]
+
+  setup do
+    previous_mode = System.get_env("REQ_LLM_FIXTURES_MODE")
+    System.put_env("REQ_LLM_FIXTURES_MODE", "replay")
+
+    on_exit(fn ->
+      case previous_mode do
+        nil -> System.delete_env("REQ_LLM_FIXTURES_MODE")
+        value -> System.put_env("REQ_LLM_FIXTURES_MODE", value)
+      end
+    end)
+
+    :ok
+  end
+
+  test "scenario ids map to exact replay fixture names" do
+    actual =
+      Scenarios.all()
+      |> Map.new(fn scenario -> {scenario.id(), scenario.fixtures(:model)} end)
+
+    assert actual == @expected_fixtures
+  end
+
+  test "each comprehensive scenario resolves to existing replay fixtures" do
+    for {scenario_id, spec} <- @scenario_specs do
+      {:ok, model} = ReqLLM.model(spec)
+      {:ok, scenario} = Scenarios.get(scenario_id)
+
+      for fixture <- scenario.fixtures(model) do
+        path = FixturePath.file(model, fixture)
+
+        assert File.exists?(path),
+               "Expected fixture for #{spec} #{scenario.id()} #{fixture} at #{path}"
+      end
+    end
+  end
+
+  test "representative provider slices resolve to existing replay fixtures" do
+    for {spec, scenario_ids} <- @provider_slices do
+      {:ok, model} = ReqLLM.model(spec)
+
+      for scenario_id <- scenario_ids do
+        {:ok, scenario} = Scenarios.get(scenario_id)
+
+        for fixture <- scenario.fixtures(model) do
+          path = FixturePath.file(model, fixture)
+
+          assert File.exists?(path),
+                 "Expected fixture for #{spec} #{scenario.id()} #{fixture} at #{path}"
+        end
+      end
+    end
+  end
+
+  test "fixture paths keep provider model slug and fixture basename stable" do
+    assert FixturePath.file("openai:gpt-4o-mini", "basic") ==
+             Path.expand("test/support/fixtures/openai/gpt_4o_mini/basic.json")
+
+    assert FixturePath.file("anthropic:claude-haiku-4-5-20251001", "reasoning_streaming") ==
+             Path.expand(
+               "test/support/fixtures/anthropic/claude_haiku_4_5_20251001/reasoning_streaming.json"
+             )
+  end
+
+  test "missing replay fixtures fail with record-mode guidance" do
+    {:ok, model} = ReqLLM.model("openai:gpt-4o-mini")
+
+    assert_raise RuntimeError,
+                 ~r/Fixture not found: .*missing_guardrail_fixture.*REQ_LLM_FIXTURES_MODE=record/s,
+                 fn ->
+                   Fixtures.replay_path(model, fixture: "missing_guardrail_fixture")
+                 end
+  end
+end

--- a/test/req_llm/scenarios/modality_taxonomy_test.exs
+++ b/test/req_llm/scenarios/modality_taxonomy_test.exs
@@ -1,0 +1,61 @@
+defmodule ReqLLM.Test.Scenarios.ModalityTaxonomyTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.ReqLlm.ModelCompat
+  alias ReqLLM.Test.Scenarios
+  alias ReqLLM.Test.Scenarios.ModalityTaxonomy
+
+  test "taxonomy ids are unique" do
+    ids = ModalityTaxonomy.ids()
+
+    assert ids == Enum.uniq(ids)
+  end
+
+  test "scenario registry groups are represented exactly" do
+    assert ModalityTaxonomy.registry_groups() == Scenarios.groups()
+  end
+
+  test "model_compat capability groups stay aligned with taxonomy scenario ids" do
+    for area <- ModalityTaxonomy.model_compat_areas() do
+      expected = Enum.map(area.scenario_ids, &Atom.to_string/1)
+
+      assert ModelCompat.capability_scenarios!(area.model_compat_capability) == expected
+    end
+  end
+
+  test "focused route files exist and model_compat points at them" do
+    for route <- ModalityTaxonomy.focused_routes(),
+        scenario_id <- route.scenario_ids do
+      scenario = Atom.to_string(scenario_id)
+
+      assert File.exists?(route.test_file), "Expected coverage file at #{route.test_file}"
+
+      assert ModelCompat.test_args_for(route.provider, route.operation, scenario) == [
+               "test",
+               route.test_file,
+               "--only",
+               "scenario:#{scenario}"
+             ]
+    end
+  end
+
+  test "documented concrete coverage files exist" do
+    for path <- ModalityTaxonomy.concrete_test_files() do
+      assert File.exists?(path), "Expected documented coverage file at #{path}"
+    end
+  end
+
+  test "taxonomy distinguishes fixture-backed proof from planned gaps" do
+    assert :ocr in ModalityTaxonomy.gap_ids()
+    assert :vision_input in ModalityTaxonomy.gap_ids()
+    assert :file_input in ModalityTaxonomy.gap_ids()
+    assert :media_url_content in ModalityTaxonomy.gap_ids()
+    assert :audio_output_chat in ModalityTaxonomy.gap_ids()
+
+    assert :embedding in ModalityTaxonomy.fixture_backed_ids()
+    assert :image in ModalityTaxonomy.fixture_backed_ids()
+    assert :transcription in ModalityTaxonomy.fixture_backed_ids()
+    assert :speech in ModalityTaxonomy.fixture_backed_ids()
+    assert :rerank in ModalityTaxonomy.fixture_backed_ids()
+  end
+end

--- a/test/req_llm/scenarios/object_reasoning_test.exs
+++ b/test/req_llm/scenarios/object_reasoning_test.exs
@@ -40,10 +40,15 @@ defmodule ReqLLM.Test.Scenarios.ObjectReasoningTest do
       provider: :anthropic,
       id: "claude-haiku-4-5-20251001",
       capabilities: %{
-        json: %{schema: false},
+        json: %{schema: true},
         tools: %{enabled: true},
         streaming: %{tool_calls: true},
         reasoning: %{enabled: true}
+      },
+      extra: %{
+        provider_capabilities: %{
+          structured_outputs: %{supported: true}
+        }
       }
     }
 

--- a/test/req_llm/scenarios/object_reasoning_test.exs
+++ b/test/req_llm/scenarios/object_reasoning_test.exs
@@ -1,0 +1,73 @@
+defmodule ReqLLM.Test.Scenarios.ObjectReasoningTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Test.Scenarios
+
+  @object_reasoning [
+    ReqLLM.Test.Scenarios.ObjectBasic,
+    ReqLLM.Test.Scenarios.ObjectStreaming,
+    ReqLLM.Test.Scenarios.Reasoning
+  ]
+
+  test "registry includes extracted object and reasoning scenarios after tool scenarios" do
+    assert Enum.take(Scenarios.all(), -3) == @object_reasoning
+    assert Enum.take(Scenarios.ids(), -3) == [:object_basic, :object_streaming, :reasoning]
+  end
+
+  test "object and reasoning scenarios preserve fixture names" do
+    assert ReqLLM.Test.Scenarios.ObjectBasic.fixtures(:model) == ["object_basic"]
+    assert ReqLLM.Test.Scenarios.ObjectStreaming.fixtures(:model) == ["object_streaming"]
+
+    assert ReqLLM.Test.Scenarios.Reasoning.fixtures(:model) == [
+             "reasoning_basic",
+             "reasoning_streaming"
+           ]
+  end
+
+  test "object and reasoning applicability follows model capabilities" do
+    object_model = %LLMDB.Model{
+      provider: :openai,
+      id: "gpt-4o-mini",
+      capabilities: %{
+        json: %{schema: true},
+        tools: %{enabled: false},
+        streaming: %{tool_calls: true},
+        reasoning: %{enabled: false}
+      }
+    }
+
+    reasoning_model = %LLMDB.Model{
+      provider: :anthropic,
+      id: "claude-haiku-4-5-20251001",
+      capabilities: %{
+        json: %{schema: false},
+        tools: %{enabled: true},
+        streaming: %{tool_calls: true},
+        reasoning: %{enabled: true}
+      }
+    }
+
+    plain_model = %LLMDB.Model{
+      provider: :openai,
+      id: "plain",
+      capabilities: %{
+        json: %{schema: false},
+        tools: %{enabled: false},
+        streaming: %{tool_calls: false},
+        reasoning: %{enabled: false}
+      }
+    }
+
+    assert ReqLLM.Test.Scenarios.ObjectBasic.applies?(object_model)
+    assert ReqLLM.Test.Scenarios.ObjectStreaming.applies?(object_model)
+    refute ReqLLM.Test.Scenarios.Reasoning.applies?(object_model)
+
+    assert ReqLLM.Test.Scenarios.ObjectBasic.applies?(reasoning_model)
+    assert ReqLLM.Test.Scenarios.ObjectStreaming.applies?(reasoning_model)
+    assert ReqLLM.Test.Scenarios.Reasoning.applies?(reasoning_model)
+
+    refute ReqLLM.Test.Scenarios.ObjectBasic.applies?(plain_model)
+    refute ReqLLM.Test.Scenarios.ObjectStreaming.applies?(plain_model)
+    refute ReqLLM.Test.Scenarios.Reasoning.applies?(plain_model)
+  end
+end

--- a/test/req_llm/scenarios/scenario_test.exs
+++ b/test/req_llm/scenarios/scenario_test.exs
@@ -63,4 +63,13 @@ defmodule ReqLLM.Test.ScenarioTest do
     assert Scenarios.for_model(:model, modules) == [AlwaysScenario]
     assert Scenarios.fixture_manifest(:model, modules) == %{always: ["always"]}
   end
+
+  test "registry string lookups do not create atoms for unknown ids" do
+    missing = "missing_#{System.unique_integer([:positive])}"
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(missing) end
+    assert Scenarios.get(missing, [AlwaysScenario]) == :error
+    assert Scenarios.ids_for_group(missing, [AlwaysScenario]) == []
+    assert_raise ArgumentError, fn -> String.to_existing_atom(missing) end
+  end
 end

--- a/test/req_llm/scenarios/scenario_test.exs
+++ b/test/req_llm/scenarios/scenario_test.exs
@@ -1,0 +1,66 @@
+defmodule ReqLLM.Test.ScenarioTest do
+  use ExUnit.Case, async: true
+
+  defmodule AlwaysScenario do
+    use ReqLLM.Test.Scenario,
+      id: :always,
+      name: "always",
+      description: "always applies"
+
+    @impl ReqLLM.Test.Scenario
+    def run(_model_spec, _model, _opts) do
+      Scenario.ok(__MODULE__, [Scenario.step(:request, "always")], %{checked: true})
+    end
+  end
+
+  defmodule NeverScenario do
+    use ReqLLM.Test.Scenario,
+      id: :never,
+      name: "never",
+      description: "never applies"
+
+    @impl ReqLLM.Test.Scenario
+    def applies?(_model), do: false
+
+    @impl ReqLLM.Test.Scenario
+    def run(_model_spec, _model, _opts), do: Scenario.ok(__MODULE__)
+  end
+
+  alias ReqLLM.Test.Scenario
+  alias ReqLLM.Test.Scenarios
+
+  test "scenario metadata and default fixture naming are deterministic" do
+    assert AlwaysScenario.id() == :always
+    assert AlwaysScenario.name() == "always"
+    assert AlwaysScenario.description() == "always applies"
+    assert AlwaysScenario.fixtures(:model) == ["always"]
+    assert Scenario.fixture_name(:token_limit) == "token_limit"
+  end
+
+  test "result maps include scenario id, status, steps, error, and metadata" do
+    result =
+      AlwaysScenario.run(
+        "openai:gpt-4o-mini",
+        %LLMDB.Model{provider: :openai, id: "gpt-4o-mini"},
+        provider: :openai
+      )
+
+    assert %{
+             id: :always,
+             status: :ok,
+             steps: [%{id: :request, fixture: "always", metadata: %{}}],
+             error: nil,
+             metadata: %{checked: true}
+           } = result
+  end
+
+  test "registry filters by applies?/1 and exposes ids" do
+    modules = [AlwaysScenario, NeverScenario]
+
+    assert Scenarios.ids(modules) == [:always, :never]
+    assert Scenarios.get("always", modules) == {:ok, AlwaysScenario}
+    assert Scenarios.get(:missing, modules) == :error
+    assert Scenarios.for_model(:model, modules) == [AlwaysScenario]
+    assert Scenarios.fixture_manifest(:model, modules) == %{always: ["always"]}
+  end
+end

--- a/test/req_llm/scenarios/tool_test.exs
+++ b/test/req_llm/scenarios/tool_test.exs
@@ -1,0 +1,45 @@
+defmodule ReqLLM.Test.Scenarios.ToolTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Test.Scenarios
+
+  @tool_scenarios [
+    ReqLLM.Test.Scenarios.ToolMulti,
+    ReqLLM.Test.Scenarios.ToolRoundTrip,
+    ReqLLM.Test.Scenarios.ToolNone
+  ]
+
+  test "registry includes extracted tool scenarios after core text scenarios" do
+    assert Enum.take(Scenarios.all(), -3) == @tool_scenarios
+    assert Enum.take(Scenarios.ids(), -3) == [:tool_multi, :tool_round_trip, :tool_none]
+  end
+
+  test "tool scenarios preserve fixture names" do
+    assert ReqLLM.Test.Scenarios.ToolMulti.fixtures(:model) == ["multi_tool"]
+
+    assert ReqLLM.Test.Scenarios.ToolRoundTrip.fixtures(:model) == [
+             "tool_round_trip_1",
+             "tool_round_trip_2"
+           ]
+
+    assert ReqLLM.Test.Scenarios.ToolNone.fixtures(:model) == ["no_tool"]
+  end
+
+  test "tool scenarios only apply to tool-capable models" do
+    tool_model = %LLMDB.Model{
+      provider: :openai,
+      id: "gpt-4o-mini",
+      capabilities: %{tools: %{enabled: true}}
+    }
+
+    plain_model = %LLMDB.Model{
+      provider: :openai,
+      id: "text-only",
+      capabilities: %{tools: %{enabled: false}}
+    }
+
+    assert Scenarios.for_model(tool_model) -- Scenarios.for_model(plain_model) == @tool_scenarios
+    assert Enum.all?(@tool_scenarios, & &1.applies?(tool_model))
+    refute Enum.any?(@tool_scenarios, & &1.applies?(plain_model))
+  end
+end

--- a/test/req_llm/scenarios/tool_test.exs
+++ b/test/req_llm/scenarios/tool_test.exs
@@ -10,8 +10,8 @@ defmodule ReqLLM.Test.Scenarios.ToolTest do
   ]
 
   test "registry includes extracted tool scenarios after core text scenarios" do
-    assert Enum.take(Scenarios.all(), -3) == @tool_scenarios
-    assert Enum.take(Scenarios.ids(), -3) == [:tool_multi, :tool_round_trip, :tool_none]
+    assert Enum.slice(Scenarios.all(), 5, 3) == @tool_scenarios
+    assert Enum.slice(Scenarios.ids(), 5, 3) == [:tool_multi, :tool_round_trip, :tool_none]
   end
 
   test "tool scenarios preserve fixture names" do
@@ -38,7 +38,6 @@ defmodule ReqLLM.Test.Scenarios.ToolTest do
       capabilities: %{tools: %{enabled: false}}
     }
 
-    assert Scenarios.for_model(tool_model) -- Scenarios.for_model(plain_model) == @tool_scenarios
     assert Enum.all?(@tool_scenarios, & &1.applies?(tool_model))
     refute Enum.any?(@tool_scenarios, & &1.applies?(plain_model))
   end

--- a/test/support/provider_test/comprehensive.ex
+++ b/test/support/provider_test/comprehensive.ex
@@ -238,156 +238,32 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
           if ReqLLM.ProviderTest.Comprehensive.supports_tool_calling?(model_spec) do
             @tag scenario: :tool_multi
             test "tool calling - multi-tool selection" do
-              tools = [
-                ReqLLM.tool(
-                  name: "get_weather",
-                  description: "Get current weather information for a location",
-                  parameter_schema: [
-                    location: [type: :string, required: true],
-                    unit: [type: {:in, ["celsius", "fahrenheit"]}]
-                  ],
-                  callback: fn _args -> {:ok, "Weather data"} end
-                ),
-                ReqLLM.tool(
-                  name: "tell_joke",
-                  description: "Tell a funny joke",
-                  parameter_schema: [
-                    topic: [type: :string, doc: "Topic for the joke"]
-                  ],
-                  callback: fn _args -> {:ok, "Why did the cat cross the road?"} end
-                ),
-                ReqLLM.tool(
-                  name: "get_time",
-                  description: "Get the current time",
-                  parameter_schema: [],
-                  callback: fn _args -> {:ok, "12:00 PM"} end
-                )
-              ]
-
-              base_opts =
-                param_bundles().deterministic
-                |> Keyword.put(:max_tokens, tool_budget_for(@model_spec))
-                |> then(
-                  &reasoning_overlay(
-                    @model_spec,
-                    &1,
-                    tool_budget_for(@model_spec) * 2
-                  )
-                )
-
-              result =
-                ReqLLM.generate_text(
-                  @model_spec,
-                  "What's the weather like in Paris, France?",
-                  fixture_opts("multi_tool", base_opts ++ [tools: tools])
-                )
-
-              case result do
-                {:ok, response} ->
-                  assert_basic_response(result)
-
-                  tool_calls = ReqLLM.Response.tool_calls(response) || []
-
-                  if Enum.empty?(tool_calls) and truncated?(response) do
-                    rt = ReqLLM.Response.reasoning_tokens(response)
-                    assert is_number(rt) and rt >= 0
-                  else
-                    assert_has_tool_call(response)
-                  end
-
-                {:error, _} ->
-                  flunk("Expected successful response with tool call")
-              end
+              ReqLLM.Test.Scenario.execute(
+                ReqLLM.Test.Scenarios.ToolMulti,
+                @model_spec,
+                provider: @provider
+              )
+              |> ReqLLM.Test.Scenario.assert_result!()
             end
 
             @tag scenario: :tool_round_trip
             test "tool calling - round trip execution" do
-              tools = [
-                ReqLLM.tool(
-                  name: "add",
-                  description: "Add two integers",
-                  parameter_schema: [
-                    a: [type: :integer, required: true],
-                    b: [type: :integer, required: true]
-                  ],
-                  callback: fn %{a: a, b: b} -> {:ok, a + b} end
-                )
-              ]
-
-              base_opts =
-                param_bundles().deterministic
-                |> Keyword.put(:max_tokens, tool_budget_for(@model_spec))
-
-              # Use forced tool choice if supported, otherwise fall back to "required"
-              tool_choice =
-                if ReqLLM.ProviderTest.Comprehensive.supports_forced_tool_choice?(@model_spec) do
-                  %{type: "tool", name: "add"}
-                else
-                  "required"
-                end
-
-              {:ok, resp1} =
-                ReqLLM.generate_text(
-                  @model_spec,
-                  "Use the add tool to compute 2 + 3. After the tool result arrives, respond with 'sum=<value>'.",
-                  fixture_opts(
-                    "tool_round_trip_1",
-                    base_opts ++
-                      [
-                        tools: tools,
-                        tool_choice: tool_choice
-                      ]
-                  )
-                )
-
-              tool_calls = ReqLLM.Response.tool_calls(resp1)
-              assert tool_calls != []
-
-              ctx2 = ReqLLM.Context.execute_and_append_tools(resp1.context, tool_calls, tools)
-
-              {:ok, resp2} =
-                ReqLLM.generate_text(
-                  @model_spec,
-                  ctx2,
-                  fixture_opts("tool_round_trip_2", base_opts)
-                )
-
-              text = ReqLLM.Response.text(resp2) || ""
-              assert text != ""
-              assert String.contains?(text, "5")
-              assert Enum.empty?(ReqLLM.Response.tool_calls(resp2))
+              ReqLLM.Test.Scenario.execute(
+                ReqLLM.Test.Scenarios.ToolRoundTrip,
+                @model_spec,
+                provider: @provider
+              )
+              |> ReqLLM.Test.Scenario.assert_result!()
             end
 
             @tag scenario: :tool_none
             test "tool calling - no tool when inappropriate" do
-              tools = [
-                ReqLLM.tool(
-                  name: "get_weather",
-                  description: "Get current weather information for a location",
-                  parameter_schema: [
-                    location: [type: :string, required: true]
-                  ],
-                  callback: fn _args -> {:ok, "Weather data"} end
-                )
-              ]
-
-              base_opts =
-                param_bundles().deterministic
-                |> Keyword.put(:max_tokens, tool_budget_for(@model_spec))
-                |> then(
-                  &reasoning_overlay(
-                    @model_spec,
-                    &1,
-                    tool_budget_for(@model_spec) * 2
-                  )
-                )
-
-              ReqLLM.generate_text(
+              ReqLLM.Test.Scenario.execute(
+                ReqLLM.Test.Scenarios.ToolNone,
                 @model_spec,
-                "Tell me a joke about cats",
-                fixture_opts("no_tool", base_opts ++ [tools: tools])
+                provider: @provider
               )
-              |> assert_basic_response()
+              |> ReqLLM.Test.Scenario.assert_result!()
             end
           end
 

--- a/test/support/provider_test/comprehensive.ex
+++ b/test/support/provider_test/comprehensive.ex
@@ -270,294 +270,39 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
           if ReqLLM.ProviderTest.Comprehensive.supports_object_generation?(model_spec) do
             @tag scenario: :object_basic
             test "object generation (non-streaming)" do
-              schema = [
-                name: [type: :string, required: true, doc: "Person's full name"],
-                age: [type: :pos_integer, required: true, doc: "Person's age in years"],
-                occupation: [type: :string, doc: "Person's job or profession"]
-              ]
-
-              opts =
-                param_bundles(@provider).deterministic
-                |> Keyword.put(:max_tokens, 500)
-                |> then(&reasoning_overlay(@model_spec, @provider, &1, 500))
-
-              {:ok, response} =
-                ReqLLM.generate_object(
-                  @model_spec,
-                  "Generate a software engineer profile",
-                  schema,
-                  fixture_opts(@provider, "object_basic", opts)
-                )
-
-              assert %ReqLLM.Response{} = response
-              object = ReqLLM.Response.object(response)
-              rt = ReqLLM.Response.reasoning_tokens(response)
-
-              cond do
-                is_map(object) and map_size(object) > 0 ->
-                  assert Map.has_key?(object, "name")
-                  assert Map.has_key?(object, "age")
-                  assert is_binary(object["name"])
-                  assert object["name"] != ""
-                  assert is_integer(object["age"])
-                  assert object["age"] > 0
-
-                truncated?(response) ->
-                  assert is_number(rt) and rt >= 0
-
-                is_number(rt) and rt > 0 ->
-                  :ok
-
-                is_map(object) ->
-                  :ok
-
-                true ->
-                  flunk("Expected object or reasoning tokens but got: #{inspect(object)}")
-              end
+              ReqLLM.Test.Scenario.execute(
+                ReqLLM.Test.Scenarios.ObjectBasic,
+                @model_spec,
+                provider: @provider
+              )
+              |> ReqLLM.Test.Scenario.assert_result!()
             end
           end
 
           if ReqLLM.ProviderTest.Comprehensive.supports_streaming_object_generation?(model_spec) do
             @tag scenario: :object_streaming
             test "object generation (streaming)" do
-              schema = [
-                name: [type: :string, required: true, doc: "Person's full name"],
-                age: [type: :pos_integer, required: true, doc: "Person's age in years"],
-                occupation: [type: :string, doc: "Person's job or profession"]
-              ]
-
-              opts =
-                param_bundles(@provider).deterministic
-                |> Keyword.put(:max_tokens, 500)
-                |> then(&reasoning_overlay(@model_spec, @provider, &1, 500))
-
-              {:ok, response} =
-                ReqLLM.stream_object(
-                  @model_spec,
-                  "Generate a software engineer profile",
-                  schema,
-                  fixture_opts(@provider, "object_streaming", opts)
-                )
-
-              response =
-                if match?(%ReqLLM.StreamResponse{}, response) do
-                  {:ok, resp} = ReqLLM.StreamResponse.to_response(response)
-                  resp
-                else
-                  response
-                end
-
-              object = ReqLLM.Response.object(response)
-              rt = ReqLLM.Response.reasoning_tokens(response)
-
-              cond do
-                is_map(object) and map_size(object) > 0 ->
-                  assert Map.has_key?(object, "name")
-                  assert Map.has_key?(object, "age")
-                  assert is_binary(object["name"])
-                  assert object["name"] != ""
-                  assert is_integer(object["age"])
-                  assert object["age"] > 0
-
-                truncated?(response) ->
-                  assert is_number(rt) and rt >= 0
-
-                is_number(rt) and rt > 0 ->
-                  :ok
-
-                is_map(object) ->
-                  :ok
-
-                true ->
-                  flunk("Expected object or reasoning tokens but got: #{inspect(object)}")
-              end
+              ReqLLM.Test.Scenario.execute(
+                ReqLLM.Test.Scenarios.ObjectStreaming,
+                @model_spec,
+                provider: @provider
+              )
+              |> ReqLLM.Test.Scenario.assert_result!()
             end
           end
 
           if ReqLLM.ProviderTest.Comprehensive.supports_reasoning?(model_spec) do
             @tag scenario: :reasoning
             test "reasoning/thinking tokens (non-streaming + streaming)" do
-              dbug(
-                fn -> "\n[Comprehensive] model_spec=#{@model_spec}, test=reasoning" end,
-                component: :test
+              ReqLLM.Test.Scenario.execute(
+                ReqLLM.Test.Scenarios.Reasoning,
+                @model_spec,
+                provider: @provider
               )
-
-              {:ok, model} = ReqLLM.model(@model_spec)
-
-              provider_config = param_bundles(@provider)
-
-              # Bedrock requires max_tokens > budget_tokens (4000 for :low)
-              # Use 5000 to be safe for all providers
-              base_opts =
-                provider_config.deterministic
-                |> Keyword.delete(:temperature)
-                |> Keyword.merge(
-                  max_tokens: 5000,
-                  temperature: 1.0,
-                  reasoning_effort: provider_config.reasoning[:reasoning_effort]
-                )
-
-              prompt = provider_config.reasoning_prompts.basic
-
-              {:ok, response} =
-                ReqLLM.generate_text(
-                  @model_spec,
-                  prompt,
-                  fixture_opts(@provider, "reasoning_basic", base_opts)
-                )
-
-              assert %ReqLLM.Response{} = response
-              assert response.message.role == :assistant
-
-              text = ReqLLM.Response.text(response) || ""
-              thinking = ReqLLM.Response.thinking(response) || ""
-              combined = text <> thinking
-              assert combined != ""
-
-              has_thinking_part? =
-                Enum.any?(
-                  response.message.content,
-                  &(&1.type == :thinking and is_binary(&1.text) and &1.text != "")
-                )
-
-              reasoning_tokens = ReqLLM.Response.reasoning_tokens(response)
-
-              # Some reasoning models (like gpt-5-codex) don't expose thinking content
-              # They reason internally but only output final text
-              # Accept responses with: thinking content, reasoning tokens, or just regular text
-              has_any_output = combined != ""
-
-              assert has_thinking_part? or (is_number(reasoning_tokens) and reasoning_tokens > 0) or
-                       has_any_output,
-                     "Expected thinking content, reasoning tokens, or text output; got thinking: #{inspect(thinking)} tokens: #{inspect(reasoning_tokens)} text: #{inspect(text)}"
-
-              last = List.last(response.context.messages)
-              assert last == response.message
-
-              assert_reasoning_details_if_present(response.message)
-
-              context =
-                ReqLLM.Context.new([
-                  system(provider_config.reasoning_prompts.streaming_system),
-                  user(provider_config.reasoning_prompts.streaming_user)
-                ])
-
-              stream_opts =
-                provider_config.creative
-                |> Keyword.delete(:temperature)
-                |> Keyword.merge(
-                  max_tokens: 5000,
-                  temperature: 1.0,
-                  reasoning_effort: provider_config.reasoning[:reasoning_effort]
-                )
-
-              {:ok, stream_response} =
-                ReqLLM.stream_text(
-                  @model_spec,
-                  context,
-                  fixture_opts(@provider, "reasoning_streaming", stream_opts)
-                )
-
-              assert %ReqLLM.StreamResponse{} = stream_response
-              assert stream_response.stream
-              assert stream_response.metadata_handle
-
-              # Collect stream chunks once (streams are single-use)
-              stream_chunks = Enum.to_list(stream_response.stream)
-
-              {thinking_count, reasoning_tokens_stream} =
-                stream_chunks
-                |> Enum.reduce({0, 0}, fn chunk, {tc, rt} ->
-                  case chunk.type do
-                    :thinking ->
-                      {tc + 1, rt}
-
-                    :meta ->
-                      usage = chunk.metadata[:usage] || %{}
-                      rt2 = Map.get(usage, :reasoning_tokens, 0)
-                      {tc, max(rt, (is_number(rt2) && rt2) || 0)}
-
-                    _ ->
-                      {tc, rt}
-                  end
-                end)
-
-              # Build response from collected chunks
-              stream_with_chunks = %{stream_response | stream: stream_chunks}
-              {:ok, response} = ReqLLM.StreamResponse.to_response(stream_with_chunks)
-              rt_final = ReqLLM.Response.reasoning_tokens(response)
-
-              # Adaptive reasoning models (like gpt-5-chat) may choose not to reason
-              # for simple prompts, so also accept text output like non-streaming does
-              streaming_text = ReqLLM.Response.text(response) || ""
-              has_streaming_output = streaming_text != ""
-
-              assert thinking_count > 0 or reasoning_tokens_stream > 0 or rt_final > 0 or
-                       has_streaming_output,
-                     "Expected at least one :thinking chunk, positive reasoning_tokens, or text output; got tc=#{thinking_count} rt_stream=#{reasoning_tokens_stream} rt_final=#{rt_final} text_len=#{String.length(streaming_text)}"
-
-              assert %ReqLLM.Response{} = response
-              assert response.message.role == :assistant
-
-              assert_reasoning_details_if_present(response.message)
+              |> ReqLLM.Test.Scenario.assert_result!()
             end
           end
         end
-      end
-
-      defp assert_usage_cost_fields(usage, required?) do
-        present? =
-          Enum.any?([:input_cost, :output_cost, :total_cost], &Map.has_key?(usage, &1))
-
-        if required? or present? do
-          assert is_number(usage.input_cost) and usage.input_cost >= 0
-
-          assert is_number(usage.output_cost) and
-                   usage.output_cost >= 0
-
-          assert is_number(usage.total_cost) and usage.total_cost >= 0
-
-          expected = usage.input_cost + usage.output_cost
-          assert abs(usage.total_cost - expected) < 0.00001
-        end
-      end
-
-      defp assert_streaming_usage(nil), do: :ok
-
-      defp assert_streaming_usage(usage) when is_map(usage) do
-        assert is_number(usage.input_tokens) and usage.input_tokens > 0
-        assert is_number(usage.output_tokens) and usage.output_tokens >= 0
-        assert is_number(usage.total_tokens) and usage.total_tokens > 0
-        assert is_number(usage.cached_input) and usage.cached_input >= 0
-        assert is_number(usage.reasoning) and usage.reasoning >= 0
-      end
-
-      defp assert_streaming_usage(usage),
-        do: flunk("Expected usage map or nil, got: #{inspect(usage)}")
-
-      defp assert_reasoning_details_if_present(%ReqLLM.Message{reasoning_details: nil}), do: :ok
-      defp assert_reasoning_details_if_present(%ReqLLM.Message{reasoning_details: []}), do: :ok
-
-      defp assert_reasoning_details_if_present(%ReqLLM.Message{reasoning_details: details})
-           when is_list(details) do
-        for {detail, idx} <- Enum.with_index(details) do
-          assert %ReqLLM.Message.ReasoningDetails{} = detail,
-                 "reasoning_details[#{idx}] should be a ReasoningDetails struct, got: #{inspect(detail)}"
-
-          assert is_atom(detail.provider) and not is_nil(detail.provider),
-                 "reasoning_details[#{idx}].provider should be a provider atom, got: #{inspect(detail.provider)}"
-
-          assert is_binary(detail.format) and detail.format != "",
-                 "reasoning_details[#{idx}].format should be a non-empty string, got: #{inspect(detail.format)}"
-
-          assert is_integer(detail.index) and detail.index >= 0,
-                 "reasoning_details[#{idx}].index should be a non-negative integer, got: #{inspect(detail.index)}"
-
-          assert is_boolean(detail.encrypted?),
-                 "reasoning_details[#{idx}].encrypted? should be a boolean, got: #{inspect(detail.encrypted?)}"
-        end
-
-        :ok
       end
     end
   end

--- a/test/support/provider_test/comprehensive.ex
+++ b/test/support/provider_test/comprehensive.ex
@@ -186,201 +186,53 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
 
           @tag scenario: :basic
           test "basic generate_text (non-streaming)" do
-            require Logger
-
-            dbug(
-              fn -> "\n[Comprehensive] model_spec=#{@model_spec}, test=basic_generate" end,
-              component: :test
-            )
-
-            opts =
-              reasoning_overlay(
-                @model_spec,
-                param_bundles().deterministic,
-                2000
-              )
-
-            ReqLLM.generate_text(
+            ReqLLM.Test.Scenario.execute(
+              ReqLLM.Test.Scenarios.Basic,
               @model_spec,
-              "Hello world!",
-              fixture_opts("basic", opts)
+              provider: @provider
             )
-            |> assert_basic_response()
+            |> ReqLLM.Test.Scenario.assert_result!()
           end
 
           @tag scenario: :streaming
           test "stream_text with system context and creative params" do
-            require Logger
-
-            dbug(
-              fn -> "\n[Comprehensive] model_spec=#{@model_spec}, test=streaming" end,
-              component: :test
+            ReqLLM.Test.Scenario.execute(
+              ReqLLM.Test.Scenarios.Streaming,
+              @model_spec,
+              provider: @provider
             )
-
-            context =
-              ReqLLM.Context.new([
-                system("You are a helpful, creative assistant."),
-                user("Say hello in one short, imaginative sentence.")
-              ])
-
-            opts =
-              reasoning_overlay(@model_spec, @provider, param_bundles(@provider).creative, 2000)
-
-            {:ok, stream_response} =
-              ReqLLM.stream_text(
-                @model_spec,
-                context,
-                fixture_opts(@provider, "streaming", opts)
-              )
-
-            assert %ReqLLM.StreamResponse{} = stream_response
-            assert stream_response.stream
-            assert stream_response.metadata_handle
-
-            {:ok, response} = ReqLLM.StreamResponse.to_response(stream_response)
-
-            finish_reason = ReqLLM.StreamResponse.finish_reason(stream_response)
-
-            # Assert response structure without context advancement check
-            # (streaming doesn't auto-append to context)
-            assert %ReqLLM.Response{} = response
-
-            text = ReqLLM.Response.text(response) || ""
-            thinking = ReqLLM.Response.thinking(response) || ""
-            combined = text <> thinking
-
-            assert combined != "",
-                   "Expected text or thinking content, got empty (text: #{inspect(text)}, thinking: #{inspect(thinking)})"
-
-            assert response.message.role == :assistant
-
-            refute is_nil(finish_reason)
-
-            assert_streaming_usage(response.usage)
+            |> ReqLLM.Test.Scenario.assert_result!()
           end
 
           @tag scenario: :token_limit
           @tag timeout: 600_000
           test "token limit constraints" do
-            opts =
-              param_bundles(@provider).minimal
-              |> Keyword.put(:max_tokens, 100)
-              |> then(&reasoning_overlay(@model_spec, @provider, &1, 3000))
-
-            case ReqLLM.generate_text(
-                   @model_spec,
-                   "Write a very long story about dragons and adventures",
-                   fixture_opts(@provider, "token_limit", opts)
-                 ) do
-              {:ok, response} ->
-                assert_basic_response({:ok, response})
-
-                content = combined_content(response)
-
-                if truncated?(response) do
-                  rt = ReqLLM.Response.reasoning_tokens(response)
-                  assert is_number(rt) and rt >= 0
-
-                  if content != "" do
-                    assert String.length(content) > 0,
-                           "Truncated response should have some content or reasoning tokens"
-                  end
-                else
-                  assert_text_length(response, 150)
-                end
-
-              other ->
-                flunk("Expected {:ok, %ReqLLM.Response{}}, got: #{inspect(other)}")
-            end
+            ReqLLM.Test.Scenario.execute(
+              ReqLLM.Test.Scenarios.TokenLimit,
+              @model_spec,
+              provider: @provider
+            )
+            |> ReqLLM.Test.Scenario.assert_result!()
           end
 
           @tag scenario: :usage
           test "usage metrics and cost calculations" do
-            require Logger
-
-            dbug(
-              fn -> "\n[Comprehensive] model_spec=#{@model_spec}, test=usage" end,
-              component: :test
+            ReqLLM.Test.Scenario.execute(
+              ReqLLM.Test.Scenarios.Usage,
+              @model_spec,
+              provider: @provider
             )
-
-            max_tokens =
-              case ReqLLM.model(@model_spec) do
-                {:ok, %{capabilities: %{reasoning: true}}} -> 500
-                {:ok, %{model: "gpt-4.1" <> _}} -> 16
-                {:ok, %{extra: %{wire: %{protocol: "openai_responses"}}}} -> 200
-                _ -> 10
-              end
-
-            {:ok, response} =
-              ReqLLM.generate_text(
-                @model_spec,
-                "Hi there!",
-                fixture_opts(
-                  "usage",
-                  Keyword.put(param_bundles().deterministic, :max_tokens, max_tokens)
-                )
-              )
-
-            assert %ReqLLM.Response{} = response
-
-            # For reasoning models, allow empty text if reasoning tokens were used
-            text = ReqLLM.Response.text(response) || ""
-            reasoning_tokens = response.usage.reasoning_tokens || 0
-
-            assert text != "" or reasoning_tokens > 0,
-                   "Expected either text content or reasoning tokens, got neither"
-
-            assert is_map(response.usage)
-
-            assert is_number(response.usage.input_tokens) and response.usage.input_tokens > 0
-            assert is_number(response.usage.output_tokens) and response.usage.output_tokens >= 0
-            assert is_number(response.usage.total_tokens) and response.usage.total_tokens > 0
-            assert is_number(response.usage.cached_tokens) and response.usage.cached_tokens >= 0
-
-            assert is_number(response.usage.reasoning_tokens) and
-                     response.usage.reasoning_tokens >= 0
-
-            case ReqLLM.model(@model_spec) do
-              {:ok, %LLMDB.Model{cost: cost_map}} when is_map(cost_map) ->
-                assert_usage_cost_fields(response.usage, true)
-
-              _ ->
-                assert_usage_cost_fields(response.usage, false)
-            end
+            |> ReqLLM.Test.Scenario.assert_result!()
           end
 
           @tag scenario: :context_append
           test "context append continues conversation" do
-            ctx = ReqLLM.Context.new([user("Respond with a single word 'Hi'.")])
-
-            opts =
-              param_bundles().deterministic
-              # Required as thinking models like gpt-5-mini or gemini might not fit into the default budget of 50 tokens
-              |> Keyword.put(:max_tokens, 1024)
-
-            {:ok, resp1} =
-              ReqLLM.generate_text(
-                @model_spec,
-                ctx,
-                fixture_opts(@provider, "context_append_1", opts)
-              )
-
-            ctx2 = ReqLLM.Context.append(resp1.context, user("Hi again"))
-
-            {:ok, resp2} =
-              ReqLLM.generate_text(
-                @model_spec,
-                ctx2,
-                fixture_opts(@provider, "context_append_2", opts)
-              )
-
-            text = ReqLLM.Response.text(resp2) || ""
-            reasoning_tokens = Map.get(resp2.usage || %{}, :reasoning_tokens, 0)
-
-            assert text != "" or reasoning_tokens > 0
-            assert length(resp2.context.messages) >= 4
-            assert List.last(resp2.context.messages) == resp2.message
-            assert resp2.message.role == :assistant
+            ReqLLM.Test.Scenario.execute(
+              ReqLLM.Test.Scenarios.ContextAppend,
+              @model_spec,
+              provider: @provider
+            )
+            |> ReqLLM.Test.Scenario.assert_result!()
           end
 
           if ReqLLM.ProviderTest.Comprehensive.supports_tool_calling?(model_spec) do

--- a/test/support/provider_test/comprehensive.ex
+++ b/test/support/provider_test/comprehensive.ex
@@ -2,16 +2,9 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
   @moduledoc """
   Comprehensive per-model provider tests.
 
-  Consolidates all provider capability testing into up to 9 focused tests per model:
-  1. Basic generate_text (non-streaming)
-  2. Streaming with system context + creative params
-  3. Token limit constraints
-  4. Usage metrics and cost calculations
-  5. Tool calling - multi-tool selection
-  6. Tool calling - no tool when inappropriate
-  7. Object generation (non-streaming) - only for models with object generation support
-  8. Object generation (streaming) - only for models with object generation support
-  9. Reasoning/thinking tokens - only for models with :reasoning capability
+  Generates registry-backed provider scenarios for each selected text model.
+  Scenario modules own prompts, fixture names, capability applicability, and
+  assertions; this macro owns ExUnit model/provider/scenario tags.
 
   Tests use fixtures for fast, deterministic execution while supporting
   live API recording with REQ_LLM_FIXTURES_MODE=record.
@@ -30,127 +23,23 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
   """
 
   def supports_object_generation?(model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, model} ->
-        object_generation_supported?(model)
-
-      {:error, _} ->
-        false
-    end
+    ReqLLM.Test.Scenarios.Capabilities.supports_object_generation?(model_spec)
   end
 
   def supports_streaming_object_generation?(model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, model} ->
-        caps = model.capabilities || %{}
-
-        # Must support object generation AND streaming tool calls
-        supports_object = supports_object_generation?(model_spec)
-        supports_streaming = get_in(caps, [:streaming, :tool_calls]) != false
-
-        supports_object && supports_streaming
-
-      {:error, _} ->
-        false
-    end
+    ReqLLM.Test.Scenarios.Capabilities.supports_streaming_object_generation?(model_spec)
   end
 
   def supports_tool_calling?(model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, model} -> get_in(model.capabilities, [:tools, :enabled]) == true
-      {:error, _} -> false
-    end
+    ReqLLM.Test.Scenarios.Capabilities.supports_tool_calling?(model_spec)
   end
 
   def supports_reasoning?(model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, model} -> get_in(model.capabilities, [:reasoning, :enabled]) == true
-      {:error, _} -> false
-    end
+    ReqLLM.Test.Scenarios.Capabilities.supports_reasoning?(model_spec)
   end
 
   def supports_forced_tool_choice?(model_spec) do
-    case ReqLLM.model(model_spec) do
-      {:ok, model} -> get_in(model.capabilities, [:tools, :forced_choice]) != false
-      {:error, _} -> true
-    end
-  end
-
-  defp object_generation_supported?(%LLMDB.Model{} = model) do
-    structured_outputs_supported?(model) and
-      (execution_object_supported?(model) or
-         json_output_supported?(model) or
-         strict_tool_output_supported?(model) or
-         tool_workaround_supported?(model))
-  end
-
-  defp execution_object_supported?(%LLMDB.Model{execution: execution}) when is_map(execution) do
-    execution
-    |> map_value(:object)
-    |> supported_entry?()
-  end
-
-  defp execution_object_supported?(_model), do: false
-
-  defp json_output_supported?(%LLMDB.Model{capabilities: capabilities}) do
-    capability_enabled?(capabilities, [:json, :native]) or
-      capability_enabled?(capabilities, [:json, :schema])
-  end
-
-  defp strict_tool_output_supported?(%LLMDB.Model{capabilities: capabilities}) do
-    capability_enabled?(capabilities, [:tools, :strict])
-  end
-
-  defp tool_workaround_supported?(%LLMDB.Model{provider: :anthropic}), do: false
-
-  defp tool_workaround_supported?(%LLMDB.Model{capabilities: capabilities}) do
-    capability_enabled?(capabilities, [:tools, :enabled])
-  end
-
-  defp structured_outputs_supported?(%LLMDB.Model{provider: :anthropic, extra: extra}) do
-    cond do
-      get_in(extra || %{}, [:provider_capabilities, :structured_outputs, :supported]) == false ->
-        false
-
-      get_in(extra || %{}, [:capabilities, :structured_outputs, :supported]) == false ->
-        false
-
-      true ->
-        true
-    end
-  end
-
-  defp structured_outputs_supported?(_model), do: true
-
-  defp capability_enabled?(capabilities, path) do
-    capabilities
-    |> path_value(path)
-    |> enabled_value?()
-  end
-
-  defp supported_entry?(entry) when is_map(entry),
-    do: enabled_value?(map_value(entry, :supported))
-
-  defp supported_entry?(_entry), do: false
-
-  defp enabled_value?(true), do: true
-  defp enabled_value?(_value), do: false
-
-  defp path_value(value, []), do: value
-
-  defp path_value(value, [key | rest]) when is_map(value) do
-    value
-    |> map_value(key)
-    |> path_value(rest)
-  end
-
-  defp path_value(_value, _path), do: nil
-
-  defp map_value(map, key) when is_map(map) do
-    case Map.fetch(map, key) do
-      {:ok, value} -> value
-      :error -> Map.get(map, to_string(key))
-    end
+    ReqLLM.Test.Scenarios.Capabilities.supports_forced_tool_choice?(model_spec)
   end
 
   defmacro __using__(opts) do
@@ -158,11 +47,6 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
 
     quote bind_quoted: [provider: provider] do
       use ExUnit.Case, async: false
-
-      import ExUnit.Case
-      import ReqLLM.Context
-      import ReqLLM.Debug, only: [dbug: 2]
-      import ReqLLM.Test.Helpers
 
       alias ReqLLM.Test.ModelMatrix
 
@@ -181,121 +65,23 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
       for model_spec <- @models do
         @model_spec model_spec
 
+        {:ok, model} = ReqLLM.model(model_spec)
+        scenario_modules = ReqLLM.Test.Scenarios.for_model(model)
+
         describe "#{model_spec}" do
           @describetag model: model_spec |> String.split(":", parts: 2) |> List.last()
 
-          @tag scenario: :basic
-          test "basic generate_text (non-streaming)" do
-            ReqLLM.Test.Scenario.execute(
-              ReqLLM.Test.Scenarios.Basic,
-              @model_spec,
-              provider: @provider
-            )
-            |> ReqLLM.Test.Scenario.assert_result!()
-          end
+          for scenario_module <- scenario_modules do
+            @scenario_module scenario_module
+            @tag scenario: scenario_module.id()
 
-          @tag scenario: :streaming
-          test "stream_text with system context and creative params" do
-            ReqLLM.Test.Scenario.execute(
-              ReqLLM.Test.Scenarios.Streaming,
-              @model_spec,
-              provider: @provider
-            )
-            |> ReqLLM.Test.Scenario.assert_result!()
-          end
-
-          @tag scenario: :token_limit
-          @tag timeout: 600_000
-          test "token limit constraints" do
-            ReqLLM.Test.Scenario.execute(
-              ReqLLM.Test.Scenarios.TokenLimit,
-              @model_spec,
-              provider: @provider
-            )
-            |> ReqLLM.Test.Scenario.assert_result!()
-          end
-
-          @tag scenario: :usage
-          test "usage metrics and cost calculations" do
-            ReqLLM.Test.Scenario.execute(
-              ReqLLM.Test.Scenarios.Usage,
-              @model_spec,
-              provider: @provider
-            )
-            |> ReqLLM.Test.Scenario.assert_result!()
-          end
-
-          @tag scenario: :context_append
-          test "context append continues conversation" do
-            ReqLLM.Test.Scenario.execute(
-              ReqLLM.Test.Scenarios.ContextAppend,
-              @model_spec,
-              provider: @provider
-            )
-            |> ReqLLM.Test.Scenario.assert_result!()
-          end
-
-          if ReqLLM.ProviderTest.Comprehensive.supports_tool_calling?(model_spec) do
-            @tag scenario: :tool_multi
-            test "tool calling - multi-tool selection" do
-              ReqLLM.Test.Scenario.execute(
-                ReqLLM.Test.Scenarios.ToolMulti,
-                @model_spec,
-                provider: @provider
-              )
-              |> ReqLLM.Test.Scenario.assert_result!()
+            if scenario_module.id() == :token_limit do
+              @tag timeout: 600_000
             end
 
-            @tag scenario: :tool_round_trip
-            test "tool calling - round trip execution" do
+            test scenario_module.name() do
               ReqLLM.Test.Scenario.execute(
-                ReqLLM.Test.Scenarios.ToolRoundTrip,
-                @model_spec,
-                provider: @provider
-              )
-              |> ReqLLM.Test.Scenario.assert_result!()
-            end
-
-            @tag scenario: :tool_none
-            test "tool calling - no tool when inappropriate" do
-              ReqLLM.Test.Scenario.execute(
-                ReqLLM.Test.Scenarios.ToolNone,
-                @model_spec,
-                provider: @provider
-              )
-              |> ReqLLM.Test.Scenario.assert_result!()
-            end
-          end
-
-          if ReqLLM.ProviderTest.Comprehensive.supports_object_generation?(model_spec) do
-            @tag scenario: :object_basic
-            test "object generation (non-streaming)" do
-              ReqLLM.Test.Scenario.execute(
-                ReqLLM.Test.Scenarios.ObjectBasic,
-                @model_spec,
-                provider: @provider
-              )
-              |> ReqLLM.Test.Scenario.assert_result!()
-            end
-          end
-
-          if ReqLLM.ProviderTest.Comprehensive.supports_streaming_object_generation?(model_spec) do
-            @tag scenario: :object_streaming
-            test "object generation (streaming)" do
-              ReqLLM.Test.Scenario.execute(
-                ReqLLM.Test.Scenarios.ObjectStreaming,
-                @model_spec,
-                provider: @provider
-              )
-              |> ReqLLM.Test.Scenario.assert_result!()
-            end
-          end
-
-          if ReqLLM.ProviderTest.Comprehensive.supports_reasoning?(model_spec) do
-            @tag scenario: :reasoning
-            test "reasoning/thinking tokens (non-streaming + streaming)" do
-              ReqLLM.Test.Scenario.execute(
-                ReqLLM.Test.Scenarios.Reasoning,
+                @scenario_module,
                 @model_spec,
                 provider: @provider
               )

--- a/test/support/scenario.ex
+++ b/test/support/scenario.ex
@@ -1,0 +1,147 @@
+defmodule ReqLLM.Test.Scenario do
+  @moduledoc """
+  Contract for reusable provider coverage scenarios.
+
+  Scenarios describe one fixture-backed behavior check and can be run by the
+  comprehensive coverage macro, model compatibility tooling, or focused tests.
+  """
+
+  @type step :: %{
+          required(:id) => atom(),
+          required(:fixture) => binary() | nil,
+          optional(:metadata) => map()
+        }
+
+  @type result :: %{
+          required(:id) => atom(),
+          required(:status) => :ok | :error,
+          required(:steps) => [step()],
+          required(:error) => term() | nil,
+          required(:metadata) => map()
+        }
+
+  @callback id() :: atom()
+  @callback name() :: binary()
+  @callback description() :: binary()
+  @callback applies?(binary() | LLMDB.Model.t()) :: boolean()
+  @callback fixtures(binary() | LLMDB.Model.t()) :: [binary()]
+  @callback run(binary(), LLMDB.Model.t(), keyword()) :: result()
+
+  defmacro __using__(opts) do
+    id = Keyword.fetch!(opts, :id)
+    name = Keyword.fetch!(opts, :name)
+    description = Keyword.get(opts, :description, name)
+
+    quote bind_quoted: [id: id, name: name, description: description] do
+      @behaviour ReqLLM.Test.Scenario
+
+      import ExUnit.Assertions
+      import ReqLLM.Context
+      import ReqLLM.Debug, only: [dbug: 2]
+      import ReqLLM.Test.Helpers
+
+      alias ReqLLM.Test.Scenario
+
+      @scenario_id id
+      @scenario_name name
+      @scenario_description description
+
+      @impl ReqLLM.Test.Scenario
+      def id, do: @scenario_id
+
+      @impl ReqLLM.Test.Scenario
+      def name, do: @scenario_name
+
+      @impl ReqLLM.Test.Scenario
+      def description, do: @scenario_description
+
+      @impl ReqLLM.Test.Scenario
+      def applies?(_model), do: true
+
+      @impl ReqLLM.Test.Scenario
+      def fixtures(_model), do: [Scenario.fixture_name(@scenario_id)]
+
+      defoverridable applies?: 1, fixtures: 1
+    end
+  end
+
+  @spec fixture_name(atom() | binary()) :: binary()
+  def fixture_name(id) when is_atom(id), do: Atom.to_string(id)
+  def fixture_name(id) when is_binary(id), do: id
+
+  @spec step(atom(), binary() | nil, map()) :: step()
+  def step(id, fixture, metadata \\ %{}) when is_atom(id) and is_map(metadata) do
+    %{id: id, fixture: fixture, metadata: metadata}
+  end
+
+  @spec ok(module() | atom(), [step()], map()) :: result()
+  def ok(scenario, steps \\ [], metadata \\ %{}) when is_list(steps) and is_map(metadata) do
+    %{id: scenario_id(scenario), status: :ok, steps: steps, error: nil, metadata: metadata}
+  end
+
+  @spec error(module() | atom(), [step()], term(), map()) :: result()
+  def error(scenario, steps, error, metadata \\ %{})
+      when is_list(steps) and is_map(metadata) do
+    %{id: scenario_id(scenario), status: :error, steps: steps, error: error, metadata: metadata}
+  end
+
+  @spec execute(module(), binary(), keyword()) :: result()
+  def execute(scenario, model_spec, opts \\ [])
+      when is_atom(scenario) and is_binary(model_spec) do
+    with {:ok, model} <- ReqLLM.model(model_spec) do
+      scenario
+      |> run_scenario(model_spec, model, opts)
+      |> normalize_result(scenario)
+    else
+      {:error, reason} ->
+        error(scenario, [], %{kind: :error, reason: reason, stacktrace: []})
+    end
+  end
+
+  @spec assert_result!(result()) :: result()
+  def assert_result!(%{status: :ok} = result), do: result
+
+  def assert_result!(%{
+        status: :error,
+        error: %{kind: :error, reason: exception, stacktrace: stacktrace}
+      })
+      when is_exception(exception) and is_list(stacktrace) do
+    reraise exception, stacktrace
+  end
+
+  def assert_result!(%{status: :error} = result) do
+    ExUnit.Assertions.flunk("Scenario #{inspect(result.id)} failed: #{inspect(result.error)}")
+  end
+
+  defp run_scenario(scenario, model_spec, model, opts) do
+    scenario.run(model_spec, model, opts)
+  rescue
+    exception ->
+      error(scenario, [], %{kind: :error, reason: exception, stacktrace: __STACKTRACE__})
+  catch
+    kind, reason ->
+      error(scenario, [], %{kind: kind, reason: reason, stacktrace: __STACKTRACE__})
+  end
+
+  defp normalize_result(%{status: status} = result, scenario) when status in [:ok, :error] do
+    result
+    |> Map.put_new(:id, scenario_id(scenario))
+    |> Map.put_new(:steps, [])
+    |> Map.put_new(:error, nil)
+    |> Map.put_new(:metadata, %{})
+  end
+
+  defp normalize_result(:ok, scenario), do: ok(scenario)
+
+  defp normalize_result(other, scenario) do
+    error(scenario, [], %{kind: :invalid_result, reason: other})
+  end
+
+  defp scenario_id(scenario) when is_atom(scenario) do
+    if function_exported?(scenario, :id, 0) do
+      scenario.id()
+    else
+      scenario
+    end
+  end
+end

--- a/test/support/scenario.ex
+++ b/test/support/scenario.ex
@@ -4,6 +4,11 @@ defmodule ReqLLM.Test.Scenario do
 
   Scenarios describe one fixture-backed behavior check and can be run by the
   comprehensive coverage macro, model compatibility tooling, or focused tests.
+
+  Scenario fixture names are part of the replay compatibility contract. Do not
+  change a scenario's prompt, request options, tool schema, object schema, or
+  fixture names unless the work also includes an explicit fixture-refresh task
+  and replay proof for the affected providers.
   """
 
   @type step :: %{

--- a/test/support/scenarios.ex
+++ b/test/support/scenarios.ex
@@ -3,7 +3,13 @@ defmodule ReqLLM.Test.Scenarios do
   Registry for provider coverage scenarios.
   """
 
-  @default_modules []
+  @default_modules [
+    ReqLLM.Test.Scenarios.Basic,
+    ReqLLM.Test.Scenarios.Streaming,
+    ReqLLM.Test.Scenarios.TokenLimit,
+    ReqLLM.Test.Scenarios.Usage,
+    ReqLLM.Test.Scenarios.ContextAppend
+  ]
 
   @spec all() :: [module()]
   def all, do: @default_modules

--- a/test/support/scenarios.ex
+++ b/test/support/scenarios.ex
@@ -11,7 +11,10 @@ defmodule ReqLLM.Test.Scenarios do
     ReqLLM.Test.Scenarios.ContextAppend,
     ReqLLM.Test.Scenarios.ToolMulti,
     ReqLLM.Test.Scenarios.ToolRoundTrip,
-    ReqLLM.Test.Scenarios.ToolNone
+    ReqLLM.Test.Scenarios.ToolNone,
+    ReqLLM.Test.Scenarios.ObjectBasic,
+    ReqLLM.Test.Scenarios.ObjectStreaming,
+    ReqLLM.Test.Scenarios.Reasoning
   ]
 
   @spec all() :: [module()]

--- a/test/support/scenarios.ex
+++ b/test/support/scenarios.ex
@@ -1,0 +1,53 @@
+defmodule ReqLLM.Test.Scenarios do
+  @moduledoc """
+  Registry for provider coverage scenarios.
+  """
+
+  @default_modules []
+
+  @spec all() :: [module()]
+  def all, do: @default_modules
+
+  @spec all([module()]) :: [module()]
+  def all(modules) when is_list(modules), do: modules
+
+  @spec ids() :: [atom()]
+  def ids, do: ids(all())
+
+  @spec ids([module()]) :: [atom()]
+  def ids(modules) when is_list(modules), do: Enum.map(modules, & &1.id())
+
+  @spec get(atom() | binary()) :: {:ok, module()} | :error
+  def get(id), do: get(id, all())
+
+  @spec get(atom() | binary(), [module()]) :: {:ok, module()} | :error
+  def get(id, modules) when is_list(modules) do
+    target = normalize_id(id)
+
+    case Enum.find(modules, &(&1.id() == target)) do
+      nil -> :error
+      module -> {:ok, module}
+    end
+  end
+
+  @spec for_model(binary() | LLMDB.Model.t()) :: [module()]
+  def for_model(model), do: for_model(model, all())
+
+  @spec for_model(binary() | LLMDB.Model.t(), [module()]) :: [module()]
+  def for_model(model, modules) when is_list(modules) do
+    Enum.filter(modules, & &1.applies?(model))
+  end
+
+  @spec fixture_manifest(binary() | LLMDB.Model.t()) :: %{atom() => [binary()]}
+  def fixture_manifest(model), do: fixture_manifest(model, all())
+
+  @spec fixture_manifest(binary() | LLMDB.Model.t(), [module()]) :: %{atom() => [binary()]}
+  def fixture_manifest(model, modules) when is_list(modules) do
+    model
+    |> for_model(modules)
+    |> Map.new(fn scenario -> {scenario.id(), scenario.fixtures(model)} end)
+  end
+
+  defp normalize_id(id) when is_atom(id), do: id
+  defp normalize_id(id) when is_binary(id), do: String.to_atom(id)
+end

--- a/test/support/scenarios.ex
+++ b/test/support/scenarios.ex
@@ -17,6 +17,15 @@ defmodule ReqLLM.Test.Scenarios do
     ReqLLM.Test.Scenarios.Reasoning
   ]
 
+  @groups %{
+    core: [:basic, :usage, :token_limit],
+    conversation: [:context_append],
+    streaming: [:streaming],
+    tools: [:tool_none, :tool_multi, :tool_round_trip],
+    objects: [:object_basic, :object_streaming],
+    reasoning: [:reasoning]
+  }
+
   @spec all() :: [module()]
   def all, do: @default_modules
 
@@ -28,6 +37,22 @@ defmodule ReqLLM.Test.Scenarios do
 
   @spec ids([module()]) :: [atom()]
   def ids(modules) when is_list(modules), do: Enum.map(modules, & &1.id())
+
+  @spec groups() :: %{atom() => [atom()]}
+  def groups, do: @groups
+
+  @spec ids_for_group(atom() | binary()) :: [atom()]
+  def ids_for_group(group), do: ids_for_group(group, all())
+
+  @spec ids_for_group(atom() | binary(), [module()]) :: [atom()]
+  def ids_for_group(group, modules) when is_list(modules) do
+    available = modules |> ids() |> MapSet.new()
+
+    group
+    |> normalize_id()
+    |> then(&Map.get(@groups, &1, []))
+    |> Enum.filter(&MapSet.member?(available, &1))
+  end
 
   @spec get(atom() | binary()) :: {:ok, module()} | :error
   def get(id), do: get(id, all())

--- a/test/support/scenarios.ex
+++ b/test/support/scenarios.ex
@@ -8,7 +8,10 @@ defmodule ReqLLM.Test.Scenarios do
     ReqLLM.Test.Scenarios.Streaming,
     ReqLLM.Test.Scenarios.TokenLimit,
     ReqLLM.Test.Scenarios.Usage,
-    ReqLLM.Test.Scenarios.ContextAppend
+    ReqLLM.Test.Scenarios.ContextAppend,
+    ReqLLM.Test.Scenarios.ToolMulti,
+    ReqLLM.Test.Scenarios.ToolRoundTrip,
+    ReqLLM.Test.Scenarios.ToolNone
   ]
 
   @spec all() :: [module()]

--- a/test/support/scenarios.ex
+++ b/test/support/scenarios.ex
@@ -49,8 +49,7 @@ defmodule ReqLLM.Test.Scenarios do
     available = modules |> ids() |> MapSet.new()
 
     group
-    |> normalize_id()
-    |> then(&Map.get(@groups, &1, []))
+    |> group_ids()
     |> Enum.filter(&MapSet.member?(available, &1))
   end
 
@@ -59,9 +58,7 @@ defmodule ReqLLM.Test.Scenarios do
 
   @spec get(atom() | binary(), [module()]) :: {:ok, module()} | :error
   def get(id, modules) when is_list(modules) do
-    target = normalize_id(id)
-
-    case Enum.find(modules, &(&1.id() == target)) do
+    case Enum.find(modules, &id_match?(&1.id(), id)) do
       nil -> :error
       module -> {:ok, module}
     end
@@ -85,6 +82,20 @@ defmodule ReqLLM.Test.Scenarios do
     |> Map.new(fn scenario -> {scenario.id(), scenario.fixtures(model)} end)
   end
 
-  defp normalize_id(id) when is_atom(id), do: id
-  defp normalize_id(id) when is_binary(id), do: String.to_atom(id)
+  defp group_ids(group) do
+    Enum.find_value(@groups, [], fn {group_id, ids} ->
+      if id_match?(group_id, group), do: ids
+    end)
+  end
+
+  defp id_match?(left, right) when is_atom(left) and is_atom(right), do: left == right
+
+  defp id_match?(left, right) when is_atom(left) and is_binary(right),
+    do: Atom.to_string(left) == right
+
+  defp id_match?(left, right) when is_binary(left) and is_atom(right),
+    do: left == Atom.to_string(right)
+
+  defp id_match?(left, right) when is_binary(left) and is_binary(right), do: left == right
+  defp id_match?(_left, _right), do: false
 end

--- a/test/support/scenarios/assertions.ex
+++ b/test/support/scenarios/assertions.ex
@@ -1,0 +1,38 @@
+defmodule ReqLLM.Test.Scenarios.Assertions do
+  @moduledoc """
+  Assertions shared by provider coverage scenarios.
+  """
+
+  import ExUnit.Assertions
+
+  def assert_usage_cost_fields(usage, required?) do
+    present? =
+      Enum.any?([:input_cost, :output_cost, :total_cost], &Map.has_key?(usage, &1))
+
+    if required? or present? do
+      assert is_number(usage.input_cost) and usage.input_cost >= 0
+
+      assert is_number(usage.output_cost) and
+               usage.output_cost >= 0
+
+      assert is_number(usage.total_cost) and usage.total_cost >= 0
+
+      expected = usage.input_cost + usage.output_cost
+      assert abs(usage.total_cost - expected) < 0.00001
+    end
+  end
+
+  def assert_streaming_usage(nil), do: :ok
+
+  def assert_streaming_usage(usage) when is_map(usage) do
+    assert is_number(usage.input_tokens) and usage.input_tokens > 0
+    assert is_number(usage.output_tokens) and usage.output_tokens >= 0
+    assert is_number(usage.total_tokens) and usage.total_tokens > 0
+    assert is_number(usage.cached_input) and usage.cached_input >= 0
+    assert is_number(usage.reasoning) and usage.reasoning >= 0
+  end
+
+  def assert_streaming_usage(usage) do
+    flunk("Expected usage map or nil, got: #{inspect(usage)}")
+  end
+end

--- a/test/support/scenarios/assertions.ex
+++ b/test/support/scenarios/assertions.ex
@@ -35,4 +35,56 @@ defmodule ReqLLM.Test.Scenarios.Assertions do
   def assert_streaming_usage(usage) do
     flunk("Expected usage map or nil, got: #{inspect(usage)}")
   end
+
+  def assert_profile_object_or_reasoning(response) do
+    object = ReqLLM.Response.object(response)
+    rt = ReqLLM.Response.reasoning_tokens(response)
+
+    cond do
+      is_map(object) and map_size(object) > 0 ->
+        assert Map.has_key?(object, "name")
+        assert Map.has_key?(object, "age")
+        assert is_binary(object["name"])
+        assert object["name"] != ""
+        assert is_integer(object["age"])
+        assert object["age"] > 0
+
+      response.finish_reason == :length ->
+        assert is_number(rt) and rt >= 0
+
+      is_number(rt) and rt > 0 ->
+        :ok
+
+      is_map(object) ->
+        :ok
+
+      true ->
+        flunk("Expected object or reasoning tokens but got: #{inspect(object)}")
+    end
+  end
+
+  def assert_reasoning_details_if_present(%ReqLLM.Message{reasoning_details: nil}), do: :ok
+  def assert_reasoning_details_if_present(%ReqLLM.Message{reasoning_details: []}), do: :ok
+
+  def assert_reasoning_details_if_present(%ReqLLM.Message{reasoning_details: details})
+      when is_list(details) do
+    for {detail, idx} <- Enum.with_index(details) do
+      assert %ReqLLM.Message.ReasoningDetails{} = detail,
+             "reasoning_details[#{idx}] should be a ReasoningDetails struct, got: #{inspect(detail)}"
+
+      assert is_atom(detail.provider) and not is_nil(detail.provider),
+             "reasoning_details[#{idx}].provider should be a provider atom, got: #{inspect(detail.provider)}"
+
+      assert is_binary(detail.format) and detail.format != "",
+             "reasoning_details[#{idx}].format should be a non-empty string, got: #{inspect(detail.format)}"
+
+      assert is_integer(detail.index) and detail.index >= 0,
+             "reasoning_details[#{idx}].index should be a non-negative integer, got: #{inspect(detail.index)}"
+
+      assert is_boolean(detail.encrypted?),
+             "reasoning_details[#{idx}].encrypted? should be a boolean, got: #{inspect(detail.encrypted?)}"
+    end
+
+    :ok
+  end
 end

--- a/test/support/scenarios/capabilities.ex
+++ b/test/support/scenarios/capabilities.ex
@@ -1,0 +1,98 @@
+defmodule ReqLLM.Test.Scenarios.Capabilities do
+  @moduledoc """
+  Capability predicates used by provider coverage scenarios.
+  """
+
+  @spec supports_object_generation?(binary() | LLMDB.Model.t()) :: boolean()
+  def supports_object_generation?(model_or_spec) do
+    case model_for(model_or_spec) do
+      {:ok, model} ->
+        caps = model.capabilities || %{}
+
+        structured_outputs_supported?(model) and
+          (cap(caps, [:json, :native]) ||
+             cap(caps, [:json, :schema]) ||
+             cap(caps, [:tools, :strict]) == true ||
+             cap(caps, [:tools, :enabled]) == true)
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  @spec supports_streaming_object_generation?(binary() | LLMDB.Model.t()) :: boolean()
+  def supports_streaming_object_generation?(model_or_spec) do
+    case model_for(model_or_spec) do
+      {:ok, model} ->
+        caps = model.capabilities || %{}
+
+        supports_object_generation?(model) and cap(caps, [:streaming, :tool_calls]) != false
+
+      {:error, _} ->
+        false
+    end
+  end
+
+  @spec supports_tool_calling?(binary() | LLMDB.Model.t()) :: boolean()
+  def supports_tool_calling?(model_or_spec) do
+    case model_for(model_or_spec) do
+      {:ok, model} -> cap(model.capabilities || %{}, [:tools, :enabled]) == true
+      {:error, _} -> false
+    end
+  end
+
+  @spec supports_reasoning?(binary() | LLMDB.Model.t()) :: boolean()
+  def supports_reasoning?(model_or_spec) do
+    case model_for(model_or_spec) do
+      {:ok, model} -> cap(model.capabilities || %{}, [:reasoning, :enabled]) == true
+      {:error, _} -> false
+    end
+  end
+
+  @spec supports_forced_tool_choice?(binary() | LLMDB.Model.t()) :: boolean()
+  def supports_forced_tool_choice?(model_or_spec) do
+    case model_for(model_or_spec) do
+      {:ok, model} -> cap(model.capabilities || %{}, [:tools, :forced_choice]) != false
+      {:error, _} -> true
+    end
+  end
+
+  defp model_for(%LLMDB.Model{} = model), do: {:ok, model}
+  defp model_for(model_spec) when is_binary(model_spec), do: ReqLLM.model(model_spec)
+  defp model_for(_), do: {:error, :invalid_model}
+
+  defp structured_outputs_supported?(%LLMDB.Model{provider: :anthropic, extra: extra}) do
+    case cap(extra || %{}, [:capabilities, :structured_outputs, :supported]) do
+      false -> false
+      _ -> true
+    end
+  end
+
+  defp structured_outputs_supported?(_model), do: true
+
+  defp cap(value, []), do: value
+
+  defp cap(value, [key | rest]) when is_map(value) do
+    value
+    |> fetch_cap(key)
+    |> cap(rest)
+  end
+
+  defp cap(_value, _path), do: nil
+
+  defp fetch_cap(map, key) do
+    cond do
+      Map.has_key?(map, key) ->
+        Map.get(map, key)
+
+      is_atom(key) and Map.has_key?(map, Atom.to_string(key)) ->
+        Map.get(map, Atom.to_string(key))
+
+      is_binary(key) and Map.has_key?(map, String.to_atom(key)) ->
+        Map.get(map, String.to_atom(key))
+
+      true ->
+        nil
+    end
+  end
+end

--- a/test/support/scenarios/capabilities.ex
+++ b/test/support/scenarios/capabilities.ex
@@ -80,19 +80,37 @@ defmodule ReqLLM.Test.Scenarios.Capabilities do
 
   defp cap(_value, _path), do: nil
 
-  defp fetch_cap(map, key) do
+  defp fetch_cap(map, key) when is_atom(key) do
     cond do
       Map.has_key?(map, key) ->
         Map.get(map, key)
 
-      is_atom(key) and Map.has_key?(map, Atom.to_string(key)) ->
+      Map.has_key?(map, Atom.to_string(key)) ->
         Map.get(map, Atom.to_string(key))
-
-      is_binary(key) and Map.has_key?(map, String.to_atom(key)) ->
-        Map.get(map, String.to_atom(key))
 
       true ->
         nil
     end
+  end
+
+  defp fetch_cap(map, key) when is_binary(key) do
+    atom_key = existing_atom(key)
+
+    cond do
+      Map.has_key?(map, key) ->
+        Map.get(map, key)
+
+      not is_nil(atom_key) and Map.has_key?(map, atom_key) ->
+        Map.get(map, atom_key)
+
+      true ->
+        nil
+    end
+  end
+
+  defp existing_atom(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
   end
 end

--- a/test/support/scenarios/capabilities.ex
+++ b/test/support/scenarios/capabilities.ex
@@ -7,13 +7,7 @@ defmodule ReqLLM.Test.Scenarios.Capabilities do
   def supports_object_generation?(model_or_spec) do
     case model_for(model_or_spec) do
       {:ok, model} ->
-        caps = model.capabilities || %{}
-
-        structured_outputs_supported?(model) and
-          (cap(caps, [:json, :native]) ||
-             cap(caps, [:json, :schema]) ||
-             cap(caps, [:tools, :strict]) == true ||
-             cap(caps, [:tools, :enabled]) == true)
+        object_generation_supported?(model)
 
       {:error, _} ->
         false
@@ -61,14 +55,65 @@ defmodule ReqLLM.Test.Scenarios.Capabilities do
   defp model_for(model_spec) when is_binary(model_spec), do: ReqLLM.model(model_spec)
   defp model_for(_), do: {:error, :invalid_model}
 
+  defp object_generation_supported?(%LLMDB.Model{} = model) do
+    structured_outputs_supported?(model) and
+      (execution_object_supported?(model) or
+         json_output_supported?(model) or
+         strict_tool_output_supported?(model) or
+         tool_workaround_supported?(model))
+  end
+
+  defp execution_object_supported?(%LLMDB.Model{execution: execution}) when is_map(execution) do
+    execution
+    |> cap([:object])
+    |> supported_entry?()
+  end
+
+  defp execution_object_supported?(_model), do: false
+
+  defp json_output_supported?(%LLMDB.Model{capabilities: capabilities}) do
+    capability_enabled?(capabilities, [:json, :native]) or
+      capability_enabled?(capabilities, [:json, :schema])
+  end
+
+  defp strict_tool_output_supported?(%LLMDB.Model{capabilities: capabilities}) do
+    capability_enabled?(capabilities, [:tools, :strict])
+  end
+
+  defp tool_workaround_supported?(%LLMDB.Model{provider: :anthropic}), do: false
+
+  defp tool_workaround_supported?(%LLMDB.Model{capabilities: capabilities}) do
+    capability_enabled?(capabilities, [:tools, :enabled])
+  end
+
   defp structured_outputs_supported?(%LLMDB.Model{provider: :anthropic, extra: extra}) do
-    case cap(extra || %{}, [:capabilities, :structured_outputs, :supported]) do
-      false -> false
-      _ -> true
+    cond do
+      cap(extra || %{}, [:provider_capabilities, :structured_outputs, :supported]) == false ->
+        false
+
+      cap(extra || %{}, [:capabilities, :structured_outputs, :supported]) == false ->
+        false
+
+      true ->
+        true
     end
   end
 
   defp structured_outputs_supported?(_model), do: true
+
+  defp capability_enabled?(capabilities, path) do
+    capabilities
+    |> cap(path)
+    |> enabled_value?()
+  end
+
+  defp supported_entry?(entry) when is_map(entry),
+    do: entry |> cap([:supported]) |> enabled_value?()
+
+  defp supported_entry?(_entry), do: false
+
+  defp enabled_value?(true), do: true
+  defp enabled_value?(_value), do: false
 
   defp cap(value, []), do: value
 

--- a/test/support/scenarios/modality_taxonomy.ex
+++ b/test/support/scenarios/modality_taxonomy.ex
@@ -1,0 +1,539 @@
+defmodule ReqLLM.Test.Scenarios.ModalityTaxonomy do
+  @moduledoc """
+  ReqLLM v2 scenario and modality coverage taxonomy.
+
+  This module documents the current proof surface for text and non-text
+  behavior without changing fixture behavior. Entries marked as fixture-backed
+  have replay coverage today. Entries marked as unit-guarded or macro-available
+  are visible gaps to promote into fixture-backed scenarios in later epics.
+  """
+
+  @registry_areas [
+    %{
+      id: :core,
+      title: "Core text generation",
+      operation: :text,
+      modality: :text,
+      proof: :scenario_registry,
+      status: :fixture_backed,
+      scenario_ids: [:basic, :usage, :token_limit],
+      model_compat_capability: "core",
+      test_files: ["test/coverage/*/comprehensive_test.exs"],
+      notes: "Basic non-streaming text, usage accounting, and token limits."
+    },
+    %{
+      id: :conversation,
+      title: "Conversation continuation",
+      operation: :text,
+      modality: :text,
+      proof: :scenario_registry,
+      status: :fixture_backed,
+      scenario_ids: [:context_append],
+      model_compat_capability: "conversation",
+      test_files: ["test/coverage/*/comprehensive_test.exs"],
+      notes: "Context append and follow-up message behavior."
+    },
+    %{
+      id: :streaming,
+      title: "Text streaming",
+      operation: :text,
+      modality: :text,
+      proof: :scenario_registry,
+      status: :fixture_backed,
+      scenario_ids: [:streaming],
+      model_compat_capability: "streaming",
+      test_files: ["test/coverage/*/comprehensive_test.exs"],
+      notes: "Stream materialization into a canonical response."
+    },
+    %{
+      id: :tools,
+      title: "Function tools",
+      operation: :text,
+      modality: :tool,
+      proof: :scenario_registry,
+      status: :fixture_backed,
+      scenario_ids: [:tool_none, :tool_multi, :tool_round_trip],
+      model_compat_capability: "tools",
+      test_files: ["test/coverage/*/comprehensive_test.exs"],
+      notes: "Tool avoidance, tool selection, and tool round-trip execution."
+    },
+    %{
+      id: :objects,
+      title: "Structured object output",
+      operation: :text,
+      modality: :structured_output,
+      proof: :scenario_registry,
+      status: :fixture_backed,
+      scenario_ids: [:object_basic, :object_streaming],
+      model_compat_capability: "objects",
+      test_files: ["test/coverage/*/comprehensive_test.exs"],
+      notes: "Non-streaming and streaming object generation."
+    },
+    %{
+      id: :reasoning,
+      title: "Reasoning output",
+      operation: :text,
+      modality: :reasoning,
+      proof: :scenario_registry,
+      status: :fixture_backed,
+      scenario_ids: [:reasoning],
+      model_compat_capability: "reasoning",
+      test_files: ["test/coverage/*/comprehensive_test.exs"],
+      notes: "Thinking/reasoning parts for non-streaming and streaming responses."
+    }
+  ]
+
+  @focused_areas [
+    %{
+      id: :embedding,
+      title: "Embeddings",
+      operation: :embedding,
+      modality: :embedding,
+      proof: :provider_test_macro,
+      status: :fixture_backed,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      model_compat_capability: "embedding",
+      test_files: [
+        "test/coverage/amazon_bedrock/embedding_test.exs",
+        "test/coverage/azure/embedding_test.exs",
+        "test/coverage/google/embedding_test.exs",
+        "test/coverage/google_vertex_gemini/embedding_test.exs",
+        "test/coverage/openai/embedding_test.exs",
+        "test/coverage/openrouter/embedding_test.exs"
+      ],
+      notes: "Single input, usage-returning input, and batch vector generation."
+    },
+    %{
+      id: :image,
+      title: "Image generation",
+      operation: :image,
+      modality: :image_output,
+      proof: :provider_test_macro,
+      status: :fixture_backed,
+      scenario_ids: [:image_basic],
+      model_compat_capability: "image",
+      test_files: [
+        "test/coverage/google/image_generation_test.exs",
+        "test/coverage/openai/image_generation_test.exs",
+        "test/coverage/xai/image_generation_test.exs"
+      ],
+      notes: "Basic generated image response parts; edit/mask variants remain unit-guarded."
+    },
+    %{
+      id: :transcription,
+      title: "Audio transcription",
+      operation: :transcription,
+      modality: :audio_input,
+      proof: :provider_test_macro,
+      status: :fixture_backed,
+      scenario_ids: [:transcription_basic],
+      model_compat_capability: "transcription",
+      test_files: [
+        "test/coverage/groq/transcription_test.exs",
+        "test/coverage/openai/transcription_test.exs"
+      ],
+      notes: "Binary audio input, media type handling, and transcript result shape."
+    },
+    %{
+      id: :speech,
+      title: "Speech generation",
+      operation: :speech,
+      modality: :audio_output,
+      proof: :provider_test_macro,
+      status: :fixture_backed,
+      scenario_ids: [:speech_basic],
+      model_compat_capability: "speech",
+      test_files: [
+        "test/coverage/elevenlabs/speech_test.exs",
+        "test/coverage/openai/speech_test.exs"
+      ],
+      notes: "Generated audio binary, media type, format, and voice options."
+    },
+    %{
+      id: :rerank,
+      title: "Rerank",
+      operation: :rerank,
+      modality: :ranking,
+      proof: :provider_test_macro,
+      status: :fixture_backed,
+      scenario_ids: [:rerank_basic],
+      model_compat_capability: "rerank",
+      test_files: ["test/coverage/cohere/rerank_test.exs"],
+      notes: "Document relevance scores and top-n response shape."
+    },
+    %{
+      id: :ocr,
+      title: "OCR",
+      operation: :ocr,
+      modality: :document_input,
+      proof: :provider_test_macro,
+      status: :macro_available,
+      scenario_ids: [:ocr_basic],
+      model_compat_capability: "ocr",
+      test_files: [],
+      notes: "The provider macro exists; no focused coverage file is currently registered."
+    },
+    %{
+      id: :grounding,
+      title: "Google grounding",
+      operation: :text,
+      modality: :web_tool,
+      proof: :focused_fixture,
+      status: :fixture_backed,
+      scenario_ids: [:grounding_basic, :grounding_with_context, :grounding_streaming],
+      model_compat_capability: "grounding",
+      test_files: ["test/coverage/google/grounding_test.exs"],
+      notes: "Google Search grounding, grounding metadata, and web-search usage cost."
+    },
+    %{
+      id: :grounding_legacy,
+      title: "Google legacy grounding",
+      operation: :text,
+      modality: :web_tool,
+      proof: :focused_fixture,
+      status: :fixture_backed,
+      scenario_ids: [:grounding_legacy],
+      model_compat_capability: "grounding_legacy",
+      test_files: ["test/coverage/google/grounding_test.exs"],
+      notes: "Gemini 1.5 dynamic retrieval compatibility."
+    },
+    %{
+      id: :multimodal_tool_result,
+      title: "Multimodal tool result",
+      operation: :text,
+      modality: :document_input,
+      proof: :focused_fixture,
+      status: :fixture_backed,
+      scenario_ids: [:multimodal_tool_result],
+      model_compat_capability: "multimodal_tool_result",
+      test_files: ["test/coverage/google/multimodal_tool_result_test.exs"],
+      notes: "Tool result content that combines text with PDF/file parts."
+    },
+    %{
+      id: :web_search,
+      title: "Web search tools",
+      operation: :text,
+      modality: :web_tool,
+      proof: :focused_fixture,
+      status: :fixture_backed,
+      scenario_ids: [:web_search_basic, :web_search_streaming, :x_search_streaming],
+      model_compat_capability: "web_search",
+      test_files: [
+        "test/coverage/anthropic/web_search_test.exs",
+        "test/coverage/openai/web_search_test.exs",
+        "test/coverage/xai/web_search_test.exs"
+      ],
+      notes: "Provider-native web search, streaming web search, and xAI x_search usage."
+    },
+    %{
+      id: :web_fetch,
+      title: "Web fetch tools",
+      operation: :text,
+      modality: :web_tool,
+      proof: :focused_fixture,
+      status: :fixture_backed,
+      scenario_ids: [:web_fetch_basic],
+      model_compat_capability: "web_fetch",
+      test_files: ["test/coverage/anthropic/web_fetch_test.exs"],
+      notes: "Anthropic URL fetch and response analysis."
+    },
+    %{
+      id: :streaming_structured_output,
+      title: "Focused streaming structured output",
+      operation: :text,
+      modality: :structured_output,
+      proof: :focused_fixture,
+      status: :fixture_backed,
+      scenario_ids: [
+        :object_streaming_json_schema,
+        :object_streaming_tool_strict,
+        :object_streaming_auto,
+        :streaming_error_handling
+      ],
+      model_compat_capability: "streaming_structured_output",
+      test_files: [
+        "test/coverage/anthropic/streaming_structured_output_test.exs",
+        "test/coverage/azure/streaming_structured_output_test.exs",
+        "test/coverage/xai/streaming_structured_output_test.exs"
+      ],
+      notes: "Provider-specific streaming object strategies and error behavior."
+    },
+    %{
+      id: :vision_input,
+      title: "Vision input content",
+      operation: :text,
+      modality: :vision_input,
+      proof: :provider_unit,
+      status: :unit_guarded,
+      scenario_ids: [],
+      model_compat_capability: nil,
+      test_files: [
+        "test/providers/google_test.exs",
+        "test/providers/openai_test.exs",
+        "test/providers/xai_test.exs",
+        "test/req_llm/message/content_part_test.exs"
+      ],
+      notes: "Image binary, image URL, and mixed text/image message encoding."
+    },
+    %{
+      id: :file_input,
+      title: "File and document input",
+      operation: :text,
+      modality: :document_input,
+      proof: :provider_unit,
+      status: :mixed_proof,
+      scenario_ids: [],
+      model_compat_capability: nil,
+      test_files: [
+        "test/provider/openai/responses_api_unit_test.exs",
+        "test/providers/anthropic_test.exs",
+        "test/providers/google_test.exs",
+        "test/providers/openrouter_test.exs"
+      ],
+      notes: "File IDs, inline files, PDFs, provider rejection paths, and OpenRouter file-parser."
+    },
+    %{
+      id: :media_url_content,
+      title: "Media URL content parts",
+      operation: :text,
+      modality: :media_url,
+      proof: :provider_unit,
+      status: :unit_guarded,
+      scenario_ids: [],
+      model_compat_capability: nil,
+      test_files: [
+        "test/providers/google_test.exs",
+        "test/req_llm/context_test.exs",
+        "test/req_llm/message/content_part_test.exs",
+        "test/req_llm/provider/defaults_test.exs"
+      ],
+      notes: "Image URL and video URL content part normalization and provider handling."
+    },
+    %{
+      id: :audio_output_chat,
+      title: "Audio-output chat",
+      operation: :text,
+      modality: :audio_output,
+      proof: :provider_unit,
+      status: :unit_guarded,
+      scenario_ids: [],
+      model_compat_capability: nil,
+      test_files: ["test/providers/openai_test.exs"],
+      notes: "Chat models that request text plus audio and decode audio transcripts."
+    }
+  ]
+
+  @focused_routes [
+    %{
+      provider: :amazon_bedrock,
+      operation: :embedding,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      test_file: "test/coverage/amazon_bedrock/embedding_test.exs"
+    },
+    %{
+      provider: :azure,
+      operation: :embedding,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      test_file: "test/coverage/azure/embedding_test.exs"
+    },
+    %{
+      provider: :google,
+      operation: :embedding,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      test_file: "test/coverage/google/embedding_test.exs"
+    },
+    %{
+      provider: :google_vertex,
+      operation: :embedding,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      test_file: "test/coverage/google_vertex_gemini/embedding_test.exs"
+    },
+    %{
+      provider: :openai,
+      operation: :embedding,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      test_file: "test/coverage/openai/embedding_test.exs"
+    },
+    %{
+      provider: :openrouter,
+      operation: :embedding,
+      scenario_ids: [:embed_basic, :embed_usage, :embed_batch],
+      test_file: "test/coverage/openrouter/embedding_test.exs"
+    },
+    %{
+      provider: :google,
+      operation: :image,
+      scenario_ids: [:image_basic],
+      test_file: "test/coverage/google/image_generation_test.exs"
+    },
+    %{
+      provider: :openai,
+      operation: :image,
+      scenario_ids: [:image_basic],
+      test_file: "test/coverage/openai/image_generation_test.exs"
+    },
+    %{
+      provider: :xai,
+      operation: :image,
+      scenario_ids: [:image_basic],
+      test_file: "test/coverage/xai/image_generation_test.exs"
+    },
+    %{
+      provider: :groq,
+      operation: :transcription,
+      scenario_ids: [:transcription_basic],
+      test_file: "test/coverage/groq/transcription_test.exs"
+    },
+    %{
+      provider: :openai,
+      operation: :transcription,
+      scenario_ids: [:transcription_basic],
+      test_file: "test/coverage/openai/transcription_test.exs"
+    },
+    %{
+      provider: :elevenlabs,
+      operation: :speech,
+      scenario_ids: [:speech_basic],
+      test_file: "test/coverage/elevenlabs/speech_test.exs"
+    },
+    %{
+      provider: :openai,
+      operation: :speech,
+      scenario_ids: [:speech_basic],
+      test_file: "test/coverage/openai/speech_test.exs"
+    },
+    %{
+      provider: :cohere,
+      operation: :rerank,
+      scenario_ids: [:rerank_basic],
+      test_file: "test/coverage/cohere/rerank_test.exs"
+    },
+    %{
+      provider: :google,
+      operation: :text,
+      scenario_ids: [
+        :grounding_basic,
+        :grounding_with_context,
+        :grounding_streaming,
+        :grounding_legacy
+      ],
+      test_file: "test/coverage/google/grounding_test.exs"
+    },
+    %{
+      provider: :google,
+      operation: :text,
+      scenario_ids: [:multimodal_tool_result],
+      test_file: "test/coverage/google/multimodal_tool_result_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      operation: :text,
+      scenario_ids: [:web_search_basic],
+      test_file: "test/coverage/anthropic/web_search_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      operation: :text,
+      scenario_ids: [:web_fetch_basic],
+      test_file: "test/coverage/anthropic/web_fetch_test.exs"
+    },
+    %{
+      provider: :openai,
+      operation: :text,
+      scenario_ids: [:web_search_basic, :web_search_streaming],
+      test_file: "test/coverage/openai/web_search_test.exs"
+    },
+    %{
+      provider: :xai,
+      operation: :text,
+      scenario_ids: [:web_search_basic, :web_search_streaming, :x_search_streaming],
+      test_file: "test/coverage/xai/web_search_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      operation: :text,
+      scenario_ids: [
+        :object_streaming_json_schema,
+        :object_streaming_tool_strict,
+        :object_streaming_auto,
+        :streaming_error_handling
+      ],
+      test_file: "test/coverage/anthropic/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      operation: :text,
+      scenario_ids: [
+        :object_streaming_json_schema,
+        :object_streaming_tool_strict,
+        :object_streaming_auto,
+        :streaming_error_handling
+      ],
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :xai,
+      operation: :text,
+      scenario_ids: [
+        :object_streaming_json_schema,
+        :object_streaming_tool_strict,
+        :object_streaming_auto,
+        :streaming_error_handling
+      ],
+      test_file: "test/coverage/xai/streaming_structured_output_test.exs"
+    }
+  ]
+
+  @areas @registry_areas ++ @focused_areas
+
+  @spec all() :: [map()]
+  def all, do: @areas
+
+  @spec ids() :: [atom()]
+  def ids, do: Enum.map(@areas, & &1.id)
+
+  @spec get(atom()) :: {:ok, map()} | :error
+  def get(id) when is_atom(id) do
+    case Enum.find(@areas, &(&1.id == id)) do
+      nil -> :error
+      area -> {:ok, area}
+    end
+  end
+
+  @spec registry_groups() :: %{atom() => [atom()]}
+  def registry_groups do
+    @registry_areas
+    |> Map.new(fn area -> {area.id, area.scenario_ids} end)
+  end
+
+  @spec model_compat_areas() :: [map()]
+  def model_compat_areas do
+    Enum.filter(@areas, &is_binary(&1.model_compat_capability))
+  end
+
+  @spec focused_routes() :: [map()]
+  def focused_routes, do: @focused_routes
+
+  @spec concrete_test_files() :: [binary()]
+  def concrete_test_files do
+    @areas
+    |> Enum.flat_map(& &1.test_files)
+    |> Enum.reject(&String.contains?(&1, "*"))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  @spec fixture_backed_ids() :: [atom()]
+  def fixture_backed_ids do
+    @areas
+    |> Enum.filter(&(&1.status == :fixture_backed))
+    |> Enum.map(& &1.id)
+  end
+
+  @spec gap_ids() :: [atom()]
+  def gap_ids do
+    @areas
+    |> Enum.reject(&(&1.status == :fixture_backed))
+    |> Enum.map(& &1.id)
+  end
+end

--- a/test/support/scenarios/objects_reasoning.ex
+++ b/test/support/scenarios/objects_reasoning.ex
@@ -1,0 +1,257 @@
+defmodule ReqLLM.Test.Scenarios.ObjectBasic do
+  @moduledoc """
+  Non-streaming object generation scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :object_basic,
+    name: "object generation (non-streaming)",
+    description: "Validates object generation with the standard software engineer schema."
+
+  alias ReqLLM.Test.Scenarios.Assertions
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  @impl ReqLLM.Test.Scenario
+  def applies?(model), do: Capabilities.supports_object_generation?(model)
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["object_basic"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    schema = [
+      name: [type: :string, required: true, doc: "Person's full name"],
+      age: [type: :pos_integer, required: true, doc: "Person's age in years"],
+      occupation: [type: :string, doc: "Person's job or profession"]
+    ]
+
+    request_opts =
+      param_bundles(provider).deterministic
+      |> Keyword.put(:max_tokens, 500)
+      |> then(&reasoning_overlay(model_spec, provider, &1, 500))
+
+    {:ok, response} =
+      ReqLLM.generate_object(
+        model_spec,
+        "Generate a software engineer profile",
+        schema,
+        fixture_opts(provider, "object_basic", request_opts)
+      )
+
+    assert %ReqLLM.Response{} = response
+    Assertions.assert_profile_object_or_reasoning(response)
+
+    Scenario.ok(__MODULE__, [Scenario.step(:generate_object, "object_basic")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.ObjectStreaming do
+  @moduledoc """
+  Streaming object generation scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :object_streaming,
+    name: "object generation (streaming)",
+    description:
+      "Validates streaming object generation with the standard software engineer schema."
+
+  alias ReqLLM.Test.Scenarios.Assertions
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  @impl ReqLLM.Test.Scenario
+  def applies?(model), do: Capabilities.supports_streaming_object_generation?(model)
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["object_streaming"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    schema = [
+      name: [type: :string, required: true, doc: "Person's full name"],
+      age: [type: :pos_integer, required: true, doc: "Person's age in years"],
+      occupation: [type: :string, doc: "Person's job or profession"]
+    ]
+
+    request_opts =
+      param_bundles(provider).deterministic
+      |> Keyword.put(:max_tokens, 500)
+      |> then(&reasoning_overlay(model_spec, provider, &1, 500))
+
+    {:ok, response} =
+      ReqLLM.stream_object(
+        model_spec,
+        "Generate a software engineer profile",
+        schema,
+        fixture_opts(provider, "object_streaming", request_opts)
+      )
+
+    response =
+      if match?(%ReqLLM.StreamResponse{}, response) do
+        {:ok, resp} = ReqLLM.StreamResponse.to_response(response)
+        resp
+      else
+        response
+      end
+
+    Assertions.assert_profile_object_or_reasoning(response)
+
+    Scenario.ok(__MODULE__, [Scenario.step(:stream_object, "object_streaming")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.Reasoning do
+  @moduledoc """
+  Non-streaming and streaming reasoning scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :reasoning,
+    name: "reasoning/thinking tokens (non-streaming + streaming)",
+    description: "Validates reasoning output acceptance rules for generate_text and stream_text."
+
+  alias ReqLLM.Test.Scenarios.Assertions
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  @impl ReqLLM.Test.Scenario
+  def applies?(model), do: Capabilities.supports_reasoning?(model)
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["reasoning_basic", "reasoning_streaming"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    dbug(
+      fn -> "\n[Comprehensive] model_spec=#{model_spec}, test=reasoning" end,
+      component: :test
+    )
+
+    provider_config = param_bundles(provider)
+
+    base_opts =
+      provider_config.deterministic
+      |> Keyword.delete(:temperature)
+      |> Keyword.merge(
+        max_tokens: 5000,
+        temperature: 1.0,
+        reasoning_effort: provider_config.reasoning[:reasoning_effort]
+      )
+
+    prompt = provider_config.reasoning_prompts.basic
+
+    {:ok, response} =
+      ReqLLM.generate_text(
+        model_spec,
+        prompt,
+        fixture_opts(provider, "reasoning_basic", base_opts)
+      )
+
+    assert %ReqLLM.Response{} = response
+    assert response.message.role == :assistant
+
+    text = ReqLLM.Response.text(response) || ""
+    thinking = ReqLLM.Response.thinking(response) || ""
+    combined = text <> thinking
+    assert combined != ""
+
+    has_thinking_part? =
+      Enum.any?(
+        response.message.content,
+        &(&1.type == :thinking and is_binary(&1.text) and &1.text != "")
+      )
+
+    reasoning_tokens = ReqLLM.Response.reasoning_tokens(response)
+    has_any_output = combined != ""
+
+    assert has_thinking_part? or (is_number(reasoning_tokens) and reasoning_tokens > 0) or
+             has_any_output,
+           "Expected thinking content, reasoning tokens, or text output; got thinking: #{inspect(thinking)} tokens: #{inspect(reasoning_tokens)} text: #{inspect(text)}"
+
+    last = List.last(response.context.messages)
+    assert last == response.message
+
+    Assertions.assert_reasoning_details_if_present(response.message)
+
+    context =
+      ReqLLM.Context.new([
+        system(provider_config.reasoning_prompts.streaming_system),
+        user(provider_config.reasoning_prompts.streaming_user)
+      ])
+
+    stream_opts =
+      provider_config.creative
+      |> Keyword.delete(:temperature)
+      |> Keyword.merge(
+        max_tokens: 5000,
+        temperature: 1.0,
+        reasoning_effort: provider_config.reasoning[:reasoning_effort]
+      )
+
+    {:ok, stream_response} =
+      ReqLLM.stream_text(
+        model_spec,
+        context,
+        fixture_opts(provider, "reasoning_streaming", stream_opts)
+      )
+
+    assert %ReqLLM.StreamResponse{} = stream_response
+    assert stream_response.stream
+    assert stream_response.metadata_handle
+
+    stream_chunks = Enum.to_list(stream_response.stream)
+
+    {thinking_count, reasoning_tokens_stream} =
+      stream_chunks
+      |> Enum.reduce({0, 0}, fn chunk, {tc, rt} ->
+        case chunk.type do
+          :thinking ->
+            {tc + 1, rt}
+
+          :meta ->
+            usage = chunk.metadata[:usage] || %{}
+            rt2 = Map.get(usage, :reasoning_tokens, 0)
+            {tc, max(rt, (is_number(rt2) && rt2) || 0)}
+
+          _ ->
+            {tc, rt}
+        end
+      end)
+
+    stream_with_chunks = %{stream_response | stream: stream_chunks}
+    {:ok, response} = ReqLLM.StreamResponse.to_response(stream_with_chunks)
+    rt_final = ReqLLM.Response.reasoning_tokens(response)
+
+    streaming_text = ReqLLM.Response.text(response) || ""
+    has_streaming_output = streaming_text != ""
+
+    assert thinking_count > 0 or reasoning_tokens_stream > 0 or rt_final > 0 or
+             has_streaming_output,
+           "Expected at least one :thinking chunk, positive reasoning_tokens, or text output; got tc=#{thinking_count} rt_stream=#{reasoning_tokens_stream} rt_final=#{rt_final} text_len=#{String.length(streaming_text)}"
+
+    assert %ReqLLM.Response{} = response
+    assert response.message.role == :assistant
+
+    Assertions.assert_reasoning_details_if_present(response.message)
+
+    Scenario.ok(
+      __MODULE__,
+      [
+        Scenario.step(:generate_text, "reasoning_basic"),
+        Scenario.step(:stream_text, "reasoning_streaming")
+      ],
+      %{provider: provider, model: model.id}
+    )
+  end
+end

--- a/test/support/scenarios/objects_reasoning.ex
+++ b/test/support/scenarios/objects_reasoning.ex
@@ -101,6 +101,7 @@ defmodule ReqLLM.Test.Scenarios.ObjectStreaming do
         response
       end
 
+    assert %ReqLLM.Response{} = response
     Assertions.assert_profile_object_or_reasoning(response)
 
     Scenario.ok(__MODULE__, [Scenario.step(:stream_object, "object_streaming")], %{
@@ -167,10 +168,9 @@ defmodule ReqLLM.Test.Scenarios.Reasoning do
     assert combined != ""
 
     has_thinking_part? =
-      Enum.any?(
-        response.message.content,
-        &(&1.type == :thinking and is_binary(&1.text) and &1.text != "")
-      )
+      response.message.content
+      |> List.wrap()
+      |> Enum.any?(&(&1.type == :thinking and is_binary(&1.text) and &1.text != ""))
 
     reasoning_tokens = ReqLLM.Response.reasoning_tokens(response)
     has_any_output = combined != ""

--- a/test/support/scenarios/text.ex
+++ b/test/support/scenarios/text.ex
@@ -1,0 +1,288 @@
+defmodule ReqLLM.Test.Scenarios.Basic do
+  @moduledoc """
+  Basic non-streaming text generation scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :basic,
+    name: "basic generate_text (non-streaming)",
+    description: "Validates a deterministic non-streaming text response."
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    dbug(
+      fn -> "\n[Comprehensive] model_spec=#{model_spec}, test=basic_generate" end,
+      component: :test
+    )
+
+    request_opts =
+      reasoning_overlay(
+        model_spec,
+        param_bundles().deterministic,
+        2000
+      )
+
+    ReqLLM.generate_text(
+      model_spec,
+      "Hello world!",
+      fixture_opts("basic", request_opts)
+    )
+    |> assert_basic_response()
+
+    Scenario.ok(__MODULE__, [Scenario.step(:generate_text, "basic")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.Streaming do
+  @moduledoc """
+  Streaming text generation scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :streaming,
+    name: "stream_text with system context and creative params",
+    description: "Validates streaming response shape, content, finish reason, and usage."
+
+  alias ReqLLM.Test.Scenarios.Assertions
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    dbug(
+      fn -> "\n[Comprehensive] model_spec=#{model_spec}, test=streaming" end,
+      component: :test
+    )
+
+    context =
+      ReqLLM.Context.new([
+        system("You are a helpful, creative assistant."),
+        user("Say hello in one short, imaginative sentence.")
+      ])
+
+    request_opts =
+      reasoning_overlay(model_spec, provider, param_bundles(provider).creative, 2000)
+
+    {:ok, stream_response} =
+      ReqLLM.stream_text(
+        model_spec,
+        context,
+        fixture_opts(provider, "streaming", request_opts)
+      )
+
+    assert %ReqLLM.StreamResponse{} = stream_response
+    assert stream_response.stream
+    assert stream_response.metadata_handle
+
+    {:ok, response} = ReqLLM.StreamResponse.to_response(stream_response)
+
+    finish_reason = ReqLLM.StreamResponse.finish_reason(stream_response)
+
+    assert %ReqLLM.Response{} = response
+
+    text = ReqLLM.Response.text(response) || ""
+    thinking = ReqLLM.Response.thinking(response) || ""
+    combined = text <> thinking
+
+    assert combined != "",
+           "Expected text or thinking content, got empty (text: #{inspect(text)}, thinking: #{inspect(thinking)})"
+
+    assert response.message.role == :assistant
+
+    refute is_nil(finish_reason)
+
+    Assertions.assert_streaming_usage(response.usage)
+
+    Scenario.ok(__MODULE__, [Scenario.step(:stream_text, "streaming")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.TokenLimit do
+  @moduledoc """
+  Token limit constraint scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :token_limit,
+    name: "token limit constraints",
+    description: "Validates constrained generation and length handling."
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    request_opts =
+      param_bundles(provider).minimal
+      |> Keyword.put(:max_tokens, 100)
+      |> then(&reasoning_overlay(model_spec, provider, &1, 3000))
+
+    case ReqLLM.generate_text(
+           model_spec,
+           "Write a very long story about dragons and adventures",
+           fixture_opts(provider, "token_limit", request_opts)
+         ) do
+      {:ok, response} ->
+        assert_basic_response({:ok, response})
+
+        content = combined_content(response)
+
+        if truncated?(response) do
+          rt = ReqLLM.Response.reasoning_tokens(response)
+          assert is_number(rt) and rt >= 0
+
+          if content != "" do
+            assert String.length(content) > 0,
+                   "Truncated response should have some content or reasoning tokens"
+          end
+        else
+          assert_text_length(response, 150)
+        end
+
+      other ->
+        flunk("Expected {:ok, %ReqLLM.Response{}}, got: #{inspect(other)}")
+    end
+
+    Scenario.ok(__MODULE__, [Scenario.step(:generate_text, "token_limit")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.Usage do
+  @moduledoc """
+  Usage and cost normalization scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :usage,
+    name: "usage metrics and cost calculations",
+    description: "Validates usage metrics, cached tokens, reasoning tokens, and costs."
+
+  alias ReqLLM.Test.Scenarios.Assertions
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    dbug(
+      fn -> "\n[Comprehensive] model_spec=#{model_spec}, test=usage" end,
+      component: :test
+    )
+
+    max_tokens =
+      case model do
+        %{capabilities: %{reasoning: true}} -> 500
+        %{model: "gpt-4.1" <> _} -> 16
+        %{extra: %{wire: %{protocol: "openai_responses"}}} -> 200
+        _ -> 10
+      end
+
+    {:ok, response} =
+      ReqLLM.generate_text(
+        model_spec,
+        "Hi there!",
+        fixture_opts(
+          "usage",
+          Keyword.put(param_bundles().deterministic, :max_tokens, max_tokens)
+        )
+      )
+
+    assert %ReqLLM.Response{} = response
+
+    text = ReqLLM.Response.text(response) || ""
+    reasoning_tokens = response.usage.reasoning_tokens || 0
+
+    assert text != "" or reasoning_tokens > 0,
+           "Expected either text content or reasoning tokens, got neither"
+
+    assert is_map(response.usage)
+
+    assert is_number(response.usage.input_tokens) and response.usage.input_tokens > 0
+    assert is_number(response.usage.output_tokens) and response.usage.output_tokens >= 0
+    assert is_number(response.usage.total_tokens) and response.usage.total_tokens > 0
+    assert is_number(response.usage.cached_tokens) and response.usage.cached_tokens >= 0
+
+    assert is_number(response.usage.reasoning_tokens) and
+             response.usage.reasoning_tokens >= 0
+
+    case model do
+      %LLMDB.Model{cost: cost_map} when is_map(cost_map) ->
+        Assertions.assert_usage_cost_fields(response.usage, true)
+
+      _ ->
+        Assertions.assert_usage_cost_fields(response.usage, false)
+    end
+
+    Scenario.ok(__MODULE__, [Scenario.step(:generate_text, "usage")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.ContextAppend do
+  @moduledoc """
+  Conversation context append scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :context_append,
+    name: "context append continues conversation",
+    description: "Validates that generated responses can advance an existing context."
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["context_append_1", "context_append_2"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    ctx = ReqLLM.Context.new([user("Respond with a single word 'Hi'.")])
+
+    request_opts =
+      param_bundles().deterministic
+      |> Keyword.put(:max_tokens, 1024)
+
+    {:ok, resp1} =
+      ReqLLM.generate_text(
+        model_spec,
+        ctx,
+        fixture_opts(provider, "context_append_1", request_opts)
+      )
+
+    ctx2 = ReqLLM.Context.append(resp1.context, user("Hi again"))
+
+    {:ok, resp2} =
+      ReqLLM.generate_text(
+        model_spec,
+        ctx2,
+        fixture_opts(provider, "context_append_2", request_opts)
+      )
+
+    text = ReqLLM.Response.text(resp2) || ""
+    reasoning_tokens = Map.get(resp2.usage || %{}, :reasoning_tokens, 0)
+
+    assert text != "" or reasoning_tokens > 0
+    assert length(resp2.context.messages) >= 4
+    assert List.last(resp2.context.messages) == resp2.message
+    assert resp2.message.role == :assistant
+
+    Scenario.ok(
+      __MODULE__,
+      [
+        Scenario.step(:first_turn, "context_append_1"),
+        Scenario.step(:second_turn, "context_append_2")
+      ],
+      %{provider: provider, model: model.id}
+    )
+  end
+end

--- a/test/support/scenarios/tools.ex
+++ b/test/support/scenarios/tools.ex
@@ -64,7 +64,7 @@ defmodule ReqLLM.Test.Scenarios.ToolMulti do
       {:ok, response} ->
         assert_basic_response(result)
 
-        tool_calls = ReqLLM.Response.tool_calls(response) || []
+        tool_calls = ReqLLM.Response.tool_calls(response)
 
         if Enum.empty?(tool_calls) and truncated?(response) do
           rt = ReqLLM.Response.reasoning_tokens(response)

--- a/test/support/scenarios/tools.ex
+++ b/test/support/scenarios/tools.ex
@@ -1,0 +1,226 @@
+defmodule ReqLLM.Test.Scenarios.ToolMulti do
+  @moduledoc """
+  Multi-tool selection scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :tool_multi,
+    name: "tool calling - multi-tool selection",
+    description: "Validates that tool-capable models can select an appropriate tool."
+
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  @impl ReqLLM.Test.Scenario
+  def applies?(model), do: Capabilities.supports_tool_calling?(model)
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["multi_tool"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    tools = [
+      ReqLLM.tool(
+        name: "get_weather",
+        description: "Get current weather information for a location",
+        parameter_schema: [
+          location: [type: :string, required: true],
+          unit: [type: {:in, ["celsius", "fahrenheit"]}]
+        ],
+        callback: fn _args -> {:ok, "Weather data"} end
+      ),
+      ReqLLM.tool(
+        name: "tell_joke",
+        description: "Tell a funny joke",
+        parameter_schema: [
+          topic: [type: :string, doc: "Topic for the joke"]
+        ],
+        callback: fn _args -> {:ok, "Why did the cat cross the road?"} end
+      ),
+      ReqLLM.tool(
+        name: "get_time",
+        description: "Get the current time",
+        parameter_schema: [],
+        callback: fn _args -> {:ok, "12:00 PM"} end
+      )
+    ]
+
+    budget = tool_budget_for(model_spec)
+
+    base_opts =
+      param_bundles().deterministic
+      |> Keyword.put(:max_tokens, budget)
+      |> then(&reasoning_overlay(model_spec, &1, budget * 2))
+
+    result =
+      ReqLLM.generate_text(
+        model_spec,
+        "What's the weather like in Paris, France?",
+        fixture_opts("multi_tool", base_opts ++ [tools: tools])
+      )
+
+    case result do
+      {:ok, response} ->
+        assert_basic_response(result)
+
+        tool_calls = ReqLLM.Response.tool_calls(response) || []
+
+        if Enum.empty?(tool_calls) and truncated?(response) do
+          rt = ReqLLM.Response.reasoning_tokens(response)
+          assert is_number(rt) and rt >= 0
+        else
+          assert_has_tool_call(response)
+        end
+
+      {:error, _} ->
+        flunk("Expected successful response with tool call")
+    end
+
+    Scenario.ok(__MODULE__, [Scenario.step(:generate_text, "multi_tool")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.ToolRoundTrip do
+  @moduledoc """
+  Tool round-trip execution scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :tool_round_trip,
+    name: "tool calling - round trip execution",
+    description: "Validates tool execution, context append, and final response."
+
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  @impl ReqLLM.Test.Scenario
+  def applies?(model), do: Capabilities.supports_tool_calling?(model)
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["tool_round_trip_1", "tool_round_trip_2"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    tools = [
+      ReqLLM.tool(
+        name: "add",
+        description: "Add two integers",
+        parameter_schema: [
+          a: [type: :integer, required: true],
+          b: [type: :integer, required: true]
+        ],
+        callback: fn %{a: a, b: b} -> {:ok, a + b} end
+      )
+    ]
+
+    base_opts =
+      param_bundles().deterministic
+      |> Keyword.put(:max_tokens, tool_budget_for(model_spec))
+
+    tool_choice =
+      if Capabilities.supports_forced_tool_choice?(model) do
+        %{type: "tool", name: "add"}
+      else
+        "required"
+      end
+
+    {:ok, resp1} =
+      ReqLLM.generate_text(
+        model_spec,
+        "Use the add tool to compute 2 + 3. After the tool result arrives, respond with 'sum=<value>'.",
+        fixture_opts(
+          "tool_round_trip_1",
+          base_opts ++
+            [
+              tools: tools,
+              tool_choice: tool_choice
+            ]
+        )
+      )
+
+    tool_calls = ReqLLM.Response.tool_calls(resp1)
+    assert tool_calls != []
+
+    ctx2 = ReqLLM.Context.execute_and_append_tools(resp1.context, tool_calls, tools)
+
+    {:ok, resp2} =
+      ReqLLM.generate_text(
+        model_spec,
+        ctx2,
+        fixture_opts("tool_round_trip_2", base_opts)
+      )
+
+    text = ReqLLM.Response.text(resp2) || ""
+    assert text != ""
+    assert String.contains?(text, "5")
+    assert Enum.empty?(ReqLLM.Response.tool_calls(resp2))
+
+    Scenario.ok(
+      __MODULE__,
+      [
+        Scenario.step(:tool_request, "tool_round_trip_1"),
+        Scenario.step(:tool_result, "tool_round_trip_2")
+      ],
+      %{provider: provider, model: model.id}
+    )
+  end
+end
+
+defmodule ReqLLM.Test.Scenarios.ToolNone do
+  @moduledoc """
+  No-tool text generation scenario.
+  """
+
+  use ReqLLM.Test.Scenario,
+    id: :tool_none,
+    name: "tool calling - no tool when inappropriate",
+    description: "Validates that regular text output still works when tools are available."
+
+  alias ReqLLM.Test.Scenarios.Capabilities
+
+  @impl ReqLLM.Test.Scenario
+  def applies?(model), do: Capabilities.supports_tool_calling?(model)
+
+  @impl ReqLLM.Test.Scenario
+  def fixtures(_model), do: ["no_tool"]
+
+  @impl ReqLLM.Test.Scenario
+  def run(model_spec, model, opts) do
+    provider = Keyword.fetch!(opts, :provider)
+
+    tools = [
+      ReqLLM.tool(
+        name: "get_weather",
+        description: "Get current weather information for a location",
+        parameter_schema: [
+          location: [type: :string, required: true]
+        ],
+        callback: fn _args -> {:ok, "Weather data"} end
+      )
+    ]
+
+    budget = tool_budget_for(model_spec)
+
+    base_opts =
+      param_bundles().deterministic
+      |> Keyword.put(:max_tokens, budget)
+      |> then(&reasoning_overlay(model_spec, &1, budget * 2))
+
+    ReqLLM.generate_text(
+      model_spec,
+      "Tell me a joke about cats",
+      fixture_opts("no_tool", base_opts ++ [tools: tools])
+    )
+    |> assert_basic_response()
+
+    Scenario.ok(__MODULE__, [Scenario.step(:generate_text, "no_tool")], %{
+      provider: provider,
+      model: model.id
+    })
+  end
+end


### PR DESCRIPTION
## ReqLLM v2 draft

This draft PR starts the ReqLLM v2 architecture migration branch. ReqLLM v2 is intended to be a completely separate release path from the current ReqLLM package line, not a wholesale replacement merged all at once.

Feedback is welcome directly on this branch and PR while the architecture is still being shaped.

## Goals

- Gradually pull the best architecture ideas from `reqllm_next` into `req_llm`.
- Preserve current `req_llm` public behavior while refactoring internals incrementally.
- Separate semantic request/response models from provider wire formats.
- Put provider-specific request encoding, response decoding, stream event parsing, and option translation behind provider-owned boundaries.
- Keep fixture-backed compatibility coverage as proof that provider behavior still works during the migration.
- Make each architecture step small enough to review independently.

## Implementation plan

Checklist items in this section represent Beadwork epics, not individual tasks.

- [x] `req-qqb` - Transition coverage to scenario-based tests: added the provider scenario contract and registry, extracted core text/tool/object/reasoning scenarios, rewired comprehensive provider coverage and `mix req_llm.model_compat` to use the shared scenario registry, added fixture guardrails, documented the workflow, and hardened scenario lookup/capability handling.
- [x] `req-aa2` - Map scenario taxonomy and modality coverage gaps: added a machine-checkable modality taxonomy for text and non-text behavior, guarded scenario groups against `model_compat` capability drift, aligned focused provider scenario routes, documented fixture-backed proof versus known gaps, and captured brainstormed follow-up epics.

## Brainstormed next steps

This list is brainstormed and subject to change. Items should be promoted into separate Beadwork epics before implementation.

- Promote OCR into focused fixture-backed coverage once a stable provider/model target is selected.
- Add vision-input replay scenarios for image binary, image URL, and mixed text/image messages.
- Add document-input replay scenarios for file IDs, inline PDFs, OpenRouter file-parser behavior, and OpenAI Responses file handling.
- Split image generation into basic generation, edit/source image, mask, and provider option scenarios.
- Add audio-output chat scenarios for models that return text plus audio metadata or transcripts.
- Add video/media URL replay coverage where providers support it, and explicit rejection scenarios where they do not.
- Convert focused non-text provider macros into reusable scenario modules once the taxonomy is stable.
- Extract provider wire-format request encoding behind provider-owned modules.
- Extract provider response decoding behind provider-owned modules.
- Extract streaming event parsing behind provider-owned modules.
- Move deterministic request planning and option translation into a clearer internal layer.
- Keep live fixture recording explicit and reviewable when scenario behavior changes.
- Prepare v2 release notes and compatibility guidance once the internal migration is stable.

## Current verification

- `mix compile --warnings-as-errors`
- `mix test test/req_llm/scenarios test/mix/tasks/model_compat_test.exs`
- `mix test test/coverage/openai/web_search_test.exs --include coverage --only scenario:web_search_basic`
- `REQ_LLM_MODELS="openai:gpt-4o-mini" mix test test/coverage/openai/comprehensive_test.exs --include coverage`
- `mix test`
