### PR TITLE
fix: clarify tool call response contract

### DIFF
--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -150,15 +150,19 @@ defmodule ReqLLM.Response do
   Extract tool calls from the response message.
 
   Returns a list of tool calls if the message contains them, empty list otherwise.
-  Always returns normalized maps with `.name` and `.arguments` fields.
+  Provider responses expose tool calls as `ReqLLM.ToolCall` structs. Use struct
+  field access such as `call.id` and `call.function.name`, or call
+  `ReqLLM.ToolCall.to_map/1` when you need decoded arguments in a plain map.
+  Use `classify/1` when you want response text, finish reason, and normalized
+  tool call maps in one value.
 
   ## Examples
 
       iex> ReqLLM.Response.tool_calls(response)
-      [%{name: "get_weather", arguments: %{location: "San Francisco"}}]
+      [%ReqLLM.ToolCall{id: "call_123", type: "function", function: %{name: "get_weather", arguments: ~s({"location":"San Francisco"})}}]
 
   """
-  @spec tool_calls(t()) :: [term()]
+  @spec tool_calls(t()) :: [ToolCall.t()]
   def tool_calls(%__MODULE__{message: nil}), do: []
 
   def tool_calls(%__MODULE__{message: %Message{tool_calls: tool_calls}})

--- a/lib/req_llm/tool_call.ex
+++ b/lib/req_llm/tool_call.ex
@@ -19,6 +19,10 @@ defmodule ReqLLM.ToolCall do
   - `type` - Always "function" (reserved for future extensibility)
   - `function` - Map with `name` (string) and `arguments` (JSON string)
 
+  `ToolCall` is a struct, not an `Access`-compatible map. Read fields with
+  `call.id`, `call.function.name`, and `call.function.arguments`, or use
+  `to_map/1` when a plain map with decoded arguments is more convenient.
+
   ## Examples
 
       iex> ToolCall.new("call_abc", "get_weather", ~s({"location":"Paris"}))

--- a/test/req_llm/response_test.exs
+++ b/test/req_llm/response_test.exs
@@ -146,12 +146,32 @@ defmodule ReqLLM.ResponseTest do
 
     test "extracts from message.tool_calls field" do
       tool_calls = [
-        %{name: "get_weather", arguments: %{location: "NYC"}, id: "call-123"},
-        %{name: "calculate", arguments: %{expression: "2+2"}, id: "call-456"}
+        ToolCall.new("call-123", "get_weather", ~s({"location":"NYC"})),
+        ToolCall.new("call-456", "calculate", ~s({"expression":"2+2"}))
       ]
 
       response = create_response(message: tool_message(tool_calls))
       assert Response.tool_calls(response) == tool_calls
+    end
+
+    test "returns ToolCall structs with field access" do
+      response =
+        create_response(
+          message: tool_message([ToolCall.new("call-123", "get_weather", ~s({"location":"NYC"}))])
+        )
+
+      [tool_call] = Response.tool_calls(response)
+
+      assert tool_call.id == "call-123"
+      assert tool_call.function.name == "get_weather"
+
+      assert ToolCall.to_map(tool_call) == %{
+               id: "call-123",
+               name: "get_weather",
+               arguments: %{"location" => "NYC"}
+             }
+
+      assert_raise UndefinedFunctionError, fn -> tool_call[:id] end
     end
   end
 


### PR DESCRIPTION
## Summary

- Tightens `ReqLLM.Response.tool_calls/1` docs and spec to the `ReqLLM.ToolCall` struct contract returned by provider responses.
- Documents that `ReqLLM.ToolCall` is not `Access`-compatible and callers should use struct fields or `ReqLLM.ToolCall.to_map/1`.
- Updates response tests to use real `ToolCall` structs and cover the field-access path.

Fixes #802.

## Validation

- `mix test test/req_llm/response_test.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`

Note: plain `mix compile --warnings-as-errors` in the new worktree is blocked by the dev-only `git_hooks` dependency trying to install hooks from inside `deps/git_hooks`; test-env compile passes.