### PR TITLE
fix(ollama): provider sent an empty request body (Content-Length: 0) → Ollama 400 EOF

### DIFF
--- a/lib/req_llm/providers/ollama.ex
+++ b/lib/req_llm/providers/ollama.ex
@@ -113,7 +113,7 @@ defmodule ReqLLM.Providers.Ollama do
     )
     |> ReqLLM.Step.Retry.attach()
     |> ReqLLM.Step.Error.attach()
-    |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, user_opts)

--- a/test/req_llm/integration/ollama_request_body_test.exs
+++ b/test/req_llm/integration/ollama_request_body_test.exs
@@ -1,0 +1,50 @@
+defmodule ReqLLM.Integration.OllamaRequestBodyTest do
+  @moduledoc """
+  Live integration test that round-trips a real request against a local Ollama.
+
+  Regression coverage for the empty-request-body bug: the built-in `:ollama`
+  provider used to send `Content-Length: 0` (the encoded JSON body never reached
+  the outgoing request), so Ollama rejected every call with
+  `400 {"error":{"message":"EOF","type":"invalid_request_error"}}`.
+
+  This test is gated on a reachable Ollama instance and skipped otherwise, so it
+  never breaks CI where no Ollama is running.
+
+  Run with:
+
+      mix test test/req_llm/integration/ollama_request_body_test.exs --include integration
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+  @moduletag timeout: 120_000
+
+  @model "ollama:llama3.1"
+  @base_url "http://localhost:11434"
+
+  @ollama_up? match?(
+                {:ok, %{status: 200}},
+                Req.get(@base_url <> "/api/tags", retry: false, receive_timeout: 1_000)
+              )
+
+  if not @ollama_up? do
+    @moduletag skip: "Local Ollama not reachable at #{@base_url}"
+  end
+
+  test "generate_text round-trips against live Ollama with a non-empty body" do
+    case ReqLLM.generate_text(@model, "Reply with the single word: pong") do
+      {:ok, response} ->
+        assert %ReqLLM.Response{} = response
+        text = ReqLLM.Response.text(response)
+        assert is_binary(text)
+        assert String.trim(text) != ""
+
+      {:error, error} ->
+        flunk("""
+        Ollama rejected the request — likely an empty request body regression:
+        #{inspect(error, pretty: true)}
+        """)
+    end
+  end
+end

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -17,9 +17,7 @@ defmodule ReqLLM.Providers.OllamaTest do
     %Req.Request{options: Map.new(opts)}
   end
 
-  # Runs the request pipeline steps in order, skipping network-making steps,
-  # so the returned request.body reflects what would actually be sent.
-  defp run_request_steps(%Req.Request{} = request) do
+  defp materialize_body_through_request_steps(%Req.Request{} = request) do
     skip = [:run_finch, :put_plug, :cache, :llm_telemetry_start]
 
     Enum.reduce(request.request_steps, request, fn {name, step}, acc ->
@@ -111,15 +109,6 @@ defmodule ReqLLM.Providers.OllamaTest do
   end
 
   describe "request body materialization" do
-    # Regression guard for the empty-request-body bug: the provider's attach/3
-    # must run llm_encode_body BEFORE Req's built-in encode_body step, otherwise
-    # options[:json] is set too late and the outgoing request carries an empty
-    # body (Content-Length: 0), which Ollama rejects with `400 ... EOF`.
-    #
-    # Unlike tests that call encode_body/1 directly (which always populates
-    # options[:json] regardless of pipeline order), this drives the full Req
-    # request pipeline and asserts on the materialized request.body — the gap
-    # that let the bug ship.
     test "llm_encode_body runs before Req's encode_body so the body is materialized" do
       {:ok, request} = Ollama.prepare_request(:chat, ollama_model(), "ping", [])
 
@@ -133,10 +122,7 @@ defmodule ReqLLM.Providers.OllamaTest do
     test "outgoing request carries a non-empty JSON body with model + messages" do
       {:ok, request} = Ollama.prepare_request(:chat, ollama_model(), "ping", [])
 
-      # Run the request steps in the exact order Req would, stopping just before
-      # the network adapter. After the full pipeline, request.body is what would
-      # be sent on the wire — this is where the empty-body bug manifests.
-      materialized = run_request_steps(request)
+      materialized = materialize_body_through_request_steps(request)
 
       body = materialized.body
       assert is_binary(body) or is_list(body)

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -17,6 +17,23 @@ defmodule ReqLLM.Providers.OllamaTest do
     %Req.Request{options: Map.new(opts)}
   end
 
+  # Runs the request pipeline steps in order, skipping network-making steps,
+  # so the returned request.body reflects what would actually be sent.
+  defp run_request_steps(%Req.Request{} = request) do
+    skip = [:run_finch, :put_plug, :cache, :llm_telemetry_start]
+
+    Enum.reduce(request.request_steps, request, fn {name, step}, acc ->
+      if name in skip do
+        acc
+      else
+        case step.(acc) do
+          %Req.Request{} = req -> req
+          {%Req.Request{} = req, _resp_or_err} -> req
+        end
+      end
+    end)
+  end
+
   defp simple_context do
     %ReqLLM.Context{
       messages: [
@@ -90,6 +107,46 @@ defmodule ReqLLM.Providers.OllamaTest do
 
       refute Map.has_key?(body, "tools")
       refute Map.has_key?(body, "tool_choice")
+    end
+  end
+
+  describe "request body materialization" do
+    # Regression guard for the empty-request-body bug: the provider's attach/3
+    # must run llm_encode_body BEFORE Req's built-in encode_body step, otherwise
+    # options[:json] is set too late and the outgoing request carries an empty
+    # body (Content-Length: 0), which Ollama rejects with `400 ... EOF`.
+    #
+    # Unlike tests that call encode_body/1 directly (which always populates
+    # options[:json] regardless of pipeline order), this drives the full Req
+    # request pipeline and asserts on the materialized request.body — the gap
+    # that let the bug ship.
+    test "llm_encode_body runs before Req's encode_body so the body is materialized" do
+      {:ok, request} = Ollama.prepare_request(:chat, ollama_model(), "ping", [])
+
+      step_keys = Keyword.keys(request.request_steps)
+
+      assert Enum.find_index(step_keys, &(&1 == :llm_encode_body)) <
+               Enum.find_index(step_keys, &(&1 == :encode_body)),
+             "llm_encode_body must precede Req's encode_body, got: #{inspect(step_keys)}"
+    end
+
+    test "outgoing request carries a non-empty JSON body with model + messages" do
+      {:ok, request} = Ollama.prepare_request(:chat, ollama_model(), "ping", [])
+
+      # Run the request steps in the exact order Req would, stopping just before
+      # the network adapter. After the full pipeline, request.body is what would
+      # be sent on the wire — this is where the empty-body bug manifests.
+      materialized = run_request_steps(request)
+
+      body = materialized.body
+      assert is_binary(body) or is_list(body)
+      body_string = IO.iodata_to_binary(body)
+      refute body_string == "", "outgoing request body must not be empty"
+
+      decoded = Jason.decode!(body_string)
+      assert decoded["model"] == "qwen2.5-coder:14b"
+      assert is_list(decoded["messages"])
+      assert decoded["messages"] != []
     end
   end
 


### PR DESCRIPTION
## Problem
The built-in `:ollama` provider sends an empty request body (`Content-Length: 0`) to Ollama's `/v1/chat/completions`, so Ollama rejects every call with `400 {"error":{"message":"EOF","type":"invalid_request_error"}}`. The encoded body never reaches the outgoing request.

Reproduced identically on v1.13.0–v1.16.0 (broken since the provider was introduced), against a live Ollama. The provider's unit tests called `encode_body/1` directly (which always populates `options[:json]` regardless of pipeline order) and never asserted the real request body, so it shipped broken.

## Repro
```elixir
Mix.install([{:req_llm, "1.16.0"}])
ReqLLM.generate_text("ollama:llama3.1", "ping")
# => {:error, %ReqLLM.Error.API.Request{status: 400, reason: "...Ollama API error: EOF", ...}}
```
Wire capture confirmed `Content-Length: 0`.

## Root cause
`ReqLLM.Providers.Ollama.attach/3` registered its body-encoding step with `Req.Request.append_request_steps(llm_encode_body: &encode_body/1)`, which placed `llm_encode_body` at the **end** of the Req request pipeline — **after** Req's built-in `encode_body` step:

```
put_user_agent, compressed, encode_body, ..., llm_encode_body, llm_telemetry_start
```

`llm_encode_body` only sets `options[:json]` (via `encode_body_from_map/2`); Req's built-in `encode_body` is what serializes `options[:json]` into `request.body`. With `llm_encode_body` running *after* `encode_body`, Req's encoder saw no `:json` and produced an empty body, and `options[:json]` was set too late for anything to serialize it.

Every other OpenAI-compatible provider goes through `ReqLLM.Provider.Defaults.default_attach/4`, which uses `prepend_request_steps` so `llm_encode_body` runs **first** (e.g. OpenAI: `[:llm_encode_body, :put_user_agent, :compressed, :encode_body, ...]`). The Ollama override diverged from that contract because it hand-rolls `attach/3` to skip the `Authorization` header.

## Fix
One line in `lib/req_llm/providers/ollama.ex` — switch `append_request_steps` to `prepend_request_steps`, matching `default_attach/4`:

```diff
-    |> Req.Request.append_request_steps(llm_encode_body: &encode_body/1)
+    |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
```

## Tests
- **Deterministic regression guard** (`test/req_llm/providers/ollama_test.exs`): drives the real `prepare_request → attach` pipeline and (a) asserts `llm_encode_body` precedes Req's `encode_body`, and (b) runs the request steps in pipeline order and asserts the materialized `request.body` is a non-empty JSON object containing `model` + `messages`. Both fail on `main` (body is `nil`) and pass after the fix. This is exactly the assertion the old mocked tests skipped.
- **Gated live integration test** (`test/req_llm/integration/ollama_request_body_test.exs`, `@moduletag :integration`): round-trips `generate_text` against a local Ollama, skipped when Ollama isn't reachable.

Verified live against a real Ollama (`llama3.1`):
- `ReqLLM.generate_text("ollama:llama3.1", "ping")` → `{:ok, %ReqLLM.Response{}}`, text `"Pong!"`, `finish_reason: :stop`.
- Wire capture after the fix: `PATH=/v1/chat/completions CONTENT_LENGTH=81 BODY={"messages":[{"role":"user","content":"ping"}],"stream":false,"model":"llama3.1"}` (was `Content-Length: 0`, empty body).

`mix quality` passes (format, compile --warnings-as-errors, credo --strict, dialyzer — 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
