### PR TITLE
fix(google): disable thought summaries for object generation

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1251,7 +1251,8 @@ defmodule ReqLLM.Providers.Google do
       |> maybe_put(:topK, request.options[:top_k])
       |> maybe_add_thinking_config(
         request.options[:google_thinking_budget],
-        request.options[:google_thinking_level]
+        request.options[:google_thinking_level],
+        false
       )
       |> put_schema_for_model(model_name, compiled_schema)
 
@@ -1704,7 +1705,7 @@ defmodule ReqLLM.Providers.Google do
 
   defp extract_grounding_metadata(_), do: nil
 
-  defp maybe_add_thinking_config(config, budget, level) do
+  defp maybe_add_thinking_config(config, budget, level, include_thoughts \\ true) do
     case {budget, level} do
       {b, l} when not is_nil(b) and not is_nil(l) ->
         raise ArgumentError,
@@ -1717,12 +1718,15 @@ defmodule ReqLLM.Providers.Google do
         Map.put(config, :thinkingConfig, %{thinkingBudget: 0})
 
       {budget, nil} when is_integer(budget) and budget > 0 ->
-        Map.put(config, :thinkingConfig, %{thinkingBudget: budget, includeThoughts: true})
+        Map.put(config, :thinkingConfig, %{
+          thinkingBudget: budget,
+          includeThoughts: include_thoughts
+        })
 
       {nil, level} ->
         Map.put(config, :thinkingConfig, %{
           thinkingLevel: to_string(level),
-          includeThoughts: true
+          includeThoughts: include_thoughts
         })
     end
   end

--- a/priv/model_compat_scenarios.json
+++ b/priv/model_compat_scenarios.json
@@ -8656,7 +8656,7 @@
         "fixtures": [
           "object_basic"
         ],
-        "last_checked": "2026-05-29T22:24:48Z",
+        "last_checked": "2026-06-10T21:03:14Z",
         "mode": "record",
         "status": "pass"
       },

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1875,6 +1875,30 @@ defmodule ReqLLM.Providers.GoogleTest do
       refute Map.has_key?(decoded, "toolConfig")
     end
 
+    test "encode_object_body disables thought summaries when thinking is enabled" do
+      {:ok, model} = ReqLLM.model("google:gemini-3-flash")
+      context = context_fixture()
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          operation: :object,
+          compiled_schema: schema,
+          google_thinking_level: :low,
+          provider_options: [google_api_version: "v1beta"]
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      thinking_config = decoded["generationConfig"]["thinkingConfig"]
+      assert thinking_config["thinkingLevel"] == "low"
+      assert thinking_config["includeThoughts"] == false
+    end
+
     test "encode_object_body uses responseSchema for non-2.5 models" do
       context = context_fixture()
 

--- a/test/support/fixtures/google/gemini_3_5_flash/object_basic.json
+++ b/test/support/fixtures/google/gemini_3_5_flash/object_basic.json
@@ -3,7 +3,7 @@
   "provider": "google",
   "request": {
     "body": {
-      "b64": "eyJjb250ZW50cyI6W3sicGFydHMiOlt7InRleHQiOiJHZW5lcmF0ZSBhIHNvZnR3YXJlIGVuZ2luZWVyIHByb2ZpbGUifV0sInJvbGUiOiJ1c2VyIn1dLCJnZW5lcmF0aW9uQ29uZmlnIjp7ImNhbmRpZGF0ZUNvdW50IjoxLCJtYXhPdXRwdXRUb2tlbnMiOjUwMCwicmVzcG9uc2VKc29uU2NoZW1hIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicHJvcGVydGllcyI6eyJhZ2UiOnsiZGVzY3JpcHRpb24iOiJQZXJzb24ncyBhZ2UgaW4geWVhcnMiLCJtaW5pbXVtIjoxLCJ0eXBlIjoiaW50ZWdlciJ9LCJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiUGVyc29uJ3MgZnVsbCBuYW1lIiwidHlwZSI6InN0cmluZyJ9LCJvY2N1cGF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiUGVyc29uJ3Mgam9iIG9yIHByb2Zlc3Npb24iLCJ0eXBlIjoic3RyaW5nIn19LCJwcm9wZXJ0eU9yZGVyaW5nIjpbIm5hbWUiLCJhZ2UiLCJvY2N1cGF0aW9uIl0sInJlcXVpcmVkIjpbIm5hbWUiLCJhZ2UiXSwidHlwZSI6Im9iamVjdCJ9LCJyZXNwb25zZU1pbWVUeXBlIjoiYXBwbGljYXRpb24vanNvbiIsInRlbXBlcmF0dXJlIjowLjAsInRoaW5raW5nQ29uZmlnIjp7ImluY2x1ZGVUaG91Z2h0cyI6dHJ1ZSwidGhpbmtpbmdMZXZlbCI6ImxvdyJ9fX0="
+      "b64": "eyJjb250ZW50cyI6W3sicGFydHMiOlt7InRleHQiOiJHZW5lcmF0ZSBhIHNvZnR3YXJlIGVuZ2luZWVyIHByb2ZpbGUifV0sInJvbGUiOiJ1c2VyIn1dLCJnZW5lcmF0aW9uQ29uZmlnIjp7ImNhbmRpZGF0ZUNvdW50IjoxLCJtYXhPdXRwdXRUb2tlbnMiOjUwMCwicmVzcG9uc2VKc29uU2NoZW1hIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicHJvcGVydGllcyI6eyJhZ2UiOnsiZGVzY3JpcHRpb24iOiJQZXJzb24ncyBhZ2UgaW4geWVhcnMiLCJtaW5pbXVtIjoxLCJ0eXBlIjoiaW50ZWdlciJ9LCJuYW1lIjp7ImRlc2NyaXB0aW9uIjoiUGVyc29uJ3MgZnVsbCBuYW1lIiwidHlwZSI6InN0cmluZyJ9LCJvY2N1cGF0aW9uIjp7ImRlc2NyaXB0aW9uIjoiUGVyc29uJ3Mgam9iIG9yIHByb2Zlc3Npb24iLCJ0eXBlIjoic3RyaW5nIn19LCJwcm9wZXJ0eU9yZGVyaW5nIjpbIm5hbWUiLCJhZ2UiLCJvY2N1cGF0aW9uIl0sInJlcXVpcmVkIjpbIm5hbWUiLCJhZ2UiXSwidHlwZSI6Im9iamVjdCJ9LCJyZXNwb25zZU1pbWVUeXBlIjoiYXBwbGljYXRpb24vanNvbiIsInRlbXBlcmF0dXJlIjowLjAsInRoaW5raW5nQ29uZmlnIjp7ImluY2x1ZGVUaG91Z2h0cyI6ZmFsc2UsInRoaW5raW5nTGV2ZWwiOiJsb3cifX19"
     },
     "canonical_json": {
       "contents": [
@@ -50,7 +50,7 @@
         "responseMimeType": "application/json",
         "temperature": 0.0,
         "thinkingConfig": {
-          "includeThoughts": true,
+          "includeThoughts": false,
           "thinkingLevel": "low"
         }
       }
@@ -79,12 +79,8 @@
           "content": {
             "parts": [
               {
-                "text": "**My Thought Process: Crafting a Software Engineer Profile**\n\nOkay, the user wants a \"software engineer profile.\" Right, I understand the goal. My mind immediately kicks into gear, breaking down the request and formulating a plan.\n\nFirst, I need to understand what's *required*. I internally reference the implicit schema. There's a `name` which is a string and absolutely mandatory. Then there's an `age`, which has to be an integer, and importantly, it needs to be greater than or equal to 1. Finally, there's `occupation`, which is technically optional, but for a \"software engineer\" profile, it’s absolutely critical – almost a given.\n\nNow, it's time to generate some data. I'll make this up, but it's important to be realistic. Let’s go with \"Jane Doe\" for the name. For age, let's keep it around the experience level, I'll set it to 29. And, of course, the occupation is \"Software Engineer\".\n\nThe *most* important part now is formatting the output correctly. I need a single, valid JSON object that strictly adheres to the schema. No extra text, comments, or any other noise that would throw off parsing. It needs to be clean, concise, and technically accurate. It is important to the user!\n\n\n",
-                "thought": true
-              },
-              {
                 "text": "{\n  \"name\": \"Jane Doe\",\n  \"age\": 29,\n  \"occupation\": \"Software Engineer\"\n}",
-                "thoughtSignature": "EtAECs0EAQw51sfkJyK+mpEQuhEpb4L+ldLVv8+HwnuCQwXbz/TKQCK3zXwu1ToR2JErYo7bsQsdvtVaNy96cIkjvlcXOYI73PIq6MYU+MME9swSMQg4p/6vT3xcZCxDZyFbwzt93oT2VMtuK76B0ZsdjwpWmFS+6EUrvDYTS3QFboSZV9p6oekPEXWzi6yBNFpkDu15chtXuKvCNjdl+7tA+moxNuwbAJCq0MrFE+VWprU+9cuv9MKBr6GoZ9VrIusWGPudjsMVZz8r6L4/YOf0JBYWTn01rBNE4Ir0HaCzTgxDdJ8c8NAwreyRymCYZEnAtqiRGOcMgyMHGbTu/BLdA4YlQjYHRSlGydvAOBgB0igPdBg1sqybHKO2hoYwNhu7cnw6Cdo2PnAAfBkzvGEh77V9N5nouExFoB/nWq3+GQ6nHH6POfihD7l+lh0zBwcjvNJAAPO1pPY5XH5I6Hcf63b1GxM1/pFYp6ok0LrzgzDlJfBydX5A998ptO9Dxok6Sguxcmr1D6T0Hx/nTfYwNVnWoakntE6k/FB5VPcOKdakZ1n31AhbCDknfytLiAcv/8Vagfnc55otAAS+8DgCX7Kj6BqeszmcXUf8TJWh/RrwKJQ4DejActceb4qPDIGIkhS2tFLv21ZUOac+yE8kgXFu4Bw+7kRZ8drMdOFPiLIZH02OMmti3ggnVHXzoz9/bFl1zL6z4t2zUInLDAc9f2klaA/Y+QUN9oWDgyYGNGCL/L3Yre9dmxGvjO1TdpMR4EOKfyPeFzEtj1g3cxK5DQ=="
+                "thoughtSignature": "EtAECs0EAQw51sca+LJ8bqOD33tehnv59LH48DddeHcrtcjIB9xAXC2gXyw/NNwBmNnikSszpomQoRn7Zm44qtBC2hbGjLdNbbOhdtBwMahPhuTSAL0FuxotFxdhBcphClj5o2PQ6Mna2L4w4pEf0y5TXYWbumqkobk4dQweoiqc/cChb68F+V4MlAqxJEWg2VPBfamlHoM6qIQ/EL51C4r7Dc9/jBrZ3ERvIP99cvZNpi7vKpGB98J2cGYEyP9vq127NLbZTew15rOo1gcsQIH/fK7Up/RbOaIulpwFrSScW6g+ygghwKZyv3OxFCdKttGD6Di+/6ytyQg5ii6ul3ikhhV7lOTUUJVdB2Fu99lF23kPRPtwpFaYZcylpFmZverQSP5D9kz7tLxJJyD608rJcI0S+iRKY6ZXKjORxWslD2r7SAqJWu/MCuRPBPSoMhTFoPpvZF+8j2iIzqKTV/q9IFb3OSEX8cF+bnWi0lzWx/bQSEnCzo1U8iSx2kuSA1qa4Lilr+l3MlZicsuvq1Ht7YI8mxtz7BMrpFhJLPC70/zbnn4cLARTYfLp4Mz1XUSqjEN/sO7gj7PLMo3O4l0LrKWI2xz7xS7vhjBHoJO2PayU5q9XIgNeTcNe7tW3MV2+2croAaqhB+h++jTjkLhN8nY5tWTMbmte0pa6vKwk+SyEy49zXcMo+Xcb30aYK6UE7LphfrRun45dL/GO0/U1GrjbIwauus+29yl65Oze9S6/gW9LTBDN5BBChXijuxFshXESYEaVwLjgVQs8XaVC8A=="
               }
             ],
             "role": "model"
@@ -94,7 +90,7 @@
         }
       ],
       "modelVersion": "gemini-3.5-flash",
-      "responseId": "LRIaateVMsu01MkP8OmykQ8",
+      "responseId": "ENEpauaiHb6o_uMPtO650AI",
       "usageMetadata": {
         "candidatesTokenCount": 30,
         "promptTokenCount": 6,
@@ -117,13 +113,13 @@
         "application/json; charset=UTF-8"
       ],
       "date": [
-        "Fri, 29 May 2026 22:24:48 GMT"
+        "Wed, 10 Jun 2026 21:03:13 GMT"
       ],
       "server": [
         "scaffolding on HTTPServer2"
       ],
       "server-timing": [
-        "gfet4t7; dur=3139"
+        "gfet4t7; dur=1564"
       ],
       "transfer-encoding": [
         "chunked"


### PR DESCRIPTION
## Problem

`generate_object` (the `:object` operation) on Google returns `nil` from `ReqLLM.Response.object/1` whenever thinking is enabled (`google_thinking_level` or `google_thinking_budget`) on a model that emits thought summaries (e.g. Gemini 2.5/3.x at medium/high).

### Root cause

Two settings on the request contradict each other:

- `encode_object_body` sets `generationConfig.responseMimeType = "application/json"` — the model must output only JSON.
- `maybe_add_thinking_config/3` hardcoded `includeThoughts: true` for **every** thinking request.

With `includeThoughts: true`, Gemini returns two parts:

1. a thought-summary part — `{"text": "**My Thought Process...**", "thought": true}`
2. the JSON part — `{"text": "{\"name\": ...}"}`

`convert_google_json_mode_to_openai_format/1` concatenates **every** part that has a `"text"` key:

```elixir
parts
|> Enum.filter(&Map.has_key?(&1, "text"))   # keeps the thought part too
|> Enum.map_join("", & &1["text"])
```

So the prose summary is prepended to the JSON, producing an unparseable string → `unwrap_object` fails → `response.object` is `nil`.

## Fix

Thread an `include_thoughts` flag through `maybe_add_thinking_config` (**default `true`**, so the chat and image call sites are byte-for-byte unchanged) and pass `false` from `encode_object_body`. The model still reasons; it just no longer emits a thought summary that JSON mode cannot carry.

This only changes an already-broken path: `object` + thinking + `includeThoughts: true` never produced a usable object, so flipping it to `false` is a pure bugfix.

## Verification

- New encode-side regression test: an `:object` request with `google_thinking_level: :low` asserts `thinkingConfig.includeThoughts == false`.
- Re-recorded `test/support/fixtures/google/gemini_3_5_flash/object_basic.json` — the request now sends `includeThoughts: false`, the response collapses from 2 parts to 1 clean JSON part, and the object decodes (`{"name": "Jane Doe", "age": 29, "occupation": "Software Engineer"}`).
- `mix test test/providers/google_test.exs` — passing.
- `mix mc "google:*"` — **3/37 identical to `main`** (no regression; the unchanged failures are pre-existing missing-fixture models).
- `mix format` / `mix compile --warnings-as-errors` / `mix credo --strict` clean on the changed file.

### Note for reviewers

Regarding the long term direction of generate object, I noticed that the Vercel AI sdk decided to deprecate generate object in favor of generate text.  


https://github.com/vercel/ai/pull/10754


It may be worth while to patch this bug but consider moving in this direction too. Let me know if this has already been contemplated or if you want me to put some thought into it.  

