### PR TITLE
fix(oauth): serialize and atomically persist refreshes

### DIFF
--- a/lib/req_llm/oauth.ex
+++ b/lib/req_llm/oauth.ex
@@ -17,8 +17,24 @@ defmodule ReqLLM.OAuth do
     provider_opts = get_option(opts, :provider_options) || []
 
     with {:ok, provider, provider_mod} <- fetch_provider(provider_or_model),
-         {:ok, oauth_file} <- oauth_file_path(opts, provider_opts),
-         {:ok, payload} <- read_oauth_file(oauth_file),
+         {:ok, oauth_file} <- oauth_file_path(opts, provider_opts) do
+      resolve_serialized(provider, provider_mod, oauth_file, opts, provider_opts)
+    end
+  end
+
+  defp resolve_serialized(provider, provider_mod, oauth_file, opts, provider_opts) do
+    lock_id = {{__MODULE__, oauth_file}, self()}
+
+    case :global.trans(lock_id, fn ->
+           resolve_from_file(provider, provider_mod, oauth_file, opts, provider_opts)
+         end) do
+      :aborted -> {:error, "Unable to lock OAuth file #{oauth_file} for credential refresh"}
+      result -> result
+    end
+  end
+
+  defp resolve_from_file(provider, provider_mod, oauth_file, opts, provider_opts) do
+    with {:ok, payload} <- read_oauth_file(oauth_file),
          {:ok, provider_key, credentials} <- fetch_credentials(payload, provider, provider_mod),
          {:ok, normalized} <- normalize_credentials(credentials, provider_key, oauth_file),
          {:ok, refreshed, source} <-
@@ -235,10 +251,32 @@ defmodule ReqLLM.OAuth do
       |> drop_nil_values()
       |> Jason.encode_to_iodata!(pretty: true)
 
-    case File.write(oauth_file, serialized) do
+    case atomic_replace(oauth_file, serialized) do
       :ok -> :ok
       {:error, reason} -> {:error, "Unable to write OAuth file #{oauth_file}: #{inspect(reason)}"}
     end
+  end
+
+  defp atomic_replace(path, contents) do
+    temporary_path = temporary_path(path)
+
+    result =
+      with {:ok, stat} <- File.stat(path),
+           :ok <- File.write(temporary_path, contents, [:exclusive]),
+           :ok <- File.chmod(temporary_path, Bitwise.band(stat.mode, 0o777)) do
+        File.rename(temporary_path, path)
+      end
+
+    File.rm(temporary_path)
+    result
+  end
+
+  defp temporary_path(path) do
+    suffix =
+      [System.system_time(:nanosecond), System.unique_integer([:positive, :monotonic])]
+      |> Enum.join("-")
+
+    Path.join(Path.dirname(path), ".#{Path.basename(path)}.#{suffix}.tmp")
   end
 
   defp oauth_refresh_opts(opts, provider_opts) do

--- a/lib/req_llm/oauth.ex
+++ b/lib/req_llm/oauth.ex
@@ -262,8 +262,9 @@ defmodule ReqLLM.OAuth do
 
     result =
       with {:ok, stat} <- File.stat(path),
-           :ok <- File.write(temporary_path, contents, [:exclusive]),
-           :ok <- File.chmod(temporary_path, Bitwise.band(stat.mode, 0o777)) do
+           :ok <- File.write(temporary_path, <<>>, [:exclusive]),
+           :ok <- File.chmod(temporary_path, Bitwise.band(stat.mode, 0o777)),
+           :ok <- File.write(temporary_path, contents) do
         File.rename(temporary_path, path)
       end
 

--- a/test/req_llm/auth_test.exs
+++ b/test/req_llm/auth_test.exs
@@ -101,6 +101,67 @@ defmodule ReqLLM.AuthTest do
       assert is_integer(refreshed["openai-codex"]["expires"])
       assert refreshed["openai-codex"]["expires"] > System.system_time(:millisecond)
     end
+
+    test "serializes concurrent refreshes and atomically replaces the oauth file", %{
+      tmp_dir: tmp_dir
+    } do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      path = Path.join(tmp_dir, "oauth.json")
+      parent = self()
+
+      write_oauth_file(path, %{
+        "openai-codex" => %{
+          "type" => "oauth",
+          "access" => "expired-access",
+          "refresh" => "shared-refresh-token",
+          "expires" => past_expiry()
+        },
+        "unrelated-provider" => %{"access" => "preserve-me"}
+      })
+
+      File.chmod!(path, 0o600)
+
+      Req.Test.stub(ReqLLM.AuthConcurrentOpenAIRefreshTest, fn conn ->
+        send(parent, :refresh_request)
+        Process.sleep(100)
+
+        Req.Test.json(conn, %{
+          "access_token" => "serialized-access-token",
+          "refresh_token" => "serialized-refresh-token",
+          "expires_in" => 3600
+        })
+      end)
+
+      opts = [
+        provider_options: [
+          auth_mode: :oauth,
+          oauth_file: path,
+          oauth_http_options: [plug: {Req.Test, ReqLLM.AuthConcurrentOpenAIRefreshTest}]
+        ]
+      ]
+
+      results =
+        1..2
+        |> Enum.map(fn _ -> Task.async(fn -> OAuth.resolve(model, opts) end) end)
+        |> Task.await_many(1_000)
+
+      assert [
+               {:ok, %{token: "serialized-access-token"}},
+               {:ok, %{token: "serialized-access-token"}}
+             ] = results
+
+      assert_receive :refresh_request
+      refute_receive :refresh_request, 100
+
+      persisted = path |> File.read!() |> Jason.decode!()
+      {:ok, stat} = File.stat(path)
+
+      assert persisted["openai-codex"]["access"] == "serialized-access-token"
+      assert persisted["openai-codex"]["refresh"] == "serialized-refresh-token"
+      assert persisted["unrelated-provider"] == %{"access" => "preserve-me"}
+      assert Bitwise.band(stat.mode, 0o777) == 0o600
+      assert Path.wildcard(Path.join(tmp_dir, ".oauth.json.*.tmp")) == []
+    end
   end
 
   describe "OAuth.resolve/2 account id handling" do


### PR DESCRIPTION
## Summary

- serialize file-backed OAuth resolution and refreshes per OAuth file within the runtime
- re-read credentials inside the lock so queued refreshes observe the latest rotated tokens and provider entries
- persist updates through a same-directory temporary file and atomic rename while preserving file permissions
- add regression coverage for concurrent refreshes, unrelated provider entries, permissions, and temporary-file cleanup

## Root cause

OAuth resolution previously read the shared file before refresh and rewrote it directly with `File.write/2`. Concurrent callers could refresh the same token or overwrite another caller's update, and a process failure during the write could leave the credential file truncated.

Runtime serialization intentionally covers callers in the same BEAM. External-process coordination remains separate; atomic replacement still prevents this library from exposing a partially written file.

## Validation

- `mix test`: 3,536 passed, 11 skipped, 144 excluded
- `mix test test/req_llm/auth_test.exs`: 14 passed
- `mix quality`: passed formatting, warnings-as-errors compilation, Credo strict, and Dialyzer with zero errors

Closes #811