### PR TITLE
feat: add thinking and reasoning options to deepseek

### DIFF
--- a/lib/req_llm/providers/deepseek.ex
+++ b/lib/req_llm/providers/deepseek.ex
@@ -31,12 +31,59 @@ defmodule ReqLLM.Providers.Deepseek do
       ReqLLM.stream_text("deepseek:deepseek-chat", "Tell me a story")
       |> Enum.each(&IO.write/1)
 
+      # With thinking mode enabled (default for reasoning models)
+      ReqLLM.generate_text("deepseek:deepseek-v4-pro", "Solve this complex problem",
+        provider_options: [
+          thinking: %{type: "enabled"},
+          reasoning_effort: :high
+        ]
+      )
+
+      # With maximum reasoning effort for complex tasks
+      ReqLLM.generate_text("deepseek:deepseek-v4-pro", "Complex reasoning task",
+        provider_options: [
+          reasoning_effort: :max
+        ]
+      )
+
+      # Disable thinking mode
+      ReqLLM.generate_text("deepseek:deepseek-v4-pro", "Quick question",
+        provider_options: [
+          thinking: %{type: "disabled"}
+        ]
+      )
+
   ## Models
 
   DeepSeek offers several models including:
 
   - `deepseek-chat` - General purpose conversational model
   - `deepseek-reasoner` - Reasoning and problem-solving
+  - `deepseek-v4-flash` - Fast reasoning model with lower latency
+  - `deepseek-v4-pro` - Latest reasoning model with thinking support
+
+  ## Thinking Mode
+
+  DeepSeek models support thinking mode for improved reasoning.
+
+  See [DeepSeek Thinking Mode Guide](https://api-docs.deepseek.com/guides/thinking_mode) for details.
+
+  ### Options
+
+  - `thinking: %{type: "enabled"}` - Enable thinking mode (default for reasoning models)
+  - `thinking: %{type: "disabled"}` - Disable thinking mode
+
+  ### Reasoning Effort
+
+  The `reasoning_effort` option controls the depth of reasoning. For compatibility,
+  `:low` and `:medium` are mapped to `"high"`, and `:xhigh` is mapped to `"max"`.
+
+  Only `"high"` and `"max"` are the meaningful values sent to the API:
+
+  - `:low` → mapped to `"high"`
+  - `:medium` → mapped to `"high"`
+  - `:high` → `"high"` (default for thinking mode)
+  - `:xhigh` → mapped to `"max"` (maximum effort for complex tasks)
 
   See https://platform.deepseek.com/docs for full model documentation.
   """
@@ -48,38 +95,71 @@ defmodule ReqLLM.Providers.Deepseek do
 
   use ReqLLM.Provider.Defaults
 
-  @provider_schema []
+  import ReqLLM.Provider.Utils, only: [maybe_put: 3]
+
+  @provider_schema [
+    thinking: [
+      type: :map,
+      doc: """
+      Thinking mode configuration. Set to %{type: "enabled"} to enable or %{type: "disabled"} to disable.
+      Defaults to enabled for reasoning models. See https://api-docs.deepseek.com/guides/thinking_mode
+      """
+    ]
+  ]
+
+  @impl ReqLLM.Provider
+  def translate_options(_operation, _model, opts) do
+    {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
+
+    opts =
+      case reasoning_effort do
+        :low -> Keyword.put(opts, :reasoning_effort, "high")
+        :medium -> Keyword.put(opts, :reasoning_effort, "high")
+        :high -> Keyword.put(opts, :reasoning_effort, "high")
+        :xhigh -> Keyword.put(opts, :reasoning_effort, "max")
+        nil -> opts
+        other when is_binary(other) -> Keyword.put(opts, :reasoning_effort, other)
+        other -> Keyword.put(opts, :reasoning_effort, to_string(other))
+      end
+
+    {opts, []}
+  end
 
   @impl ReqLLM.Provider
   def build_body(request) do
-    body = ReqLLM.Provider.Defaults.default_build_body(request)
+    provider_opts = request.options[:provider_options] || []
 
-    messages =
-      case Map.get(body, :messages) do
-        nil ->
-          nil
+    ReqLLM.Provider.Defaults.default_build_body(request)
+    |> ensure_assistant_reasoning_content()
+    |> maybe_put(:thinking, normalize_thinking(provider_opts[:thinking]))
+    |> maybe_put(:reasoning_effort, request.options[:reasoning_effort])
+  end
 
-        msgs when is_list(msgs) ->
-          Enum.map(msgs, &ensure_assistant_reasoning_content/1)
+  defp ensure_assistant_reasoning_content(body) do
+    case get_messages(body) do
+      nil ->
+        body
 
-        other ->
-          other
-      end
-
-    if messages do
-      Map.put(body, :messages, messages)
-    else
-      body
+      messages when is_list(messages) ->
+        key = messages_key(body)
+        Map.put(body, key, Enum.map(messages, &add_reasoning_content_to_message/1))
     end
   end
 
-  defp ensure_assistant_reasoning_content(msg) do
+  defp add_reasoning_content_to_message(msg) do
     if assistant_message?(msg) and not has_reasoning_content?(msg) do
       Map.put(msg, :reasoning_content, "")
     else
       msg
     end
   end
+
+  defp get_messages(%{messages: msgs}), do: msgs
+  defp get_messages(%{"messages" => msgs}), do: msgs
+  defp get_messages(_), do: nil
+
+  defp messages_key(%{messages: _}), do: :messages
+  defp messages_key(%{"messages" => _}), do: "messages"
 
   defp assistant_message?(msg) when is_map(msg) do
     Map.get(msg, :role) == "assistant" or Map.get(msg, "role") == "assistant"
@@ -91,5 +171,10 @@ defmodule ReqLLM.Providers.Deepseek do
     Map.has_key?(msg, :reasoning_content) or Map.has_key?(msg, "reasoning_content")
   end
 
-  defp has_reasoning_content?(_msg), do: false
+  defp normalize_thinking(nil), do: nil
+
+  defp normalize_thinking(%{type: type} = thinking) when is_atom(type),
+    do: %{thinking | type: to_string(type)}
+
+  defp normalize_thinking(thinking) when is_map(thinking), do: thinking
 end

--- a/lib/req_llm/providers/deepseek.ex
+++ b/lib/req_llm/providers/deepseek.ex
@@ -33,17 +33,15 @@ defmodule ReqLLM.Providers.Deepseek do
 
       # With thinking mode enabled (default for reasoning models)
       ReqLLM.generate_text("deepseek:deepseek-v4-pro", "Solve this complex problem",
+        reasoning_effort: :high,
         provider_options: [
-          thinking: %{type: "enabled"},
-          reasoning_effort: :high
+          thinking: %{type: "enabled"}
         ]
       )
 
       # With maximum reasoning effort for complex tasks
       ReqLLM.generate_text("deepseek:deepseek-v4-pro", "Complex reasoning task",
-        provider_options: [
-          reasoning_effort: :max
-        ]
+        reasoning_effort: :xhigh
       )
 
       # Disable thinking mode

--- a/test/providers/deepseek_test.exs
+++ b/test/providers/deepseek_test.exs
@@ -33,9 +33,14 @@ defmodule ReqLLM.Providers.DeepseekTest do
       assert Deepseek.default_env_key() == "DEEPSEEK_API_KEY"
     end
 
-    test "provider schema is empty (pure OpenAI-compatible)" do
-      schema_keys = Deepseek.provider_schema().schema |> Keyword.keys()
-      assert schema_keys == []
+    test "provider schema includes thinking option" do
+      schema = Deepseek.provider_schema().schema
+      schema_keys = Keyword.keys(schema)
+
+      assert :thinking in schema_keys
+
+      thinking_schema = Keyword.get(schema, :thinking)
+      assert thinking_schema[:type] == :map
     end
 
     test "provider_extended_generation_schema includes all core keys" do
@@ -63,6 +68,19 @@ defmodule ReqLLM.Providers.DeepseekTest do
       assert %Req.Request{} = request
       assert request.url.path == "/chat/completions"
       assert request.method == :post
+    end
+
+    test "prepare_request accepts reasoning_effort: :xhigh and encodes it as max" do
+      model = deepseek_model("deepseek-reasoner")
+      prompt = "Hello world"
+      opts = [reasoning_effort: :xhigh]
+
+      {:ok, request} = Deepseek.prepare_request(:chat, model, prompt, opts)
+      assert request.options[:reasoning_effort] == "max"
+
+      encoded = Deepseek.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+      assert body["reasoning_effort"] == "max"
     end
 
     test "prepare_request rejects unsupported operations" do
@@ -225,6 +243,141 @@ defmodule ReqLLM.Providers.DeepseekTest do
 
       assert %ReqLLM.Error.API.Response{} = error
       assert error.status == 401
+    end
+  end
+
+  describe "translate_options" do
+    test "maps reasoning_effort atoms to correct string values" do
+      model = deepseek_model()
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :low)
+      assert opts[:reasoning_effort] == "high"
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :medium)
+      assert opts[:reasoning_effort] == "high"
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :high)
+      assert opts[:reasoning_effort] == "high"
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :max)
+      assert opts[:reasoning_effort] == "max"
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :xhigh)
+      assert opts[:reasoning_effort] == "max"
+    end
+
+    test "passes through string reasoning_effort values unchanged" do
+      model = deepseek_model()
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: "high")
+      assert opts[:reasoning_effort] == "high"
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: "max")
+      assert opts[:reasoning_effort] == "max"
+    end
+
+    test "handles nil reasoning_effort" do
+      model = deepseek_model()
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: nil)
+      refute Keyword.has_key?(opts, :reasoning_effort)
+
+      assert {opts, []} = Deepseek.translate_options(:chat, model, [])
+      refute Keyword.has_key?(opts, :reasoning_effort)
+    end
+  end
+
+  describe "build_body" do
+    test "includes thinking in body when provided via provider_options" do
+      model = deepseek_model()
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          provider_options: [thinking: %{type: "enabled"}]
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assert body[:thinking] == %{type: "enabled"}
+    end
+
+    test "normalizes thinking type from atom to string" do
+      model = deepseek_model()
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          provider_options: [thinking: %{type: :disabled}]
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assert body[:thinking] == %{type: "disabled"}
+    end
+
+    test "includes reasoning_effort in body when provided" do
+      model = deepseek_model()
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          reasoning_effort: "high"
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assert body[:reasoning_effort] == "high"
+    end
+
+    test "includes both thinking and reasoning_effort when both provided" do
+      model = deepseek_model()
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          provider_options: [thinking: %{type: "enabled"}],
+          reasoning_effort: "max"
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      assert body[:thinking] == %{type: "enabled"}
+      assert body[:reasoning_effort] == "max"
+    end
+
+    test "does not include thinking or reasoning_effort when not provided" do
+      model = deepseek_model()
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      body = Deepseek.build_body(mock_request)
+
+      refute Map.has_key?(body, :thinking)
+      refute Map.has_key?(body, :reasoning_effort)
     end
   end
 

--- a/test/providers/deepseek_test.exs
+++ b/test/providers/deepseek_test.exs
@@ -259,9 +259,6 @@ defmodule ReqLLM.Providers.DeepseekTest do
       assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :high)
       assert opts[:reasoning_effort] == "high"
 
-      assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :max)
-      assert opts[:reasoning_effort] == "max"
-
       assert {opts, []} = Deepseek.translate_options(:chat, model, reasoning_effort: :xhigh)
       assert opts[:reasoning_effort] == "max"
     end


### PR DESCRIPTION
## Description

Add thinking and reasoning options to deepseek:
* Allow enabling or disabling the thinking
* Allow tweaking the reasoning effort

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
