### PR TITLE
fix(google): pass thinking config to Gemini image generation

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -964,6 +964,10 @@ defmodule ReqLLM.Providers.Google do
       |> maybe_put_google_aspect_ratio(request.options[:aspect_ratio])
       |> maybe_put_google_response_modalities(request.options[:response_modalities])
       |> maybe_put(:candidateCount, image_candidate_count(request.options))
+      |> maybe_add_thinking_config(
+        request.options[:google_thinking_budget],
+        request.options[:google_thinking_level]
+      )
 
     generation_config = if generation_config != %{}, do: generation_config
 

--- a/test/providers/google_images_test.exs
+++ b/test/providers/google_images_test.exs
@@ -147,6 +147,23 @@ defmodule ReqLLM.Providers.GoogleImagesTest do
     assert get_in(body, ["generationConfig", "responseModalities"]) == ["TEXT", "IMAGE"]
   end
 
+  test "prepare_request/4 passes google_thinking_level into generationConfig.thinkingConfig" do
+    {:ok, model} = ReqLLM.model("google:gemini-3.1-flash-image")
+
+    {:ok, request} =
+      Google.prepare_request(
+        :image,
+        model,
+        "A cat in space",
+        provider_options: [google_thinking_level: :high]
+      )
+
+    encoded = Google.encode_body(request)
+    body = ReqLLM.Test.Helpers.json_body(encoded)
+
+    assert get_in(body, ["generationConfig", "thinkingConfig", "thinkingLevel"]) == "high"
+  end
+
   test "decode_response/1 converts inlineData to ContentPart.image" do
     req =
       Req.new(url: "/models/gemini-2.0-flash-exp-image-generation:generateContent")


### PR DESCRIPTION
## Description

The Google provider already supports `google_thinking_budget` / `google_thinking_level` for chat (`encode_chat_body`) and object generation (`encode_object_body`), but `encode_gemini_image_body/1` never piped the `generation_config` through `maybe_add_thinking_config/3`. As a result, thinking config was silently dropped for Gemini image generation requests.

Per the [Gemini image generation docs](https://ai.google.dev/gemini-api/docs/interactions/image-generation#thinking-levels), Gemini 3 image models (e.g. `gemini-3.1-flash-image`) are thinking models and expose a `thinking_level` field in `generationConfig` (`minimal` default, `high`) to balance quality vs. latency. This change adds the missing one-line pipeline step so the option reaches the API, matching the chat/object code paths exactly.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests pass (`mix test` — Google suite: 115 tests, 0 failures)
- [x] `mix format` clean
- [x] `mix credo --strict` clean on the changed file

Added an encode test in `test/providers/google_images_test.exs` (TDD: confirmed red before the fix, green after) verifying `google_thinking_level` flows through the full `prepare_request` → `Options.process` → `encode_body` path into `generationConfig.thinkingConfig.thinkingLevel` for `gemini-3.1-flash-image`.

## Notes

- Reuses the existing `maybe_add_thinking_config/3` helper — no schema change required, since `google_thinking_*` are already in `@provider_schema` and valid for all operations. `thinking_level` is the relevant knob for Gemini 3 image models; `google_thinking_budget` is forwarded by the same helper for consistency with the chat/object paths, though the image API only documents `thinking_level`.
- No live fixture is included: the test follows the same mocked encode pattern as the existing image tests, asserting the request body rather than hitting the API.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)