### PR TITLE
fix(streaming): don't finalize OpenAI-compatible streams at finish_reason

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1150,15 +1150,6 @@ defmodule ReqLLM.Provider.Defaults do
 
             if finish_reason do
               normalized_reason = parse_openai_finish_reason(finish_reason)
-
-              # The finish_reason chunk is deliberately NOT marked terminal:
-              # it is not the end of an OpenAI-compatible stream. With
-              # stream_options.include_usage (set automatically when
-              # streaming), a final usage chunk (choices: []) arrives *after*
-              # it, and marking finish_reason terminal finalized the stream
-              # early - dropping usage whenever it landed in a later network
-              # chunk. Termination is signaled by the standalone usage chunk
-              # below, the [DONE] event, or HTTP stream end.
               meta_chunk = ReqLLM.StreamChunk.meta(%{finish_reason: normalized_reason})
 
               content_chunks ++

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1151,11 +1151,18 @@ defmodule ReqLLM.Provider.Defaults do
             if finish_reason do
               normalized_reason = parse_openai_finish_reason(finish_reason)
 
-              meta = %{finish_reason: normalized_reason}
-              meta = if normalized_reason, do: Map.put(meta, :terminal?, true), else: meta
+              # The finish_reason chunk is deliberately NOT marked terminal:
+              # it is not the end of an OpenAI-compatible stream. With
+              # stream_options.include_usage (set automatically when
+              # streaming), a final usage chunk (choices: []) arrives *after*
+              # it, and marking finish_reason terminal finalized the stream
+              # early - dropping usage whenever it landed in a later network
+              # chunk. Termination is signaled by the standalone usage chunk
+              # below, the [DONE] event, or HTTP stream end.
+              meta_chunk = ReqLLM.StreamChunk.meta(%{finish_reason: normalized_reason})
 
               content_chunks ++
-                reasoning_details_chunks ++ logprobs_chunks ++ [ReqLLM.StreamChunk.meta(meta)]
+                reasoning_details_chunks ++ logprobs_chunks ++ [meta_chunk]
             else
               content_chunks ++ reasoning_details_chunks ++ logprobs_chunks
             end

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -856,11 +856,6 @@ defmodule ReqLLM.Provider.DefaultsTest do
     end
 
     test "finish_reason chunk is not terminal - a usage chunk may still follow", %{model: model} do
-      # With stream_options.include_usage, the final usage chunk arrives in a
-      # separate SSE event *after* finish_reason. Marking finish_reason
-      # terminal finalized the stream early and dropped that usage whenever
-      # it landed in a later network chunk. Stream termination is signaled by
-      # the standalone usage chunk, [DONE], or HTTP stream end instead.
       event = %{
         data: %{
           "choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls"}]
@@ -873,7 +868,6 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert finish_chunk.metadata.finish_reason == :tool_calls
       refute Map.get(finish_chunk.metadata, :terminal?)
 
-      # The standalone usage chunk (empty choices) remains the terminal signal
       usage_event = %{
         data: %{
           "choices" => [],

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -852,7 +852,37 @@ defmodule ReqLLM.Provider.DefaultsTest do
 
       finish_chunk = Enum.find(chunks, &Map.has_key?(&1.metadata, :finish_reason))
       assert finish_chunk.metadata.finish_reason == :stop
-      assert finish_chunk.metadata.terminal? == true
+      refute Map.get(finish_chunk.metadata, :terminal?)
+    end
+
+    test "finish_reason chunk is not terminal - a usage chunk may still follow", %{model: model} do
+      # With stream_options.include_usage, the final usage chunk arrives in a
+      # separate SSE event *after* finish_reason. Marking finish_reason
+      # terminal finalized the stream early and dropped that usage whenever
+      # it landed in a later network chunk. Stream termination is signaled by
+      # the standalone usage chunk, [DONE], or HTTP stream end instead.
+      event = %{
+        data: %{
+          "choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls"}]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(event, model)
+
+      finish_chunk = Enum.find(chunks, &Map.has_key?(&1.metadata, :finish_reason))
+      assert finish_chunk.metadata.finish_reason == :tool_calls
+      refute Map.get(finish_chunk.metadata, :terminal?)
+
+      # The standalone usage chunk (empty choices) remains the terminal signal
+      usage_event = %{
+        data: %{
+          "choices" => [],
+          "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 5, "total_tokens" => 15}
+        }
+      }
+
+      assert [usage_chunk] = Defaults.default_decode_stream_event(usage_event, model)
+      assert usage_chunk.metadata.terminal? == true
     end
 
     test "emits terminal error chunk for SSE error event with nested message", %{model: model} do

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -145,4 +145,57 @@ defmodule ReqLLM.StreamServer.MetadataTest do
       StreamServer.cancel(server)
     end
   end
+
+  describe "usage arriving after finish_reason (default decoder)" do
+    # No decode_stream_event/2 exported, so StreamServer falls back to
+    # ReqLLM.Provider.Defaults.default_decode_stream_event/2 - the path used
+    # by OpenAI-compatible providers (OpenAI, OpenRouter, Groq, xAI, ...).
+    defmodule DefaultsDecodeProvider do
+      @moduledoc false
+    end
+
+    test "usage in a separate network chunk after finish_reason is captured" do
+      # OpenAI-compatible streams with stream_options.include_usage deliver
+      # usage in a standalone event *after* the finish_reason event. Whether
+      # the two share an HTTP chunk depends on upstream buffering - some
+      # providers flush them separately. Regression: the finish_reason chunk
+      # was marked terminal, finalizing the stream (and replying to metadata
+      # waiters) before the usage event arrived, so usage was silently
+      # dropped.
+      server = start_server(provider_mod: DefaultsDecodeProvider)
+      _task = mock_http_task(server)
+
+      # Like production consumers, await metadata *while* the stream is in
+      # flight - early finalization replies to this waiter with a frozen,
+      # usage-less snapshot
+      metadata_task = Task.async(fn -> StreamServer.await_metadata(server, 500) end)
+      :timer.sleep(20)
+
+      finish_payload =
+        Jason.encode!(%{
+          "id" => "gen-123",
+          "choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls"}]
+        })
+
+      usage_payload =
+        Jason.encode!(%{
+          "id" => "gen-123",
+          "choices" => [],
+          "usage" => %{"prompt_tokens" => 100, "completion_tokens" => 25, "total_tokens" => 125}
+        })
+
+      # Each http_event is a separate network chunk
+      StreamServer.http_event(server, {:data, "data: #{finish_payload}\n\n"})
+      StreamServer.http_event(server, {:data, "data: #{usage_payload}\n\n"})
+      StreamServer.http_event(server, {:data, "data: [DONE]\n\n"})
+      StreamServer.http_event(server, :done)
+
+      assert {:ok, metadata} = Task.await(metadata_task)
+      assert metadata.finish_reason == :tool_calls
+      assert metadata.usage.input_tokens == 100
+      assert metadata.usage.output_tokens == 25
+
+      StreamServer.cancel(server)
+    end
+  end
 end

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -147,27 +147,14 @@ defmodule ReqLLM.StreamServer.MetadataTest do
   end
 
   describe "usage arriving after finish_reason (default decoder)" do
-    # No decode_stream_event/2 exported, so StreamServer falls back to
-    # ReqLLM.Provider.Defaults.default_decode_stream_event/2 - the path used
-    # by OpenAI-compatible providers (OpenAI, OpenRouter, Groq, xAI, ...).
     defmodule DefaultsDecodeProvider do
       @moduledoc false
     end
 
     test "usage in a separate network chunk after finish_reason is captured" do
-      # OpenAI-compatible streams with stream_options.include_usage deliver
-      # usage in a standalone event *after* the finish_reason event. Whether
-      # the two share an HTTP chunk depends on upstream buffering - some
-      # providers flush them separately. Regression: the finish_reason chunk
-      # was marked terminal, finalizing the stream (and replying to metadata
-      # waiters) before the usage event arrived, so usage was silently
-      # dropped.
       server = start_server(provider_mod: DefaultsDecodeProvider)
       _task = mock_http_task(server)
 
-      # Like production consumers, await metadata *while* the stream is in
-      # flight - early finalization replies to this waiter with a frozen,
-      # usage-less snapshot
       metadata_task = Task.async(fn -> StreamServer.await_metadata(server, 500) end)
       :timer.sleep(20)
 
@@ -184,7 +171,6 @@ defmodule ReqLLM.StreamServer.MetadataTest do
           "usage" => %{"prompt_tokens" => 100, "completion_tokens" => 25, "total_tokens" => 125}
         })
 
-      # Each http_event is a separate network chunk
       StreamServer.http_event(server, {:data, "data: #{finish_payload}\n\n"})
       StreamServer.http_event(server, {:data, "data: #{usage_payload}\n\n"})
       StreamServer.http_event(server, {:data, "data: [DONE]\n\n"})


### PR DESCRIPTION
For OpenAI-compatible providers, streaming requests set `stream_options: {include_usage: true}` automatically, and per the OpenAI streaming protocol the final usage payload arrives in a standalone SSE event (`"choices": []`) **after** the event carrying `finish_reason`.

`default_decode_stream_event/2` marked the `finish_reason` chunk `terminal?: true`, and `StreamServer` finalizes the stream as soon as a terminal chunk appears in a batch; the metadata snapshot is frozen and metadata waiters are replied. Whether usage survived therefore depended on network buffering:

- `finish_reason` and the usage event land in the **same HTTP chunk** -> the batch decodes together, usage is captured
- the upstream flushes them in **separate chunks** -> the stream finalizes at `finish_reason`, and the usage event is silently dropped: `StreamResponse.usage/1` returns `nil` and `on_meta` callbacks never see it.

I hit this consistently via OpenRouter when requests were routed to an upstream that flushes the two events separately (and intermittently with other routings); affected requests reported no usage at all, with no error.

The fix removes the `terminal?` mark from the `finish_reason` chunk. It is not the end of an OpenAI-compatible stream; the protocol terminators remain in place and all still finalize:

- the standalone usage chunk (`"choices": []`), already marked terminal
- the `data: [DONE]` event (`termination_event?/1`)
- HTTP stream end (`process_http_event(:done, ...)`)

Worst case, finalization is deferred by one or two SSE events on streams that previously finalized at `finish_reason`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. `finish_reason` is still captured into metadata exactly as before; only the early-finalization side effect is removed.

## Testing

- [x] Tests pass (`mix test` — 3412 tests, 0 failures)
- [x] Quality checks pass (`mix quality`)

New coverage:

- Decode-level test asserting the `finish_reason` chunk is not terminal while the standalone usage chunk still is (`test/req_llm/provider/defaults_test.exs`)
- `StreamServer` end-to-end regression mirroring production: a metadata waiter registered mid-stream, with `finish_reason` and usage delivered as separate `http_event` data chunks (`test/req_llm/stream_server/metadata_test.exs`). Without the fix it fails with the production symptom (`metadata.usage` missing); with it, usage is captured.
- One existing assertion that pinned the old terminal flag updated to the new behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (inline comment documenting why `finish_reason` is not terminal)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

None filed; happy to open one first if preferred.