### PR TITLE
fix(groq): omit reasoning fields from assistant history

### DIFF
--- a/lib/req_llm/providers/groq.ex
+++ b/lib/req_llm/providers/groq.ex
@@ -148,6 +148,7 @@ defmodule ReqLLM.Providers.Groq do
   @impl ReqLLM.Provider
   def build_body(request) do
     ReqLLM.Provider.Defaults.default_build_body(request)
+    |> strip_message_reasoning_fields()
     |> ReqLLM.Providers.OpenAI.AdapterHelpers.translate_tool_choice_format()
     |> maybe_put_skip(:service_tier, request.options[:service_tier], ["auto"])
     |> maybe_put_skip(:reasoning_effort, request.options[:reasoning_effort], ["default"])
@@ -177,8 +178,36 @@ defmodule ReqLLM.Providers.Groq do
 
     base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, processed_opts)
     opts_with_base_url = Keyword.put(processed_opts, :base_url, base_url)
-    ReqLLM.Providers.OpenAI.ChatAPI.attach_stream(model, context, opts_with_base_url, finch_name)
+
+    ReqLLM.Provider.Defaults.default_attach_stream(
+      __MODULE__,
+      model,
+      context,
+      opts_with_base_url,
+      finch_name
+    )
   end
+
+  defp strip_message_reasoning_fields(%{messages: messages} = body) when is_list(messages) do
+    Map.put(body, :messages, Enum.map(messages, &strip_reasoning_fields/1))
+  end
+
+  defp strip_message_reasoning_fields(%{"messages" => messages} = body) when is_list(messages) do
+    Map.put(body, "messages", Enum.map(messages, &strip_reasoning_fields/1))
+  end
+
+  defp strip_message_reasoning_fields(body), do: body
+
+  defp strip_reasoning_fields(message) when is_map(message) do
+    Map.drop(message, [
+      :reasoning_content,
+      :reasoning_details,
+      "reasoning_content",
+      "reasoning_details"
+    ])
+  end
+
+  defp strip_reasoning_fields(message), do: message
 
   @doc """
   Initialize streaming state for <think> tag normalization.

--- a/test/providers/groq_test.exs
+++ b/test/providers/groq_test.exs
@@ -9,7 +9,50 @@ defmodule ReqLLM.Providers.GroqTest do
   use ReqLLM.ProviderCase, provider: ReqLLM.Providers.Groq
 
   alias ReqLLM.Context
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Message.ReasoningDetails
   alias ReqLLM.Providers.Groq
+
+  defp groq_gpt_oss_model do
+    %LLMDB.Model{
+      id: "openai/gpt-oss-120b",
+      model: "openai/gpt-oss-120b",
+      provider: :groq,
+      capabilities: %{chat: true, streaming: true},
+      limits: %{context: 131_072, output: 8192}
+    }
+  end
+
+  defp reasoning_context do
+    %Context{
+      messages: [
+        %Message{
+          role: :user,
+          content: [ContentPart.text("How would you build a pyramid?")]
+        },
+        %Message{
+          role: :assistant,
+          content: [
+            ContentPart.thinking("Plan the answer carefully."),
+            ContentPart.text("Use a stable foundation and stack stone courses.")
+          ],
+          reasoning_details: [
+            %ReasoningDetails{
+              text: "Plan the answer carefully.",
+              provider: :groq,
+              format: "groq-reasoning",
+              index: 0
+            }
+          ]
+        },
+        %Message{
+          role: :user,
+          content: [ContentPart.text("What is your favorite pyramid?")]
+        }
+      ]
+    }
+  end
 
   describe "provider contract" do
     test "provider identity and configuration" do
@@ -330,6 +373,50 @@ defmodule ReqLLM.Providers.GroqTest do
         decoded = ReqLLM.Test.Helpers.json_body(updated_request)
         assertion.(decoded)
       end
+    end
+
+    test "encode_body omits unsupported reasoning fields from assistant history" do
+      mock_request = %Req.Request{
+        options: [
+          context: reasoning_context(),
+          model: "openai/gpt-oss-120b",
+          stream: false,
+          reasoning_effort: "high"
+        ]
+      }
+
+      updated_request = Groq.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      assistant_message = Enum.find(decoded["messages"], &(&1["role"] == "assistant"))
+
+      assert decoded["reasoning_effort"] == "high"
+      assert assistant_message["content"] == "Use a stable foundation and stack stone courses."
+      refute Map.has_key?(assistant_message, "reasoning_content")
+      refute Map.has_key?(assistant_message, "reasoning_details")
+    end
+
+    test "attach_stream omits unsupported reasoning fields from assistant history" do
+      {:ok, request} =
+        Groq.attach_stream(
+          groq_gpt_oss_model(),
+          reasoning_context(),
+          [reasoning_effort: :high],
+          ReqLLM.Finch
+        )
+
+      decoded =
+        request.body
+        |> IO.iodata_to_binary()
+        |> Jason.decode!()
+
+      assistant_message = Enum.find(decoded["messages"], &(&1["role"] == "assistant"))
+
+      assert decoded["stream"] == true
+      assert decoded["reasoning_effort"] == "high"
+      assert assistant_message["content"] == "Use a stable foundation and stack stone courses."
+      refute Map.has_key?(assistant_message, "reasoning_content")
+      refute Map.has_key?(assistant_message, "reasoning_details")
     end
   end
 


### PR DESCRIPTION
## Summary

- Remove Groq message-level `reasoning_content` and `reasoning_details` before request encoding.
- Route Groq streaming requests through the same provider body builder so streaming and non-streaming follow-up turns match.
- Add Groq regression coverage for GPT OSS multi-turn reasoning context encoding.

## Validation

- `mix format --check-formatted lib/req_llm/providers/groq.ex test/providers/groq_test.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `git diff --check`
- `mix test test/providers/groq_test.exs`

Fixes #772