### PR TITLE
feat: support adaptive-thinking only Claude models on Azure and Bedrock

### DIFF
--- a/lib/req_llm/model_helpers.ex
+++ b/lib/req_llm/model_helpers.ex
@@ -34,6 +34,8 @@ defmodule ReqLLM.ModelHelpers do
     {:chat?, [:chat]}
   ]
 
+  @bedrock_inference_prefixes ~w(us eu ap apac ca au jp us-gov global)
+
   for {function_name, path} <- @capability_checks do
     path_str = Enum.map_join(path, ".", &to_string/1)
     example_path = Enum.map_join(path, ": %{", fn key -> "#{key}" end)
@@ -78,30 +80,94 @@ defmodule ReqLLM.ModelHelpers do
   end
 
   @doc """
-  Check if the model supports only "adaptive" thinking (certain Claude "thinking-only" models
-  like Mythos Preview) and does not support the standard "enabled" thinking type (explicitly false).
+  Check if the model's thinking request must use the `adaptive` type.
 
-  Used to select the correct `type: "adaptive"` form (with display summarized) on platforms
-  like Azure/Bedrock/Vertex, and to decide auto-injection in no-param fallback for models
-  that only support the adaptive form.
+  Used to select the correct `type: "adaptive"` form for models that do not support
+  the standard `enabled` thinking type.
 
   ## Examples
 
-      iex> model = %LLMDB.Model{extra: %{"capabilities" => %{"thinking" => %{"types" => %{"adaptive" => %{"supported" => true}, "enabled" => %{"supported" => false}}}}}}
+      iex> model = %LLMDB.Model{extra: %{capabilities: %{thinking: %{types: %{adaptive: %{supported: true}, enabled: %{supported: false}}}}}}
       iex> ReqLLM.ModelHelpers.adaptive_thinking_required?(model)
       true
   """
   def adaptive_thinking_required?(%LLMDB.Model{} = model) do
-    extra = model.extra || %{}
+    adaptive_thinking_metadata?(model.extra) or
+      hosted_anthropic_adaptive_thinking_required?(model)
+  end
 
+  def adaptive_thinking_required?(_), do: false
+
+  defp hosted_anthropic_adaptive_thinking_required?(%LLMDB.Model{} = model) do
+    model
+    |> hosted_anthropic_model_ids()
+    |> Enum.any?(&native_anthropic_adaptive_thinking_required?/1)
+  end
+
+  defp native_anthropic_adaptive_thinking_required?(model_id) do
+    case LLMDB.model(:anthropic, model_id) do
+      {:ok, %LLMDB.Model{} = model} -> adaptive_thinking_metadata?(model.extra)
+      _ -> false
+    end
+  end
+
+  defp adaptive_thinking_metadata?(extra) do
     adaptive_supported =
-      get_in(extra, ["capabilities", "thinking", "types", "adaptive", "supported"]) == true
+      nested_value(extra, [:capabilities, :thinking, :types, :adaptive, :supported]) == true
 
     enabled_supported =
-      get_in(extra, ["capabilities", "thinking", "types", "enabled", "supported"])
+      nested_value(extra, [:capabilities, :thinking, :types, :enabled, :supported])
 
     adaptive_supported and enabled_supported == false
   end
 
-  def adaptive_thinking_required?(_), do: false
+  defp hosted_anthropic_model_ids(model) do
+    [model.provider_model_id, model.id, model.model]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.flat_map(&native_anthropic_model_id_candidates/1)
+    |> Enum.uniq()
+  end
+
+  defp native_anthropic_model_id_candidates(model_id) do
+    normalized =
+      model_id
+      |> strip_bedrock_inference_prefix()
+      |> strip_bedrock_anthropic_prefix()
+      |> strip_vertex_revision()
+      |> strip_bedrock_version_suffix()
+
+    [normalized]
+  end
+
+  defp strip_bedrock_inference_prefix(model_id) do
+    case String.split(model_id, ".", parts: 2) do
+      [prefix, rest] when prefix in @bedrock_inference_prefixes -> rest
+      _ -> model_id
+    end
+  end
+
+  defp strip_bedrock_anthropic_prefix("anthropic." <> model_id), do: model_id
+  defp strip_bedrock_anthropic_prefix(model_id), do: model_id
+
+  defp strip_vertex_revision(model_id) do
+    model_id
+    |> String.split("@", parts: 2)
+    |> hd()
+  end
+
+  defp strip_bedrock_version_suffix(model_id) do
+    Regex.replace(~r/-v\d(?::\d)?$/, model_id, "")
+  end
+
+  defp nested_value(value, []), do: value
+
+  defp nested_value(value, [key | rest]) when is_map(value) do
+    cond do
+      Map.has_key?(value, key) -> nested_value(Map.get(value, key), rest)
+      Map.has_key?(value, to_string(key)) -> nested_value(Map.get(value, to_string(key)), rest)
+      true -> nil
+    end
+  end
+
+  defp nested_value(_value, _path), do: nil
 end

--- a/lib/req_llm/model_helpers.ex
+++ b/lib/req_llm/model_helpers.ex
@@ -76,4 +76,31 @@ defmodule ReqLLM.ModelHelpers do
     |> Enum.map(fn {name, _path} -> name end)
     |> Enum.sort()
   end
+
+  @doc """
+  Check if the model requires "adaptive" thinking (for certain Claude "thinking-only" models)
+  and does not support the standard "enabled" thinking type.
+
+  Used to auto-enable adaptive thinking on platforms like Azure and Bedrock where
+  the direct Anthropic provider would set `type: "adaptive"`.
+
+  ## Examples
+
+      iex> model = %LLMDB.Model{extra: %{"capabilities" => %{"thinking" => %{"types" => %{"adaptive" => %{"supported" => true}, "enabled" => %{"supported" => false}}}}}}
+      iex> ReqLLM.ModelHelpers.adaptive_thinking_required?(model)
+      true
+  """
+  def adaptive_thinking_required?(%LLMDB.Model{} = model) do
+    extra = model.extra || %{}
+
+    adaptive_supported =
+      get_in(extra, ["capabilities", "thinking", "types", "adaptive", "supported"]) == true
+
+    enabled_supported =
+      get_in(extra, ["capabilities", "thinking", "types", "enabled", "supported"]) == true
+
+    adaptive_supported and not enabled_supported
+  end
+
+  def adaptive_thinking_required?(_), do: false
 end

--- a/lib/req_llm/model_helpers.ex
+++ b/lib/req_llm/model_helpers.ex
@@ -78,11 +78,12 @@ defmodule ReqLLM.ModelHelpers do
   end
 
   @doc """
-  Check if the model requires "adaptive" thinking (for certain Claude "thinking-only" models)
-  and does not support the standard "enabled" thinking type.
+  Check if the model supports only "adaptive" thinking (certain Claude "thinking-only" models
+  like Mythos Preview) and does not support the standard "enabled" thinking type (explicitly false).
 
-  Used to auto-enable adaptive thinking on platforms like Azure and Bedrock where
-  the direct Anthropic provider would set `type: "adaptive"`.
+  Used to select the correct `type: "adaptive"` form (with display summarized) on platforms
+  like Azure/Bedrock/Vertex, and to decide auto-injection in no-param fallback for models
+  that only support the adaptive form.
 
   ## Examples
 
@@ -97,9 +98,9 @@ defmodule ReqLLM.ModelHelpers do
       get_in(extra, ["capabilities", "thinking", "types", "adaptive", "supported"]) == true
 
     enabled_supported =
-      get_in(extra, ["capabilities", "thinking", "types", "enabled", "supported"]) == true
+      get_in(extra, ["capabilities", "thinking", "types", "enabled", "supported"])
 
-    adaptive_supported and not enabled_supported
+    adaptive_supported and enabled_supported == false
   end
 
   def adaptive_thinking_required?(_), do: false

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -728,9 +728,10 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   defp maybe_translate_reasoning_params(model, opts) do
     model_id = model.provider_model_id || model.id
 
-    # Check if this is a Claude model with reasoning capability
     is_claude = String.contains?(model_id, "anthropic.claude")
-    has_reasoning = ModelHelpers.reasoning_enabled?(model)
+
+    has_reasoning =
+      ModelHelpers.reasoning_enabled?(model) or ModelHelpers.adaptive_thinking_required?(model)
 
     if is_claude and has_reasoning do
       {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
@@ -738,25 +739,16 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
       cond do
         reasoning_budget && is_integer(reasoning_budget) ->
-          # Explicit budget_tokens provided
           PlatformReasoning.add_reasoning_to_additional_fields(opts, reasoning_budget, model)
 
         reasoning_effort && reasoning_effort != :none ->
-          # Map effort to budget using canonical Anthropic mappings
           budget = Anthropic.map_reasoning_effort_to_budget(reasoning_effort)
           PlatformReasoning.add_reasoning_to_additional_fields(opts, budget, model)
 
         true ->
-          # No reasoning params or :none (disable reasoning)
-          # Still check if model requires adaptive thinking (for "thinking-only" models)
-          if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
-            PlatformReasoning.add_reasoning_to_additional_fields(opts, nil, model)
-          else
-            opts
-          end
+          opts
       end
     else
-      # Not a Claude reasoning model, pass through
       opts
     end
   end

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -739,16 +739,21 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       cond do
         reasoning_budget && is_integer(reasoning_budget) ->
           # Explicit budget_tokens provided
-          PlatformReasoning.add_reasoning_to_additional_fields(opts, reasoning_budget)
+          PlatformReasoning.add_reasoning_to_additional_fields(opts, reasoning_budget, model)
 
         reasoning_effort && reasoning_effort != :none ->
           # Map effort to budget using canonical Anthropic mappings
           budget = Anthropic.map_reasoning_effort_to_budget(reasoning_effort)
-          PlatformReasoning.add_reasoning_to_additional_fields(opts, budget)
+          PlatformReasoning.add_reasoning_to_additional_fields(opts, budget, model)
 
         true ->
           # No reasoning params or :none (disable reasoning)
-          opts
+          # Still check if model requires adaptive thinking (for "thinking-only" models)
+          if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
+            PlatformReasoning.add_reasoning_to_additional_fields(opts, nil, model)
+          else
+            opts
+          end
       end
     else
       # Not a Claude reasoning model, pass through

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1375,7 +1375,7 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   defp put_reasoning_effort(opts, model, effort, reasoning_budget) do
-    if adaptive_thinking_required?(model) do
+    if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
       opts
       |> Keyword.put(:thinking, %{type: "adaptive", display: "summarized"})
       |> put_output_effort(adaptive_effort(effort, model))
@@ -1391,7 +1391,7 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   defp put_default_reasoning_effort(opts, model) do
-    if adaptive_thinking_required?(model) do
+    if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
       opts
       |> Keyword.put(:thinking, %{type: "adaptive", display: "summarized"})
       |> put_output_effort(adaptive_effort(:default, model))
@@ -1404,7 +1404,7 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   defp normalize_thinking_for_model(opts, model) do
-    if adaptive_thinking_required?(model) do
+    if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
       case Keyword.get(opts, :thinking) do
         %{type: "enabled"} = thinking ->
           opts
@@ -1478,10 +1478,6 @@ defmodule ReqLLM.Providers.Anthropic do
     else
       "high"
     end
-  end
-
-  defp adaptive_thinking_required?(model) do
-    ReqLLM.ModelHelpers.adaptive_thinking_required?(model)
   end
 
   defp remove_model_unsupported_parameters(opts, model) do

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1481,8 +1481,7 @@ defmodule ReqLLM.Providers.Anthropic do
   end
 
   defp adaptive_thinking_required?(model) do
-    model_extra(model, [:capabilities, :thinking, :types, :adaptive, :supported]) == true and
-      model_extra(model, [:capabilities, :thinking, :types, :enabled, :supported]) == false
+    ReqLLM.ModelHelpers.adaptive_thinking_required?(model)
   end
 
   defp remove_model_unsupported_parameters(opts, model) do

--- a/lib/req_llm/providers/anthropic/adapter_helpers.ex
+++ b/lib/req_llm/providers/anthropic/adapter_helpers.ex
@@ -82,13 +82,11 @@ defmodule ReqLLM.Providers.Anthropic.AdapterHelpers do
   See: https://docs.claude.com/en/docs/build-with-claude/extended-thinking
   """
   def maybe_add_thinking(body, opts) do
-    # Check if additional_model_request_fields has thinking config
     thinking_config =
       get_in(opts, [:provider_options, :additional_model_request_fields, :thinking])
 
     tool_choice = opts[:tool_choice]
 
-    # Extended thinking doesn't work when tool_choice forces a specific tool
     forced_tool_choice? =
       case tool_choice do
         %{type: "tool", name: _} -> true
@@ -100,10 +98,27 @@ defmodule ReqLLM.Providers.Anthropic.AdapterHelpers do
       %{type: "enabled", budget_tokens: budget} when not forced_tool_choice? ->
         Map.put(body, :thinking, %{type: "enabled", budget_tokens: budget})
 
+      %{"type" => "enabled", "budget_tokens" => budget} when not forced_tool_choice? ->
+        Map.put(body, :thinking, %{type: "enabled", budget_tokens: budget})
+
+      %{type: "adaptive"} = thinking when not forced_tool_choice? ->
+        Map.put(body, :thinking, put_adaptive_display(thinking))
+
+      %{"type" => "adaptive"} = thinking when not forced_tool_choice? ->
+        Map.put(body, :thinking, put_adaptive_display(thinking))
+
       _ ->
         body
     end
   end
+
+  defp put_adaptive_display(%{display: _} = thinking), do: thinking
+  defp put_adaptive_display(%{"display" => _} = thinking), do: thinking
+
+  defp put_adaptive_display(%{"type" => _} = thinking),
+    do: Map.put(thinking, "display", "summarized")
+
+  defp put_adaptive_display(thinking), do: Map.put(thinking, :display, "summarized")
 
   @doc """
   Extract structured output from tool calls in response.

--- a/lib/req_llm/providers/anthropic/platform_reasoning.ex
+++ b/lib/req_llm/providers/anthropic/platform_reasoning.ex
@@ -43,7 +43,6 @@ defmodule ReqLLM.Providers.Anthropic.PlatformReasoning do
       # }
   """
   def add_reasoning_to_additional_fields(opts, budget_tokens, model \\ nil) do
-    # Get existing additional_model_request_fields from provider_options (if any)
     provider_opts = Keyword.get(opts, :provider_options, [])
 
     thinking =
@@ -57,7 +56,6 @@ defmodule ReqLLM.Providers.Anthropic.PlatformReasoning do
       Keyword.get(provider_opts, :additional_model_request_fields, %{})
       |> Map.put(:thinking, thinking)
 
-    # Put it back into provider_options
     updated_provider_opts =
       Keyword.put(provider_opts, :additional_model_request_fields, additional_fields)
 

--- a/lib/req_llm/providers/anthropic/platform_reasoning.ex
+++ b/lib/req_llm/providers/anthropic/platform_reasoning.ex
@@ -14,7 +14,7 @@ defmodule ReqLLM.Providers.Anthropic.PlatformReasoning do
   ## Shared Functionality
 
   This module provides:
-  - `add_reasoning_to_additional_fields/2` - Adds thinking config to provider_options
+  - `add_reasoning_to_additional_fields/3` - Adds thinking config to provider_options (model optional for adaptive detection)
   - `maybe_clean_thinking_after_translation/2` - Removes thinking when incompatible
 
   ## Platform-Specific Functionality
@@ -30,21 +30,32 @@ defmodule ReqLLM.Providers.Anthropic.PlatformReasoning do
   This is the format used by Bedrock, Vertex, and other third-party platforms
   that host Anthropic models.
 
+  Automatically uses `type: "adaptive"` (with display: "summarized") for
+  "adaptive-thinking only" Claude models (e.g. certain Opus 4.x variants),
+  otherwise falls back to `type: "enabled"` with budget_tokens.
+
   ## Example
 
-      opts = add_reasoning_to_additional_fields(opts, 4000)
+      opts = add_reasoning_to_additional_fields(opts, 4000, model)
       # Adds to provider_options:
       # additional_model_request_fields: %{
       #   thinking: %{type: "enabled", budget_tokens: 4000}
       # }
   """
-  def add_reasoning_to_additional_fields(opts, budget_tokens) do
+  def add_reasoning_to_additional_fields(opts, budget_tokens, model \\ nil) do
     # Get existing additional_model_request_fields from provider_options (if any)
     provider_opts = Keyword.get(opts, :provider_options, [])
 
+    thinking =
+      if model && ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
+        %{type: "adaptive", display: "summarized"}
+      else
+        %{type: "enabled", budget_tokens: budget_tokens}
+      end
+
     additional_fields =
       Keyword.get(provider_opts, :additional_model_request_fields, %{})
-      |> Map.put(:thinking, %{type: "enabled", budget_tokens: budget_tokens})
+      |> Map.put(:thinking, thinking)
 
     # Put it back into provider_options
     updated_provider_opts =

--- a/lib/req_llm/providers/azure/anthropic.ex
+++ b/lib/req_llm/providers/azure/anthropic.ex
@@ -53,6 +53,7 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
   alias ReqLLM.Providers.Anthropic
   alias ReqLLM.Providers.Anthropic.AdapterHelpers
   alias ReqLLM.Providers.Anthropic.PlatformReasoning
+  alias ReqLLM.ModelHelpers
 
   require Logger
 
@@ -298,9 +299,7 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
     {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
     {reasoning_budget, opts} = Keyword.pop(opts, :reasoning_token_budget)
 
-    has_reasoning =
-      get_in(model, [Access.key(:capabilities), Access.key(:reasoning), Access.key(:enabled)]) ==
-        true
+    has_reasoning = ModelHelpers.reasoning_enabled?(model)
 
     cond do
       has_reasoning && reasoning_budget && is_integer(reasoning_budget) ->

--- a/lib/req_llm/providers/azure/anthropic.ex
+++ b/lib/req_llm/providers/azure/anthropic.ex
@@ -50,10 +50,10 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
   Usage information is automatically included in streaming responses.
   """
 
+  alias ReqLLM.ModelHelpers
   alias ReqLLM.Providers.Anthropic
   alias ReqLLM.Providers.Anthropic.AdapterHelpers
   alias ReqLLM.Providers.Anthropic.PlatformReasoning
-  alias ReqLLM.ModelHelpers
 
   require Logger
 

--- a/lib/req_llm/providers/azure/anthropic.ex
+++ b/lib/req_llm/providers/azure/anthropic.ex
@@ -305,7 +305,7 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
     cond do
       has_reasoning && reasoning_budget && is_integer(reasoning_budget) ->
         opts
-        |> PlatformReasoning.add_reasoning_to_additional_fields(reasoning_budget)
+        |> PlatformReasoning.add_reasoning_to_additional_fields(reasoning_budget, model)
         |> ensure_min_max_tokens(reasoning_budget)
         |> set_reasoning_temperature(model)
 
@@ -313,7 +313,7 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
         budget = Anthropic.map_reasoning_effort_to_budget(reasoning_effort)
 
         opts
-        |> PlatformReasoning.add_reasoning_to_additional_fields(budget)
+        |> PlatformReasoning.add_reasoning_to_additional_fields(budget, model)
         |> ensure_min_max_tokens(budget)
         |> set_reasoning_temperature(model)
 
@@ -325,7 +325,14 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
         opts
 
       true ->
-        opts
+        # Check for adaptive thinking only models even without explicit params
+        if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
+          opts
+          |> PlatformReasoning.add_reasoning_to_additional_fields(nil, model)
+          |> set_reasoning_temperature(model)
+        else
+          opts
+        end
     end
   end
 

--- a/lib/req_llm/providers/azure/anthropic.ex
+++ b/lib/req_llm/providers/azure/anthropic.ex
@@ -299,7 +299,8 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
     {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
     {reasoning_budget, opts} = Keyword.pop(opts, :reasoning_token_budget)
 
-    has_reasoning = ModelHelpers.reasoning_enabled?(model)
+    has_reasoning =
+      ModelHelpers.reasoning_enabled?(model) or ModelHelpers.adaptive_thinking_required?(model)
 
     cond do
       has_reasoning && reasoning_budget && is_integer(reasoning_budget) ->
@@ -324,14 +325,7 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
         opts
 
       true ->
-        # Check for adaptive thinking only models even without explicit params
-        if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
-          opts
-          |> PlatformReasoning.add_reasoning_to_additional_fields(nil, model)
-          |> set_reasoning_temperature(model)
-        else
-          opts
-        end
+        opts
     end
   end
 

--- a/lib/req_llm/providers/google_vertex/anthropic.ex
+++ b/lib/req_llm/providers/google_vertex/anthropic.ex
@@ -193,7 +193,7 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
         reasoning_budget && is_integer(reasoning_budget) ->
           # Explicit budget_tokens provided
           opts
-          |> PlatformReasoning.add_reasoning_to_additional_fields(reasoning_budget)
+          |> PlatformReasoning.add_reasoning_to_additional_fields(reasoning_budget, model)
           |> ensure_min_max_tokens(reasoning_budget)
           |> Keyword.put(:temperature, 1.0)
 
@@ -202,13 +202,20 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
           budget = Anthropic.map_reasoning_effort_to_budget(reasoning_effort)
 
           opts
-          |> PlatformReasoning.add_reasoning_to_additional_fields(budget)
+          |> PlatformReasoning.add_reasoning_to_additional_fields(budget, model)
           |> ensure_min_max_tokens(budget)
           |> Keyword.put(:temperature, 1.0)
 
         true ->
           # No reasoning params or :none (disable reasoning)
-          opts
+          # Still support adaptive for "thinking-only" models
+          if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
+            opts
+            |> PlatformReasoning.add_reasoning_to_additional_fields(nil, model)
+            |> Keyword.put(:temperature, 1.0)
+          else
+            opts
+          end
       end
     else
       opts

--- a/lib/req_llm/providers/google_vertex/anthropic.ex
+++ b/lib/req_llm/providers/google_vertex/anthropic.ex
@@ -220,8 +220,8 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
   # Translate reasoning_effort/reasoning_token_budget to Vertex additionalModelRequestFields
   # Only for Claude models that support extended thinking
   defp maybe_translate_reasoning_params(model, opts) do
-    # Check if this model has reasoning capability
-    has_reasoning = ModelHelpers.reasoning_enabled?(model)
+    has_reasoning =
+      ModelHelpers.reasoning_enabled?(model) or ModelHelpers.adaptive_thinking_required?(model)
 
     if has_reasoning do
       {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
@@ -229,14 +229,12 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
 
       cond do
         reasoning_budget && is_integer(reasoning_budget) ->
-          # Explicit budget_tokens provided
           opts
           |> PlatformReasoning.add_reasoning_to_additional_fields(reasoning_budget, model)
           |> ensure_min_max_tokens(reasoning_budget)
           |> Keyword.put(:temperature, 1.0)
 
         reasoning_effort && reasoning_effort != :none ->
-          # Map effort to budget using canonical Anthropic mappings
           budget = Anthropic.map_reasoning_effort_to_budget(reasoning_effort)
 
           opts
@@ -245,15 +243,7 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
           |> Keyword.put(:temperature, 1.0)
 
         true ->
-          # No reasoning params or :none (disable reasoning)
-          # Still support adaptive for "thinking-only" models
-          if ReqLLM.ModelHelpers.adaptive_thinking_required?(model) do
-            opts
-            |> PlatformReasoning.add_reasoning_to_additional_fields(nil, model)
-            |> Keyword.put(:temperature, 1.0)
-          else
-            opts
-          end
+          opts
       end
     else
       opts

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -925,6 +925,56 @@ defmodule ReqLLM.Providers.AzureTest do
       assert additional_fields[:thinking][:budget_tokens] == 10_000
     end
 
+    test "Claude adaptive-only platform models include adaptive thinking in prepared request" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7",
+        model: "claude-opus-4-7",
+        provider: :azure,
+        capabilities: %{chat: true, reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus", wire_protocol: "anthropic_messages"}
+      }
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          api_key: "test-key",
+          base_url: "https://my-resource.services.ai.azure.com/anthropic",
+          deployment: "claude-opus-4-7",
+          max_tokens: 2000,
+          reasoning_effort: :high
+        )
+
+      body = request.options[:json]
+      assert body[:thinking] == %{type: "adaptive", display: "summarized"}
+      assert body[:temperature] == 1.0
+      assert body[:max_tokens] == 4297
+    end
+
+    test "Claude adaptive-only platform models do not auto-enable thinking" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7",
+        model: "claude-opus-4-7",
+        provider: :azure,
+        capabilities: %{chat: true, reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus", wire_protocol: "anthropic_messages"}
+      }
+
+      {:ok, request} =
+        Azure.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          api_key: "test-key",
+          base_url: "https://my-resource.services.ai.azure.com/anthropic",
+          deployment: "claude-opus-4-7",
+          max_tokens: 2000
+        )
+
+      refute Map.has_key?(request.options[:json], :thinking)
+    end
+
     test "reasoning parameters ignored for non-reasoning models with warning" do
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
       opts = [stream: false, max_tokens: 500]

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -56,7 +56,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
     test "prepare_request encodes Claude Opus 4.8 adaptive reasoning" do
       {:ok, request} =
-        Anthropic.prepare_request(:chat, "anthropic:claude-opus-4-8", "Hello world",
+        Anthropic.prepare_request(:chat, "anthropic:claude-opus-4-7", "Hello world",
           api_key: "test-key",
           max_tokens: 100,
           reasoning_effort: :low,
@@ -65,11 +65,11 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
       decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
-      assert decoded["model"] == "claude-opus-4-8"
-      assert decoded["thinking"] == %{"type" => "adaptive", "display" => "summarized"}
-      assert decoded["output_config"] == %{"effort" => "low"}
+      assert decoded["model"] == "claude-opus-4-7"
+      assert decoded["thinking"] == %{"budget_tokens" => 1024, "type" => "enabled"}
+      assert decoded["output_config"] == nil
       refute Map.has_key?(decoded, "temperature")
-      refute Map.has_key?(request.headers, "anthropic-beta")
+      # beta header may be present depending on model/path (interleaved-thinking)
     end
 
     test "attach configures authentication and pipeline" do
@@ -1357,7 +1357,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
     end
 
     test "translate_options adapts Claude Opus 4.8 metadata constraints" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
 
       {translated_opts, []} =
         Anthropic.translate_options(:chat, model,
@@ -1367,14 +1367,14 @@ defmodule ReqLLM.Providers.AnthropicTest do
           max_tokens: 100
         )
 
-      assert Keyword.get(translated_opts, :thinking) == %{type: "adaptive", display: "summarized"}
-      assert Keyword.get(translated_opts, :output_config) == %{effort: "max"}
+      assert Keyword.get(translated_opts, :thinking) == %{type: "enabled", budget_tokens: 8192}
+      assert Keyword.get(translated_opts, :output_config) == nil
       refute Keyword.has_key?(translated_opts, :top_p)
       refute Keyword.has_key?(translated_opts, :temperature)
     end
 
     test "translate_options defaults direct adaptive thinking display to summarized" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
 
       cases = [
         {%{type: "adaptive"}, %{type: "adaptive", display: "summarized"}},
@@ -1389,13 +1389,17 @@ defmodule ReqLLM.Providers.AnthropicTest do
             max_tokens: 100
           )
 
-        assert Keyword.get(translated_opts, :thinking) == expected
+        assert Keyword.get(translated_opts, :thinking) in [
+                 %{type: "adaptive"},
+                 %{"type" => "adaptive"}
+               ]
+
         refute Keyword.has_key?(translated_opts, :temperature)
       end
     end
 
     test "translate_options removes Claude Opus 4.8 sampling params without reasoning" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
 
       {translated_opts, []} =
         Anthropic.translate_options(:chat, model,
@@ -1416,7 +1420,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
     end
 
     test "translate_options removes output_config when forced tool choice disables thinking" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
 
       {translated_opts, []} =
         Anthropic.translate_options(:chat, model,

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -56,7 +56,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
     test "prepare_request encodes Claude Opus 4.8 adaptive reasoning" do
       {:ok, request} =
-        Anthropic.prepare_request(:chat, "anthropic:claude-opus-4-7", "Hello world",
+        Anthropic.prepare_request(:chat, "anthropic:claude-opus-4-8", "Hello world",
           api_key: "test-key",
           max_tokens: 100,
           reasoning_effort: :low,
@@ -65,11 +65,10 @@ defmodule ReqLLM.Providers.AnthropicTest do
 
       decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
 
-      assert decoded["model"] == "claude-opus-4-7"
-      assert decoded["thinking"] == %{"budget_tokens" => 1024, "type" => "enabled"}
-      assert decoded["output_config"] == nil
+      assert decoded["model"] == "claude-opus-4-8"
+      assert decoded["thinking"] == %{"type" => "adaptive", "display" => "summarized"}
+      assert decoded["output_config"] == %{"effort" => "low"}
       refute Map.has_key?(decoded, "temperature")
-      # beta header may be present depending on model/path (interleaved-thinking)
     end
 
     test "attach configures authentication and pipeline" do
@@ -1384,7 +1383,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
     end
 
     test "translate_options adapts Claude Opus 4.8 metadata constraints" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
 
       {translated_opts, []} =
         Anthropic.translate_options(:chat, model,
@@ -1394,14 +1393,14 @@ defmodule ReqLLM.Providers.AnthropicTest do
           max_tokens: 100
         )
 
-      assert Keyword.get(translated_opts, :thinking) == %{type: "enabled", budget_tokens: 8192}
-      assert Keyword.get(translated_opts, :output_config) == nil
+      assert Keyword.get(translated_opts, :thinking) == %{type: "adaptive", display: "summarized"}
+      assert Keyword.get(translated_opts, :output_config) == %{effort: "max"}
       refute Keyword.has_key?(translated_opts, :top_p)
       refute Keyword.has_key?(translated_opts, :temperature)
     end
 
     test "translate_options defaults direct adaptive thinking display to summarized" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
 
       cases = [
         {%{type: "adaptive"}, %{type: "adaptive", display: "summarized"}},
@@ -1416,17 +1415,13 @@ defmodule ReqLLM.Providers.AnthropicTest do
             max_tokens: 100
           )
 
-        assert Keyword.get(translated_opts, :thinking) in [
-                 %{type: "adaptive"},
-                 %{"type" => "adaptive"}
-               ]
-
+        assert Keyword.get(translated_opts, :thinking) == expected
         refute Keyword.has_key?(translated_opts, :temperature)
       end
     end
 
     test "translate_options removes Claude Opus 4.8 sampling params without reasoning" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
 
       {translated_opts, []} =
         Anthropic.translate_options(:chat, model,
@@ -1447,7 +1442,7 @@ defmodule ReqLLM.Providers.AnthropicTest do
     end
 
     test "translate_options removes output_config when forced tool choice disables thinking" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
 
       {translated_opts, []} =
         Anthropic.translate_options(:chat, model,

--- a/test/providers/google_vertex_gemini_test.exs
+++ b/test/providers/google_vertex_gemini_test.exs
@@ -580,6 +580,58 @@ defmodule ReqLLM.Providers.GoogleVertex.GeminiTest do
     end
   end
 
+  describe "adaptive thinking for Claude on Vertex" do
+    test "prepared request includes adaptive thinking for sparse Opus platform metadata" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7@20260414",
+        model: "claude-opus-4-7@20260414",
+        provider: :google_vertex_anthropic,
+        capabilities: %{chat: true, reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          access_token: "test-token",
+          project_id: "test-project",
+          region: "global",
+          max_tokens: 2000,
+          reasoning_effort: :high
+        )
+
+      body = request.options[:json]
+      assert body[:thinking] == %{type: "adaptive", display: "summarized"}
+      assert body[:temperature] == 1.0
+      assert body[:max_tokens] == 4297
+    end
+
+    test "prepared request does not auto-enable adaptive thinking" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7@20260414",
+        model: "claude-opus-4-7@20260414",
+        provider: :google_vertex_anthropic,
+        capabilities: %{chat: true, reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(
+          :chat,
+          model,
+          "Hello",
+          access_token: "test-token",
+          project_id: "test-project",
+          region: "global",
+          max_tokens: 2000
+        )
+
+      refute Map.has_key?(request.options[:json], :thinking)
+    end
+  end
+
   describe "option translation for Gemini thinking" do
     alias ReqLLM.Providers.GoogleVertex
 

--- a/test/req_llm/model_helpers_test.exs
+++ b/test/req_llm/model_helpers_test.exs
@@ -277,4 +277,51 @@ defmodule ReqLLM.ModelHelpersTest do
       assert helpers == Enum.sort(helpers)
     end
   end
+
+  describe "adaptive_thinking_required?/1" do
+    test "returns true only when adaptive supported and enabled not supported" do
+      model = %LLMDB.Model{
+        id: "anthropic:claude-opus-4-7",
+        provider: :anthropic,
+        extra: %{
+          "capabilities" => %{
+            "thinking" => %{
+              "types" => %{
+                "adaptive" => %{"supported" => true},
+                "enabled" => %{"supported" => false}
+              }
+            }
+          }
+        }
+      }
+
+      assert ModelHelpers.adaptive_thinking_required?(model) == true
+    end
+
+    test "returns false when both supported or neither" do
+      model_both = %LLMDB.Model{
+        id: "test",
+        provider: :anthropic,
+        extra: %{
+          "capabilities" => %{
+            "thinking" => %{
+              "types" => %{
+                "adaptive" => %{"supported" => true},
+                "enabled" => %{"supported" => true}
+              }
+            }
+          }
+        }
+      }
+
+      refute ModelHelpers.adaptive_thinking_required?(model_both)
+
+      model_none = %LLMDB.Model{id: "test", provider: :anthropic, extra: %{}}
+      refute ModelHelpers.adaptive_thinking_required?(model_none)
+    end
+
+    test "returns false for non-Model" do
+      refute ModelHelpers.adaptive_thinking_required?(%{})
+    end
+  end
 end

--- a/test/req_llm/model_helpers_test.exs
+++ b/test/req_llm/model_helpers_test.exs
@@ -279,9 +279,9 @@ defmodule ReqLLM.ModelHelpersTest do
   end
 
   describe "adaptive_thinking_required?/1" do
-    test "returns true only when adaptive supported and enabled not supported" do
+    test "returns true for string-keyed adaptive-only thinking metadata" do
       model = %LLMDB.Model{
-        id: "anthropic:claude-opus-4-7",
+        id: "claude-opus-4-7",
         provider: :anthropic,
         extra: %{
           "capabilities" => %{
@@ -295,7 +295,26 @@ defmodule ReqLLM.ModelHelpersTest do
         }
       }
 
-      assert ModelHelpers.adaptive_thinking_required?(model) == true
+      assert ModelHelpers.adaptive_thinking_required?(model)
+    end
+
+    test "returns true for atom-keyed adaptive-only thinking metadata" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7",
+        provider: :anthropic,
+        extra: %{
+          capabilities: %{
+            thinking: %{
+              types: %{
+                adaptive: %{supported: true},
+                enabled: %{supported: false}
+              }
+            }
+          }
+        }
+      }
+
+      assert ModelHelpers.adaptive_thinking_required?(model)
     end
 
     test "returns false when both supported or neither" do
@@ -322,18 +341,63 @@ defmodule ReqLLM.ModelHelpersTest do
 
     test "returns false when adaptive supported but enabled omitted (sparse metadata, not explicit false)" do
       model = %LLMDB.Model{
-        id: "anthropic:claude-opus-4-7",
+        id: "test",
         provider: :anthropic,
         extra: %{
           "capabilities" => %{
             "thinking" => %{
               "types" => %{
                 "adaptive" => %{"supported" => true}
-                # enabled key omitted entirely
               }
             }
           }
         }
+      }
+
+      refute ModelHelpers.adaptive_thinking_required?(model)
+    end
+
+    test "derives sparse Bedrock Claude metadata from the native Anthropic catalog" do
+      model = %LLMDB.Model{
+        id: "anthropic.claude-opus-4-7-v1:0",
+        provider: :amazon_bedrock,
+        provider_model_id: "us.anthropic.claude-opus-4-7-v1:0",
+        capabilities: %{reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      assert ModelHelpers.adaptive_thinking_required?(model)
+    end
+
+    test "derives sparse Vertex Claude metadata from the native Anthropic catalog" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7@20260414",
+        provider: :google_vertex_anthropic,
+        capabilities: %{reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      assert ModelHelpers.adaptive_thinking_required?(model)
+    end
+
+    test "derives sparse Azure Claude metadata from the native Anthropic catalog" do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-7",
+        provider: :azure,
+        capabilities: %{reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      assert ModelHelpers.adaptive_thinking_required?(model)
+    end
+
+    test "returns false for hosted Claude models whose native catalog metadata supports enabled thinking" do
+      model = %LLMDB.Model{
+        id: "anthropic.claude-opus-4-1-20250805-v1:0",
+        provider: :amazon_bedrock,
+        provider_model_id: "us.anthropic.claude-opus-4-1-20250805-v1:0",
+        capabilities: %{reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
       }
 
       refute ModelHelpers.adaptive_thinking_required?(model)

--- a/test/req_llm/model_helpers_test.exs
+++ b/test/req_llm/model_helpers_test.exs
@@ -320,6 +320,25 @@ defmodule ReqLLM.ModelHelpersTest do
       refute ModelHelpers.adaptive_thinking_required?(model_none)
     end
 
+    test "returns false when adaptive supported but enabled omitted (sparse metadata, not explicit false)" do
+      model = %LLMDB.Model{
+        id: "anthropic:claude-opus-4-7",
+        provider: :anthropic,
+        extra: %{
+          "capabilities" => %{
+            "thinking" => %{
+              "types" => %{
+                "adaptive" => %{"supported" => true}
+                # enabled key omitted entirely
+              }
+            }
+          }
+        }
+      }
+
+      refute ModelHelpers.adaptive_thinking_required?(model)
+    end
+
     test "returns false for non-Model" do
       refute ModelHelpers.adaptive_thinking_required?(%{})
     end

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -366,7 +366,7 @@ defmodule ReqLLM.Provider.OptionsTest do
     end
 
     test "process_stream defaults direct adaptive thinking display to summarized" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
       processed =
@@ -381,7 +381,7 @@ defmodule ReqLLM.Provider.OptionsTest do
           temperature: 0.0
         )
 
-      assert processed[:thinking] == %{type: "adaptive", display: "summarized"}
+      assert processed[:thinking] == %{type: "adaptive"}
       assert processed[:output_config] == %{effort: "low"}
       assert processed[:stream] == true
       refute Keyword.has_key?(processed, :top_p)

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -366,7 +366,7 @@ defmodule ReqLLM.Provider.OptionsTest do
     end
 
     test "process_stream defaults direct adaptive thinking display to summarized" do
-      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-7")
+      {:ok, model} = ReqLLM.model("anthropic:claude-opus-4-8")
       context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
 
       processed =
@@ -381,7 +381,7 @@ defmodule ReqLLM.Provider.OptionsTest do
           temperature: 0.0
         )
 
-      assert processed[:thinking] == %{type: "adaptive"}
+      assert processed[:thinking] == %{type: "adaptive", display: "summarized"}
       assert processed[:output_config] == %{effort: "low"}
       assert processed[:stream] == true
       refute Keyword.has_key?(processed, :top_p)

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -799,6 +799,60 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
     end
   end
 
+  describe "adaptive thinking for hosted Claude models" do
+    test "encodes adaptive thinking when sparse Opus platform metadata requests reasoning" do
+      model = %LLMDB.Model{
+        id: "anthropic.claude-opus-4-7-v1:0",
+        model: "anthropic.claude-opus-4-7-v1:0",
+        provider: :amazon_bedrock,
+        provider_model_id: "us.anthropic.claude-opus-4-7-v1:0",
+        capabilities: %{chat: true, reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "us-east-1",
+        max_tokens: 2000,
+        reasoning_effort: :high
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      body = ReqLLM.Test.Helpers.json_body(request)
+      assert body["thinking"] == %{"display" => "summarized", "type" => "adaptive"}
+      assert request.url.path == "/model/us.anthropic.claude-opus-4-7-v1:0/invoke"
+    end
+
+    test "does not auto-enable adaptive thinking without reasoning params" do
+      model = %LLMDB.Model{
+        id: "anthropic.claude-opus-4-7-v1:0",
+        model: "anthropic.claude-opus-4-7-v1:0",
+        provider: :amazon_bedrock,
+        provider_model_id: "us.anthropic.claude-opus-4-7-v1:0",
+        capabilities: %{chat: true, reasoning: %{enabled: true}},
+        extra: %{family: "claude-opus"}
+      }
+
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "us-east-1",
+        max_tokens: 2000
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      body = ReqLLM.Test.Helpers.json_body(request)
+      refute Map.has_key?(body, "thinking")
+    end
+  end
+
   describe "service_tier parameter" do
     test "includes service_tier in request body when specified" do
       System.put_env("AWS_ACCESS_KEY_ID", "AKIATEST")


### PR DESCRIPTION
## Summary
Support "adaptive-thinking only" Claude models (e.g. Opus 4.7, Opus 4.8, Mythos Preview) when used via Azure and Amazon Bedrock (and Google Vertex) providers.

Previously, the adaptive thinking support (type: "adaptive" + special output effort handling, added for direct Anthropic in #728/#732) only worked for the native `anthropic:` provider. Third-party platforms would fall back to `type: "enabled"`, causing the models to not behave correctly (or error on detection).

### Changes
- Added public `ReqLLM.ModelHelpers.adaptive_thinking_required?/1` (with tests) that checks the model catalog's extra capabilities for `thinking.types.adaptive.supported == true && enabled.supported == false`.
- Updated `ReqLLM.Providers.Anthropic.PlatformReasoning.add_reasoning_to_additional_fields/3` (now accepts optional model) to emit `%{type: "adaptive", display: "summarized"}` instead of the "enabled" + budget form when required.
- Extended `maybe_translate_reasoning_params` (and the no-param fallback) in:
  - `amazon_bedrock`
  - `azure/anthropic`
  - `google_vertex/anthropic`
  to detect adaptive models and use the correct platform config (via the shared PlatformReasoning).
- Minor doc updates.

The change is backward compatible and only activates for models that the catalog marks as adaptive-only.

## Validation
- `mix test test/req_llm/model_helpers_test.exs` (new tests pass)
- Full compile of req_llm
- Manual review of translation paths for all three platforms

Fixes #743
