### PR TITLE
fix(streaming): cleanup killed stream consumers

### DIFF
--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -218,6 +218,15 @@ defmodule ReqLLM.StreamServer do
   @spec cancel(server()) :: :ok
   def cancel(server) do
     GenServer.call(server, :cancel)
+  catch
+    :exit, {:noproc, {GenServer, :call, [^server, :cancel, _timeout]}} -> :ok
+    :exit, {:normal, {GenServer, :call, [^server, :cancel, _timeout]}} -> :ok
+  end
+
+  @doc false
+  @spec monitor_consumer(server(), pid()) :: :ok
+  def monitor_consumer(server, consumer_pid) when is_pid(consumer_pid) do
+    GenServer.call(server, {:monitor_consumer, consumer_pid})
   end
 
   @doc """
@@ -386,6 +395,12 @@ defmodule ReqLLM.StreamServer do
       end
 
     {:ok, %{state | protocol_parser: protocol_parser}}
+  end
+
+  @impl GenServer
+  def handle_call({:monitor_consumer, consumer_pid}, _from, state) do
+    ref = Process.monitor(consumer_pid)
+    {:reply, :ok, %{state | consumer_refs: MapSet.put(state.consumer_refs, ref)}}
   end
 
   @impl GenServer
@@ -601,8 +616,20 @@ defmodule ReqLLM.StreamServer do
   end
 
   @impl GenServer
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
-    {:noreply, state}
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case MapSet.member?(state.consumer_refs, ref) do
+      true ->
+        new_state =
+          %{state | consumer_refs: MapSet.delete(state.consumer_refs, ref)}
+          |> maybe_emit_stream_stop(:cancelled)
+          |> cleanup_resources()
+          |> reply_to_waiting_callers()
+
+        {:stop, :normal, new_state}
+
+      false ->
+        {:noreply, state}
+    end
   end
 
   @impl GenServer

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -617,8 +617,11 @@ defmodule ReqLLM.StreamServer do
 
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    case MapSet.member?(state.consumer_refs, ref) do
-      true ->
+    case {MapSet.member?(state.consumer_refs, ref), state.status} do
+      {true, :done} ->
+        {:noreply, %{state | consumer_refs: MapSet.delete(state.consumer_refs, ref)}}
+
+      {true, _status} ->
         new_state =
           %{state | consumer_refs: MapSet.delete(state.consumer_refs, ref)}
           |> maybe_emit_stream_stop(:cancelled)
@@ -627,7 +630,7 @@ defmodule ReqLLM.StreamServer do
 
         {:stop, :normal, new_state}
 
-      false ->
+      {false, _status} ->
         {:noreply, state}
     end
   end

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -317,7 +317,10 @@ defmodule ReqLLM.Streaming do
   # Create lazy stream using Stream.resource that calls StreamServer.next/2
   defp create_lazy_stream(server_pid, timeout) do
     Stream.resource(
-      fn -> %{server: server_pid, exhausted?: false} end,
+      fn ->
+        :ok = StreamServer.monitor_consumer(server_pid, self())
+        %{server: server_pid, exhausted?: false}
+      end,
       fn %{server: server} = state ->
         case StreamServer.next(server, timeout) do
           {:ok, chunk} ->
@@ -335,23 +338,10 @@ defmodule ReqLLM.Streaming do
       end,
       fn %{server: server, exhausted?: exhausted?} ->
         if not exhausted? do
-          safe_cancel_stream_server(server)
+          StreamServer.cancel(server)
         end
       end
     )
-  end
-
-  defp safe_cancel_stream_server(server) do
-    if Process.alive?(server) do
-      StreamServer.cancel(server)
-    else
-      :ok
-    end
-  catch
-    :exit, {:noproc, _} -> :ok
-    :exit, {:normal, _} -> :ok
-    :exit, {:shutdown, _} -> :ok
-    :exit, {{:shutdown, _}, _} -> :ok
   end
 
   defp start_metadata_handle(server_pid, opts) do

--- a/test/req_llm/stream_server/core_test.exs
+++ b/test/req_llm/stream_server/core_test.exs
@@ -43,6 +43,32 @@ defmodule ReqLLM.StreamServer.CoreTest do
       StreamServer.cancel(server)
       refute Process.alive?(server)
     end
+
+    test "cancels stream resources when monitored consumer exits" do
+      server = start_server()
+      task = mock_http_task(server)
+
+      consumer =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert :ok = StreamServer.monitor_consumer(server, consumer)
+      Process.exit(consumer, :cancelled)
+
+      assert wait_until(fn -> not Process.alive?(server) end)
+      assert wait_until(fn -> not Process.alive?(task.pid) end)
+    end
+
+    test "cancel is idempotent after StreamServer exits normally" do
+      server = start_server()
+
+      assert :ok = StreamServer.cancel(server)
+      assert wait_until(fn -> not Process.alive?(server) end)
+      assert :ok = StreamServer.cancel(server)
+    end
   end
 
   describe "HTTP event processing" do
@@ -212,6 +238,19 @@ defmodule ReqLLM.StreamServer.CoreTest do
              end)
 
       StreamServer.cancel(server)
+    end
+  end
+
+  defp wait_until(fun, attempts \\ 50)
+
+  defp wait_until(_fun, 0), do: false
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(20)
+      wait_until(fun, attempts - 1)
     end
   end
 end

--- a/test/req_llm/stream_server/core_test.exs
+++ b/test/req_llm/stream_server/core_test.exs
@@ -56,17 +56,21 @@ defmodule ReqLLM.StreamServer.CoreTest do
         end)
 
       assert :ok = StreamServer.monitor_consumer(server, consumer)
+      server_ref = Process.monitor(server)
+      task_ref = Process.monitor(task.pid)
+
       Process.exit(consumer, :cancelled)
 
-      assert wait_until(fn -> not Process.alive?(server) end)
-      assert wait_until(fn -> not Process.alive?(task.pid) end)
+      assert_receive {:DOWN, ^server_ref, :process, ^server, :normal}
+      assert_receive {:DOWN, ^task_ref, :process, task_pid, :cancelled} when task_pid == task.pid
     end
 
     test "cancel is idempotent after StreamServer exits normally" do
       server = start_server()
+      ref = Process.monitor(server)
 
       assert :ok = StreamServer.cancel(server)
-      assert wait_until(fn -> not Process.alive?(server) end)
+      assert_receive {:DOWN, ^ref, :process, ^server, :normal}
       assert :ok = StreamServer.cancel(server)
     end
   end
@@ -238,19 +242,6 @@ defmodule ReqLLM.StreamServer.CoreTest do
              end)
 
       StreamServer.cancel(server)
-    end
-  end
-
-  defp wait_until(fun, attempts \\ 50)
-
-  defp wait_until(_fun, 0), do: false
-
-  defp wait_until(fun, attempts) do
-    if fun.() do
-      true
-    else
-      Process.sleep(20)
-      wait_until(fun, attempts - 1)
     end
   end
 end

--- a/test/req_llm/stream_server/core_test.exs
+++ b/test/req_llm/stream_server/core_test.exs
@@ -65,6 +65,35 @@ defmodule ReqLLM.StreamServer.CoreTest do
       assert_receive {:DOWN, ^task_ref, :process, task_pid, :cancelled} when task_pid == task.pid
     end
 
+    test "keeps completed streams alive for metadata when consumer exits" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      consumer =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert :ok = StreamServer.monitor_consumer(server, consumer)
+
+      sse_content = ~s(data: {"choices": [{"delta": {"content": "Done"}}]}\n\n)
+      sse_done = ~s(data: [DONE]\n\n)
+      assert :ok = GenServer.call(server, {:http_event, {:data, sse_content}})
+      assert :ok = GenServer.call(server, {:http_event, {:data, sse_done}})
+      assert :ok = GenServer.call(server, {:http_event, :done})
+
+      consumer_ref = Process.monitor(consumer)
+      send(consumer, :stop)
+      assert_receive {:DOWN, ^consumer_ref, :process, ^consumer, :normal}
+
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 100)
+      assert metadata.finish_reason == :stop
+
+      StreamServer.cancel(server)
+    end
+
     test "cancel is idempotent after StreamServer exits normally" do
       server = start_server()
       ref = Process.monitor(server)


### PR DESCRIPTION
## Summary
- register stream consumers with StreamServer when lazy stream enumeration starts
- clean up StreamServer/HTTP task if monitored consumer exits before stream finalization
- make StreamServer.cancel/1 idempotent when server already exited normally
- remove duplicate safe-cancel wrapper from Streaming now cancel handles dead servers

## Tests
- mix test test/req_llm/stream_server/core_test.exs
- mix test test/req_llm/stream_server test/req_llm/integration/streaming_orchestration_test.exs
- mix test