### PR TITLE
fix(openrouter): preserve reasoning details

### DIFF
--- a/lib/req_llm/message.ex
+++ b/lib/req_llm/message.ex
@@ -43,10 +43,64 @@ defmodule ReqLLM.Message do
 
     @type t :: unquote(Zoi.type_spec(@schema))
 
+    @openai_compatible_keys ["text", "signature", "signature_encrypted", "format", "index"]
+
     @enforce_keys Zoi.Struct.enforce_keys(@schema)
     defstruct Zoi.Struct.struct_fields(@schema)
 
     def schema, do: @schema
+
+    @doc """
+    Builds normalized reasoning details from an OpenAI-compatible wire map.
+
+    OpenAI-compatible providers such as OpenRouter attach provider-specific
+    fields to `reasoning_details` entries. ReqLLM keeps common fields on the
+    struct and stores unknown provider fields in `provider_data` so the entry
+    can be encoded back to the provider without losing wire metadata.
+    """
+    @spec from_openai_compatible(map(), atom() | nil, non_neg_integer()) :: t()
+    @spec from_openai_compatible(map(), atom() | nil, non_neg_integer(), String.t()) :: t()
+    def from_openai_compatible(
+          raw,
+          provider,
+          fallback_index,
+          default_format \\ "openai-compatible-v1"
+        )
+        when is_map(raw) and is_binary(default_format) do
+      %__MODULE__{
+        text: raw["text"],
+        signature: raw["signature"],
+        encrypted?: raw["signature_encrypted"] == true,
+        provider: provider,
+        format: raw["format"] || default_format,
+        index: raw["index"] || fallback_index,
+        provider_data: Map.drop(raw, @openai_compatible_keys)
+      }
+    end
+
+    @doc """
+    Encodes normalized reasoning details to an OpenAI-compatible wire map.
+    """
+    @spec to_openai_compatible(t()) :: map()
+    def to_openai_compatible(%__MODULE__{} = detail) do
+      detail.provider_data
+      |> ensure_map()
+      |> put_wire_field("text", detail.text)
+      |> put_wire_field("signature", detail.signature)
+      |> put_wire_field("signature_encrypted", encrypted_signature(detail))
+      |> put_wire_field("format", detail.format)
+      |> put_wire_field("index", detail.index)
+    end
+
+    defp encrypted_signature(%__MODULE__{encrypted?: true}), do: true
+    defp encrypted_signature(_detail), do: nil
+
+    defp put_wire_field(map, _key, nil), do: map
+    defp put_wire_field(map, _key, ""), do: map
+    defp put_wire_field(map, key, value), do: Map.put(map, key, value)
+
+    defp ensure_map(map) when is_map(map), do: map
+    defp ensure_map(_), do: %{}
   end
 
   @derive Jason.Encoder

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -822,25 +822,33 @@ defmodule ReqLLM.Provider.Defaults do
   Provider.Defaults for the protocol removal refactoring.
   """
   @spec encode_context_to_openai_format(ReqLLM.Context.t(), String.t()) :: map()
-  def encode_context_to_openai_format(%ReqLLM.Context{messages: messages}, _model_name) do
+  def encode_context_to_openai_format(context, model_name) do
+    encode_context_to_openai_format(context, model_name, [])
+  end
+
+  @spec encode_context_to_openai_format(ReqLLM.Context.t(), String.t(), keyword()) :: map()
+  def encode_context_to_openai_format(%ReqLLM.Context{messages: messages}, _model_name, opts) do
     %{
-      messages: encode_openai_messages(messages)
+      messages: encode_openai_messages(messages, opts)
     }
   end
 
-  defp encode_openai_messages(messages) do
-    Enum.map(messages, &encode_openai_message/1)
+  defp encode_openai_messages(messages, opts) do
+    Enum.map(messages, &encode_openai_message(&1, opts))
   end
 
-  defp encode_openai_message(%ReqLLM.Message{
-         role: r,
-         content: c,
-         tool_calls: tc,
-         tool_call_id: tcid,
-         name: name,
-         reasoning_details: rd,
-         metadata: metadata
-       }) do
+  defp encode_openai_message(
+         %ReqLLM.Message{
+           role: r,
+           content: c,
+           tool_calls: tc,
+           tool_call_id: tcid,
+           name: name,
+           reasoning_details: rd,
+           metadata: metadata
+         },
+         opts
+       ) do
     {reasoning_content, content_without_thinking} = extract_reasoning_content(c)
 
     base_message = %{
@@ -853,7 +861,7 @@ defmodule ReqLLM.Provider.Defaults do
     |> maybe_add_field(:tool_call_id, tcid)
     |> maybe_add_field(:name, name)
     |> maybe_add_assistant_reasoning(r, reasoning_content)
-    |> maybe_add_field(:reasoning_details, rd)
+    |> maybe_add_reasoning_details(rd, Keyword.get(opts, :encode_reasoning_details?, false))
     |> maybe_add_field(:metadata, metadata)
   end
 
@@ -883,6 +891,30 @@ defmodule ReqLLM.Provider.Defaults do
   defp maybe_add_field(message, _key, []), do: message
   defp maybe_add_field(message, _key, %{} = value) when map_size(value) == 0, do: message
   defp maybe_add_field(message, key, value), do: Map.put(message, key, value)
+
+  defp maybe_add_reasoning_details(message, nil, _encode?), do: message
+  defp maybe_add_reasoning_details(message, [], _encode?), do: message
+
+  defp maybe_add_reasoning_details(message, details, true) when is_list(details) do
+    encoded_details =
+      details
+      |> Enum.map(&encode_reasoning_detail_for_openai/1)
+      |> Enum.reject(&is_nil/1)
+
+    maybe_add_field(message, :reasoning_details, encoded_details)
+  end
+
+  defp maybe_add_reasoning_details(message, details, false) when is_list(details) do
+    maybe_add_field(message, :reasoning_details, details)
+  end
+
+  defp maybe_add_reasoning_details(message, _details, _encode?), do: message
+
+  defp encode_reasoning_detail_for_openai(%ReqLLM.Message.ReasoningDetails{} = detail) do
+    ReqLLM.Message.ReasoningDetails.to_openai_compatible(detail)
+  end
+
+  defp encode_reasoning_detail_for_openai(_detail), do: nil
 
   defp maybe_add_assistant_reasoning(message, :assistant, reasoning_content) do
     maybe_add_field(message, :reasoning_content, reasoning_content)
@@ -1101,14 +1133,17 @@ defmodule ReqLLM.Provider.Defaults do
 
     finish_reason = parse_openai_finish_reason(Map.get(first_choice, "finish_reason"))
 
-    content_chunks =
+    {content_chunks, raw_message} =
       case first_choice do
-        %{"message" => message} -> decode_openai_message(message)
-        %{"delta" => delta} -> decode_openai_delta(delta)
-        _ -> []
+        %{"message" => message} -> {decode_openai_message(message), message}
+        %{"delta" => delta} -> {decode_openai_delta(delta), delta}
+        _ -> {[], %{}}
       end
 
-    message = build_openai_message_from_chunks(content_chunks)
+    message =
+      content_chunks
+      |> build_openai_message_from_chunks()
+      |> put_openai_reasoning_details(raw_message, model.provider)
 
     context = %ReqLLM.Context{
       messages: [message]
@@ -1169,7 +1204,8 @@ defmodule ReqLLM.Provider.Defaults do
             reasoning_details_chunks =
               case delta do
                 %{"reasoning_details" => details} when is_list(details) and details != [] ->
-                  [ReqLLM.StreamChunk.meta(%{reasoning_details: details})]
+                  reasoning_details = decode_openai_reasoning_details(details, model.provider)
+                  [ReqLLM.StreamChunk.meta(%{reasoning_details: reasoning_details})]
 
                 _ ->
                   []
@@ -1275,6 +1311,39 @@ defmodule ReqLLM.Provider.Defaults do
   end
 
   defp decode_openai_tool_calls(_), do: []
+
+  defp put_openai_reasoning_details(message, %{"reasoning_details" => details}, provider)
+       when is_list(details) and details != [] do
+    normalized_details = decode_openai_reasoning_details(details, provider)
+
+    if normalized_details == [] do
+      message
+    else
+      %{message | reasoning_details: normalized_details}
+    end
+  end
+
+  defp put_openai_reasoning_details(message, _raw_message, _provider), do: message
+
+  defp decode_openai_reasoning_details(details, provider) when is_list(details) do
+    details
+    |> Enum.with_index()
+    |> Enum.map(&decode_openai_reasoning_detail(&1, provider))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp decode_openai_reasoning_detail(
+         {%ReqLLM.Message.ReasoningDetails{} = detail, _fallback_index},
+         _provider
+       ) do
+    detail
+  end
+
+  defp decode_openai_reasoning_detail({raw, fallback_index}, provider) when is_map(raw) do
+    ReqLLM.Message.ReasoningDetails.from_openai_compatible(raw, provider, fallback_index)
+  end
+
+  defp decode_openai_reasoning_detail(_detail, _provider), do: nil
 
   defp decode_openai_content_part(%{"type" => "text", "text" => text}) do
     [ReqLLM.StreamChunk.text(text)]
@@ -1620,7 +1689,7 @@ defmodule ReqLLM.Provider.Defaults do
       case request.options[:context] do
         %ReqLLM.Context{} = ctx ->
           model_name = request.options[:model]
-          encode_context_to_openai_format(ctx, model_name)
+          encode_context_to_openai_format(ctx, model_name, encode_reasoning_details?: true)
 
         _ ->
           %{messages: request.options[:messages] || []}

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -98,10 +98,12 @@ defmodule ReqLLM.Providers.Minimax do
   @impl ReqLLM.Provider
   def build_body(request) do
     reasoning_split = option_value(request.options, :reasoning_split, true)
+    original_context = request.options[:context]
 
     request
+    |> strip_reasoning_details_from_context()
     |> ReqLLM.Provider.Defaults.default_build_body()
-    |> encode_minimax_reasoning_history()
+    |> encode_minimax_reasoning_history(original_context)
     |> Map.delete(:max_tokens)
     |> Map.delete("max_tokens")
     |> maybe_put(:max_completion_tokens, request.options[:max_completion_tokens])
@@ -223,28 +225,74 @@ defmodule ReqLLM.Providers.Minimax do
 
   defp normalize_stream_chunk(chunk), do: chunk
 
-  defp encode_minimax_reasoning_history(%{messages: messages} = body) when is_list(messages) do
-    %{body | messages: Enum.map(messages, &encode_minimax_message_reasoning/1)}
+  defp strip_reasoning_details_from_context(%Req.Request{options: options} = request) do
+    case options[:context] do
+      %ReqLLM.Context{messages: messages} = context ->
+        stripped_messages =
+          Enum.map(messages, fn
+            %ReqLLM.Message{} = message -> %{message | reasoning_details: nil}
+            message -> message
+          end)
+
+        put_in(request.options[:context], %{context | messages: stripped_messages})
+
+      _ ->
+        request
+    end
   end
 
-  defp encode_minimax_reasoning_history(%{"messages" => messages} = body)
-       when is_list(messages) do
-    %{body | "messages" => Enum.map(messages, &encode_minimax_message_reasoning/1)}
+  defp encode_minimax_reasoning_history(body, %ReqLLM.Context{messages: context_messages}) do
+    cond do
+      is_list(Map.get(body, :messages)) ->
+        %{body | messages: encode_minimax_messages_reasoning(body.messages, context_messages)}
+
+      is_list(Map.get(body, "messages")) ->
+        %{
+          body
+          | "messages" => encode_minimax_messages_reasoning(body["messages"], context_messages)
+        }
+
+      true ->
+        body
+    end
   end
 
-  defp encode_minimax_reasoning_history(body), do: body
+  defp encode_minimax_reasoning_history(body, _context), do: body
 
-  defp encode_minimax_message_reasoning(%{reasoning_details: details} = message)
+  defp encode_minimax_messages_reasoning(encoded_messages, context_messages)
+       when length(encoded_messages) == length(context_messages) do
+    encoded_messages
+    |> Enum.zip(context_messages)
+    |> Enum.map(fn {encoded_message, context_message} ->
+      encode_minimax_message_reasoning(encoded_message, context_message)
+    end)
+  end
+
+  defp encode_minimax_messages_reasoning(encoded_messages, _context_messages),
+    do: encoded_messages
+
+  defp encode_minimax_message_reasoning(encoded_message, %ReqLLM.Message{
+         reasoning_details: details
+       })
        when is_list(details) do
-    %{message | reasoning_details: encode_minimax_reasoning_details(details)}
+    put_minimax_reasoning_details(encoded_message, encode_minimax_reasoning_details(details))
   end
 
-  defp encode_minimax_message_reasoning(%{"reasoning_details" => details} = message)
-       when is_list(details) do
-    %{message | "reasoning_details" => encode_minimax_reasoning_details(details)}
+  defp encode_minimax_message_reasoning(encoded_message, _context_message), do: encoded_message
+
+  defp put_minimax_reasoning_details(message, []) when is_map(message) do
+    message
+    |> Map.delete(:reasoning_details)
+    |> Map.delete("reasoning_details")
   end
 
-  defp encode_minimax_message_reasoning(message), do: message
+  defp put_minimax_reasoning_details(%{} = message, details) do
+    cond do
+      Map.has_key?(message, :role) -> Map.put(message, :reasoning_details, details)
+      Map.has_key?(message, "role") -> Map.put(message, "reasoning_details", details)
+      true -> Map.put(message, :reasoning_details, details)
+    end
+  end
 
   defp encode_minimax_reasoning_details(details) do
     Enum.map(details, &encode_minimax_reasoning_detail/1)

--- a/lib/req_llm/providers/openai/adapter_helpers.ex
+++ b/lib/req_llm/providers/openai/adapter_helpers.ex
@@ -128,6 +128,19 @@ defmodule ReqLLM.Providers.OpenAI.AdapterHelpers do
     |> maybe_recurse_defs()
   end
 
+  def enforce_strict_recursive(%{"type" => "object", "patternProperties" => patterns} = schema)
+      when is_map(patterns) do
+    updated_patterns =
+      Map.new(patterns, fn {k, v} -> {k, enforce_strict_recursive(v)} end)
+
+    schema
+    |> Map.put("patternProperties", updated_patterns)
+    |> Map.put_new("properties", %{})
+    |> Map.put("required", [])
+    |> Map.put("additionalProperties", false)
+    |> maybe_recurse_defs()
+  end
+
   def enforce_strict_recursive(%{"type" => "array", "items" => items} = schema)
       when is_map(items) do
     Map.put(schema, "items", enforce_strict_recursive(items))
@@ -141,7 +154,32 @@ defmodule ReqLLM.Providers.OpenAI.AdapterHelpers do
     Map.put(schema, "oneOf", Enum.map(variants, &enforce_strict_recursive/1))
   end
 
+  def enforce_strict_recursive(%{} = schema) do
+    if annotation_only_schema?(schema) do
+      schema
+      |> Map.put("type", "object")
+      |> Map.put("properties", %{})
+      |> Map.put("required", [])
+      |> Map.put("additionalProperties", false)
+      |> maybe_recurse_defs()
+    else
+      schema
+    end
+  end
+
   def enforce_strict_recursive(schema), do: schema
+
+  # Annotation-only schemas such as %{"description" => "..."} are valid JSON Schema
+  # unrestricted subschemas, but OpenAI strict tool schemas reject subschemas without an
+  # assertion/applicator keyword. In strict OpenAI mode, represent them as empty strict objects.
+  @schema_shape_keys ["type", "anyOf", "oneOf", "allOf", "$ref", "const", "enum"]
+  @annotation_keys ["description", "title", "default", "examples"]
+
+  defp annotation_only_schema?(schema) do
+    map_size(schema) > 0 and
+      not Enum.any?(@schema_shape_keys, &Map.has_key?(schema, &1)) and
+      Enum.all?(Map.keys(schema), &(&1 in @annotation_keys))
+  end
 
   defp maybe_recurse_defs(%{"$defs" => defs} = schema) when is_map(defs) do
     updated_defs = Map.new(defs, fn {k, v} -> {k, enforce_strict_recursive(v)} end)

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -379,11 +379,15 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   @impl ReqLLM.Provider
   def build_body(request) do
-    ReqLLM.Provider.Defaults.default_build_body(request)
+    original_context = request.options[:context]
+
+    request
+    |> strip_reasoning_details_from_context()
+    |> ReqLLM.Provider.Defaults.default_build_body()
     |> encode_openrouter_content_parts(request.options)
     |> add_embedding_options(request.options)
     |> translate_tool_choice_format()
-    |> encode_reasoning_details_in_messages()
+    |> encode_reasoning_details_in_messages(original_context)
     |> maybe_put(:models, request.options[:openrouter_models])
     |> maybe_put(:route, request.options[:openrouter_route])
     |> maybe_put(:provider, request.options[:openrouter_provider])
@@ -954,72 +958,93 @@ defmodule ReqLLM.Providers.OpenRouter do
   defp extract_reasoning_details(_), do: nil
 
   defp normalize_reasoning_detail({raw, fallback_index}) do
-    %ReqLLM.Message.ReasoningDetails{
-      text: raw["text"],
-      signature: raw["signature"],
-      encrypted?: raw["signature_encrypted"] || false,
-      provider: :openrouter,
-      format: raw["format"] || "openrouter-v1",
-      index: raw["index"] || fallback_index,
-      provider_data: %{"type" => raw["type"]}
-    }
+    ReqLLM.Message.ReasoningDetails.from_openai_compatible(
+      raw,
+      :openrouter,
+      fallback_index,
+      "openrouter-v1"
+    )
   end
 
-  defp encode_reasoning_details_in_messages(%{messages: messages} = body)
-       when is_list(messages) do
-    updated_messages = Enum.map(messages, &encode_message_reasoning_details/1)
-    Map.put(body, :messages, updated_messages)
+  defp strip_reasoning_details_from_context(%Req.Request{options: options} = request) do
+    case options[:context] do
+      %ReqLLM.Context{messages: messages} = context ->
+        stripped_messages =
+          Enum.map(messages, fn
+            %ReqLLM.Message{} = message -> %{message | reasoning_details: nil}
+            message -> message
+          end)
+
+        put_in(request.options[:context], %{context | messages: stripped_messages})
+
+      _ ->
+        request
+    end
   end
 
-  defp encode_reasoning_details_in_messages(%{"messages" => messages} = body)
-       when is_list(messages) do
-    updated_messages = Enum.map(messages, &encode_message_reasoning_details/1)
-    Map.put(body, "messages", updated_messages)
+  defp encode_reasoning_details_in_messages(body, %ReqLLM.Context{messages: context_messages}) do
+    cond do
+      is_list(Map.get(body, :messages)) ->
+        updated_messages = encode_messages_reasoning_details(body.messages, context_messages)
+        Map.put(body, :messages, updated_messages)
+
+      is_list(Map.get(body, "messages")) ->
+        updated_messages = encode_messages_reasoning_details(body["messages"], context_messages)
+        Map.put(body, "messages", updated_messages)
+
+      true ->
+        body
+    end
   end
 
-  defp encode_reasoning_details_in_messages(body), do: body
+  defp encode_reasoning_details_in_messages(body, _context), do: body
 
-  defp encode_message_reasoning_details(%{reasoning_details: details} = message)
+  defp encode_messages_reasoning_details(encoded_messages, context_messages)
+       when length(encoded_messages) == length(context_messages) do
+    encoded_messages
+    |> Enum.zip(context_messages)
+    |> Enum.map(fn {encoded_message, context_message} ->
+      encode_message_reasoning_details(encoded_message, context_message)
+    end)
+  end
+
+  defp encode_messages_reasoning_details(encoded_messages, _context_messages),
+    do: encoded_messages
+
+  defp encode_message_reasoning_details(encoded_message, %ReqLLM.Message{
+         reasoning_details: details
+       })
        when is_list(details) and details != [] do
     encoded_details =
       details
       |> Enum.map(&encode_single_reasoning_detail/1)
       |> Enum.reject(&is_nil/1)
 
-    if encoded_details == [] do
-      Map.delete(message, :reasoning_details)
-    else
-      Map.put(message, :reasoning_details, encoded_details)
-    end
+    put_encoded_reasoning_details(encoded_message, encoded_details)
   end
 
-  defp encode_message_reasoning_details(%{"reasoning_details" => details} = message)
-       when is_list(details) and details != [] do
-    encoded_details =
-      details
-      |> Enum.map(&encode_single_reasoning_detail/1)
-      |> Enum.reject(&is_nil/1)
+  defp encode_message_reasoning_details(encoded_message, _context_message), do: encoded_message
 
-    if encoded_details == [] do
-      Map.delete(message, "reasoning_details")
-    else
-      Map.put(message, "reasoning_details", encoded_details)
-    end
+  defp put_encoded_reasoning_details(message, []) when is_map(message) do
+    message
+    |> Map.delete(:reasoning_details)
+    |> Map.delete("reasoning_details")
   end
 
-  defp encode_message_reasoning_details(message), do: message
+  defp put_encoded_reasoning_details(%{} = message, details) do
+    cond do
+      Map.has_key?(message, :role) -> Map.put(message, :reasoning_details, details)
+      Map.has_key?(message, "role") -> Map.put(message, "reasoning_details", details)
+      true -> Map.put(message, :reasoning_details, details)
+    end
+  end
 
   defp encode_single_reasoning_detail(
          %ReqLLM.Message.ReasoningDetails{provider: :openrouter} = detail
        ) do
-    base = %{
-      "type" => detail.provider_data["type"] || "reasoning.text",
-      "format" => detail.format,
-      "index" => detail.index,
-      "text" => detail.text
-    }
-
-    if detail.signature, do: Map.put(base, "signature", detail.signature), else: base
+    detail
+    |> ReqLLM.Message.ReasoningDetails.to_openai_compatible()
+    |> Map.put_new("type", "reasoning.text")
   end
 
   defp encode_single_reasoning_detail(%ReqLLM.Message.ReasoningDetails{provider: provider}) do
@@ -1028,16 +1053,9 @@ defmodule ReqLLM.Providers.OpenRouter do
   end
 
   defp encode_single_reasoning_detail(%{"provider" => "openrouter"} = decoded_struct) do
-    base = %{
-      "type" => get_in(decoded_struct, ["provider_data", "type"]) || "reasoning.text",
-      "format" => decoded_struct["format"],
-      "index" => decoded_struct["index"],
-      "text" => decoded_struct["text"]
-    }
-
-    if decoded_struct["signature"],
-      do: Map.put(base, "signature", decoded_struct["signature"]),
-      else: base
+    decoded_struct
+    |> openrouter_reasoning_detail_to_wire()
+    |> Map.put_new("type", "reasoning.text")
   end
 
   defp encode_single_reasoning_detail(%{"provider" => provider}) when is_binary(provider) do
@@ -1050,6 +1068,28 @@ defmodule ReqLLM.Providers.OpenRouter do
   end
 
   defp encode_single_reasoning_detail(_), do: nil
+
+  defp openrouter_reasoning_detail_to_wire(detail) do
+    detail
+    |> Map.get("provider_data", %{})
+    |> ensure_map()
+    |> put_wire_field("text", detail["text"])
+    |> put_wire_field("signature", detail["signature"])
+    |> put_wire_field("signature_encrypted", encrypted_signature?(detail))
+    |> put_wire_field("format", detail["format"])
+    |> put_wire_field("index", detail["index"])
+  end
+
+  defp encrypted_signature?(%{"encrypted?" => true}), do: true
+  defp encrypted_signature?(%{"encrypted" => true}), do: true
+  defp encrypted_signature?(_detail), do: nil
+
+  defp put_wire_field(map, _key, nil), do: map
+  defp put_wire_field(map, _key, ""), do: map
+  defp put_wire_field(map, key, value), do: Map.put(map, key, value)
+
+  defp ensure_map(map) when is_map(map), do: map
+  defp ensure_map(_), do: %{}
 
   defp attach_reasoning_details_to_response(resp, nil), do: resp
 

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -130,6 +130,68 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert Enum.sort(encoded_tool["parameters"]["required"]) == ["location", "units"]
     end
 
+    test "strictifies raw function tools with JSON schema placeholder parameters" do
+      tool = %{
+        "type" => "function",
+        "function" => %{
+          "name" => "websearch",
+          "description" => "Search the web",
+          "parameters" => %{
+            "type" => "object",
+            "required" => ["query"],
+            "properties" => %{
+              "query" => %{"type" => "string"},
+              "outputSchema" => %{
+                "description" => "JSON schema for synthesized output.content"
+              },
+              "summary" => %{
+                "anyOf" => [
+                  %{"type" => "boolean"},
+                  %{
+                    "type" => "object",
+                    "properties" => %{
+                      "schema" => %{
+                        "description" => "JSON schema for structured summary output"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+
+      request = build_request(tools: [tool])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert [encoded_tool] = body["tools"]
+      assert encoded_tool["type"] == "function"
+      assert encoded_tool["name"] == "websearch"
+      assert encoded_tool["strict"] == true
+
+      params = encoded_tool["parameters"]
+      assert Enum.sort(params["required"]) == ["outputSchema", "query", "summary"]
+      assert params["additionalProperties"] == false
+
+      output_schema = params["properties"]["outputSchema"]
+      assert output_schema["description"] == "JSON schema for synthesized output.content"
+      assert output_schema["type"] == "object"
+      assert output_schema["properties"] == %{}
+      assert output_schema["required"] == []
+      assert output_schema["additionalProperties"] == false
+
+      [_, summary_object] = params["properties"]["summary"]["anyOf"]
+      nested_schema = summary_object["properties"]["schema"]
+      assert nested_schema["description"] == "JSON schema for structured summary output"
+      assert nested_schema["type"] == "object"
+      assert nested_schema["properties"] == %{}
+      assert nested_schema["required"] == []
+      assert nested_schema["additionalProperties"] == false
+    end
+
     test "passes through code_interpreter tool maps unchanged" do
       tool = %{
         "type" => "code_interpreter",

--- a/test/provider/openai_structured_output_test.exs
+++ b/test/provider/openai_structured_output_test.exs
@@ -627,6 +627,26 @@ defmodule ReqLLM.Providers.OpenAI.StructuredOutputTest do
       assert Enum.sort(item_schema["required"]) == ["name", "qty"]
     end
 
+    test "enforce_strict_recursive handles patternProperties objects" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "headers" => %{
+            "type" => "object",
+            "patternProperties" => %{"^.*$" => %{"type" => "string"}}
+          }
+        }
+      }
+
+      result = ReqLLM.Providers.OpenAI.AdapterHelpers.enforce_strict_recursive(schema)
+
+      headers = result["properties"]["headers"]
+      assert headers["additionalProperties"] == false
+      assert headers["properties"] == %{}
+      assert headers["required"] == []
+      assert headers["patternProperties"] == %{"^.*$" => %{"type" => "string"}}
+    end
+
     test "enforce_strict_recursive handles anyOf branches" do
       schema = %{
         "type" => "object",

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -1585,7 +1585,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       assert log =~ "anthropic"
     end
 
-    test "encodes ReasoningDetails with signature field" do
+    test "encodes ReasoningDetails with signature and provider data fields" do
       message_with_signature = %ReqLLM.Message{
         role: :assistant,
         content: [ReqLLM.Message.ContentPart.text("The answer")],
@@ -1597,7 +1597,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
             provider: :openrouter,
             format: "google-gemini-v1",
             index: 0,
-            provider_data: %{"type" => "reasoning.text"}
+            provider_data: %{"type" => "reasoning.text", "id" => "rs_123"}
           }
         ]
       }
@@ -1623,7 +1623,9 @@ defmodule ReqLLM.Providers.OpenRouterTest do
         Enum.find(decoded_body["messages"], fn msg -> msg["role"] == "assistant" end)
 
       [detail] = assistant_message["reasoning_details"]
+      assert detail["id"] == "rs_123"
       assert detail["signature"] == "encrypted-sig-token"
+      assert detail["signature_encrypted"] == true
       assert detail["text"] == "Reasoning text"
     end
   end

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -4,6 +4,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
   alias ReqLLM.Context
   alias ReqLLM.Message
   alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Message.ReasoningDetails
   alias ReqLLM.Provider.Defaults
   alias ReqLLM.Provider.Defaults.ResponseBuilder
   alias ReqLLM.StreamChunk
@@ -303,9 +304,17 @@ defmodule ReqLLM.Provider.DefaultsTest do
              ) == expected_message_result
     end
 
-    test "encodes reasoning_details for round-trip preservation" do
+    test "encodes normalized reasoning_details for round-trip preservation" do
       reasoning_details = [
-        %{"type" => "encrypted_thought", "data" => "abc123", "format" => "google-gemini-v1"}
+        %ReasoningDetails{
+          text: "hidden thought",
+          signature: "sig-123",
+          encrypted?: true,
+          provider: :openrouter,
+          format: "google-gemini-v1",
+          index: 0,
+          provider_data: %{"type" => "encrypted_thought", "data" => "abc123"}
+        }
       ]
 
       message = %Message{
@@ -315,11 +324,26 @@ defmodule ReqLLM.Provider.DefaultsTest do
       }
 
       context = %Context{messages: [message]}
-      result = Defaults.encode_context_to_openai_format(context, "gemini-2.5-flash")
+
+      result =
+        Defaults.encode_context_to_openai_format(context, "gemini-2.5-flash",
+          encode_reasoning_details?: true
+        )
 
       [encoded_message] = result.messages
 
-      assert encoded_message.reasoning_details == reasoning_details
+      assert encoded_message.reasoning_details == [
+               %{
+                 "type" => "encrypted_thought",
+                 "data" => "abc123",
+                 "text" => "hidden thought",
+                 "signature" => "sig-123",
+                 "signature_encrypted" => true,
+                 "format" => "google-gemini-v1",
+                 "index" => 0
+               }
+             ]
+
       assert encoded_message.role == "assistant"
       assert encoded_message.content == "I'll help with that."
     end
@@ -527,6 +551,50 @@ defmodule ReqLLM.Provider.DefaultsTest do
         {:ok, result} = Defaults.decode_response_body_openai_format(response_data, model)
         assertion_fn.(result)
       end
+    end
+
+    test "decodes reasoning_details to normalized structs", %{model: model} do
+      response_data = %{
+        "id" => "chatcmpl-reasoning",
+        "model" => "openai/gpt-5-mini-2025-08-07",
+        "choices" => [
+          %{
+            "message" => %{
+              "role" => "assistant",
+              "content" => nil,
+              "reasoning" => "I should answer briefly.",
+              "reasoning_details" => [
+                %{
+                  "type" => "reasoning.text",
+                  "format" => "openrouter-v1",
+                  "index" => 0,
+                  "text" => "I should answer briefly.",
+                  "signature" => "sig-abc",
+                  "signature_encrypted" => true,
+                  "provider_extra" => %{"kept" => true}
+                }
+              ]
+            },
+            "finish_reason" => "length"
+          }
+        ]
+      }
+
+      {:ok, result} = Defaults.decode_response_body_openai_format(response_data, model)
+
+      assert ReqLLM.Response.thinking(result) == "I should answer briefly."
+      assert [%ReasoningDetails{} = detail] = result.message.reasoning_details
+      assert detail.text == "I should answer briefly."
+      assert detail.signature == "sig-abc"
+      assert detail.encrypted? == true
+      assert detail.provider == :openai
+      assert detail.format == "openrouter-v1"
+      assert detail.index == 0
+
+      assert detail.provider_data == %{
+               "type" => "reasoning.text",
+               "provider_extra" => %{"kept" => true}
+             }
     end
 
     test "decodes tool calls without type field (Mistral format)", %{model: model} do
@@ -804,7 +872,9 @@ defmodule ReqLLM.Provider.DefaultsTest do
       chunks = Defaults.default_decode_stream_event(event, model)
 
       assert [%StreamChunk{type: :meta, metadata: meta}] = chunks
-      assert meta.reasoning_details == reasoning_details
+      assert [%ReasoningDetails{}, %ReasoningDetails{}] = meta.reasoning_details
+      assert Enum.map(meta.reasoning_details, & &1.provider_data) == reasoning_details
+      assert Enum.map(meta.reasoning_details, & &1.provider) == [:openai, :openai]
     end
 
     test "emits reasoning_details alongside content chunks", %{model: model} do
@@ -831,7 +901,10 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert content_chunk.text == "Hello world"
 
       meta_chunk = Enum.find(chunks, &(&1.type == :meta))
-      assert meta_chunk.metadata.reasoning_details == reasoning_details
+      assert [%ReasoningDetails{} = detail] = meta_chunk.metadata.reasoning_details
+      assert detail.provider_data == %{"type" => "thought"}
+      assert detail.signature == "xyz789"
+      assert detail.provider == :openai
     end
 
     test "does not emit reasoning_details meta when list is empty", %{model: model} do
@@ -892,7 +965,9 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert length(chunks) == 2
 
       reasoning_chunk = Enum.find(chunks, &Map.has_key?(&1.metadata, :reasoning_details))
-      assert reasoning_chunk.metadata.reasoning_details == reasoning_details
+      assert [%ReasoningDetails{} = detail] = reasoning_chunk.metadata.reasoning_details
+      assert detail.provider_data == %{"type" => "thought", "data" => "final"}
+      assert detail.provider == :openai
 
       finish_chunk = Enum.find(chunks, &Map.has_key?(&1.metadata, :finish_reason))
       assert finish_chunk.metadata.finish_reason == :stop
@@ -994,8 +1069,14 @@ defmodule ReqLLM.Provider.DefaultsTest do
 
     test "accumulates reasoning_details from meta chunks", %{model: model, context: context} do
       reasoning_details = [
-        %{"type" => "encrypted_thought", "data" => "abc123"},
-        %{"type" => "encrypted_thought", "data" => "def456"}
+        %ReasoningDetails{
+          provider: :openai,
+          provider_data: %{"type" => "encrypted_thought", "data" => "abc123"}
+        },
+        %ReasoningDetails{
+          provider: :openai,
+          provider_data: %{"type" => "encrypted_thought", "data" => "def456"}
+        }
       ]
 
       chunks = [
@@ -1013,8 +1094,19 @@ defmodule ReqLLM.Provider.DefaultsTest do
       model: model,
       context: context
     } do
-      details1 = [%{"type" => "thought", "data" => "first"}]
-      details2 = [%{"type" => "thought", "data" => "second"}]
+      details1 = [
+        %ReasoningDetails{
+          provider: :openai,
+          provider_data: %{"type" => "thought", "data" => "first"}
+        }
+      ]
+
+      details2 = [
+        %ReasoningDetails{
+          provider: :openai,
+          provider_data: %{"type" => "thought", "data" => "second"}
+        }
+      ]
 
       chunks = [
         StreamChunk.text("Hello"),
@@ -1056,7 +1148,13 @@ defmodule ReqLLM.Provider.DefaultsTest do
     end
 
     test "preserves reasoning_details alongside tool calls", %{model: model, context: context} do
-      reasoning_details = [%{"type" => "thought", "signature" => "xyz"}]
+      reasoning_details = [
+        %ReasoningDetails{
+          provider: :openai,
+          signature: "xyz",
+          provider_data: %{"type" => "thought"}
+        }
+      ]
 
       chunks = [
         StreamChunk.tool_call("get_weather", %{"city" => "NYC"}, %{id: "call_123"}),


### PR DESCRIPTION
## Description

This PR preserves OpenAI-compatible `reasoning_details` across ReqLLM's provider boundary.

OpenRouter can return `reasoning_details` as OpenAI-compatible wire maps with provider-specific metadata such as `type`, signatures, encrypted-signature markers, indexes, and other opaque fields. ReqLLM already has a normalized `%ReqLLM.Message.ReasoningDetails{}` struct with `provider_data`; this change makes that contract explicit and lossless across decode, context storage, and provider-boundary re-encoding.

This change:

- Decodes OpenAI-compatible `reasoning_details` into `%ReqLLM.Message.ReasoningDetails{}`.
- Preserves unknown/provider-specific fields in `provider_data` for lossless round-trips.
- Decodes both non-streaming response messages and streaming delta metadata.
- Keeps normalized `reasoning_details` as the internal representation by default.
- Adds an explicit `encode_context_to_openai_format/3` option, `encode_reasoning_details?: true`, for callers that intentionally need OpenAI-compatible wire maps.
- Makes OpenRouter and MiniMax own their provider-specific reasoning-details re-encoding at the provider boundary.
- Filters provider-specific reasoning details so OpenRouter does not accidentally emit MiniMax/Anthropic/Google details, and MiniMax preserves its own wire shape.

#791 has landed. This branch has been rebased onto current `agentjido/main` as a single reasoning-details commit.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None expected.

The internal representation becomes stricter and more consistent: OpenAI-compatible `reasoning_details` decoded by `ReqLLM.Provider.Defaults` are normalized to `%ReqLLM.Message.ReasoningDetails{}`. Existing raw maps are still tolerated in provider-specific encoders where they were already accepted.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Ran focused tests:

```text
mix test test/providers/openrouter_test.exs test/req_llm/provider/defaults_test.exs test/providers/minimax_test.exs test/provider/openai/responses_api_unit_test.exs test/provider/openai_structured_output_test.exs
Result: 306 passed
```

Ran full tests:

```text
mix test
Result: 3523 passed, 11 skipped, 144 excluded
```

Ran project quality gate:

```text
mix quality
Result: passed
```

GitHub CI is green on commit `a18e86c0e5d8359309ee9e632936bc50cf4f157e`.

## Model Compatibility

No live model compatibility fixtures were recorded for this PR.

The change is local decode/encode behavior for OpenAI-compatible reasoning metadata and provider-boundary request rendering. It is covered by unit/provider tests for:

- default OpenAI-compatible response decoding
- streaming reasoning-details metadata decoding
- explicit OpenAI-compatible reasoning-details encoding
- OpenRouter response decode and request re-encode round-trip
- OpenRouter provider-data/signature preservation
- MiniMax provider-specific reasoning-details wire encoding
- provider filtering so unrelated providers' reasoning details are not emitted

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

Docs note: no docs were updated because this is an internal provider-boundary correctness fix for existing `reasoning_details` data, not a new public user-facing API.
