### PR TITLE
fix(openai_codex): keep HTTP responses stateless

### DIFF
--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -357,6 +357,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
       |> Keyword.delete(:compiled_schema)
       |> Keyword.put(:provider_options, Keyword.get(opts, :provider_options, []))
       |> Keyword.put(:stream, nil)
+      |> Keyword.put(:responses_transport, :websocket)
       |> Keyword.put(:model, model.id)
       |> Keyword.put(:context, context)
       |> Keyword.put(:base_url, base_url)
@@ -394,7 +395,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
   end
 
   defp build_codex_body(context, model_name, opts, request) do
-    opts = opts |> ensure_provider_options() |> force_store_false() |> put_responses_transport()
+    opts = opts |> ensure_provider_options() |> force_store_false()
     body = ResponsesAPI.build_request_body(context, model_name, opts, request)
     provider_opts = provider_options(opts)
     instructions = extract_instructions(context) || ""
@@ -440,12 +441,6 @@ defmodule ReqLLM.Providers.OpenAICodex do
     do: provider_opts |> Map.to_list() |> Keyword.put(:store, false)
 
   defp provider_options_store_false(_provider_opts), do: [store: false]
-
-  defp put_responses_transport(opts) when is_list(opts),
-    do: Keyword.put(opts, :responses_transport, :websocket)
-
-  defp put_responses_transport(opts) when is_map(opts),
-    do: Map.put(opts, :responses_transport, :websocket)
 
   defp tool_resume_body?(%{"input" => input}) when is_list(input) do
     Enum.any?(input, fn

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -121,7 +121,10 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       {:ok, config} =
         OpenAICodex.attach_websocket_stream(
           model,
-          ReqLLM.context([ReqLLM.Context.user("Say hi")]),
+          ReqLLM.context([
+            ReqLLM.Context.assistant("Previous answer", metadata: %{response_id: "resp_ws_789"}),
+            ReqLLM.Context.user("Say hi")
+          ]),
           provider_options: [
             auth_mode: :oauth,
             access_token: jwt_with_account_id("acct_ws"),
@@ -141,6 +144,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert payload["model"] == "gpt-5.3-codex-spark"
       assert payload["store"] == false
       assert payload["stream"] == true
+      assert payload["previous_response_id"] == "resp_ws_789"
       refute Map.has_key?(payload, "max_completion_tokens")
       refute Map.has_key?(payload, "response")
     end
@@ -214,7 +218,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
              )
     end
 
-    test "sends previous_response_id from context metadata while keeping store=false" do
+    test "omits previous_response_id from HTTP context metadata while keeping store=false" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
 
       context =
@@ -238,10 +242,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
 
       body = ReqLLM.Test.Helpers.json_body(request)
 
-      # Codex forces store=false, but multi-turn chaining over the Responses
-      # WebSocket depends on previous_response_id resolving against the
-      # connection-local cache. The id must be sent, not suppressed.
-      assert body["previous_response_id"] == "resp_prev_789"
+      refute Map.has_key?(body, "previous_response_id")
       assert body["store"] == false
     end
 


### PR DESCRIPTION
## Summary
- Only mark Codex Responses requests as websocket transport in `attach_websocket_stream/3`
- Keep Codex HTTP/SSE requests stateless with `store: false`, so replayed `response_id` metadata does not emit `previous_response_id`
- Preserve websocket `previous_response_id` behavior where connection-local chaining still applies

## Tests
- `mix test test/providers/openai_codex_test.exs test/provider/openai/responses_api_unit_test.exs`
- `mix format --check-formatted lib/req_llm/providers/openai_codex.ex test/providers/openai_codex_test.exs`
- `git diff --check $(git merge-base origin/main HEAD)..HEAD`