### PR TITLE
fix(openrouter): encode audio files as input_audio

### DIFF
--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -724,8 +724,6 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> Enum.find_value(:ok, &unsupported_openrouter_audio_error/1)
   end
 
-  defp validate_openrouter_stream_content(_context), do: :ok
-
   defp openrouter_message_content(%ReqLLM.Message{content: content}) when is_list(content),
     do: content
 

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -266,6 +266,32 @@ defmodule ReqLLM.Providers.OpenRouter do
   end
 
   @impl ReqLLM.Provider
+  def attach_stream(model, context, opts, finch_name) do
+    processed_opts =
+      ReqLLM.Provider.Options.process_stream!(
+        __MODULE__,
+        opts[:operation] || :chat,
+        model,
+        context,
+        opts
+      )
+
+    case validate_openrouter_stream_content(context) do
+      :ok ->
+        ReqLLM.Provider.Defaults.default_attach_stream(
+          __MODULE__,
+          model,
+          context,
+          processed_opts,
+          finch_name
+        )
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @impl ReqLLM.Provider
   def translate_options(_operation, model, opts) do
     warnings = []
 
@@ -691,6 +717,29 @@ defmodule ReqLLM.Providers.OpenRouter do
   end
 
   defp merge_content_metadata(base, _metadata), do: base
+
+  defp validate_openrouter_stream_content(%ReqLLM.Context{messages: messages}) do
+    messages
+    |> Stream.flat_map(&openrouter_message_content/1)
+    |> Enum.find_value(:ok, &unsupported_openrouter_audio_error/1)
+  end
+
+  defp validate_openrouter_stream_content(_context), do: :ok
+
+  defp openrouter_message_content(%ReqLLM.Message{content: content}) when is_list(content),
+    do: content
+
+  defp openrouter_message_content(_message), do: []
+
+  defp unsupported_openrouter_audio_error(part) do
+    if openrouter_audio_file_part?(part) and not openrouter_input_audio_part?(part) do
+      {:error,
+       ReqLLM.Error.Invalid.Message.exception(
+         reason:
+           "OpenRouter chat audio input supports only mp3 and wav file parts; got #{inspect(part.media_type)}."
+       )}
+    end
+  end
 
   defp add_embedding_options(body, request_options) do
     if request_options[:operation] == :embedding do

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -354,7 +354,7 @@ defmodule ReqLLM.Providers.OpenRouter do
   @impl ReqLLM.Provider
   def build_body(request) do
     ReqLLM.Provider.Defaults.default_build_body(request)
-    |> encode_file_parser_pdf_files(request.options)
+    |> encode_openrouter_content_parts(request.options)
     |> add_embedding_options(request.options)
     |> translate_tool_choice_format()
     |> encode_reasoning_details_in_messages()
@@ -375,12 +375,12 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> add_stream_options(request.options)
   end
 
-  defp encode_file_parser_pdf_files(body, request_options) do
+  defp encode_openrouter_content_parts(body, request_options) do
     context = request_options[:context]
     plugins = request_options[:openrouter_plugins]
 
-    if file_parser_plugin?(plugins) and match?(%ReqLLM.Context{}, context) do
-      replace_file_parser_messages(body, context)
+    if match?(%ReqLLM.Context{}, context) do
+      replace_openrouter_content_messages(body, context, file_parser_plugin?(plugins))
     else
       body
     end
@@ -396,39 +396,61 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   defp file_parser_plugin?(_plugins), do: false
 
-  defp replace_file_parser_messages(%{messages: encoded_messages} = body, context)
+  defp replace_openrouter_content_messages(
+         %{messages: encoded_messages} = body,
+         context,
+         pdf_files?
+       )
        when is_list(encoded_messages) do
-    Map.put(body, :messages, encode_file_parser_messages(encoded_messages, context.messages))
+    Map.put(
+      body,
+      :messages,
+      encode_openrouter_content_messages(encoded_messages, context.messages, pdf_files?)
+    )
   end
 
-  defp replace_file_parser_messages(%{"messages" => encoded_messages} = body, context)
+  defp replace_openrouter_content_messages(
+         %{"messages" => encoded_messages} = body,
+         context,
+         pdf_files?
+       )
        when is_list(encoded_messages) do
-    Map.put(body, "messages", encode_file_parser_messages(encoded_messages, context.messages))
+    Map.put(
+      body,
+      "messages",
+      encode_openrouter_content_messages(encoded_messages, context.messages, pdf_files?)
+    )
   end
 
-  defp replace_file_parser_messages(body, _context), do: body
+  defp replace_openrouter_content_messages(body, _context, _pdf_files?), do: body
 
-  defp encode_file_parser_messages(encoded_messages, context_messages)
+  defp encode_openrouter_content_messages(encoded_messages, context_messages, pdf_files?)
        when length(encoded_messages) == length(context_messages) do
     encoded_messages
     |> Enum.zip(context_messages)
     |> Enum.map(fn {encoded_message, context_message} ->
-      encode_file_parser_message(encoded_message, context_message)
+      encode_openrouter_content_message(encoded_message, context_message, pdf_files?)
     end)
   end
 
-  defp encode_file_parser_messages(encoded_messages, _context_messages), do: encoded_messages
+  defp encode_openrouter_content_messages(encoded_messages, _context_messages, _pdf_files?),
+    do: encoded_messages
 
-  defp encode_file_parser_message(encoded_message, %ReqLLM.Message{content: content})
+  defp encode_openrouter_content_message(
+         encoded_message,
+         %ReqLLM.Message{content: content},
+         pdf_files?
+       )
        when is_list(content) do
-    if Enum.any?(content, &openrouter_pdf_file_part?/1) do
-      put_message_content(encoded_message, encode_openrouter_content(content))
+    if Enum.any?(content, &openrouter_reencoded_content_part?(&1, pdf_files?)) do
+      put_message_content(encoded_message, encode_openrouter_content(content, pdf_files?))
     else
       encoded_message
     end
   end
 
-  defp encode_file_parser_message(encoded_message, _message), do: encoded_message
+  defp encode_openrouter_content_message(encoded_message, _message, _pdf_files?),
+    do: encoded_message
 
   defp put_message_content(%{content: _} = message, content),
     do: Map.put(message, :content, content)
@@ -438,9 +460,9 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   defp put_message_content(message, content), do: Map.put(message, :content, content)
 
-  defp encode_openrouter_content(content) do
+  defp encode_openrouter_content(content, pdf_files?) do
     content
-    |> Enum.map(&encode_openrouter_content_part/1)
+    |> Enum.map(&encode_openrouter_content_part(&1, pdf_files?))
     |> Enum.reject(&is_nil/1)
     |> normalize_openrouter_content()
   end
@@ -453,29 +475,38 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   defp normalize_openrouter_content(content), do: content
 
-  defp encode_openrouter_content_part(%ContentPart{type: :text, text: text, metadata: metadata}) do
+  defp encode_openrouter_content_part(
+         %ContentPart{type: :text, text: text, metadata: metadata},
+         _pdf_files?
+       ) do
     %{type: "text", text: text}
     |> merge_content_metadata(metadata)
   end
 
-  defp encode_openrouter_content_part(%ContentPart{
-         type: :image,
-         data: data,
-         media_type: media_type,
-         metadata: metadata
-       })
+  defp encode_openrouter_content_part(
+         %ContentPart{
+           type: :image,
+           data: data,
+           media_type: media_type,
+           metadata: metadata
+         },
+         _pdf_files?
+       )
        when is_binary(data) do
     data
     |> image_url_content_part(media_type)
     |> merge_content_metadata(metadata)
   end
 
-  defp encode_openrouter_content_part(%ContentPart{
-         type: :image_url,
-         url: url,
-         media_type: media_type,
-         metadata: metadata
-       }) do
+  defp encode_openrouter_content_part(
+         %ContentPart{
+           type: :image_url,
+           url: url,
+           media_type: media_type,
+           metadata: metadata
+         },
+         _pdf_files?
+       ) do
     image_url_map = %{url: url}
 
     image_url_map =
@@ -489,23 +520,55 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> merge_content_metadata(metadata)
   end
 
-  defp encode_openrouter_content_part(%ContentPart{type: :file, data: data} = part)
+  defp encode_openrouter_content_part(%ContentPart{type: :file, data: data} = part, pdf_files?)
        when is_binary(data) do
-    if openrouter_pdf_file_part?(part) do
-      %{
-        type: "file",
-        file: %{
-          filename: openrouter_file_filename(part),
-          file_data: "data:#{openrouter_file_media_type(part)};base64,#{Base.encode64(data)}"
+    cond do
+      openrouter_input_audio_part?(part) ->
+        data
+        |> input_audio_content_part(openrouter_input_audio_format(part))
+        |> merge_content_metadata(part.metadata)
+
+      openrouter_audio_file_part?(part) ->
+        raise ReqLLM.Error.Invalid.Message.exception(
+                reason:
+                  "OpenRouter chat audio input supports only mp3 and wav file parts; got #{inspect(part.media_type)}."
+              )
+
+      pdf_files? and openrouter_pdf_file_part?(part) ->
+        %{
+          type: "file",
+          file: %{
+            filename: openrouter_file_filename(part),
+            file_data: "data:#{openrouter_file_media_type(part)};base64,#{Base.encode64(data)}"
+          }
         }
-      }
-    else
-      image_url_content_part(data, part.media_type)
+
+      true ->
+        image_url_content_part(data, part.media_type)
     end
   end
 
-  defp encode_openrouter_content_part(%ContentPart{type: :thinking}), do: nil
-  defp encode_openrouter_content_part(_part), do: nil
+  defp encode_openrouter_content_part(%ContentPart{type: :thinking}, _pdf_files?), do: nil
+  defp encode_openrouter_content_part(_part, _pdf_files?), do: nil
+
+  defp openrouter_reencoded_content_part?(part, true) do
+    openrouter_input_audio_part?(part) or openrouter_audio_file_part?(part) or
+      openrouter_pdf_file_part?(part)
+  end
+
+  defp openrouter_reencoded_content_part?(part, _pdf_files?) do
+    openrouter_input_audio_part?(part) or openrouter_audio_file_part?(part)
+  end
+
+  defp input_audio_content_part(data, format) do
+    %{
+      type: "input_audio",
+      input_audio: %{
+        data: Base.encode64(data),
+        format: format
+      }
+    }
+  end
 
   defp image_url_content_part(data, media_type) do
     %{
@@ -522,6 +585,73 @@ defmodule ReqLLM.Providers.OpenRouter do
   end
 
   defp openrouter_pdf_file_part?(_part), do: false
+
+  defp openrouter_audio_file_part?(%ContentPart{type: :file, data: data, media_type: media_type})
+       when is_binary(data) and is_binary(media_type) do
+    media_type
+    |> normalize_openrouter_media_type()
+    |> String.starts_with?("audio/")
+  end
+
+  defp openrouter_audio_file_part?(_part), do: false
+
+  defp openrouter_input_audio_part?(%ContentPart{type: :file, data: data} = part)
+       when is_binary(data) do
+    is_binary(openrouter_input_audio_format(part))
+  end
+
+  defp openrouter_input_audio_part?(_part), do: false
+
+  defp openrouter_input_audio_format(%ContentPart{media_type: media_type, filename: filename}) do
+    case openrouter_audio_format_from_media_type(media_type) do
+      format when is_binary(format) -> format
+      nil -> openrouter_audio_format_from_non_audio_media_type(media_type, filename)
+    end
+  end
+
+  defp openrouter_audio_format_from_media_type(media_type) when is_binary(media_type) do
+    case normalize_openrouter_media_type(media_type) do
+      "audio/mpeg" -> "mp3"
+      "audio/mp3" -> "mp3"
+      "audio/wav" -> "wav"
+      "audio/wave" -> "wav"
+      "audio/x-wav" -> "wav"
+      _ -> nil
+    end
+  end
+
+  defp openrouter_audio_format_from_media_type(_media_type), do: nil
+
+  defp openrouter_audio_format_from_non_audio_media_type(media_type, filename)
+       when is_binary(media_type) do
+    if String.starts_with?(normalize_openrouter_media_type(media_type), "audio/") do
+      nil
+    else
+      openrouter_audio_format_from_filename(filename)
+    end
+  end
+
+  defp openrouter_audio_format_from_non_audio_media_type(_media_type, filename) do
+    openrouter_audio_format_from_filename(filename)
+  end
+
+  defp normalize_openrouter_media_type(media_type) do
+    media_type
+    |> String.downcase()
+    |> String.split(";", parts: 2)
+    |> List.first()
+    |> String.trim()
+  end
+
+  defp openrouter_audio_format_from_filename(filename) when is_binary(filename) do
+    case filename |> String.downcase() |> Path.extname() do
+      ".mp3" -> "mp3"
+      ".wav" -> "wav"
+      _ -> nil
+    end
+  end
+
+  defp openrouter_audio_format_from_filename(_filename), do: nil
 
   defp openrouter_pdf_filename?(filename) when is_binary(filename) do
     filename

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -561,6 +561,22 @@ defmodule ReqLLM.Providers.OpenRouterTest do
              }
     end
 
+    test "attach_stream rejects unsupported audio file formats" do
+      model = ReqLLM.model!("openrouter:openai/gpt-4")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.file("audio bytes", "speech.ogg", "audio/ogg")
+          ])
+        ])
+
+      assert {:error, %ReqLLM.Error.Invalid.Message{} = error} =
+               OpenRouter.attach_stream(model, context, [], MyApp.Finch)
+
+      assert Exception.message(error) =~ "OpenRouter chat audio input supports only mp3 and wav"
+    end
+
     test "encode_body with response_format" do
       {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
       context = context_fixture()

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -433,6 +433,70 @@ defmodule ReqLLM.Providers.OpenRouterTest do
              }
     end
 
+    test "encode_body encodes mp3 file parts as OpenRouter input_audio" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      audio_data = "audio bytes"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Transcribe this audio"),
+            ContentPart.file(audio_data, "speech.mp3", "audio/mpeg")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      [message] = decoded["messages"]
+      [text_part, audio_part] = message["content"]
+
+      assert text_part == %{"type" => "text", "text" => "Transcribe this audio"}
+
+      assert audio_part == %{
+               "type" => "input_audio",
+               "input_audio" => %{
+                 "data" => Base.encode64(audio_data),
+                 "format" => "mp3"
+               }
+             }
+
+      refute Map.has_key?(audio_part, "image_url")
+    end
+
+    test "encode_body rejects unsupported audio file formats" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.file("audio bytes", "speech.ogg", "audio/ogg")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      assert_raise ReqLLM.Error.Invalid.Message,
+                   ~r/OpenRouter chat audio input supports only mp3 and wav/,
+                   fn ->
+                     OpenRouter.encode_body(mock_request)
+                   end
+    end
+
     test "attach_stream with file-parser plugin encodes PDF files in OpenRouter format" do
       model = ReqLLM.model!("openrouter:openai/gpt-4")
       pdf_data = "%PDF stream"
@@ -464,6 +528,35 @@ defmodule ReqLLM.Providers.OpenRouterTest do
                "file" => %{
                  "filename" => "stream.pdf",
                  "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               }
+             }
+    end
+
+    test "attach_stream encodes wav file parts as OpenRouter input_audio" do
+      model = ReqLLM.model!("openrouter:openai/gpt-4")
+      audio_data = "wav bytes"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Describe the audio"),
+            ContentPart.file(audio_data, "clip.wav", "audio/wav")
+          ])
+        ])
+
+      {:ok, finch_request} = OpenRouter.attach_stream(model, context, [], MyApp.Finch)
+
+      decoded = Jason.decode!(finch_request.body)
+      [message] = decoded["messages"]
+      [_, audio_part] = message["content"]
+
+      assert decoded["stream"] == true
+
+      assert audio_part == %{
+               "type" => "input_audio",
+               "input_audio" => %{
+                 "data" => Base.encode64(audio_data),
+                 "format" => "wav"
                }
              }
     end


### PR DESCRIPTION
## Summary

- Re-encodes OpenRouter message content when file parts contain audio, independent of the file-parser plugin.
- Emits OpenRouter/OpenAI chat `input_audio` blocks for mp3 and wav file parts instead of mislabeling audio as `image_url`.
- Raises a clear invalid-message error for unsupported `audio/*` formats rather than silently sending them as another modality.
- Adds non-streaming and streaming provider tests for the OpenRouter audio path.

Fixes #800.

## Validation

- `mix test test/providers/openrouter_test.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`

Note: plain `mix compile --warnings-as-errors` in the new worktree is blocked by the dev-only `git_hooks` dependency trying to install hooks from inside `deps/git_hooks`; test-env compile passes.