### PR TITLE
fix(context): improve error handling around tool calls

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -509,7 +509,15 @@ defmodule ReqLLM.Context do
           append(ctx, tool_result_msg)
 
         {:error, error} ->
-          error_result = %{error: to_string(error)}
+          error_result = %{
+            error:
+              if is_exception(error) do
+                Exception.message(error)
+              else
+                to_string(error)
+              end
+          }
+
           tool_result_msg = tool_result_message(name, id, error_result, %{is_error: true})
           append(ctx, tool_result_msg)
       end

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -509,19 +509,21 @@ defmodule ReqLLM.Context do
           append(ctx, tool_result_msg)
 
         {:error, error} ->
-          error_result = %{
-            error:
-              if is_exception(error) do
-                Exception.message(error)
-              else
-                to_string(error)
-              end
-          }
+          error_result = %{error: tool_error_message(error)}
 
           tool_result_msg = tool_result_message(name, id, error_result, %{is_error: true})
           append(ctx, tool_result_msg)
       end
     end)
+  end
+
+  defp tool_error_message(error) when is_exception(error), do: Exception.message(error)
+
+  defp tool_error_message(error) do
+    case String.Chars.impl_for(error) do
+      nil -> inspect(error)
+      _impl -> to_string(error)
+    end
   end
 
   defp extract_tool_call_info(%ReqLLM.ToolCall{id: id, function: %{name: name}}), do: {name, id}

--- a/test/req_llm/context_conversational_test.exs
+++ b/test/req_llm/context_conversational_test.exs
@@ -281,6 +281,53 @@ defmodule ReqLLM.ContextConversationalTest do
       assert tool_msg.metadata[:is_error] == true
     end
 
+    test "non-exception callback errors are handled", %{context: ctx} do
+      map_error_tool =
+        ReqLLM.Tool.new!(
+          name: "map_error",
+          description: "Returns a map error",
+          callback: fn _args -> {:error, %{reason: "nope"}} end
+        )
+
+      tuple_error_tool =
+        ReqLLM.Tool.new!(
+          name: "tuple_error",
+          description: "Returns a tuple error",
+          callback: fn _args -> {:error, {:bad, :thing}} end
+        )
+
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "map_error_call",
+          type: "function",
+          function: %{name: "map_error", arguments: ~s({})}
+        },
+        %ReqLLM.ToolCall{
+          id: "tuple_error_call",
+          type: "function",
+          function: %{name: "tuple_error", arguments: ~s({})}
+        }
+      ]
+
+      result =
+        Context.execute_and_append_tools(ctx, tool_calls, [map_error_tool, tuple_error_tool])
+
+      tool_messages = Enum.filter(result.messages, &(&1.role == :tool))
+
+      map_error_msg = Enum.find(tool_messages, &(&1.tool_call_id == "map_error_call"))
+      tuple_error_msg = Enum.find(tool_messages, &(&1.tool_call_id == "tuple_error_call"))
+
+      assert %{
+               is_error: true,
+               tool_output: %{error: "%{reason: \"nope\"}"}
+             } == map_error_msg.metadata
+
+      assert %{
+               is_error: true,
+               tool_output: %{error: "{:bad, :thing}"}
+             } == tuple_error_msg.metadata
+    end
+
     test "error path sets is_error for ToolResult errors", %{
       error_tool_result: tool,
       context: ctx

--- a/test/req_llm/context_conversational_test.exs
+++ b/test/req_llm/context_conversational_test.exs
@@ -365,5 +365,54 @@ defmodule ReqLLM.ContextConversationalTest do
       refute Map.has_key?(ok_msg.metadata, :is_error)
       assert fail_msg.metadata[:is_error] == true
     end
+
+    test "parameter validation error is handled", %{context: ctx, success_tool: success_tool} do
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "invalid_call",
+          type: "function",
+          function: %{name: "echo", arguments: ~s({"text":42})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [success_tool])
+
+      [invalid_call_msg] = Enum.filter(result.messages, &(&1.role == :tool))
+
+      assert %{
+               is_error: true,
+               tool_output: %{
+                 error: "invalid value for :text option: expected string, got: 42"
+               }
+             } == invalid_call_msg.metadata
+    end
+
+    test "exceptions inside tool calls are handled", %{context: ctx} do
+      raising_tool =
+        ReqLLM.Tool.new!(
+          name: "raise",
+          description: "Always raises",
+          callback: fn _args -> raise "hell" end
+        )
+
+      tool_calls = [
+        %ReqLLM.ToolCall{
+          id: "raise_call",
+          type: "function",
+          function: %{name: "raise", arguments: ~s({})}
+        }
+      ]
+
+      result = Context.execute_and_append_tools(ctx, tool_calls, [raising_tool])
+
+      [invalid_call_msg] = Enum.filter(result.messages, &(&1.role == :tool))
+
+      assert %{
+               is_error: true,
+               tool_output: %{
+                 error: "Unknown error: \"Callback execution failed: hell\""
+               }
+             } == invalid_call_msg.metadata
+    end
   end
 end


### PR DESCRIPTION
## Description

Previously, any `ReqLLM.Error.*` would hit `to_string(error)` and crash with `Protocol.UndefinedError: protocol String.Chars not implemented`

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

No.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
