### PR TITLE
fix(streaming): preserve empty tool argument fragments

### DIFF
--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -206,7 +206,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
     args = Map.get(metadata, :tool_call_args) || Map.get(metadata, "tool_call_args")
 
     with args when is_map(args) <- args,
-         fragment when is_binary(fragment) and fragment != "" <-
+         fragment when is_binary(fragment) <-
            Map.get(args, :fragment) || Map.get(args, "fragment") do
       {Map.get(args, :index, Map.get(args, "index", 0)), fragment}
     else
@@ -306,16 +306,23 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
 
       iodata ->
         json = IO.iodata_to_binary(iodata)
+        response_tool_call_from_json(tool_call, json)
+    end
+  end
 
-        case Jason.decode(json) do
-          {:ok, args} ->
-            tool_call
-            |> Map.put(:arguments, args)
-            |> drop_accumulator_fields()
+  defp response_tool_call_from_json(tool_call, "") do
+    drop_accumulator_fields(tool_call)
+  end
 
-          {:error, _} ->
-            args_lost(tool_call, :json_decode_error, json)
-        end
+  defp response_tool_call_from_json(tool_call, json) do
+    case Jason.decode(json) do
+      {:ok, args} ->
+        tool_call
+        |> Map.put(:arguments, args)
+        |> drop_accumulator_fields()
+
+      {:error, _} ->
+        args_lost(tool_call, :json_decode_error, json)
     end
   end
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -1342,6 +1342,54 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert thinking_block[:signature] == "sig_test_123"
       assert text_block == %{type: "text", text: "Answer: 42"}
     end
+
+    test "empty streamed tool arguments do not report lost args" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      context = %ReqLLM.Context{messages: []}
+
+      events = [
+        %{
+          data: %{
+            "type" => "content_block_start",
+            "index" => 0,
+            "content_block" => %{
+              "type" => "tool_use",
+              "id" => "toolu_empty_args",
+              "name" => "test_tool",
+              "input" => %{}
+            }
+          }
+        },
+        %{
+          data: %{
+            "type" => "content_block_delta",
+            "index" => 0,
+            "delta" => %{"type" => "input_json_delta", "partial_json" => ""}
+          }
+        },
+        %{data: %{"type" => "content_block_stop", "index" => 0}}
+      ]
+
+      {chunks, _state} =
+        Enum.reduce(events, {[], Anthropic.init_stream_state(model)}, fn event, {acc, state} ->
+          {event_chunks, next_state} = Anthropic.decode_stream_event(event, model, state)
+          {acc ++ event_chunks, next_state}
+        end)
+
+      {:ok, response} =
+        ReqLLM.Providers.Anthropic.ResponseBuilder.build_response(
+          chunks,
+          %{finish_reason: :tool_calls},
+          context: context,
+          model: model
+        )
+
+      assert [tool_call] = response.message.tool_calls
+      assert tool_call.id == "toolu_empty_args"
+      assert tool_call.function.name == "test_tool"
+      assert tool_call.function.arguments == "{}"
+      refute get_in(tool_call.function, [:metadata, :error])
+    end
   end
 
   describe "option translation" do

--- a/test/req_llm/provider/chunk_accumulator_test.exs
+++ b/test/req_llm/provider/chunk_accumulator_test.exs
@@ -113,6 +113,20 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
       assert IO.iodata_to_binary(acc.arg_fragments[0]) == "{\"location\":\"SF\"}"
     end
 
+    test "tracks empty argument fragments by index" do
+      acc =
+        ChunkAccumulator.push(
+          ChunkAccumulator.new(),
+          %StreamChunk{
+            type: :meta,
+            metadata: %{tool_call_args: %{index: 0, fragment: ""}}
+          }
+        )
+
+      assert Map.has_key?(acc.arg_fragments, 0)
+      assert IO.iodata_to_binary(acc.arg_fragments[0]) == ""
+    end
+
     test "collects reasoning_details across meta chunks in arrival order" do
       details_a = %{provider: :openai, text: "first"}
       details_b = %{provider: :openai, text: "second"}
@@ -284,6 +298,29 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
 
       assert_receive {:args_lost, "call_missing_fragments", %{count: 1},
                       %{reason: :missing_fragments}}
+    end
+
+    test "does not mark empty expected argument fragments as missing" do
+      attach_args_lost_handler("call_empty_fragments")
+
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :tool_call,
+          name: "test_tool",
+          arguments: %{},
+          metadata: %{id: "call_empty_fragments", index: 0, start: true}
+        })
+        |> ChunkAccumulator.push(%StreamChunk{
+          type: :meta,
+          metadata: %{tool_call_args: %{index: 0, fragment: ""}}
+        })
+
+      assert [%{arguments: %{}} = tool_call] =
+               ChunkAccumulator.finalize_tool_calls_for_response(acc)
+
+      refute Map.has_key?(tool_call, :metadata)
+      refute_receive {:args_lost, "call_empty_fragments", _, _}
     end
 
     test "returns [] for empty accumulator" do


### PR DESCRIPTION
## Summary

- Treat empty streamed tool argument fragments as observed fragments instead of dropping them.
- Preserve the tool call's existing arguments when the observed fragment stream is empty.
- Add regression coverage for Anthropic-style no-parameter tool calls so they do not report `args_lost`.
- Add provider-level coverage for Anthropic SSE events with empty `input_json_delta` fragments.

Fixes #761

## Validation

- `mix test test/req_llm/provider/chunk_accumulator_test.exs`
- `mix test test/providers/anthropic_test.exs`
- local repro using `ChunkAccumulator` returned `%{arguments: %{}}` without args-lost metadata
- `mix test`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix quality`