### PR TITLE
feat(google-vertex): grammar-constrained structured output for Claude via output_config.format

### DIFF
--- a/lib/req_llm/providers/anthropic/adapter_helpers.ex
+++ b/lib/req_llm/providers/anthropic/adapter_helpers.ex
@@ -13,15 +13,18 @@ defmodule ReqLLM.Providers.Anthropic.AdapterHelpers do
   def maybe_add_param(body, key, value), do: Map.put(body, key, value)
 
   @doc """
-  Prepare context and options for :object operations using structured output.
+  Prepare context and options for `:object` operations using a synthetic
+  `structured_output` tool, forcing tool choice to use it.
 
-  Creates a synthetic "structured_output" tool and forces tool choice to use it.
-  This leverages Claude's tool-calling for structured JSON output.
+  This is the best-effort tool-calling path. For grammar-constrained output,
+  callers pass `anthropic_structured_output_mode: :json_schema`, which the
+  platform adapter (e.g. Google Vertex) handles via the response-level
+  `output_config.format` path instead of this tool — see
+  `structured_output_mode/1` and `strict_json_schema/1`.
   """
   def prepare_structured_output_context(context, opts) do
     compiled_schema = Keyword.fetch!(opts, :compiled_schema)
 
-    # Create the structured_output tool
     structured_output_tool =
       ReqLLM.Tool.new!(
         name: "structured_output",
@@ -30,11 +33,9 @@ defmodule ReqLLM.Providers.Anthropic.AdapterHelpers do
         callback: fn _args -> {:ok, "structured output generated"} end
       )
 
-    # Add tool to context
     existing_tools = Map.get(context, :tools, [])
     updated_context = Map.put(context, :tools, [structured_output_tool | existing_tools])
 
-    # Update opts to force tool choice
     updated_opts =
       opts
       |> Keyword.put(:tools, [structured_output_tool | Keyword.get(opts, :tools, [])])
@@ -42,6 +43,37 @@ defmodule ReqLLM.Providers.Anthropic.AdapterHelpers do
 
     {updated_context, updated_opts}
   end
+
+  @doc """
+  Resolve the `anthropic_structured_output_mode` from opts (top-level or nested
+  under `:provider_options`), defaulting to `:auto`.
+  """
+  def structured_output_mode(opts) do
+    provider_opts = get_opt(opts, :provider_options) || []
+
+    get_opt(opts, :anthropic_structured_output_mode) ||
+      get_opt(provider_opts, :anthropic_structured_output_mode) ||
+      :auto
+  end
+
+  @doc """
+  Reduce a compiled schema to the subset that grammar-constrained
+  (`output_config.format`) decoding supports: strip unsupported keywords and
+  force every property required with `additionalProperties: false`.
+
+  Array length (`minItems`/`maxItems`) cannot be expressed, so callers that need
+  an exact count must re-validate it on the response.
+  """
+  def strict_json_schema(compiled_schema) do
+    compiled_schema.schema
+    |> ReqLLM.Schema.to_json()
+    |> strip_constraints_recursive()
+    |> enforce_strict_schema_requirements()
+  end
+
+  defp get_opt(opts, key) when is_list(opts), do: Keyword.get(opts, key)
+  defp get_opt(opts, key) when is_map(opts), do: Map.get(opts, key)
+  defp get_opt(_opts, _key), do: nil
 
   @doc """
   Add extended thinking configuration to request body if enabled.
@@ -132,4 +164,55 @@ defmodule ReqLLM.Providers.Anthropic.AdapterHelpers do
       }
     end)
   end
+
+  @doc """
+  Recursively remove JSON Schema keywords that strict (grammar-constrained)
+  decoding does not support.
+
+  Strips numeric/length/array constraints (`minimum`, `maximum`, `minLength`,
+  `maxLength`, `minItems`, `maxItems`) and the Gemini-style `propertyOrdering`
+  annotation (which `ReqLLM.Schema.to_json/1` emits but Anthropic's strict tool
+  rejects) from the schema and every nested `properties`/`items` subschema.
+  """
+  def strip_constraints_recursive(schema) when is_map(schema) do
+    schema
+    |> Map.drop([
+      "minimum",
+      "maximum",
+      "minLength",
+      "maxLength",
+      "minItems",
+      "maxItems",
+      "propertyOrdering"
+    ])
+    |> Map.new(fn
+      {"properties", props} when is_map(props) ->
+        {"properties", Map.new(props, fn {k, v} -> {k, strip_constraints_recursive(v)} end)}
+
+      {"items", items} when is_map(items) ->
+        {"items", strip_constraints_recursive(items)}
+
+      {k, v} when is_map(v) ->
+        {k, strip_constraints_recursive(v)}
+
+      {k, v} ->
+        {k, v}
+    end)
+  end
+
+  def strip_constraints_recursive(value), do: value
+
+  @doc """
+  Apply the object-level requirements strict decoding mandates: every property
+  is marked required and `additionalProperties` is set to `false`.
+  """
+  def enforce_strict_schema_requirements(
+        %{"type" => "object", "properties" => properties} = schema
+      ) do
+    schema
+    |> Map.put("required", Map.keys(properties))
+    |> Map.put("additionalProperties", false)
+  end
+
+  def enforce_strict_schema_requirements(schema), do: schema
 end

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -143,6 +143,19 @@ defmodule ReqLLM.Providers.GoogleVertex do
       - `0` - first message, `1` - second, etc.
       """
     ],
+    anthropic_structured_output_mode: [
+      type: {:in, [:auto, :json_schema]},
+      default: :auto,
+      doc: """
+      Structured output strategy for Claude `:object` generation:
+      - `:auto` (default) - best-effort tool calling
+      - `:json_schema` - grammar-constrained decoding via `output_config.format`
+
+      `:json_schema` requires the `structured_outputs` partner-model feature to be
+      allow-listed by the GCP org policy (`constraints/vertexai.allowedPartnerModelFeatures`),
+      otherwise the request is rejected with HTTP 400 `FAILED_PRECONDITION`.
+      """
+    ],
     google_thinking_budget: [
       type: :non_neg_integer,
       doc: "Thinking token budget for Gemini 2.5 models (0 disables thinking, omit for dynamic)"

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -724,19 +724,14 @@ defmodule ReqLLM.Providers.GoogleVertex do
     model = Req.Request.get_private(request, :model)
     formatter = get_formatter(model)
 
-    # Build opts with operation and context from request.options (which is a map)
     opts =
-      []
-      |> then(
-        &if request.options[:operation],
-          do: Keyword.put(&1, :operation, request.options[:operation]),
-          else: &1
-      )
-      |> then(
-        &if request.options[:context],
-          do: Keyword.put(&1, :context, request.options[:context]),
-          else: &1
-      )
+      [:operation, :context, :provider_options, :anthropic_structured_output_mode]
+      |> Enum.reduce([], fn key, acc ->
+        case request.options[key] do
+          nil -> acc
+          value -> Keyword.put(acc, key, value)
+        end
+      end)
 
     # Parse response using formatter
     result = formatter.parse_response(response.body, model, opts)

--- a/lib/req_llm/providers/google_vertex/anthropic.ex
+++ b/lib/req_llm/providers/google_vertex/anthropic.ex
@@ -45,10 +45,12 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
   """
   def format_request(_model_id, context, opts) do
     operation = opts[:operation]
+    mode = AdapterHelpers.structured_output_mode(opts)
 
-    # For :object operation, we need to inject the structured_output tool
+    # For :object operation, inject the structured_output tool unless the caller
+    # requested the response-level json_schema output_format path.
     {context, opts} =
-      if operation == :object do
+      if operation == :object and mode != :json_schema do
         AdapterHelpers.prepare_structured_output_context(context, opts)
       else
         {context, opts}
@@ -78,8 +80,22 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
     |> AdapterHelpers.maybe_add_param(:stop_sequences, opts[:stop_sequences])
     |> AdapterHelpers.maybe_add_thinking(opts)
     |> maybe_add_tools(opts)
+    |> maybe_add_output_format(operation, mode, opts)
     |> Anthropic.maybe_apply_prompt_caching(opts)
   end
+
+  defp maybe_add_output_format(body, :object, :json_schema, opts) do
+    compiled_schema = Keyword.fetch!(opts, :compiled_schema)
+
+    Map.put(body, :output_config, %{
+      format: %{
+        type: "json_schema",
+        schema: AdapterHelpers.strict_json_schema(compiled_schema)
+      }
+    })
+  end
+
+  defp maybe_add_output_format(body, _operation, _mode, _opts), do: body
 
   # Add tools from opts to request body
   defp maybe_add_tools(body, opts) do
@@ -124,12 +140,19 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
         input_context = opts[:context] || %ReqLLM.Context{messages: []}
         merged_response = ReqLLM.Context.merge_response(input_context, response)
 
-        # For :object operation, extract structured output from tool call
+        # For :object operation, extract structured output. The json_schema path
+        # returns the object as message text; the tool path returns it as a tool call.
         final_response =
-          if opts[:operation] == :object do
-            AdapterHelpers.extract_and_set_object(merged_response)
-          else
-            merged_response
+          cond do
+            opts[:operation] == :object and
+                AdapterHelpers.structured_output_mode(opts) == :json_schema ->
+              extract_object_from_text(merged_response, opts)
+
+            opts[:operation] == :object ->
+              AdapterHelpers.extract_and_set_object(merged_response)
+
+            true ->
+              merged_response
           end
 
         {:ok, final_response}
@@ -137,6 +160,16 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
       error ->
         error
     end
+  end
+
+  defp extract_object_from_text(response, opts) do
+    object =
+      case ReqLLM.JSON.decode(ReqLLM.Response.text(response), opts) do
+        {:ok, decoded} -> decoded
+        _ -> nil
+      end
+
+    %{response | object: object}
   end
 
   @doc """

--- a/lib/req_llm/providers/google_vertex/anthropic.ex
+++ b/lib/req_llm/providers/google_vertex/anthropic.ex
@@ -40,15 +40,18 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
   Delegates to the native Anthropic.Context module. Vertex AI uses the
   native Anthropic Messages API format directly.
 
-  For :object operations, creates a synthetic "structured_output" tool to
-  leverage Claude's tool-calling for structured JSON output.
+  For `:object` operations the structured-output strategy depends on
+  `anthropic_structured_output_mode` (resolved via `AdapterHelpers.structured_output_mode/1`):
+
+    * `:json_schema` — sends `output_config.format` and leaves the tools alone;
+      the model returns the object as message text (grammar-constrained).
+    * otherwise (`:auto`) — injects a synthetic `structured_output` tool and
+      forces tool choice, relying on Claude's best-effort tool calling.
   """
   def format_request(_model_id, context, opts) do
     operation = opts[:operation]
     mode = AdapterHelpers.structured_output_mode(opts)
 
-    # For :object operation, inject the structured_output tool unless the caller
-    # requested the response-level json_schema output_format path.
     {context, opts} =
       if operation == :object and mode != :json_schema do
         AdapterHelpers.prepare_structured_output_context(context, opts)
@@ -123,7 +126,11 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
 
   Delegates to the native Anthropic.Response module.
 
-  For :object operations, extracts the structured output from the tool call.
+  For `:object` operations, extracts the structured output: from the message
+  text in `:json_schema` mode (`output_config.format`), or from the
+  `structured_output` tool call otherwise. The mode is read from `opts`, so the
+  caller must forward `anthropic_structured_output_mode` into response decoding
+  (see `decode_response/1`).
   """
   def parse_response(body, %LLMDB.Model{} = vertex_model, opts) when is_map(body) do
     # Create an Anthropic model struct for decode_response
@@ -140,8 +147,6 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
         input_context = opts[:context] || %ReqLLM.Context{messages: []}
         merged_response = ReqLLM.Context.merge_response(input_context, response)
 
-        # For :object operation, extract structured output. The json_schema path
-        # returns the object as message text; the tool path returns it as a tool call.
         final_response =
           cond do
             opts[:operation] == :object and

--- a/test/req_llm/providers/anthropic/adapter_helpers_test.exs
+++ b/test/req_llm/providers/anthropic/adapter_helpers_test.exs
@@ -1,0 +1,72 @@
+defmodule ReqLLM.Providers.Anthropic.AdapterHelpersTest do
+  use ExUnit.Case, async: true
+
+  @moduletag category: :core
+  @moduletag provider: :anthropic
+
+  alias ReqLLM.Providers.Anthropic
+  alias ReqLLM.Providers.Anthropic.AdapterHelpers
+
+  @json_schema %{
+    "type" => "object",
+    "properties" => %{
+      "question" => %{"type" => "string"},
+      "options" => %{
+        "type" => "array",
+        "items" => %{"type" => "string"},
+        "minItems" => 4,
+        "maxItems" => 4
+      }
+    },
+    "required" => ["options", "question"],
+    "additionalProperties" => true,
+    "propertyOrdering" => ["options", "question"]
+  }
+
+  defp compiled, do: elem(ReqLLM.Schema.compile(@json_schema), 1)
+
+  describe "prepare_structured_output_context/2" do
+    test "builds a best-effort (non-strict) structured_output tool with the schema untouched" do
+      opts = [compiled_schema: compiled()]
+      {_context, updated_opts} = AdapterHelpers.prepare_structured_output_context(%{}, opts)
+      [tool | _] = Keyword.fetch!(updated_opts, :tools)
+      formatted = Anthropic.tool_to_anthropic_format(tool)
+
+      refute Map.has_key?(formatted, :strict)
+      assert formatted[:input_schema]["properties"]["options"]["minItems"] == 4
+
+      assert Keyword.fetch!(updated_opts, :tool_choice) == %{
+               type: "tool",
+               name: "structured_output"
+             }
+    end
+  end
+
+  describe "structured_output_mode/1" do
+    test "defaults to :auto and reads top-level or nested provider_options" do
+      assert AdapterHelpers.structured_output_mode([]) == :auto
+
+      assert AdapterHelpers.structured_output_mode(anthropic_structured_output_mode: :json_schema) ==
+               :json_schema
+
+      assert AdapterHelpers.structured_output_mode(
+               provider_options: [anthropic_structured_output_mode: :json_schema]
+             ) == :json_schema
+    end
+  end
+
+  describe "strict_json_schema/1 (output_config.format reduction)" do
+    test "strips unsupported keywords and forces required + additionalProperties:false" do
+      reduced = AdapterHelpers.strict_json_schema(compiled())
+      options = reduced["properties"]["options"]
+
+      refute Map.has_key?(options, "minItems")
+      refute Map.has_key?(options, "maxItems")
+      assert options["type"] == "array"
+      assert options["items"] == %{"type" => "string"}
+      refute Map.has_key?(reduced, "propertyOrdering")
+      assert reduced["additionalProperties"] == false
+      assert Enum.sort(reduced["required"]) == ["options", "question"]
+    end
+  end
+end

--- a/test/req_llm/providers/google_vertex/anthropic_object_test.exs
+++ b/test/req_llm/providers/google_vertex/anthropic_object_test.exs
@@ -54,4 +54,47 @@ defmodule ReqLLM.Providers.GoogleVertex.AnthropicObjectTest do
       assert "structured_output" in tool_names(body)
     end
   end
+
+  describe "decode_response/1 forwards the structured-output mode" do
+    @object %{"question" => "q", "options" => ["a", "b", "c", "d"]}
+
+    defp decode(extra_options) do
+      model = %LLMDB.Model{
+        id: "claude-opus-4-6",
+        provider: :google_vertex,
+        capabilities: %{chat: true}
+      }
+
+      body = %{
+        "id" => "msg_1",
+        "type" => "message",
+        "role" => "assistant",
+        "model" => "claude-opus-4-6",
+        "content" => [%{"type" => "text", "text" => JSON.encode!(@object)}],
+        "stop_reason" => "end_turn",
+        "usage" => %{"input_tokens" => 10, "output_tokens" => 5}
+      }
+
+      request =
+        Req.new()
+        |> Req.Request.put_private(:model, model)
+
+      request = %{request | options: Map.new([operation: :object] ++ extra_options)}
+
+      {_req, %Req.Response{body: decoded}} =
+        ReqLLM.Providers.GoogleVertex.decode_response(
+          {request, %Req.Response{status: 200, body: body}}
+        )
+
+      decoded
+    end
+
+    test "json_schema mode parses the object from response text" do
+      assert decode(anthropic_structured_output_mode: :json_schema).object == @object
+    end
+
+    test "without the mode forwarded the json_schema text is not parsed (tool path → nil)" do
+      assert decode([]).object == nil
+    end
+  end
 end

--- a/test/req_llm/providers/google_vertex/anthropic_object_test.exs
+++ b/test/req_llm/providers/google_vertex/anthropic_object_test.exs
@@ -1,0 +1,57 @@
+defmodule ReqLLM.Providers.GoogleVertex.AnthropicObjectTest do
+  use ExUnit.Case, async: true
+
+  @moduletag category: :core
+  @moduletag provider: :anthropic
+
+  alias ReqLLM.Providers.GoogleVertex.Anthropic, as: VertexAnthropic
+
+  @schema %{
+    "type" => "object",
+    "properties" => %{
+      "question" => %{"type" => "string"},
+      "options" => %{
+        "type" => "array",
+        "items" => %{"type" => "string"},
+        "minItems" => 4,
+        "maxItems" => 4
+      }
+    },
+    "required" => ["options", "question"],
+    "additionalProperties" => true,
+    "propertyOrdering" => ["options", "question"]
+  }
+
+  defp build_body(extra_opts) do
+    {:ok, compiled} = ReqLLM.Schema.compile(@schema)
+    context = ReqLLM.Context.new([ReqLLM.Context.user("translate")])
+
+    opts =
+      [operation: :object, compiled_schema: compiled, model: "claude-opus-4-6"] ++ extra_opts
+
+    VertexAnthropic.format_request("claude-opus-4-6", context, opts)
+  end
+
+  defp tool_names(body), do: Enum.map(body[:tools] || [], &(&1[:name] || &1["name"]))
+
+  describe "format_request/3 for :object" do
+    test "json_schema mode emits output_config.format and no structured_output tool" do
+      body = build_body(anthropic_structured_output_mode: :json_schema)
+
+      assert get_in(body, [:output_config, :format, :type]) == "json_schema"
+
+      options = get_in(body, [:output_config, :format, :schema])["properties"]["options"]
+      refute Map.has_key?(options, "maxItems")
+      assert get_in(body, [:output_config, :format, :schema])["additionalProperties"] == false
+
+      refute "structured_output" in tool_names(body)
+    end
+
+    test "default mode injects a structured_output tool and no output_config" do
+      body = build_body([])
+
+      refute Map.has_key?(body, :output_config)
+      assert "structured_output" in tool_names(body)
+    end
+  end
+end


### PR DESCRIPTION
Generating `:object` output for Claude on Vertex uses a best-effort `structured_output` tool call, which intermittently double-encodes nested arrays as JSON strings (`"options": "[\"a\",\"b\"]"`) — see anthropics/claude-agent-sdk-python#510. Downstream schema validation then rejects the payload.

Add an opt-in `anthropic_structured_output_mode: :json_schema` for the Vertex Anthropic adapter. On `:object`, it sends `output_config: %{format: %{type: "json_schema", schema: <reduced>}}` in the body (instead of the tool) and parses the object from the response message text. Live testing: arrays come back as real arrays every time, vs intermittent stringification before.

Grammar-constrained decoding only accepts a subset of JSON Schema, so the schema is reduced first (`strict_json_schema/1`): strip `min*`/`max*`/`*Items` and the Gemini `propertyOrdering` annotation, force every property required with `additionalProperties: false`. Array length cannot be expressed, so callers must re-validate the count on the response.

Default (`:auto`) is unchanged. `:json_schema` requires the GCP `structured_outputs` partner-model feature to be allow-listed (`constraints/vertexai.allowedPartnerModelFeatures`).

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [ ] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
