### PR TITLE
fix: Fix reasoning_effort not being passed through to OpenAI Chat Completion API

### DIFF
--- a/guides/groq.md
+++ b/guides/groq.md
@@ -28,7 +28,7 @@ Passed via `:provider_options` keyword:
 - **Type**: `"none"` | `"default"` | `"low"` | `"medium"` | `"high"`
 - **Purpose**: Control reasoning level for compatible models
 - **Compatible**: DeepSeek R1 distill models
-- **Example**: `provider_options: [reasoning_effort: "high"]`
+- **Example**: `reasoning_effort: "high"`
 
 ### `reasoning_format`
 - **Type**: String

--- a/guides/openai.md
+++ b/guides/openai.md
@@ -158,7 +158,7 @@ Passed via `:provider_options` keyword:
 ### `reasoning_effort`
 
 - **Type**: `:low` | `:medium` | `:high`
-- **Purpose**: Control reasoning effort (Responses API only)
+- **Purpose**: Control reasoning effort
 - **Example**: `reasoning_effort: :high`
 
 ### `service_tier`

--- a/guides/zenmux.md
+++ b/guides/zenmux.md
@@ -129,7 +129,7 @@ Configure model selection within the same provider:
 #### `reasoning_effort`
 - **Type**: `:none` | `:minimal` | `:low` | `:medium` | `:high` | `:xhigh`
 - **Purpose**: Control reasoning model effort level
-- **Example**: `provider_options: [reasoning_effort: :high]`
+- **Example**: `reasoning_effort: :high`
 
 ## Dual Protocol Support
 

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -197,8 +197,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
   end
 
   defp add_reasoning_effort(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-    maybe_put(body, :reasoning_effort, provider_opts[:reasoning_effort])
+    maybe_put(body, :reasoning_effort, request_options[:reasoning_effort])
   end
 
   defp add_service_tier(body, request_options) do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -156,6 +156,21 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert body["audio"] == %{"format" => "mp3", "voice" => "alloy"}
     end
 
+    test "prepare_request passes through top-level reasoning_effort option to Chat Completions API request body" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+
+      {:ok, request} =
+        OpenAI.prepare_request(:chat, model, "How are you?",
+          api_key: "test-key",
+          reasoning_effort: :high
+        )
+
+      encoded_request = ReqLLM.Providers.OpenAI.ChatAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded_request)
+
+      assert body["reasoning_effort"] == "high"
+    end
+
     test "attach_stream defaults chat max_tokens from model output limit" do
       model = %LLMDB.Model{
         provider: :openai,


### PR DESCRIPTION
## Description

This is in the same vein as #244. While testing Groq, I noticed that `reasoning_effort` was not getting passed through and sent to the Chat Completions API for GPT OSS models. The ChatAPI module was retrieving `reasoning_effort` from provider options, but it is a global common option that appears to be handled almost exclusively as a top-level option, not a provider option.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

I don't _think_ this is a breaking change as it didn't appear to work as documented in the first place.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

#244 
