### PR TITLE
fix(anthropic): map refusal/pause_turn/model_context_window_exceeded stop_reasons instead of collapsing to :error

### DIFF
--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -421,10 +421,6 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   defp parse_finish_reason("pause_turn"), do: :incomplete
   defp parse_finish_reason("refusal"), do: :content_filter
   defp parse_finish_reason("content_filter"), do: :content_filter
-  # An unrecognized but valid stop_reason is "unknown", not an error — reserve
-  # :error for genuine decode/transport failures. (Previously any unmapped
-  # reason — e.g. "refusal", "pause_turn" — collapsed to :error, losing the
-  # signal and surfacing a non-error turn as an error.)
   defp parse_finish_reason(reason) when is_binary(reason), do: :unknown
   defp parse_finish_reason(_), do: nil
 

--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -100,14 +100,7 @@ defmodule ReqLLM.Providers.Anthropic.Response do
         [ReqLLM.StreamChunk.meta(%{terminal?: true})]
 
       %{"type" => "message_delta", "delta" => delta} ->
-        finish_reason =
-          case Map.get(delta, "stop_reason") do
-            "end_turn" -> :stop
-            "max_tokens" -> :length
-            "stop_sequence" -> :stop
-            "tool_use" -> :tool_calls
-            _ -> :unknown
-          end
+        finish_reason = parse_finish_reason(Map.get(delta, "stop_reason")) || :unknown
 
         raw_usage = Map.get(data, "usage", %{})
 
@@ -420,11 +413,19 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   defp maybe_put_tool_usage(tool_usage, _tool, _count), do: tool_usage
 
   defp parse_finish_reason("stop"), do: :stop
-  defp parse_finish_reason("max_tokens"), do: :length
-  defp parse_finish_reason("tool_use"), do: :tool_calls
   defp parse_finish_reason("end_turn"), do: :stop
+  defp parse_finish_reason("stop_sequence"), do: :stop
+  defp parse_finish_reason("max_tokens"), do: :length
+  defp parse_finish_reason("model_context_window_exceeded"), do: :length
+  defp parse_finish_reason("tool_use"), do: :tool_calls
+  defp parse_finish_reason("pause_turn"), do: :incomplete
+  defp parse_finish_reason("refusal"), do: :content_filter
   defp parse_finish_reason("content_filter"), do: :content_filter
-  defp parse_finish_reason(reason) when is_binary(reason), do: :error
+  # An unrecognized but valid stop_reason is "unknown", not an error — reserve
+  # :error for genuine decode/transport failures. (Previously any unmapped
+  # reason — e.g. "refusal", "pause_turn" — collapsed to :error, losing the
+  # signal and surfacing a non-error turn as an error.)
+  defp parse_finish_reason(reason) when is_binary(reason), do: :unknown
   defp parse_finish_reason(_), do: nil
 
   defp ensure_stream_state(nil), do: init_stream_state()
@@ -442,14 +443,7 @@ defmodule ReqLLM.Providers.Anthropic.Response do
   end
 
   defp message_delta_chunks(data, delta) do
-    finish_reason =
-      case Map.get(delta, "stop_reason") do
-        "end_turn" -> :stop
-        "max_tokens" -> :length
-        "stop_sequence" -> :stop
-        "tool_use" -> :tool_calls
-        _ -> :unknown
-      end
+    finish_reason = parse_finish_reason(Map.get(delta, "stop_reason")) || :unknown
 
     raw_usage = Map.get(data, "usage", %{})
     chunks = [ReqLLM.StreamChunk.meta(%{finish_reason: finish_reason, terminal?: true})]

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -1161,9 +1161,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert decode.("model_context_window_exceeded") == :length
       assert decode.("tool_use") == :tool_calls
       assert decode.("pause_turn") == :incomplete
-      # Safety decline: surfaced as :content_filter, not silently collapsed to :error.
       assert decode.("refusal") == :content_filter
-      # A genuinely unknown reason is :unknown (reserve :error for real failures).
       assert decode.("some_future_reason") == :unknown
     end
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -1138,6 +1138,35 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert List.last(response.context.messages).role == :assistant
     end
 
+    test "decode_response normalizes the full set of Anthropic stop_reasons" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      decode = fn stop_reason ->
+        data = %{
+          "id" => "msg_01ABC123",
+          "type" => "message",
+          "role" => "assistant",
+          "content" => [%{"type" => "text", "text" => "ok"}],
+          "stop_reason" => stop_reason,
+          "usage" => %{"input_tokens" => 5, "output_tokens" => 2}
+        }
+
+        {:ok, response} = ReqLLM.Providers.Anthropic.Response.decode_response(data, model)
+        response.finish_reason
+      end
+
+      assert decode.("end_turn") == :stop
+      assert decode.("stop_sequence") == :stop
+      assert decode.("max_tokens") == :length
+      assert decode.("model_context_window_exceeded") == :length
+      assert decode.("tool_use") == :tool_calls
+      assert decode.("pause_turn") == :incomplete
+      # Safety decline: surfaced as :content_filter, not silently collapsed to :error.
+      assert decode.("refusal") == :content_filter
+      # A genuinely unknown reason is :unknown (reserve :error for real failures).
+      assert decode.("some_future_reason") == :unknown
+    end
+
     test "decode_response handles API errors with non-200 status" do
       # Create error response
       error_body = %{


### PR DESCRIPTION
## Problem

The Anthropic provider only recognized a subset of `stop_reason` values. Anything else was collapsed to `:error` in the non-streaming decoder:

```elixir
defp parse_finish_reason(reason) when is_binary(reason), do: :error
```

This has two consequences:

1. **Lost signal.** Newer Anthropic stop reasons — notably `"refusal"` (the model declined for safety), plus `"pause_turn"` and `"model_context_window_exceeded"` — were all flattened to `:error`.
2. **Non-errors surfaced as errors.** A `refusal` is a normal (if unfortunate) completion with an empty body, not a transport/decode failure. Reporting it as `finish_reason: :error` led a downstream caller to treat a perfectly valid `%ReqLLM.Response{}` (empty text) as success and then crash on `nil` text. The real reason was invisible until we logged the raw `stop_reason` and saw `"refusal"`.

On top of that, the **streaming** paths (`decode_stream_event/2` and `message_delta_chunks/2`) used their *own* `case` mapping that recognized `stop_sequence` but not `content_filter`/`refusal`/etc., and fell back to `:unknown` — inconsistent with the non-streaming path's `:error`.

## Change

In `lib/req_llm/providers/anthropic/response.ex`:

- Add mappings: `stop_sequence -> :stop`, `model_context_window_exceeded -> :length`, `pause_turn -> :incomplete`, `refusal -> :content_filter`.
- Change the unrecognized-binary fallback from `:error` to `:unknown`, reserving `:error` for genuine decode/transport failures (matches the streaming path's intent).
- Unify the two streaming `message_delta` mappings to reuse `parse_finish_reason/1` (`... || :unknown`) so coverage can't drift between code paths.
- Add tests covering the full `stop_reason` set.

`refusal -> :content_filter` reuses the existing canonical atom (a safety stop) rather than introducing a new `:refusal` atom; happy to add a dedicated atom instead if maintainers prefer.

## Tests

`mix test test/providers/anthropic_test.exs` — 91 passing, including a new case asserting every `stop_reason` maps as expected. `mix format` and `mix credo` clean.
