### PR TITLE
fix(ci): clear Elixir 1.20 compile warnings

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -1297,9 +1297,6 @@ defmodule ReqLLM.Context do
         not Message.valid?(msg) ->
           {:halt, {:error, "Context contains invalid messages"}}
 
-        not is_list(msg.content) ->
-          {:halt, {:error, "Message content must be a list of ContentParts"}}
-
         msg.role == :assistant and msg.tool_calls != nil and not is_list(msg.tool_calls) ->
           {:halt, {:error, "tool_calls must be a list or nil"}}
 

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -380,7 +380,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         # Otherwise use Converse formatter directly
         formatter =
           if function_exported?(family_formatter, :requires_converse_api?, 0) and
-               family_formatter.requires_converse_api?() do
+               call_formatter(family_formatter, :requires_converse_api?, []) do
             family_formatter
           else
             ReqLLM.Providers.AmazonBedrock.Converse
@@ -564,7 +564,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         # Otherwise use Converse formatter directly
         formatter =
           if function_exported?(family_formatter, :requires_converse_api?, 0) and
-               family_formatter.requires_converse_api?() do
+               call_formatter(family_formatter, :requires_converse_api?, []) do
             family_formatter
           else
             ReqLLM.Providers.AmazonBedrock.Converse
@@ -775,7 +775,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     formatter = get_formatter_module(model_family)
 
     if function_exported?(formatter, :extract_usage, 2) do
-      formatter.extract_usage(body, model)
+      call_formatter(formatter, :extract_usage, [body, model])
     else
       {:error, :no_usage_extractor}
     end
@@ -891,7 +891,6 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   defp extract_region(aws_creds) do
     case aws_creds do
       %{region: r} when is_binary(r) -> r
-      %AWSAuth.Credentials{region: r} when is_binary(r) -> r
       _ -> "us-east-1"
     end
   end
@@ -1196,12 +1195,16 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       model_family = req.options[:model_family]
       formatter = Map.get(@embedding_families, model_family)
 
-      case formatter.parse_embedding_response(parsed_body) do
-        {:ok, normalized_response} ->
-          {req, inject_usage_from_headers(%{resp | body: normalized_response})}
+      if function_exported?(formatter, :parse_embedding_response, 1) do
+        case call_formatter(formatter, :parse_embedding_response, [parsed_body]) do
+          {:ok, normalized_response} ->
+            {req, inject_usage_from_headers(%{resp | body: normalized_response})}
 
-        {:error, error} ->
-          {req, error}
+          {:error, error} ->
+            {req, error}
+        end
+      else
+        {req, ReqLLM.Error.API.Response.exception(reason: "Unsupported embedding model family")}
       end
     end
   end
@@ -1273,6 +1276,10 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     end
   end
 
+  defp call_formatter(formatter, function, args) do
+    apply(formatter, function, args)
+  end
+
   # Private helper: Determine whether to use Converse API with caching optimization
   defp determine_use_converse(model_id, opts) do
     # Check if model's formatter requires Converse API
@@ -1281,7 +1288,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
     requires_converse =
       function_exported?(formatter, :requires_converse_api?, 0) &&
-        formatter.requires_converse_api?()
+        call_formatter(formatter, :requires_converse_api?, [])
 
     # Check if formatter is Converse (fallback for unsupported families)
     is_fallback_to_converse = formatter == ReqLLM.Providers.AmazonBedrock.Converse

--- a/lib/req_llm/providers/amazon_bedrock/anthropic.ex
+++ b/lib/req_llm/providers/amazon_bedrock/anthropic.ex
@@ -145,23 +145,18 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
 
     model = LLMDB.Model.new!(%{id: model_id, provider: :anthropic})
 
-    case Anthropic.Response.decode_response(body, model) do
-      {:ok, response} ->
-        input_context = opts[:context] || %ReqLLM.Context{messages: []}
-        merged_response = ReqLLM.Context.merge_response(input_context, response)
+    {:ok, response} = Anthropic.Response.decode_response(body, model)
+    input_context = opts[:context] || %ReqLLM.Context{messages: []}
+    merged_response = ReqLLM.Context.merge_response(input_context, response)
 
-        final_response =
-          if opts[:operation] == :object do
-            AdapterHelpers.extract_and_set_object(merged_response)
-          else
-            merged_response
-          end
+    final_response =
+      if opts[:operation] == :object do
+        AdapterHelpers.extract_and_set_object(merged_response)
+      else
+        merged_response
+      end
 
-        {:ok, final_response}
-
-      error ->
-        error
-    end
+    {:ok, final_response}
   end
 
   @doc """

--- a/lib/req_llm/providers/amazon_bedrock/aws_event_stream.ex
+++ b/lib/req_llm/providers/amazon_bedrock/aws_event_stream.ex
@@ -324,16 +324,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.AWSEventStream do
             {_ref, {:data, chunk}} when is_binary(chunk) ->
               handle_chunk(buffer, chunk, pid, process_event)
 
-            {{_pool, _pid}, {:data, chunk}} when is_binary(chunk) ->
-              # Finch format when using :into :self
-              handle_chunk(buffer, chunk, pid, process_event)
-
             {_ref, :done} ->
-              # Stream is done
-              {:halt, buffer}
-
-            {{_pool, _pid}, :done} ->
-              # Finch format for done signal
               {:halt, buffer}
 
             _ ->

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -395,8 +395,6 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     end)
   end
 
-  defp all_tool_results?(_), do: false
-
   defp add_tools(request, [], _formatter_module), do: request
 
   defp add_tools(request, tools, formatter_module) when is_list(tools) do

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -103,8 +103,6 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     end)
   end
 
-  defp all_tool_results?(_), do: false
-
   defp encode_message(%ReqLLM.Message{
          role: :assistant,
          tool_calls: tool_calls,

--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -769,7 +769,7 @@ defmodule ReqLLM.Providers.Azure do
     formatter = get_formatter(model_id, model)
 
     if function_exported?(formatter, :init_stream_state, 0) do
-      formatter.init_stream_state()
+      call_formatter(formatter, :init_stream_state, [])
     end
   end
 
@@ -784,11 +784,16 @@ defmodule ReqLLM.Providers.Azure do
     model_id = effective_model_id(model)
     formatter = get_formatter(model_id, model)
 
-    if function_exported?(formatter, :decode_stream_event, 3) do
-      formatter.decode_stream_event(event, model, state)
-    else
-      chunks = formatter.decode_stream_event(event, model)
-      {chunks, state}
+    cond do
+      function_exported?(formatter, :decode_stream_event, 3) ->
+        call_formatter(formatter, :decode_stream_event, [event, model, state])
+
+      function_exported?(formatter, :decode_stream_event, 2) ->
+        chunks = call_formatter(formatter, :decode_stream_event, [event, model])
+        {chunks, state}
+
+      true ->
+        {[], state}
     end
   end
 
@@ -798,7 +803,7 @@ defmodule ReqLLM.Providers.Azure do
     formatter = get_formatter(model_id, model)
 
     if function_exported?(formatter, :flush_stream_state, 1) do
-      formatter.flush_stream_state(state)
+      call_formatter(formatter, :flush_stream_state, [state])
     else
       {[], state}
     end
@@ -815,7 +820,7 @@ defmodule ReqLLM.Providers.Azure do
     formatter = get_formatter(model_id, model)
 
     if function_exported?(formatter, :extract_usage, 2) do
-      formatter.extract_usage(body, model)
+      call_formatter(formatter, :extract_usage, [body, model])
     else
       {:error, :no_usage_extractor}
     end
@@ -888,10 +893,14 @@ defmodule ReqLLM.Providers.Azure do
     formatter = get_formatter(model_id, model)
 
     if function_exported?(formatter, :pre_validate_options, 3) do
-      formatter.pre_validate_options(operation, model, opts)
+      call_formatter(formatter, :pre_validate_options, [operation, model, opts])
     else
       {opts, []}
     end
+  end
+
+  defp call_formatter(formatter, function, args) do
+    apply(formatter, function, args)
   end
 
   @doc """

--- a/lib/req_llm/providers/azure/anthropic.ex
+++ b/lib/req_llm/providers/azure/anthropic.ex
@@ -219,23 +219,18 @@ defmodule ReqLLM.Providers.Azure.Anthropic do
     model_id = ReqLLM.ModelId.normalize(model_id, "azure-anthropic")
     anthropic_model = LLMDB.Model.new!(%{id: model_id, provider: :anthropic})
 
-    case Anthropic.Response.decode_response(body, anthropic_model) do
-      {:ok, response} ->
-        input_context = opts[:context] || %ReqLLM.Context{messages: []}
-        merged_response = ReqLLM.Context.merge_response(input_context, response)
+    {:ok, response} = Anthropic.Response.decode_response(body, anthropic_model)
+    input_context = opts[:context] || %ReqLLM.Context{messages: []}
+    merged_response = ReqLLM.Context.merge_response(input_context, response)
 
-        final_response =
-          if opts[:operation] == :object do
-            AdapterHelpers.extract_and_set_object(merged_response)
-          else
-            merged_response
-          end
+    final_response =
+      if opts[:operation] == :object do
+        AdapterHelpers.extract_and_set_object(merged_response)
+      else
+        merged_response
+      end
 
-        {:ok, final_response}
-
-      error ->
-        error
-    end
+    {:ok, final_response}
   end
 
   @doc """

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -2900,7 +2900,7 @@ defmodule ReqLLM.Providers.Google do
     case depth - 1 do
       0 ->
         length = offset + 1
-        <<json::binary-size(length), remaining::binary>> = original
+        <<json::binary-size(^length), remaining::binary>> = original
         {:ok, json, remaining}
 
       next_depth when next_depth > 0 ->

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -633,7 +633,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
     # Clean thinking after translation if incompatible
     other_opts =
       if function_exported?(formatter, :maybe_clean_thinking_after_translation, 2) do
-        formatter.maybe_clean_thinking_after_translation(other_opts, operation)
+        call_formatter(formatter, :maybe_clean_thinking_after_translation, [other_opts, operation])
       else
         other_opts
       end
@@ -766,7 +766,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
         formatter = get_formatter(model)
 
         if function_exported?(formatter, :extract_usage, 2) do
-          formatter.extract_usage(body, model)
+          call_formatter(formatter, :extract_usage, [body, model])
         else
           {:error, :no_usage_extractor}
         end
@@ -816,7 +816,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
         formatter = get_formatter(model)
 
         if function_exported?(formatter, :pre_validate_options, 3) do
-          formatter.pre_validate_options(operation, model, opts)
+          call_formatter(formatter, :pre_validate_options, [operation, model, opts])
         else
           {opts, []}
         end
@@ -949,7 +949,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
     formatter = get_formatter(model)
 
     if function_exported?(formatter, :decode_stream_event, 2) do
-      formatter.decode_stream_event(event, model)
+      call_formatter(formatter, :decode_stream_event, [event, model])
     else
       ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model)
     end
@@ -960,7 +960,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
     formatter = get_formatter(model)
 
     if function_exported?(formatter, :init_stream_state, 0) do
-      formatter.init_stream_state()
+      call_formatter(formatter, :init_stream_state, [])
     end
   end
 
@@ -970,10 +970,10 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
     cond do
       function_exported?(formatter, :decode_stream_event, 3) ->
-        formatter.decode_stream_event(event, model, state)
+        call_formatter(formatter, :decode_stream_event, [event, model, state])
 
       function_exported?(formatter, :decode_stream_event, 2) ->
-        {formatter.decode_stream_event(event, model), state}
+        {call_formatter(formatter, :decode_stream_event, [event, model]), state}
 
       true ->
         ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model, state)
@@ -986,14 +986,18 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
     cond do
       function_exported?(formatter, :flush_stream_state, 2) ->
-        formatter.flush_stream_state(model, state)
+        call_formatter(formatter, :flush_stream_state, [model, state])
 
       function_exported?(formatter, :flush_stream_state, 1) ->
-        formatter.flush_stream_state(state)
+        call_formatter(formatter, :flush_stream_state, [state])
 
       true ->
         {[], state}
     end
+  end
+
+  defp call_formatter(formatter, function, args) do
+    apply(formatter, function, args)
   end
 
   # Build streaming path for model

--- a/lib/req_llm/providers/google_vertex/anthropic.ex
+++ b/lib/req_llm/providers/google_vertex/anthropic.ex
@@ -140,31 +140,24 @@ defmodule ReqLLM.Providers.GoogleVertex.Anthropic do
 
     anthropic_model = LLMDB.Model.new!(%{id: model_id, provider: :anthropic})
 
-    # Delegate to native Anthropic response decoding
-    case Anthropic.Response.decode_response(body, anthropic_model) do
-      {:ok, response} ->
-        # Merge with input context to preserve conversation history
-        input_context = opts[:context] || %ReqLLM.Context{messages: []}
-        merged_response = ReqLLM.Context.merge_response(input_context, response)
+    {:ok, response} = Anthropic.Response.decode_response(body, anthropic_model)
+    input_context = opts[:context] || %ReqLLM.Context{messages: []}
+    merged_response = ReqLLM.Context.merge_response(input_context, response)
 
-        final_response =
-          cond do
-            opts[:operation] == :object and
-                AdapterHelpers.structured_output_mode(opts) == :json_schema ->
-              extract_object_from_text(merged_response, opts)
+    final_response =
+      cond do
+        opts[:operation] == :object and
+            AdapterHelpers.structured_output_mode(opts) == :json_schema ->
+          extract_object_from_text(merged_response, opts)
 
-            opts[:operation] == :object ->
-              AdapterHelpers.extract_and_set_object(merged_response)
+        opts[:operation] == :object ->
+          AdapterHelpers.extract_and_set_object(merged_response)
 
-            true ->
-              merged_response
-          end
+        true ->
+          merged_response
+      end
 
-        {:ok, final_response}
-
-      error ->
-        error
-    end
+    {:ok, final_response}
   end
 
   defp extract_object_from_text(response, opts) do

--- a/lib/req_llm/providers/mistral.ex
+++ b/lib/req_llm/providers/mistral.ex
@@ -255,6 +255,4 @@ defmodule ReqLLM.Providers.Mistral do
       true -> nil
     end
   end
-
-  defp option_value(_value, _key), do: nil
 end

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1371,8 +1371,6 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     end)
   end
 
-  defp encode_tool_outputs(_), do: []
-
   defp encode_tool_calls_as_function_calls(tool_calls) do
     tool_calls
     |> Enum.reject(&ReqLLM.ToolCall.builtin?/1)

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -496,8 +496,6 @@ defmodule ReqLLM.Providers.OpenRouter do
     end
   end
 
-  defp openrouter_file_media_type(_part), do: "application/pdf"
-
   @passthrough_content_metadata_keys [:cache_control, "cache_control"]
 
   defp merge_content_metadata(base, metadata) when is_map(metadata) and map_size(metadata) > 0 do

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -1295,8 +1295,6 @@ defmodule ReqLLM.Providers.XAI do
     end
   end
 
-  defp parse_json_defensively(_, _opts), do: nil
-
   defp merge_response_with_context(req, response) do
     context = req.options[:context] || %ReqLLM.Context{messages: []}
     ReqLLM.Context.merge_response(context, response)

--- a/lib/req_llm/schema.ex
+++ b/lib/req_llm/schema.ex
@@ -238,8 +238,6 @@ defmodule ReqLLM.Schema do
     module_name == "Zoi"
   end
 
-  defp zoi_schema?(_), do: false
-
   @doc false
   @spec schema_kind(any()) :: :nimble | :json | :zoi | :unknown
   defp schema_kind(schema) when is_list(schema), do: :nimble

--- a/lib/req_llm/tool_call.ex
+++ b/lib/req_llm/tool_call.ex
@@ -333,8 +333,6 @@ defmodule ReqLLM.ToolCall do
         map
       end
     end
-
-    defp maybe_put_builtin(map, _function), do: map
   end
 
   defimpl Inspect do


### PR DESCRIPTION
## Summary
- remove or narrow unreachable fallback clauses reported by Elixir 1.20
- route optional formatter callbacks through local dynamic-dispatch helpers after function_exported?/3 checks
- pin the Google JSON stream binary size now required by Elixir 1.20

## Validation
- MIX_ENV=dev mise exec elixir@1.20 erlang@29.0.1 -- mix compile --warnings-as-errors
- MIX_ENV=test mise exec elixir@1.20 erlang@29.0.1 -- mix test
- mise exec elixir@1.20 erlang@29.0.1 -- mix quality