### PR TITLE
fix: support Google Vertex app config credentials

### DIFF
--- a/guides/google_vertex.md
+++ b/guides/google_vertex.md
@@ -16,6 +16,15 @@ GOOGLE_CLOUD_PROJECT="your-project-id"
 GOOGLE_CLOUD_REGION="global"
 ```
 
+**Application Config:**
+
+```elixir
+config :req_llm, :google_vertex,
+  service_account_json: "/path/to/service-account.json",
+  project_id: "your-project-id",
+  region: "global"
+```
+
 **Provider Options:**
 
 ```elixir
@@ -44,7 +53,7 @@ Passed via `:provider_options` keyword:
 
 - **Type**: String (file path)
 - **Purpose**: Path to Google Cloud service account JSON file
-- **Fallback**: `GOOGLE_APPLICATION_CREDENTIALS` env var
+- **Fallback**: `config :req_llm, :google_vertex`, then `GOOGLE_APPLICATION_CREDENTIALS` env var
 - **Example**: `provider_options: [service_account_json: "/path/to/credentials.json"]`
 
 ### `access_token`
@@ -52,13 +61,14 @@ Passed via `:provider_options` keyword:
 - **Type**: String
 - **Purpose**: Use an existing OAuth2 access token generated outside ReqLLM (e.g., via Goth or gcloud)
 - **Behavior**: Bypasses the service account JSON flow and internal token management
+- **Fallback**: `config :req_llm, :google_vertex`
 - **Example**: `provider_options: [access_token: "your-access-token"]`
 
 ### `project_id`
 
 - **Type**: String
 - **Purpose**: Google Cloud project ID
-- **Fallback**: `GOOGLE_CLOUD_PROJECT` env var
+- **Fallback**: `config :req_llm, :google_vertex`, then `GOOGLE_CLOUD_PROJECT` env var
 - **Example**: `provider_options: [project_id: "my-project-123"]`
 - **Required**: Yes
 
@@ -67,6 +77,7 @@ Passed via `:provider_options` keyword:
 - **Type**: String
 - **Default**: `"global"`
 - **Purpose**: GCP region for Vertex AI endpoint
+- **Fallback**: `config :req_llm, :google_vertex`, then `GOOGLE_CLOUD_REGION` env var
 - **Example**: `provider_options: [region: "us-central1"]`
 - **Note**: Use `"global"` for newest models, specific regions for regional deployment
 

--- a/lib/req_llm/availability.ex
+++ b/lib/req_llm/availability.ex
@@ -99,12 +99,19 @@ defmodule ReqLLM.Availability do
   end
 
   defp google_vertex_configured?(opts) do
+    config = Application.get_env(:req_llm, :google_vertex, [])
+
     service_account_json =
       option_value(opts, :service_account_json) ||
+        config_value(config, :service_account_json) ||
         System.get_env("GOOGLE_APPLICATION_CREDENTIALS")
 
-    access_token = option_value(opts, :access_token)
-    project_id = option_value(opts, :project_id) || System.get_env("GOOGLE_CLOUD_PROJECT")
+    access_token = option_value(opts, :access_token) || config_value(config, :access_token)
+
+    project_id =
+      option_value(opts, :project_id) ||
+        config_value(config, :project_id) ||
+        System.get_env("GOOGLE_CLOUD_PROJECT")
 
     present?(project_id) and (present?(service_account_json) or present?(access_token))
   end
@@ -123,6 +130,14 @@ defmodule ReqLLM.Availability do
   defp option_value(opts, key) do
     Keyword.get(opts, key) || provider_option_value(opts, key)
   end
+
+  defp config_value(config, key) when is_list(config), do: Keyword.get(config, key)
+
+  defp config_value(config, key) when is_map(config) do
+    Map.get(config, key) || Map.get(config, Atom.to_string(key))
+  end
+
+  defp config_value(_config, _key), do: nil
 
   defp provider_option_value(opts, key) do
     case Keyword.get(opts, :provider_options, []) do

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -1029,6 +1029,14 @@ defmodule ReqLLM.Provider.Options do
 
   defp base_url_from_application_config(provider_id) do
     config = Application.get_env(:req_llm, provider_id, [])
-    Keyword.get(config, :base_url)
+    config_value(config, :base_url)
   end
+
+  defp config_value(config, key) when is_list(config), do: Keyword.get(config, key)
+
+  defp config_value(config, key) when is_map(config) do
+    Map.get(config, key) || Map.get(config, Atom.to_string(key))
+  end
+
+  defp config_value(_config, _key), do: nil
 end

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -53,6 +53,12 @@ defmodule ReqLLM.Providers.GoogleVertex do
         ]
       )
 
+      # Option 5: Application config
+      config :req_llm, :google_vertex,
+        service_account_json: "/path/to/service-account.json",
+        project_id: "your-project-id",
+        region: "us-central1"
+
   ### Access Token
 
       ReqLLM.generate_text(
@@ -492,7 +498,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
   end
 
   defp fetch_access_token(%{service_account_json: service_account_json})
-       when is_binary(service_account_json) do
+       when is_binary(service_account_json) or is_map(service_account_json) do
     ReqLLM.Providers.GoogleVertex.TokenCache.get_or_refresh(service_account_json)
   end
 
@@ -669,8 +675,12 @@ defmodule ReqLLM.Providers.GoogleVertex do
         rest -> Keyword.put(other_opts, :provider_options, rest)
       end
 
-    # Merge: top-level takes precedence over provider_options
-    merged = Keyword.merge(provider_creds, top_creds)
+    config_creds = google_vertex_config()
+
+    merged =
+      config_creds
+      |> Keyword.merge(provider_creds)
+      |> Keyword.merge(top_creds)
 
     creds = %{
       service_account_json:
@@ -683,6 +693,25 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
     {creds, other_opts}
   end
+
+  defp google_vertex_config do
+    config = Application.get_env(:req_llm, :google_vertex, [])
+
+    Enum.reduce([:service_account_json, :access_token, :project_id, :region], [], fn key, acc ->
+      case config_value(config, key) do
+        nil -> acc
+        value -> Keyword.put(acc, key, value)
+      end
+    end)
+  end
+
+  defp config_value(config, key) when is_list(config), do: Keyword.get(config, key)
+
+  defp config_value(config, key) when is_map(config) do
+    Map.get(config, key) || Map.get(config, Atom.to_string(key))
+  end
+
+  defp config_value(_config, _key), do: nil
 
   # Validate GCP credentials
   defp validate_gcp_credentials!(creds) do
@@ -705,13 +734,18 @@ defmodule ReqLLM.Providers.GoogleVertex do
            access_token: "ya29.ci...",
            project_id: "your-project-id"
          ]
+
+      4. Application config:
+         config :req_llm, :google_vertex,
+           service_account_json: "/path/to/service-account.json",
+           project_id: "your-project-id"
       """
     end
 
     if !creds[:project_id] do
       raise ArgumentError, """
       Google Cloud project ID required for Vertex AI.
-      Set GOOGLE_CLOUD_PROJECT environment variable or pass project_id in provider_options.
+      Set GOOGLE_CLOUD_PROJECT environment variable, configure :google_vertex, or pass project_id in provider_options.
       """
     end
 

--- a/test/providers/google_vertex_config_test.exs
+++ b/test/providers/google_vertex_config_test.exs
@@ -1,0 +1,126 @@
+defmodule ReqLLM.Providers.GoogleVertex.ConfigTest do
+  use ExUnit.Case, async: false
+
+  alias ReqLLM.Context
+  alias ReqLLM.Providers.GoogleVertex
+
+  @env_vars [
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_REGION"
+  ]
+
+  setup do
+    env_snapshot = Map.new(@env_vars, &{&1, System.get_env(&1)})
+    app_config = Application.get_env(:req_llm, :google_vertex)
+
+    Enum.each(@env_vars, &System.delete_env/1)
+    Application.delete_env(:req_llm, :google_vertex)
+
+    on_exit(fn ->
+      Enum.each(env_snapshot, fn
+        {var, nil} -> System.delete_env(var)
+        {var, value} -> System.put_env(var, value)
+      end)
+
+      restore_application_env(app_config)
+    end)
+
+    :ok
+  end
+
+  describe "application config credentials" do
+    test "uses keyword config for chat request credentials" do
+      Application.put_env(:req_llm, :google_vertex,
+        service_account_json: "/tmp/config-service-account.json",
+        project_id: "config-project",
+        region: "us-central1"
+      )
+
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context_fixture(), [])
+
+      url = URI.to_string(request.url)
+      creds = Req.Request.get_private(request, :gcp_credentials)
+
+      assert url =~ "us-central1-aiplatform.googleapis.com"
+      assert url =~ "projects/config-project"
+      assert creds[:service_account_json] == "/tmp/config-service-account.json"
+    end
+
+    test "uses map config for streaming access token credentials" do
+      Application.put_env(:req_llm, :google_vertex, %{
+        "access_token" => "config-token",
+        "project_id" => "map-project",
+        "region" => "europe-west4"
+      })
+
+      {:ok, model} = ReqLLM.model("google_vertex:zai-org/glm-4.7-maas")
+      {:ok, finch_request} = GoogleVertex.attach_stream(model, context_fixture(), [], nil)
+
+      assert finch_request.path =~ "projects/map-project"
+      assert finch_request.path =~ "locations/europe-west4"
+      assert authorization_header(finch_request) == "Bearer config-token"
+    end
+
+    test "request options override application config" do
+      Application.put_env(:req_llm, :google_vertex,
+        access_token: "config-token",
+        project_id: "config-project",
+        region: "global"
+      )
+
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+
+      opts = [
+        access_token: "request-token",
+        project_id: "request-project",
+        region: "us-central1"
+      ]
+
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context_fixture(), opts)
+
+      url = URI.to_string(request.url)
+      creds = Req.Request.get_private(request, :gcp_credentials)
+
+      assert url =~ "us-central1-aiplatform.googleapis.com"
+      assert url =~ "projects/request-project"
+      assert creds[:access_token] == "request-token"
+    end
+
+    test "application config overrides environment credentials" do
+      System.put_env("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/env-service-account.json")
+      System.put_env("GOOGLE_CLOUD_PROJECT", "env-project")
+      System.put_env("GOOGLE_CLOUD_REGION", "asia-northeast1")
+
+      Application.put_env(:req_llm, :google_vertex,
+        service_account_json: "/tmp/config-service-account.json",
+        project_id: "config-project",
+        region: "us-central1"
+      )
+
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+      {:ok, request} = GoogleVertex.prepare_request(:chat, model, context_fixture(), [])
+
+      url = URI.to_string(request.url)
+      creds = Req.Request.get_private(request, :gcp_credentials)
+
+      assert url =~ "us-central1-aiplatform.googleapis.com"
+      assert url =~ "projects/config-project"
+      assert creds[:service_account_json] == "/tmp/config-service-account.json"
+    end
+  end
+
+  defp context_fixture do
+    Context.new([Context.user("Hello")])
+  end
+
+  defp authorization_header(%Finch.Request{headers: headers}) do
+    Enum.find_value(headers, fn {key, value} ->
+      if String.downcase(key) == "authorization", do: value
+    end)
+  end
+
+  defp restore_application_env(nil), do: Application.delete_env(:req_llm, :google_vertex)
+  defp restore_application_env(value), do: Application.put_env(:req_llm, :google_vertex, value)
+end

--- a/test/req_llm/availability_test.exs
+++ b/test/req_llm/availability_test.exs
@@ -33,6 +33,7 @@ defmodule ReqLLM.AvailabilityTest do
     :deepseek_api_key,
     :elevenlabs_api_key,
     :google_api_key,
+    :google_vertex,
     :groq_api_key,
     :openai_api_key,
     :openrouter_api_key,
@@ -105,6 +106,28 @@ defmodule ReqLLM.AvailabilityTest do
       assert ReqLLM.available_models(scope: :google_vertex) == []
 
       System.put_env("GOOGLE_CLOUD_PROJECT", "test-project")
+
+      models = ReqLLM.available_models(scope: :google_vertex)
+
+      assert Enum.any?(models, &String.starts_with?(&1, "google_vertex:"))
+    end
+
+    test "detects google vertex keyword application config" do
+      Application.put_env(:req_llm, :google_vertex,
+        service_account_json: "/tmp/service-account.json",
+        project_id: "test-project"
+      )
+
+      models = ReqLLM.available_models(scope: :google_vertex)
+
+      assert Enum.any?(models, &String.starts_with?(&1, "google_vertex:"))
+    end
+
+    test "detects google vertex map application config" do
+      Application.put_env(:req_llm, :google_vertex, %{
+        "access_token" => "test-token",
+        "project_id" => "test-project"
+      })
 
       models = ReqLLM.available_models(scope: :google_vertex)
 


### PR DESCRIPTION
## Summary
- Load Google Vertex credentials from `config :req_llm, :google_vertex` for request preparation and model availability.
- Preserve precedence as request opts, `provider_options`, application config, then environment variables.
- Accept map-shaped provider application config in the shared base URL lookup and document Vertex runtime config.

## Tests
- `mix test test/providers/google_vertex_config_test.exs`
- `mix test test/req_llm/availability_test.exs`
- `mix test test/providers/google_vertex_openai_compat_test.exs test/providers/google_vertex_config_test.exs test/req_llm/availability_test.exs`
- `mix compile --warnings-as-errors`
- `mix quality`