### PR TITLE
fix(retry): honor caller retry limits

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -413,7 +413,7 @@ defmodule ReqLLM.Provider.Defaults do
           ] ++ http_opts
         )
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(opts)
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
           model,
@@ -504,7 +504,7 @@ defmodule ReqLLM.Provider.Defaults do
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(opts)
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
           model,
@@ -582,7 +582,7 @@ defmodule ReqLLM.Provider.Defaults do
           auth: {:bearer, api_key}
         ] ++ user_opts
     )
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.prepend_request_steps(llm_encode_body: &provider_mod.encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &provider_mod.decode_response/1)

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -456,7 +456,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
     request_with_body
     |> Step.Error.attach()
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> put_aws_sigv4(aws_creds)
     # No longer attach streaming here - it's handled by attach_stream
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
@@ -515,7 +515,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
         updated_request
         |> Step.Error.attach()
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(user_opts)
         |> put_aws_sigv4(aws_creds)
         |> Req.Request.append_response_steps(llm_decode_embedding: &decode_embedding_response/1)
         |> Step.Usage.attach(model)

--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -571,7 +571,7 @@ defmodule ReqLLM.Providers.Azure do
     end)
     |> Req.Request.register_options(registered_option_keys)
     |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request) ++ user_opts)
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)

--- a/lib/req_llm/providers/cohere.ex
+++ b/lib/req_llm/providers/cohere.ex
@@ -85,7 +85,7 @@ defmodule ReqLLM.Providers.Cohere do
           auth: {:bearer, api_key}
         ] ++ user_opts
     )
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)

--- a/lib/req_llm/providers/elevenlabs.ex
+++ b/lib/req_llm/providers/elevenlabs.ex
@@ -117,7 +117,7 @@ defmodule ReqLLM.Providers.ElevenLabs do
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("xi-api-key", api_key)
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(opts)
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
           model,
@@ -167,7 +167,7 @@ defmodule ReqLLM.Providers.ElevenLabs do
           ] ++ http_opts
         )
         |> Req.Request.put_header("xi-api-key", api_key)
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(opts)
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
           model,

--- a/lib/req_llm/providers/github_copilot.ex
+++ b/lib/req_llm/providers/github_copilot.ex
@@ -79,7 +79,7 @@ defmodule ReqLLM.Providers.GitHubCopilot do
           auth: {:bearer, token}
         ] ++ user_opts
     )
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -380,7 +380,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
     request
     |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request))
     |> ReqLLM.Step.Error.attach()
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(opts)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> ReqLLM.Step.Usage.attach(model)
     |> ReqLLM.Step.Telemetry.attach(model, opts)
@@ -412,7 +412,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
     request
     |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request))
     |> ReqLLM.Step.Error.attach()
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(opts)
     |> ReqLLM.Step.Fixture.maybe_attach(model, opts)
     |> put_gcp_auth(gcp_creds)
   end
@@ -421,7 +421,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
     request
     |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request))
     |> ReqLLM.Step.Error.attach()
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(opts)
     |> ReqLLM.Step.Usage.attach(model)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_embedding_response/1)
     |> ReqLLM.Step.Telemetry.attach(model, opts)

--- a/lib/req_llm/providers/ollama.ex
+++ b/lib/req_llm/providers/ollama.ex
@@ -111,7 +111,7 @@ defmodule ReqLLM.Providers.Ollama do
       ReqLLM.Provider.Defaults.finch_option(request) ++
         [model: model.provider_model_id || model.id] ++ user_opts
     )
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -529,7 +529,7 @@ defmodule ReqLLM.Providers.OpenAI do
           ] ++ auth_req_options(credential) ++ http_opts
         )
         |> maybe_put_authorization_header(credential)
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(opts)
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
           model,
@@ -737,7 +737,7 @@ defmodule ReqLLM.Providers.OpenAI do
           model: model.provider_model_id || model.id
         ] ++ auth_req_options(credential) ++ user_opts
     )
-    |> ReqLLM.Step.Retry.attach()
+    |> ReqLLM.Step.Retry.attach(user_opts)
     |> ReqLLM.Step.Error.attach()
     |> Req.Request.prepend_request_steps(llm_encode_body: &encode_body/1)
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -246,7 +246,7 @@ defmodule ReqLLM.Providers.OpenRouter do
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
         |> maybe_add_attribution_headers(opts)
-        |> ReqLLM.Step.Retry.attach()
+        |> ReqLLM.Step.Retry.attach(opts)
         |> ReqLLM.Step.Error.attach()
         |> ReqLLM.Step.Telemetry.attach(
           model,

--- a/lib/req_llm/step/retry.ex
+++ b/lib/req_llm/step/retry.ex
@@ -55,7 +55,7 @@ defmodule ReqLLM.Step.Retry do
   """
   @spec attach(Req.Request.t(), keyword()) :: Req.Request.t()
   def attach(%Req.Request{} = req, opts \\ []) do
-    max_retries = Keyword.get(opts, :max_retries, 3)
+    max_retries = Keyword.get(opts, :max_retries, Map.get(req.options, :max_retries, 3))
 
     req
     |> Req.Request.merge_options(

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -85,7 +85,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert request.options[:finch] == :custom_finch
     end
 
-    test "prepare_request honors caller retry limits for chat and object requests" do
+    test "prepare_request honors caller retry limits in chat and object pipelines" do
       {:ok, chat_model} = ReqLLM.model("openai:gpt-4-turbo")
       {:ok, object_model} = ReqLLM.model("openai:gpt-4o-mini")
       {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
@@ -104,6 +104,32 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert chat_request.options[:max_retries] == 0
       assert object_request.options[:max_retries] == 1
       assert default_request.options[:max_retries] == 3
+
+      cases = [
+        {:chat, chat_model, [], 0, 1},
+        {:object, object_model, [compiled_schema: schema], 1, 2}
+      ]
+
+      Enum.each(cases, fn {operation, model, extra_opts, max_retries, expected_attempts} ->
+        parent = self()
+
+        adapter = fn request ->
+          send(parent, {:attempt, operation})
+          {request, %Req.TransportError{reason: :closed}}
+        end
+
+        opts =
+          [max_retries: max_retries, req_http_options: [adapter: adapter]] ++ extra_opts
+
+        {:ok, request} = OpenAI.prepare_request(operation, model, "Hello", opts)
+        assert {:error, _reason} = Req.request(request)
+
+        Enum.each(1..expected_attempts, fn _attempt ->
+          assert_receive {:attempt, ^operation}
+        end)
+
+        refute_receive {:attempt, ^operation}, 20
+      end)
     end
 
     test "prepare_request routes gpt-4o models to Responses API" do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -85,6 +85,27 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert request.options[:finch] == :custom_finch
     end
 
+    test "prepare_request honors caller retry limits for chat and object requests" do
+      {:ok, chat_model} = ReqLLM.model("openai:gpt-4-turbo")
+      {:ok, object_model} = ReqLLM.model("openai:gpt-4o-mini")
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+
+      {:ok, chat_request} =
+        OpenAI.prepare_request(:chat, chat_model, "Hello", max_retries: 0)
+
+      {:ok, object_request} =
+        OpenAI.prepare_request(:object, object_model, "Hello",
+          compiled_schema: schema,
+          max_retries: 1
+        )
+
+      {:ok, default_request} = OpenAI.prepare_request(:chat, chat_model, "Hello", [])
+
+      assert chat_request.options[:max_retries] == 0
+      assert object_request.options[:max_retries] == 1
+      assert default_request.options[:max_retries] == 3
+    end
+
     test "prepare_request routes gpt-4o models to Responses API" do
       {:ok, model} = ReqLLM.model("openai:gpt-4o")
       context = context_fixture()

--- a/test/req_llm/step/retry_test.exs
+++ b/test/req_llm/step/retry_test.exs
@@ -15,6 +15,38 @@ defmodule ReqLLM.Step.RetryTest do
       refute updated_request.options[:retry_delay]
       assert updated_request.options[:retry_log_level] == false
     end
+
+    test "preserves max_retries already configured on the request" do
+      request = Req.new(max_retries: 0)
+
+      assert Retry.attach(request).options[:max_retries] == 0
+    end
+  end
+
+  describe "attach/2" do
+    test "honors max_retries in the real Req pipeline" do
+      for {max_retries, expected_attempts} <- [{0, 1}, {1, 2}] do
+        parent = self()
+
+        request =
+          Req.new(
+            url: "https://example.invalid",
+            adapter: fn request ->
+              send(parent, :attempt)
+              {request, %Req.TransportError{reason: :closed}}
+            end
+          )
+          |> Retry.attach(max_retries: max_retries)
+
+        assert {:error, %Req.TransportError{reason: :closed}} = Req.request(request)
+
+        Enum.each(1..expected_attempts, fn _attempt ->
+          assert_receive :attempt
+        end)
+
+        refute_receive :attempt, 20
+      end
+    end
   end
 
   describe "should_retry?/2" do
@@ -131,6 +163,21 @@ defmodule ReqLLM.Step.RetryTest do
         )
 
       assert request.options[:finch] == :custom_finch
+    end
+
+    test "default_attach preserves caller max_retries" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4")
+
+      request =
+        ReqLLM.Provider.Defaults.default_attach(
+          ReqLLM.Providers.OpenAI,
+          Req.new(),
+          model,
+          api_key: "test-key",
+          max_retries: 0
+        )
+
+      assert request.options[:max_retries] == 0
     end
 
     test "retry function correctly identifies retryable errors" do


### PR DESCRIPTION
## Summary

- forward caller options to the retry step from every non-streaming provider attachment path
- preserve an effective `max_retries` already configured on a request when the retry step is attached without explicit options
- verify OpenAI chat and object requests honor `0`, positive values, and the default
- exercise the real Req pipeline to prove `max_retries: 0` makes one physical attempt and `max_retries: 1` makes at most two

## Root cause

Several providers merged caller options into the request and then called `ReqLLM.Step.Retry.attach/1`. The retry step read only its own empty option list and wrote the default value of `3` back over the request, silently discarding the caller's retry bound. Specialized provider request paths also attached retries without forwarding their options.

## Validation

- `mix test`: 3,539 passed, 11 skipped, 144 excluded
- focused retry and OpenAI provider suites: 122 passed
- `mix quality`: passed formatting, warnings-as-errors compilation, Credo strict, and Dialyzer with zero errors

Closes #817