### PR TITLE
fix(streaming): expose stream pool configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ usage = ReqLLM.StreamResponse.usage(response)
 
 - **Production-grade streaming**
   - `stream_text/3` returns a `StreamResponse` with both real-time tokens and async metadata
-  - Finch-based streaming with HTTP/2 multiplexing and automatic connection pooling
+  - Finch-based streaming with automatic connection pooling and configurable checkout timeouts
   - OpenAI Responses models can opt into WebSocket mode with `provider_options: [openai_stream_transport: :websocket]`
   - Concurrent metadata collection (usage, finish_reason) without blocking token flow
   - Works uniformly across providers with internal SSE / chunked-response adaptation
@@ -347,50 +347,63 @@ See `examples/scripts/usage_cost_search_image.exs` and run it from `examples/` w
 
 ## Streaming Configuration
 
-ReqLLM uses Finch for streaming connections with automatic connection pooling. By default, we use HTTP/1-only pools to work around a known Finch bug with large request bodies:
+ReqLLM uses Finch for streaming connections with automatic connection pooling. By default, we use HTTP/1-only pools to avoid a known Finch mixed-protocol ALPN bug with large request bodies:
 
 ```elixir
 # Default configuration (automatic)
 config :req_llm,
-  finch: [
-    name: ReqLLM.Finch,
-    pools: %{
-      :default => [protocols: [:http1], size: 1, count: 8]
-    }
-  ]
+  stream_pool_timeout: 120_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 8
 ```
 
 ### HTTP/2 Configuration (Advanced)
 
-**Important:** Due to [Finch issue #265](https://github.com/sneako/finch/issues/265), HTTP/2 pools may fail when sending request bodies larger than 64KB (large prompts, extensive context windows). This is a bug in Finch's HTTP/2 flow control implementation, not a limitation of HTTP/2 itself.
+**Important:** Due to [Finch issue #265](https://github.com/sneako/finch/issues/265), mixed HTTP/1+HTTP/2 ALPN pools may fail when sending request bodies larger than 64KB (large prompts, extensive context windows). This is a bug in Finch's mixed-protocol flow control path, not a limitation of HTTP/2 itself.
 
-If you want to use HTTP/2 pools (e.g., for performance testing or if you know your prompts are small), you can configure it:
+If you know all target providers support HTTP/2, you can configure HTTP/2-only pools:
 
 ```elixir
-# HTTP/2 configuration (use with caution)
+# HTTP/2-only configuration
 config :req_llm,
-  finch: [
-    name: ReqLLM.Finch,
-    pools: %{
-      :default => [protocols: [:http2, :http1], size: 1, count: 8]
-    }
-  ]
+  stream_pool_protocols: [:http2],
+  stream_pool_count: 8
 ```
 
-**ReqLLM will error with a helpful message if you try to send a large request body with HTTP/2 pools.** The error will reference this section for configuration guidance.
+**ReqLLM will error with a helpful message if you try to send a large request body with mixed HTTP/1+HTTP/2 pools.** The error will reference this section for configuration guidance.
 
-For high-scale deployments with small prompts, you can increase the connection count:
+Streaming responses hold a connection until completion. For high-scale deployments, tune both the Finch pool capacity and the stream checkout timeout:
 
 ```elixir
 # High-scale configuration
+# config/runtime.exs
+round_robin = Finch.Pool.Strategy.RoundRobin.new()
+
+config :req_llm,
+  stream_pool_timeout: 300_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 32,
+  stream_pool_strategy: {Finch.Pool.Strategy.RoundRobin, round_robin}
+```
+
+With the default HTTP/1 transport, concurrent streams per origin are roughly `stream_pool_size * stream_pool_count`. Prefer increasing `stream_pool_count` first when a single pool worker is under pressure; increase `stream_pool_size` when each worker should hold more concurrent HTTP/1 connections. For high worker counts, a round-robin `stream_pool_strategy` spreads stream starts more evenly than Finch's default random selection. These settings configure ReqLLM's default Finch pool; an explicit `finch: [pools: ...]` configuration takes precedence.
+
+If you need origin-specific pools, HTTP/2, connection options, or pool metrics, configure Finch directly:
+
+```elixir
+# Advanced Finch configuration
 config :req_llm,
   finch: [
     name: ReqLLM.Finch,
     pools: %{
-      :default => [protocols: [:http1], size: 1, count: 32]  # More connections
+      :default => [protocols: [:http1], size: 1, count: 32]
     }
   ]
 ```
+
+Use `pool_timeout: ...` on an individual `stream_text/3` or `stream_object/4` call when one workload needs a longer connection checkout window than the global `stream_pool_timeout` setting.
 
 Advanced users can specify custom Finch instances per request:
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -133,6 +133,11 @@ config :llm_db,
 config :req_llm,
   receive_timeout: 120_000,
   stream_receive_timeout: 120_000,
+  stream_pool_timeout: 120_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 8,
+  stream_pool_strategy: nil,
   metadata_timeout: 120_000,
   thinking_timeout: 300_000
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -351,4 +351,9 @@ config :req_llm, :test_sample_per_provider, 1
 
 config :req_llm,
   receive_timeout: 300_000,
-  stream_receive_timeout: 300_000
+  stream_receive_timeout: 300_000,
+  stream_pool_timeout: 300_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 8,
+  stream_pool_strategy: nil

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -10,6 +10,11 @@ config :req_llm,
   # HTTP timeouts (all values in milliseconds)
   receive_timeout: 120_000,          # Default response timeout
   stream_receive_timeout: 120_000,   # Streaming chunk timeout
+  stream_pool_timeout: 120_000,      # Streaming connection checkout timeout
+  stream_pool_protocols: [:http1],   # Default stream pool protocols
+  stream_pool_size: 1,               # HTTP/1 connections per stream pool worker
+  stream_pool_count: 8,              # Stream pool workers per origin
+  stream_pool_strategy: nil,         # Finch shard selection strategy
   metadata_timeout: 120_000,         # Streaming metadata collection timeout
   thinking_timeout: 300_000,         # Extended timeout for reasoning models
   image_receive_timeout: 120_000,    # Image generation timeout
@@ -56,6 +61,66 @@ Timeout between streaming chunks. If no data arrives within this window, the str
 config :req_llm, stream_receive_timeout: 120_000
 ```
 
+### `stream_pool_timeout` (when unset: inherits from `stream_receive_timeout`)
+
+Timeout for checking out a Finch connection before a streaming request starts. Increase this when short bursts of concurrent streams can queue behind long-running responses.
+
+```elixir
+config :req_llm, stream_pool_timeout: 300_000
+```
+
+Per-request override:
+
+```elixir
+ReqLLM.stream_text(model, messages, pool_timeout: 300_000)
+```
+
+### `stream_pool_protocols` (default: `[:http1]`)
+
+Protocols for ReqLLM's default Finch stream pool. Use HTTP/1 for broad provider compatibility, or HTTP/2-only when all target providers support HTTP/2.
+
+```elixir
+config :req_llm, stream_pool_protocols: [:http2]
+```
+
+Avoid mixed HTTP/1+HTTP/2 ALPN pools for large prompts. Due to a Finch flow-control issue, `[:http2, :http1]` and `[:http1, :http2]` may fail when request bodies exceed 64KB.
+
+### `stream_pool_size` (default: 1)
+
+Maximum HTTP/1 connections per stream pool worker. With the default HTTP/1 transport, concurrent streams per origin are roughly `stream_pool_size * stream_pool_count`.
+
+```elixir
+config :req_llm, stream_pool_size: 2
+```
+
+### `stream_pool_count` (default: 8)
+
+Number of stream pool workers per origin. Increase this when high concurrent streaming load produces Finch checkout queue timeouts and the downstream provider can handle more simultaneous streams.
+
+```elixir
+config :req_llm, stream_pool_count: 32
+```
+
+### `stream_pool_strategy` (default: `nil`)
+
+Finch shard selection strategy used when `stream_pool_count` is greater than 1. Finch defaults to random shard selection. Large streaming deployments can use round-robin to spread stream starts evenly across pool workers:
+
+```elixir
+# config/runtime.exs
+round_robin = Finch.Pool.Strategy.RoundRobin.new()
+
+config :req_llm,
+  stream_pool_strategy: {Finch.Pool.Strategy.RoundRobin, round_robin}
+```
+
+Per-request override:
+
+```elixir
+ReqLLM.stream_text(model, messages, pool_strategy: Finch.Pool.Strategy.Random)
+```
+
+These settings configure ReqLLM's default Finch pool. If you set `config :req_llm, finch: [pools: ...]`, that explicit Finch pool configuration takes precedence.
+
 ### `thinking_timeout` (default: 300,000ms / 5 minutes)
 
 Extended timeout for reasoning models that "think" before responding (e.g., Claude with extended thinking, OpenAI o1/o3 models, Z.AI thinking mode). These models may take several minutes to produce the first token.
@@ -93,23 +158,36 @@ config :req_llm, image_receive_timeout: 180_000
 
 ## Connection Pool Configuration
 
-ReqLLM uses Finch for HTTP connections. By default, HTTP/1-only pools are used due to a [known Finch issue with HTTP/2 and large request bodies](https://github.com/sneako/finch/issues/265).
+ReqLLM uses Finch for HTTP connections. By default, HTTP/1-only pools are used because Finch's mixed HTTP/1+HTTP/2 ALPN pools have a [known large-body flow-control issue](https://github.com/sneako/finch/issues/265).
+
+Streaming responses hold a connection until the stream completes. With the default HTTP/1 configuration, each origin can run up to `size * count` concurrent checked-out connections before new streams wait in Finch's checkout queue.
 
 ### Default Configuration
 
 ```elixir
 config :req_llm,
-  finch: [
-    name: ReqLLM.Finch,
-    pools: %{
-      :default => [protocols: [:http1], size: 1, count: 8]
-    }
-  ]
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 8
 ```
 
 ### High-Concurrency Configuration
 
 For applications making many concurrent requests:
+
+```elixir
+# config/runtime.exs
+round_robin = Finch.Pool.Strategy.RoundRobin.new()
+
+config :req_llm,
+  stream_pool_timeout: 300_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 32,
+  stream_pool_strategy: {Finch.Pool.Strategy.RoundRobin, round_robin}
+```
+
+When this is not enough or when you need origin-specific settings, replace the full Finch pool configuration:
 
 ```elixir
 config :req_llm,
@@ -121,9 +199,37 @@ config :req_llm,
   ]
 ```
 
+If you see `Finch was unable to provide a connection within the timeout due to excess queuing for connections`, tune both sides of the limit:
+
+- Raise `stream_pool_timeout` when bursty workloads can safely wait for an existing stream to finish.
+- Increase `stream_pool_count` or `stream_pool_size` when the downstream provider and your rate limits can handle more simultaneous streams.
+- Add application-level concurrency limits when provider rate limits, costs, or latency make unbounded queueing unsafe.
+
+For example, to allow roughly 32 concurrent HTTP/1 streams per provider origin:
+
+```elixir
+# config/runtime.exs
+round_robin = Finch.Pool.Strategy.RoundRobin.new()
+
+config :req_llm,
+  stream_pool_timeout: 300_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 32,
+  stream_pool_strategy: {Finch.Pool.Strategy.RoundRobin, round_robin}
+```
+
 ### HTTP/2 Configuration (Advanced)
 
-Use with caution—HTTP/2 pools may fail with request bodies larger than 64KB:
+Use HTTP/2-only when all target providers support HTTP/2:
+
+```elixir
+config :req_llm,
+  stream_pool_protocols: [:http2],
+  stream_pool_count: 8
+```
+
+Use mixed HTTP/1+HTTP/2 ALPN pools with caution. They may fail with request bodies larger than 64KB:
 
 ```elixir
 config :req_llm,
@@ -295,16 +401,15 @@ inspect(context)
 config :req_llm,
   receive_timeout: 120_000,
   stream_receive_timeout: 120_000,
+  stream_pool_timeout: 120_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 16,
+  stream_pool_strategy: nil,
   thinking_timeout: 300_000,
   metadata_timeout: 120_000,
   telemetry: [payloads: :none],
-  load_dotenv: false,  # Use proper secrets management in production
-  finch: [
-    name: ReqLLM.Finch,
-    pools: %{
-      :default => [protocols: [:http1], size: 1, count: 16]
-    }
-  ]
+  load_dotenv: false  # Use proper secrets management in production
 ```
 
 ## Example: Development Configuration

--- a/guides/streaming-migration.md
+++ b/guides/streaming-migration.md
@@ -4,9 +4,9 @@ This guide helps you migrate from the deprecated `stream_text!/3` pattern to the
 
 ## Overview
 
-ReqLLM's streaming implementation has been completely redesigned to use Finch directly instead of REQ, providing:
+ReqLLM's streaming implementation has been completely redesigned to use Finch directly instead of Req, providing:
 
-- **HTTP/2 multiplexing** for concurrent streams
+- **Configurable Finch transport** for concurrent streams
 - **Asynchronous metadata collection** (usage, finish_reason)
 - **Production-grade connection pooling**
 - **Better error handling and resource cleanup**
@@ -224,16 +224,17 @@ The new Finch-based system allows connection pool configuration:
 ```elixir
 # In config.exs
 config :req_llm,
-  finch: [
-    name: ReqLLM.Finch,
-    pools: %{
-      :default => [protocols: [:http2, :http1], size: 1, count: 16]
-    }
-  ]
+  stream_pool_timeout: 120_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 16,
+  stream_pool_strategy: nil
 
 # Use custom Finch instance per request
 {:ok, response} = ReqLLM.stream_text(model, messages, finch_name: MyApp.Finch)
 ```
+
+With the default HTTP/1 transport, concurrent streams per provider origin are roughly `stream_pool_size * stream_pool_count`. If every target provider supports HTTP/2, set `stream_pool_protocols: [:http2]`.
 
 ## Common Migration Issues
 
@@ -322,7 +323,7 @@ end
 
 The new streaming system provides significant performance improvements:
 
-1. **HTTP/2 Multiplexing**: Multiple concurrent streams over single connection
+1. **Connection Pooling**: Configurable Finch pools for concurrent streams
 2. **Reduced Memory Usage**: Lazy stream evaluation prevents buffering
 3. **Concurrent Processing**: Metadata collection doesn't block token streaming
 4. **Connection Reuse**: Finch pools reduce connection overhead
@@ -330,13 +331,15 @@ The new streaming system provides significant performance improvements:
 For high-throughput applications, consider tuning the connection pool:
 
 ```elixir
+# config/runtime.exs
+round_robin = Finch.Pool.Strategy.RoundRobin.new()
+
 config :req_llm,
-  finch: [
-    name: ReqLLM.Finch,
-    pools: %{
-      :default => [protocols: [:http2], size: 1, count: 32]
-    }
-  ]
+  stream_pool_timeout: 300_000,
+  stream_pool_protocols: [:http1],
+  stream_pool_size: 1,
+  stream_pool_count: 32,
+  stream_pool_strategy: {Finch.Pool.Strategy.RoundRobin, round_robin}
 ```
 
 ## Next Steps

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -893,7 +893,7 @@ defmodule ReqLLM do
   zero-latency content delivery while collecting billing/usage data concurrently.
 
   The streaming implementation uses Finch directly for production-grade performance
-  with HTTP/2 multiplexing and automatic connection pooling.
+  with automatic connection pooling and configurable checkout timeouts.
 
   ## Parameters
 
@@ -901,41 +901,45 @@ defmodule ReqLLM do
 
   ## Returns
 
-    * `{:ok, stream_response}` - StreamResponse with stream and metadata task
-    * `{:error, reason}` - Request failed or invalid parameters
+   * `{:ok, stream_response}` - StreamResponse with stream and metadata task
+   * `{:error, reason}` - Request failed or invalid parameters
 
   ## Examples
 
-      # Real-time streaming
-      {:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
-      response
-      |> ReqLLM.StreamResponse.tokens()
-      |> Stream.each(&IO.write/1)
-      |> Stream.run()
+     # Real-time streaming
+     {:ok, response} = ReqLLM.stream_text("anthropic:claude-3-sonnet", "Tell me a story")
+     response
+     |> ReqLLM.StreamResponse.tokens()
+     |> Stream.each(&IO.write/1)
+     |> Stream.run()
 
-      # Concurrent metadata collection
-      usage = ReqLLM.StreamResponse.usage(response)
-      #=> %{input_tokens: 15, output_tokens: 42, total_cost: 0.087}
+     # Concurrent metadata collection
+     usage = ReqLLM.StreamResponse.usage(response)
+     #=> %{input_tokens: 15, output_tokens: 42, total_cost: 0.087}
 
-      # Simple text collection
-      text = ReqLLM.StreamResponse.text(response)
+     # Simple text collection
+     text = ReqLLM.StreamResponse.text(response)
 
-      # Backward compatibility
-      {:ok, legacy_response} = ReqLLM.StreamResponse.to_response(response)
+     # Backward compatibility
+     {:ok, legacy_response} = ReqLLM.StreamResponse.to_response(response)
 
   ## StreamResponse Fields
 
-    * `stream` - Lazy enumerable of `StreamChunk` structs for real-time consumption
-    * `metadata_handle` - Concurrent handle collecting usage and finish_reason
-    * `cancel` - Function to terminate streaming and cleanup resources
-    * `model` - Model specification that generated this response
-    * `context` - Updated conversation context including assistant's response
+   * `stream` - Lazy enumerable of `StreamChunk` structs for real-time consumption
+   * `metadata_handle` - Concurrent handle collecting usage and finish_reason
+   * `cancel` - Function to terminate streaming and cleanup resources
+   * `model` - Model specification that generated this response
+   * `context` - Updated conversation context including assistant's response
 
   ## Performance Notes
 
   The stream is lazy and supports backpressure. Metadata collection happens
   concurrently and won't block token delivery. Use cancellation for early
-  termination to free resources.
+  termination to free resources. High-concurrency streaming workloads can tune
+  Finch pool protocols with `:stream_pool_protocols`, capacity with
+  `:stream_pool_size` and `:stream_pool_count`, shard selection with
+  `:stream_pool_strategy`, and checkout behavior with `:stream_pool_timeout`
+  config or per-request `pool_timeout: ...`.
 
   """
   defdelegate stream_text(model_spec, messages, opts \\ []), to: Generation

--- a/lib/req_llm/application.ex
+++ b/lib/req_llm/application.ex
@@ -1,6 +1,10 @@
 defmodule ReqLLM.Application do
   @moduledoc false
 
+  @default_stream_pool_protocols [:http1]
+  @default_stream_pool_size 1
+  @default_stream_pool_count 8
+
   # Application supervisor for ReqLLM.
 
   # Starts and supervises the Finch instance used for all HTTP operations,
@@ -54,10 +58,17 @@ defmodule ReqLLM.Application do
   Users can override pool configurations by setting:
 
       config :req_llm,
+        stream_pool_protocols: [:http1],
+        stream_pool_size: 1,
+        stream_pool_count: 16
+
+  Advanced users can replace the full Finch configuration by setting:
+
+      config :req_llm,
         finch: [
           name: ReqLLM.Finch,
           pools: %{
-            :default => [protocols: [:http2, :http1], size: 1, count: 16]
+            :default => [protocols: [:http2], size: 1, count: 16]
           }
         ]
   """
@@ -65,10 +76,12 @@ defmodule ReqLLM.Application do
   def get_finch_config do
     user_config = Application.get_env(:req_llm, :finch, [])
 
-    default_config = [
-      name: ReqLLM.Finch,
-      pools: get_default_pools()
-    ]
+    default_config =
+      if Keyword.has_key?(user_config, :pools) do
+        [name: ReqLLM.Finch]
+      else
+        [name: ReqLLM.Finch, pools: get_default_pools()]
+      end
 
     Keyword.merge(default_config, user_config)
   end
@@ -87,17 +100,56 @@ defmodule ReqLLM.Application do
   # switch providers by just changing the model spec
   defp get_default_pools do
     %{
-      # Single default pool that handles all providers efficiently
-      # HTTP/1 only to avoid Finch issue #265 (HTTP/2 flow control bug with large bodies)
-      # Once https://github.com/sneako/finch/issues/265 is fixed, we can use [:http2, :http1]
       :default => [
-        protocols: [:http1],
-        # Single persistent connection per pool
-        size: 1,
-        # 8 pools for good concurrency
-        count: 8
+        protocols: stream_pool_protocols(),
+        size: stream_pool_size(),
+        count: stream_pool_count()
       ]
     }
+  end
+
+  defp stream_pool_protocols do
+    :req_llm
+    |> Application.get_env(:stream_pool_protocols, @default_stream_pool_protocols)
+    |> validate_protocols!()
+  end
+
+  defp stream_pool_size do
+    :req_llm
+    |> Application.get_env(:stream_pool_size, @default_stream_pool_size)
+    |> validate_positive_integer!(:stream_pool_size)
+  end
+
+  defp stream_pool_count do
+    :req_llm
+    |> Application.get_env(:stream_pool_count, @default_stream_pool_count)
+    |> validate_positive_integer!(:stream_pool_count)
+  end
+
+  defp validate_positive_integer!(value, _key) when is_integer(value) and value > 0, do: value
+
+  defp validate_positive_integer!(value, key) do
+    raise ReqLLM.Error.Invalid.Parameter.exception(
+            parameter: "#{key} must be a positive integer, got: #{inspect(value)}"
+          )
+  end
+
+  defp validate_protocols!(protocols)
+       when is_list(protocols) and protocols != [] do
+    if Enum.all?(protocols, &(&1 in [:http1, :http2])) do
+      protocols
+    else
+      invalid_protocols!(protocols)
+    end
+  end
+
+  defp validate_protocols!(protocols), do: invalid_protocols!(protocols)
+
+  defp invalid_protocols!(protocols) do
+    raise ReqLLM.Error.Invalid.Parameter.exception(
+            parameter:
+              "stream_pool_protocols must be a non-empty list containing :http1 and/or :http2, got: #{inspect(protocols)}"
+          )
   end
 
   defp dev_children do

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -461,7 +461,7 @@ defmodule ReqLLM.Generation do
 
   Returns a `ReqLLM.StreamResponse` that provides both real-time structured data streaming
   and concurrent metadata collection. Uses the same Finch-based streaming infrastructure
-  as `stream_text/3` with HTTP/2 multiplexing and connection pooling.
+  as `stream_text/3` with connection pooling and configurable checkout timeouts.
 
   ## Parameters
 

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -270,22 +270,22 @@ defmodule ReqLLM.Streaming do
     size_kb = div(body_size, 1024)
 
     """
-    Request body (#{size_kb}KB) exceeds safe limit for HTTP/2 connections (64KB).
+    Request body (#{size_kb}KB) exceeds safe limit for mixed HTTP/1+HTTP/2 Finch pools (64KB).
 
-    This is due to a known issue in Finch's HTTP/2 implementation:
+    This is due to a known issue in Finch's mixed-protocol ALPN implementation:
     https://github.com/sneako/finch/issues/265
 
     Your current pool configuration uses: #{inspect(protocols)}
 
-    To fix this, configure ReqLLM to use HTTP/1-only pools (recommended):
+    To fix this, configure ReqLLM to use HTTP/1-only pools (recommended default):
 
         config :req_llm,
-          finch: [
-            name: ReqLLM.Finch,
-            pools: %{
-              :default => [protocols: [:http1], size: 1, count: 8]
-            }
-          ]
+          stream_pool_protocols: [:http1]
+
+    If you know all target providers support HTTP/2, HTTP/2-only pools are also supported:
+
+        config :req_llm,
+          stream_pool_protocols: [:http2]
 
     See the ReqLLM README section "HTTP/2 Configuration (Advanced)" for more details:
     https://github.com/agentjido/req_llm#http2-configuration-advanced

--- a/lib/req_llm/streaming/finch_client.ex
+++ b/lib/req_llm/streaming/finch_client.ex
@@ -158,6 +158,11 @@ defmodule ReqLLM.Streaming.FinchClient do
          _fixture_path,
          opts
        ) do
+    stream_opts =
+      finch_request
+      |> Fixtures.canonical_json_from_finch_request()
+      |> stream_options(opts)
+
     task_pid =
       Task.Supervisor.async(ReqLLM.TaskSupervisor, fn ->
         finch_stream_callback = fn
@@ -178,29 +183,13 @@ defmodule ReqLLM.Streaming.FinchClient do
             acc
         end
 
-        canonical = Fixtures.canonical_json_from_finch_request(finch_request)
-
-        default_timeout =
-          if has_thinking_enabled?(canonical) do
-            Application.get_env(:req_llm, :thinking_timeout, 300_000)
-          else
-            Application.get_env(
-              :req_llm,
-              :stream_receive_timeout,
-              Application.get_env(:req_llm, :receive_timeout, 30_000)
-            )
-          end
-
-        receive_timeout = Keyword.get(opts, :receive_timeout, default_timeout)
-
         try do
           case Retry.stream(
                  finch_request,
                  finch_name,
                  :ok,
                  finch_stream_callback,
-                 receive_timeout: receive_timeout,
-                 max_retries: Keyword.get(opts, :max_retries, 3)
+                 stream_opts
                ) do
             {:ok, _} ->
               :ok
@@ -231,6 +220,21 @@ defmodule ReqLLM.Streaming.FinchClient do
     error ->
       Logger.error("Failed to start streaming task: #{inspect(error)}")
       {:error, {:task_start_failed, error}}
+  end
+
+  @doc false
+  @spec stream_options(map(), keyword()) :: keyword()
+  def stream_options(canonical, opts) do
+    receive_timeout = Keyword.get(opts, :receive_timeout, default_receive_timeout(canonical))
+    pool_timeout = Keyword.get(opts, :pool_timeout, default_pool_timeout(receive_timeout))
+
+    [
+      pool_timeout: validate_timeout!(pool_timeout, :pool_timeout),
+      receive_timeout: receive_timeout,
+      max_retries: Keyword.get(opts, :max_retries, 3)
+    ]
+    |> maybe_put_option(:request_timeout, Keyword.get(opts, :request_timeout))
+    |> maybe_put_option(:pool_strategy, pool_strategy(opts))
   end
 
   # Apply config-level adapter then per-request callback, in that order.
@@ -276,6 +280,39 @@ defmodule ReqLLM.Streaming.FinchClient do
     end
   end
 
+  defp default_receive_timeout(canonical) do
+    if has_thinking_enabled?(canonical) do
+      Application.get_env(:req_llm, :thinking_timeout, 300_000)
+    else
+      Application.get_env(
+        :req_llm,
+        :stream_receive_timeout,
+        Application.get_env(:req_llm, :receive_timeout, 30_000)
+      )
+    end
+  end
+
+  defp default_pool_timeout(receive_timeout) do
+    case Application.get_env(:req_llm, :stream_pool_timeout) do
+      nil -> receive_timeout
+      timeout -> timeout
+    end
+  end
+
+  defp validate_timeout!(:infinity, _key), do: :infinity
+
+  defp validate_timeout!(timeout, _key) when is_integer(timeout) and timeout >= 0, do: timeout
+
+  defp validate_timeout!(timeout, key) do
+    raise ReqLLM.Error.Invalid.Parameter.exception(
+            parameter:
+              "#{key} must be a non-negative integer or :infinity, got: #{inspect(timeout)}"
+          )
+  end
+
+  defp maybe_put_option(opts, _key, nil), do: opts
+  defp maybe_put_option(opts, key, value), do: Keyword.put(opts, key, value)
+
   defp safe_http_event(server, event) do
     StreamServer.http_event(server, event)
   catch
@@ -292,9 +329,9 @@ defmodule ReqLLM.Streaming.FinchClient do
 
     # Only check if body is potentially problematic (>64KB threshold from Finch #265)
     if body_size > 65_535 do
-      case get_pool_protocols(finch_name) do
+      case get_pool_protocols(finch_request, finch_name) do
         {:ok, protocols} ->
-          if :http2 in protocols do
+          if mixed_http2_protocols?(protocols) do
             {:error, {:http2_body_too_large, body_size, protocols}}
           else
             :ok
@@ -309,19 +346,80 @@ defmodule ReqLLM.Streaming.FinchClient do
     end
   end
 
-  # Get the protocols configured for the Finch pool
-  defp get_pool_protocols(_finch_name) do
-    # Get Finch configuration from application env
-    finch_config = Application.get_env(:req_llm, :finch, [])
+  defp mixed_http2_protocols?(protocols) do
+    :http1 in protocols and :http2 in protocols
+  end
+
+  defp get_pool_protocols(finch_request, finch_name) do
+    finch_config = ReqLLM.Application.get_finch_config()
+    configured_name = Keyword.get(finch_config, :name, ReqLLM.Finch)
     pools = Keyword.get(finch_config, :pools, %{})
 
-    # Get default pool config
-    case Map.get(pools, :default) do
-      nil -> {:error, :no_pool_config}
-      pool_config -> {:ok, Keyword.get(pool_config, :protocols, [:http1])}
+    cond do
+      configured_name != finch_name ->
+        {:error, :unknown_finch_config}
+
+      is_map(pools) ->
+        case matching_pool_config(pools, finch_request) do
+          nil -> {:error, :no_pool_config}
+          pool_config -> {:ok, pool_protocols(pool_config)}
+        end
+
+      true ->
+        {:error, :no_pool_config}
     end
   rescue
     _ -> {:error, :config_error}
+  end
+
+  defp matching_pool_config(pools, finch_request) do
+    request_pool = request_pool(finch_request)
+
+    Enum.find_value(pools, fn
+      {:default, _pool_config} ->
+        nil
+
+      {destination, pool_config} ->
+        if pool_matches?(destination, request_pool), do: pool_config
+    end) || Map.get(pools, :default)
+  end
+
+  defp request_pool(%Finch.Request{scheme: scheme, unix_socket: unix_socket, pool_tag: tag})
+       when is_binary(unix_socket) do
+    Finch.Pool.from_name({scheme, {:local, unix_socket}, 0, tag})
+  end
+
+  defp request_pool(%Finch.Request{scheme: scheme, host: host, port: port, pool_tag: tag}) do
+    Finch.Pool.from_name({scheme, host, port, tag})
+  end
+
+  defp pool_matches?(%Finch.Pool{} = destination, request_pool), do: destination == request_pool
+
+  defp pool_matches?(destination, request_pool) when is_binary(destination) do
+    Finch.Pool.new(destination) == request_pool
+  rescue
+    _ -> false
+  end
+
+  defp pool_matches?({scheme, {:local, path}}, request_pool)
+       when is_atom(scheme) and is_binary(path) do
+    Finch.Pool.new({scheme, {:local, path}}) == request_pool
+  end
+
+  defp pool_matches?(_destination, _request_pool), do: false
+
+  defp pool_protocols(pool_config) when is_list(pool_config) do
+    Keyword.get(pool_config, :protocols, [:http1])
+  end
+
+  defp pool_protocols(pool_config) when is_map(pool_config) do
+    Map.get(pool_config, :protocols, [:http1])
+  end
+
+  defp pool_protocols(_pool_config), do: [:http1]
+
+  defp pool_strategy(opts) do
+    Keyword.get(opts, :pool_strategy, Application.get_env(:req_llm, :stream_pool_strategy))
   end
 
   defp request_body_size(nil), do: 0

--- a/lib/req_llm/streaming/retry.ex
+++ b/lib/req_llm/streaming/retry.ex
@@ -29,7 +29,9 @@ defmodule ReqLLM.Streaming.Retry do
         ) :: {:ok, callback_acc()} | {:error, term(), callback_acc()}
   def stream(request, finch_name, acc, callback, opts, stream_fun \\ &Finch.stream/5) do
     max_retries = Keyword.get(opts, :max_retries, 3)
-    stream_opts = Keyword.take(opts, [:receive_timeout])
+
+    stream_opts =
+      Keyword.take(opts, [:pool_timeout, :receive_timeout, :request_timeout, :pool_strategy])
 
     do_stream(
       %{
@@ -153,6 +155,8 @@ defmodule ReqLLM.Streaming.Retry do
   defp classify_error(%Req.TransportError{reason: reason}, _state)
        when reason in @retryable_reasons,
        do: {:retry, 0}
+
+  defp classify_error(%Finch.Error{reason: :pool_not_available}, _state), do: {:retry, 250}
 
   defp classify_error(_reason, %{status: 429} = state) do
     {:retry, extract_retry_after_delay(state.headers)}

--- a/test/req_llm/application_test.exs
+++ b/test/req_llm/application_test.exs
@@ -6,12 +6,20 @@ defmodule ReqLLM.ApplicationTest do
   setup do
     original_req_llm_load_dotenv = Application.get_env(:req_llm, :load_dotenv)
     original_llm_db_load_dotenv = Application.get_env(:llm_db, :load_dotenv)
+    original_finch = Application.get_env(:req_llm, :finch)
+    original_stream_pool_protocols = Application.get_env(:req_llm, :stream_pool_protocols)
+    original_stream_pool_size = Application.get_env(:req_llm, :stream_pool_size)
+    original_stream_pool_count = Application.get_env(:req_llm, :stream_pool_count)
 
     on_exit(fn ->
       stop_app(:req_llm)
       stop_app(:llm_db)
       restore_app_env(:req_llm, :load_dotenv, original_req_llm_load_dotenv)
       restore_app_env(:llm_db, :load_dotenv, original_llm_db_load_dotenv)
+      restore_app_env(:req_llm, :finch, original_finch)
+      restore_app_env(:req_llm, :stream_pool_protocols, original_stream_pool_protocols)
+      restore_app_env(:req_llm, :stream_pool_size, original_stream_pool_size)
+      restore_app_env(:req_llm, :stream_pool_count, original_stream_pool_count)
       System.delete_env(@dotenv_key)
       Application.ensure_all_started(:llm_db)
       LLMDB.load(custom: Application.get_env(:llm_db, :custom, %{}))
@@ -27,6 +35,58 @@ defmodule ReqLLM.ApplicationTest do
 
       assert Keyword.get(config, :name) == ReqLLM.Finch
       assert is_map(Keyword.get(config, :pools))
+    end
+
+    test "get_finch_config/0 uses stream pool sizing configuration" do
+      Application.delete_env(:req_llm, :finch)
+      Application.put_env(:req_llm, :stream_pool_protocols, [:http2])
+      Application.put_env(:req_llm, :stream_pool_size, 2)
+      Application.put_env(:req_llm, :stream_pool_count, 16)
+
+      pool_config =
+        ReqLLM.Application.get_finch_config()
+        |> Keyword.fetch!(:pools)
+        |> Map.fetch!(:default)
+
+      assert pool_config[:protocols] == [:http2]
+      assert pool_config[:size] == 2
+      assert pool_config[:count] == 16
+    end
+
+    test "get_finch_config/0 lets explicit Finch pools override stream pool sizing" do
+      pools = %{:default => [protocols: [:http1], size: 4, count: 6]}
+
+      Application.put_env(:req_llm, :stream_pool_size, 0)
+      Application.put_env(:req_llm, :stream_pool_count, "many")
+      Application.put_env(:req_llm, :stream_pool_protocols, [:bad])
+      Application.put_env(:req_llm, :finch, name: ReqLLM.Finch, pools: pools)
+
+      config = ReqLLM.Application.get_finch_config()
+
+      assert Keyword.fetch!(config, :pools) == pools
+    end
+
+    test "get_finch_config/0 rejects invalid stream pool sizing" do
+      Application.delete_env(:req_llm, :finch)
+      Application.put_env(:req_llm, :stream_pool_size, 0)
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, ~r/stream_pool_size/, fn ->
+        ReqLLM.Application.get_finch_config()
+      end
+
+      Application.put_env(:req_llm, :stream_pool_size, 1)
+      Application.put_env(:req_llm, :stream_pool_count, "many")
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, ~r/stream_pool_count/, fn ->
+        ReqLLM.Application.get_finch_config()
+      end
+
+      Application.put_env(:req_llm, :stream_pool_count, 8)
+      Application.put_env(:req_llm, :stream_pool_protocols, [:http3])
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, ~r/stream_pool_protocols/, fn ->
+        ReqLLM.Application.get_finch_config()
+      end
     end
 
     test "finch_name/0 returns default name" do

--- a/test/req_llm/streaming/finch_client_test.exs
+++ b/test/req_llm/streaming/finch_client_test.exs
@@ -28,6 +28,8 @@ defmodule ReqLLM.Streaming.FinchClientTest do
   setup do
     adapter_config = Application.get_env(:req_llm, :finch_request_adapter)
     finch_config = Application.get_env(:req_llm, :finch)
+    stream_pool_timeout_config = Application.get_env(:req_llm, :stream_pool_timeout)
+    stream_pool_strategy_config = Application.get_env(:req_llm, :stream_pool_strategy)
     fixtures_mode = System.get_env("REQ_LLM_FIXTURES_MODE")
     openai_api_key = System.get_env("OPENAI_API_KEY")
 
@@ -37,11 +39,78 @@ defmodule ReqLLM.Streaming.FinchClientTest do
     on_exit(fn ->
       restore_app_env(:finch_request_adapter, adapter_config)
       restore_app_env(:finch, finch_config)
+      restore_app_env(:stream_pool_timeout, stream_pool_timeout_config)
+      restore_app_env(:stream_pool_strategy, stream_pool_strategy_config)
       restore_system_env("REQ_LLM_FIXTURES_MODE", fixtures_mode)
       restore_system_env("OPENAI_API_KEY", openai_api_key)
     end)
 
     :ok
+  end
+
+  describe "stream_options/2" do
+    test "defaults pool_timeout to receive_timeout when no global pool timeout is configured" do
+      Application.delete_env(:req_llm, :stream_pool_timeout)
+
+      opts = FinchClient.stream_options(%{}, receive_timeout: 42_000)
+
+      assert opts[:receive_timeout] == 42_000
+      assert opts[:pool_timeout] == 42_000
+    end
+
+    test "uses stream_pool_timeout config when request pool_timeout is not provided" do
+      Application.put_env(:req_llm, :stream_pool_timeout, 180_000)
+
+      opts = FinchClient.stream_options(%{}, receive_timeout: 42_000)
+
+      assert opts[:receive_timeout] == 42_000
+      assert opts[:pool_timeout] == 180_000
+    end
+
+    test "lets per-request pool_timeout override global stream_pool_timeout" do
+      Application.put_env(:req_llm, :stream_pool_timeout, 180_000)
+
+      opts = FinchClient.stream_options(%{}, receive_timeout: 42_000, pool_timeout: 5_000)
+
+      assert opts[:receive_timeout] == 42_000
+      assert opts[:pool_timeout] == 5_000
+    end
+
+    test "uses thinking timeout for streams that enable thinking" do
+      expected = Application.get_env(:req_llm, :thinking_timeout, 300_000)
+
+      opts = FinchClient.stream_options(%{"thinking" => %{"type" => "enabled"}}, [])
+
+      assert opts[:receive_timeout] == expected
+    end
+
+    test "uses stream_pool_strategy config when request pool_strategy is not provided" do
+      Application.put_env(:req_llm, :stream_pool_strategy, Finch.Pool.Strategy.Random)
+
+      opts = FinchClient.stream_options(%{}, receive_timeout: 42_000)
+
+      assert opts[:pool_strategy] == Finch.Pool.Strategy.Random
+    end
+
+    test "lets per-request pool_strategy override global stream_pool_strategy" do
+      Application.put_env(:req_llm, :stream_pool_strategy, Finch.Pool.Strategy.Random)
+
+      opts =
+        FinchClient.stream_options(%{},
+          receive_timeout: 42_000,
+          pool_strategy: Finch.Pool.Strategy.RoundRobin
+        )
+
+      assert opts[:pool_strategy] == Finch.Pool.Strategy.RoundRobin
+    end
+
+    test "rejects invalid configured pool_timeout values" do
+      Application.put_env(:req_llm, :stream_pool_timeout, "bad")
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+        FinchClient.stream_options(%{}, receive_timeout: 42_000)
+      end
+    end
   end
 
   defp restore_app_env(key, nil), do: Application.delete_env(:req_llm, key)

--- a/test/req_llm/streaming/http2_error_message_test.exs
+++ b/test/req_llm/streaming/http2_error_message_test.exs
@@ -19,10 +19,11 @@ defmodule ReqLLM.Streaming.HTTP2ErrorMessageTest do
 
           assert {:error, {:http2_body_too_large, message}} = result
           assert message =~ "Request body"
-          assert message =~ "exceeds safe limit for HTTP/2 connections (64KB)"
+          assert message =~ "exceeds safe limit for mixed HTTP/1+HTTP/2 Finch pools (64KB)"
           assert message =~ "https://github.com/sneako/finch/issues/265"
           assert message =~ "config :req_llm"
-          assert message =~ "protocols: [:http1]"
+          assert message =~ "stream_pool_protocols: [:http1]"
+          assert message =~ "stream_pool_protocols: [:http2]"
           assert message =~ "README"
         end)
 

--- a/test/req_llm/streaming/http2_validation_test.exs
+++ b/test/req_llm/streaming/http2_validation_test.exs
@@ -4,6 +4,9 @@ defmodule ReqLLM.Streaming.HTTP2ValidationTest do
   alias ReqLLM.Context
   alias ReqLLM.Streaming.FinchClient
 
+  @pool_match_base_url "https://pool-match.example.com/v1"
+  @pool_match_origin "https://pool-match.example.com"
+
   describe "HTTP/2 body size validation" do
     test "allows small request bodies with HTTP/2 pools" do
       configure_http2_pools!()
@@ -17,7 +20,19 @@ defmodule ReqLLM.Streaming.HTTP2ValidationTest do
       assert {:ok, _task_pid, _http_context, _canonical_json} = result
     end
 
-    test "blocks large request bodies (>64KB) with HTTP/2 pools" do
+    test "allows large request bodies (>64KB) with HTTP/2-only pools" do
+      configure_http2_only_pools!()
+
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      large_prompt = String.duplicate("This is a large prompt. ", 3000)
+      {:ok, context} = Context.normalize(large_prompt)
+
+      result = start_mock_stream(model, context)
+
+      assert {:ok, _task_pid, _http_context, _canonical_json} = result
+    end
+
+    test "blocks large request bodies (>64KB) with mixed HTTP/1 and HTTP/2 pools" do
       configure_http2_pools!()
 
       {:ok, model} = ReqLLM.model("openai:gpt-4o")
@@ -31,6 +46,61 @@ defmodule ReqLLM.Streaming.HTTP2ValidationTest do
 
       assert body_size > 65_535
       assert :http2 in protocols
+    end
+
+    test "blocks large request bodies with mixed protocol origin-specific Finch pool" do
+      configure_pools!(%{
+        :default => [protocols: [:http1], size: 1, count: 8],
+        Finch.Pool.new(@pool_match_origin) => [
+          protocols: [:http2, :http1],
+          size: 1,
+          count: 8
+        ]
+      })
+
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      large_prompt = String.duplicate("This is a large prompt. ", 3000)
+      {:ok, context} = Context.normalize(large_prompt)
+
+      result = start_mock_stream(model, context, base_url: @pool_match_base_url)
+
+      assert {:error, {:provider_build_failed, {:http2_body_too_large, _body_size, protocols}}} =
+               result
+
+      assert protocols == [:http2, :http1]
+    end
+
+    test "blocks large request bodies with mixed protocol URL string Finch pool" do
+      configure_pools!(%{
+        :default => [protocols: [:http1], size: 1, count: 8],
+        @pool_match_origin => [protocols: [:http1, :http2], size: 1, count: 8]
+      })
+
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      large_prompt = String.duplicate("This is a large prompt. ", 3000)
+      {:ok, context} = Context.normalize(large_prompt)
+
+      result = start_mock_stream(model, context, base_url: @pool_match_base_url)
+
+      assert {:error, {:provider_build_failed, {:http2_body_too_large, _body_size, protocols}}} =
+               result
+
+      assert protocols == [:http1, :http2]
+    end
+
+    test "allows large request bodies when origin-specific pool is HTTP/2-only" do
+      configure_pools!(%{
+        :default => [protocols: [:http2, :http1], size: 1, count: 8],
+        Finch.Pool.new(@pool_match_origin) => [protocols: [:http2], size: 1, count: 8]
+      })
+
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      large_prompt = String.duplicate("This is a large prompt. ", 3000)
+      {:ok, context} = Context.normalize(large_prompt)
+
+      result = start_mock_stream(model, context, base_url: @pool_match_base_url)
+
+      assert {:ok, _task_pid, _http_context, _canonical_json} = result
     end
 
     test "allows large request bodies with HTTP/1-only pools (default)" do
@@ -73,14 +143,14 @@ defmodule ReqLLM.Streaming.HTTP2ValidationTest do
     end
   end
 
-  defp start_mock_stream(model, context) do
+  defp start_mock_stream(model, context, opts \\ []) do
     {:ok, stream_server} = MockStreamServer.start_link()
 
     FinchClient.start_stream(
       ReqLLM.Providers.OpenAI,
       model,
       context,
-      [],
+      opts,
       stream_server
     )
   end

--- a/test/req_llm/streaming/retry_test.exs
+++ b/test/req_llm/streaming/retry_test.exs
@@ -3,6 +3,38 @@ defmodule ReqLLM.Streaming.RetryTest do
 
   alias ReqLLM.Streaming.Retry
 
+  test "passes Finch checkout options through to the stream transport" do
+    parent = self()
+
+    stream_fun = fn _request, _finch_name, acc, callback, opts ->
+      send(parent, {:stream_opts, opts})
+      acc = callback.(:done, acc)
+      {:ok, acc}
+    end
+
+    assert {:ok, []} =
+             Retry.stream(
+               Finch.build(:post, "https://example.com/stream"),
+               ReqLLM.Finch,
+               [],
+               fn _event, acc -> acc end,
+               [
+                 max_retries: 0,
+                 pool_timeout: 30_000,
+                 pool_strategy: :random,
+                 receive_timeout: 1_000,
+                 request_timeout: 60_000
+               ],
+               stream_fun
+             )
+
+    assert_receive {:stream_opts, opts}
+    assert opts[:pool_timeout] == 30_000
+    assert opts[:pool_strategy] == :random
+    assert opts[:receive_timeout] == 1_000
+    assert opts[:request_timeout] == 60_000
+  end
+
   test "retries transient transport errors before any data is received" do
     {:ok, counter} = Agent.start_link(fn -> 0 end)
 
@@ -42,6 +74,39 @@ defmodule ReqLLM.Streaming.RetryTest do
              {:data, "hello"},
              :done
            ]
+  end
+
+  test "retries Finch pool readiness errors before any data is received" do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    stream_fun = fn _request, _finch_name, acc, callback, _opts ->
+      attempt = Agent.get_and_update(counter, fn current -> {current + 1, current + 1} end)
+
+      case attempt do
+        1 ->
+          {:error, %Finch.Error{reason: :pool_not_available}, acc}
+
+        2 ->
+          acc = callback.({:status, 200}, acc)
+          acc = callback.(:done, acc)
+          {:ok, acc}
+      end
+    end
+
+    callback = fn event, acc -> [event | acc] end
+
+    assert {:ok, events} =
+             Retry.stream(
+               Finch.build(:post, "https://example.com/stream"),
+               ReqLLM.Finch,
+               [],
+               callback,
+               [max_retries: 1, receive_timeout: 1_000],
+               stream_fun
+             )
+
+    assert Agent.get(counter, & &1) == 2
+    assert Enum.reverse(events) == [{:status, 200}, :done]
   end
 
   test "does not retry transient transport errors after data has been received" do

--- a/test/support/streaming_case.ex
+++ b/test/support/streaming_case.ex
@@ -52,14 +52,18 @@ defmodule ReqLLM.StreamingCase do
   end
 
   @doc """
-  Configure Finch pools with custom protocol list.
+  Configure Finch pools with a custom protocol list or pool map.
   """
   def configure_pools!(protocols) when is_list(protocols) do
+    configure_pools!(%{
+      default: [protocols: protocols, size: 1, count: 8]
+    })
+  end
+
+  def configure_pools!(pools) when is_map(pools) do
     Application.put_env(:req_llm, :finch,
       name: ReqLLM.Finch,
-      pools: %{
-        default: [protocols: protocols, size: 1, count: 8]
-      }
+      pools: pools
     )
   end
 
@@ -68,6 +72,13 @@ defmodule ReqLLM.StreamingCase do
   """
   def configure_http2_pools! do
     configure_pools!([:http2, :http1])
+  end
+
+  @doc """
+  Configure Finch pools to use HTTP/2 only.
+  """
+  def configure_http2_only_pools! do
+    configure_pools!([:http2])
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- expose ReqLLM-level stream pool configuration for checkout timeout, protocols, size, count, and shard selection strategy
- pass Finch checkout/request options through the streaming retry transport
- preserve HTTP/2-only support while blocking only Finch's mixed HTTP/1+HTTP/2 ALPN large-body failure mode
- match the actual request origin when validating origin-specific Finch pool protocol settings
- retry transient Finch `:pool_not_available` readiness errors before any stream data is emitted
- document high-concurrency tuning, HTTP/2-only opt-in, mixed-protocol caveats, and direct Finch pool configuration

## Root Cause
The reported error comes from Finch connection checkout queueing. Streaming responses hold a checked-out connection until completion. With the existing HTTP/1 default pool (`size: 1`, `count: 8`), bursts beyond roughly `size * count` concurrent streams per origin wait in Finch's checkout queue. The previous streaming path passed only `receive_timeout` to `Finch.stream/5`, so connection checkout still used Finch's default `pool_timeout` and could fail before a long-running stream returned a connection.

## HTTP/2 Investigation
This PR did not introduce the HTTP/1 default. `origin/main` already defaulted to HTTP/1-only pools from #113 as a workaround for Finch issue #265.

The Finch bug affects mixed HTTP/1+HTTP/2 ALPN pools (`[:http2, :http1]` or `[:http1, :http2]`) with request bodies over 64KB. HTTP/2-only pools are not blocked. The hardening pass now validates the protocol list for the pool that will actually serve the request, including origin-specific `%Finch.Pool{}` and URL string pool keys, before falling back to `:default`.

Users can opt into HTTP/2-only streams directly with:

```elixir
config :req_llm,
  stream_pool_protocols: [:http2],
  stream_pool_count: 8
```

For broad provider compatibility, the default remains `[:http1]`. For high concurrency with the default HTTP/1 transport, users can tune:

```elixir
# config/runtime.exs
round_robin = Finch.Pool.Strategy.RoundRobin.new()

config :req_llm,
  stream_pool_timeout: 300_000,
  stream_pool_protocols: [:http1],
  stream_pool_size: 1,
  stream_pool_count: 32,
  stream_pool_strategy: {Finch.Pool.Strategy.RoundRobin, round_robin}
```

## Validation
- `mix test test/req_llm/application_test.exs test/req_llm/streaming/finch_client_test.exs test/req_llm/streaming/http2_validation_test.exs test/req_llm/streaming/http2_error_message_test.exs test/req_llm/streaming/retry_test.exs`
- `mix test test/req_llm/streaming test/req_llm/application_test.exs`
- `mix test`
- `mix quality`
- `mix format --check-formatted`
- `git diff --check`