### PR TITLE
fix(mistral): parse nested thinking chunks

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1243,10 +1243,37 @@ defmodule ReqLLM.Provider.Defaults do
   end
 
   defp decode_openai_content_part(%{"type" => "thinking", "thinking" => thinking}) do
-    [ReqLLM.StreamChunk.thinking(thinking)]
+    decode_openai_thinking_content(thinking)
   end
 
   defp decode_openai_content_part(_), do: []
+
+  defp decode_openai_thinking_content(thinking) when is_binary(thinking) do
+    [ReqLLM.StreamChunk.thinking(thinking)]
+  end
+
+  defp decode_openai_thinking_content(thinking) when is_list(thinking) do
+    thinking
+    |> Enum.flat_map(&decode_openai_thinking_part/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp decode_openai_thinking_content(_), do: []
+
+  defp decode_openai_thinking_part(%{"type" => "text", "text" => text})
+       when is_binary(text) and text != "" do
+    [ReqLLM.StreamChunk.thinking(text)]
+  end
+
+  defp decode_openai_thinking_part(%{"text" => text}) when is_binary(text) and text != "" do
+    [ReqLLM.StreamChunk.thinking(text)]
+  end
+
+  defp decode_openai_thinking_part(text) when is_binary(text) and text != "" do
+    [ReqLLM.StreamChunk.thinking(text)]
+  end
+
+  defp decode_openai_thinking_part(_), do: []
 
   defp decode_openai_tool_call(%{
          "id" => id,

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -696,7 +696,8 @@ defmodule ReqLLM.Provider.DefaultsTest do
                       %{"type" => "text", "text" => "Okay"},
                       %{"type" => "text", "text" => ", streaming thoughts."}
                     ]
-                  }
+                  },
+                  %{"type" => "text", "text" => "Then answer."}
                 ]
               },
               "finish_reason" => nil
@@ -709,7 +710,8 @@ defmodule ReqLLM.Provider.DefaultsTest do
 
       assert [
                %StreamChunk{type: :thinking, text: "Okay"},
-               %StreamChunk{type: :thinking, text: ", streaming thoughts."}
+               %StreamChunk{type: :thinking, text: ", streaming thoughts."},
+               %StreamChunk{type: :content, text: "Then answer."}
              ] = chunks
     end
 

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -516,6 +516,38 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert Jason.decode!(tool_call.function.arguments) == %{"city" => "Paris"}
       assert tool_call.id == "lVauww8VE"
     end
+
+    test "decodes nested thinking chunks from Mistral responses" do
+      model = %LLMDB.Model{provider: :mistral, id: "mistral-medium-2604"}
+
+      response_data = %{
+        "id" => "chatcmpl-mistral-reasoning",
+        "model" => "mistral-medium-2604",
+        "choices" => [
+          %{
+            "message" => %{
+              "role" => "assistant",
+              "content" => [
+                %{
+                  "type" => "thinking",
+                  "thinking" => [
+                    %{"type" => "text", "text" => "Okay"},
+                    %{"type" => "text", "text" => ", let me plan this."}
+                  ]
+                },
+                %{"type" => "text", "text" => "Build a broad foundation first."}
+              ]
+            },
+            "finish_reason" => "stop"
+          }
+        ]
+      }
+
+      {:ok, result} = Defaults.decode_response_body_openai_format(response_data, model)
+
+      assert ReqLLM.Response.thinking(result) == "Okay, let me plan this."
+      assert ReqLLM.Response.text(result) == "Build a broad foundation first."
+    end
   end
 
   describe "default_decode_stream_event/2" do
@@ -646,6 +678,39 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert chunk.name == "get_weather"
       assert chunk.arguments == %{"city" => "Paris"}
       assert chunk.metadata == %{id: "lVauww8VE", index: 0}
+    end
+
+    test "decodes nested thinking chunks from Mistral streaming deltas" do
+      model = %LLMDB.Model{provider: :mistral, id: "mistral-medium-2604"}
+
+      mistral_event = %{
+        data: %{
+          "choices" => [
+            %{
+              "index" => 0,
+              "delta" => %{
+                "content" => [
+                  %{
+                    "type" => "thinking",
+                    "thinking" => [
+                      %{"type" => "text", "text" => "Okay"},
+                      %{"type" => "text", "text" => ", streaming thoughts."}
+                    ]
+                  }
+                ]
+              },
+              "finish_reason" => nil
+            }
+          ]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(mistral_event, model)
+
+      assert [
+               %StreamChunk{type: :thinking, text: "Okay"},
+               %StreamChunk{type: :thinking, text: ", streaming thoughts."}
+             ] = chunks
     end
 
     test "handles nil tool names in streaming deltas", %{model: model} do


### PR DESCRIPTION
## Summary
- Normalize OpenAI-compatible `thinking` content parts when providers send nested text chunks
- Preserve Mistral reasoning output in both non-streaming and streaming response decoding
- Add regression coverage for Mistral-shaped reasoning payloads

Closes #742

## Tests
- mix test test/req_llm/provider/defaults_test.exs
- mix test