### PR TITLE
fix(google_vertex): Allow for specifying google_thinking_level for Google Vertex

### DIFF
--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -147,6 +147,11 @@ defmodule ReqLLM.Providers.GoogleVertex do
       type: :non_neg_integer,
       doc: "Thinking token budget for Gemini 2.5 models (0 disables thinking, omit for dynamic)"
     ],
+    google_thinking_level: [
+      type: {:or, [:atom, :string]},
+      doc:
+        "Thinking level for Gemini 3+ models (e.g. :low, :medium, :high, or \"low\", \"medium\", \"high\"). Passed directly to the Gemini API. Cannot be combined with google_thinking_budget."
+    ],
     google_grounding: [
       type: :map,
       doc:

--- a/test/providers/google_vertex_gemini_test.exs
+++ b/test/providers/google_vertex_gemini_test.exs
@@ -588,7 +588,12 @@ defmodule ReqLLM.Providers.GoogleVertex.GeminiTest do
       assert :google_thinking_budget in schema_keys
     end
 
-    test "translate_options maps reasoning_token_budget to google_thinking_budget for Gemini" do
+    test "google_thinking_level is in the Vertex provider schema" do
+      schema_keys = GoogleVertex.provider_schema().schema |> Keyword.keys()
+      assert :google_thinking_level in schema_keys
+    end
+
+    test "translate_options maps reasoning_token_budget to google_thinking_budget for Gemini 2.5 models" do
       model = %LLMDB.Model{
         id: "gemini-2.5-pro",
         provider: :google_vertex,
@@ -601,7 +606,7 @@ defmodule ReqLLM.Providers.GoogleVertex.GeminiTest do
       assert Keyword.get(translated, :google_thinking_budget) == 16_384
     end
 
-    test "translate_options maps reasoning_effort levels to google_thinking_budget for Gemini" do
+    test "translate_options maps reasoning_effort levels to google_thinking_budget for Gemini 2.5 models" do
       model = %LLMDB.Model{
         id: "gemini-2.5-flash",
         provider: :google_vertex,
@@ -623,6 +628,31 @@ defmodule ReqLLM.Providers.GoogleVertex.GeminiTest do
 
         assert Keyword.get(translated, :google_thinking_budget) == expected_budget,
                "Expected reasoning_effort #{inspect(effort)} to map to budget #{expected_budget}"
+      end
+    end
+
+    test "translate_options maps reasoning_effort levels to google_thinking_level for Gemini 3 models" do
+      model = %LLMDB.Model{
+        id: "gemini-3.1-pro-preview",
+        provider: :google_vertex,
+        capabilities: %{chat: true}
+      }
+
+      test_cases = [
+        {:none, :minimal},
+        {:minimal, :minimal},
+        {:low, :low},
+        {:medium, :medium},
+        {:high, :high},
+        {:xhigh, :high}
+      ]
+
+      for {effort, expected_level} <- test_cases do
+        opts = [reasoning_effort: effort]
+        {translated, _warnings} = GoogleVertex.translate_options(:chat, model, opts)
+
+        assert Keyword.get(translated, :google_thinking_level) == expected_level,
+               "Expected reasoning_effort #{inspect(effort)} to map to level #{expected_level}"
       end
     end
 


### PR DESCRIPTION
## Description

The `google_vertex` provider was already passing through `google_thinking_budget` to the Google provider for Gemini 2.5 models, but was not allowing `google_thinking_level` for Gemini 3 models.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
