### PR TITLE
fix(streaming): finalize metadata lifecycle

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -136,7 +136,7 @@ config :req_llm, thinking_timeout: 600_000  # 10 minutes
 
 ### `metadata_timeout` (default: 300,000ms)
 
-Timeout for collecting streaming metadata (usage, finish_reason) after the stream completes. Long-running streams or slow providers may need more time.
+Maximum time without semantic stream progress while collecting metadata. Content, reasoning, tool, and usage events restart a finite timeout, so active long-running streams are not failed based on total elapsed time. Set it to `:infinity` to disable the inactivity timeout.
 
 ```elixir
 config :req_llm, metadata_timeout: 120_000
@@ -146,6 +146,8 @@ Per-request override:
 
 ```elixir
 ReqLLM.stream_text("anthropic:claude-haiku-4-5", "Hello", metadata_timeout: 60_000)
+
+ReqLLM.stream_text("anthropic:claude-haiku-4-5", "Hello", metadata_timeout: :infinity)
 ```
 
 ### `image_receive_timeout` (default: 120,000ms)

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -173,7 +173,7 @@ defmodule ReqLLM.StreamServer do
   ## Parameters
 
     * `server` - StreamServer process
-    * `timeout` - Maximum time to wait in milliseconds (default: 30_000)
+    * `timeout` - Maximum time without semantic stream progress, or `:infinity`
 
   ## Returns
 
@@ -371,8 +371,9 @@ defmodule ReqLLM.StreamServer do
       end
 
   """
-  @spec await_metadata(server(), non_neg_integer()) :: {:ok, map()} | {:error, any()}
-  def await_metadata(server, timeout \\ 30_000) do
+  @spec await_metadata(server(), timeout()) :: {:ok, map()} | {:error, any()}
+  def await_metadata(server, timeout \\ 30_000)
+      when timeout == :infinity or (is_integer(timeout) and timeout >= 0) do
     GenServer.call(server, {:await_metadata, timeout}, :infinity)
   end
 
@@ -449,7 +450,8 @@ defmodule ReqLLM.StreamServer do
   def handle_call(:cancel, _from, state) do
     new_state =
       state
-      |> maybe_emit_stream_stop(:cancelled)
+      |> finalize_cancelled_stream()
+      |> reply_to_waiting_callers()
       |> cleanup_resources()
 
     {:stop, :normal, :ok, new_state}
@@ -624,7 +626,7 @@ defmodule ReqLLM.StreamServer do
       {true, _status} ->
         new_state =
           %{state | consumer_refs: MapSet.delete(state.consumer_refs, ref)}
-          |> maybe_emit_stream_stop(:cancelled)
+          |> finalize_cancelled_stream()
           |> cleanup_resources()
           |> reply_to_waiting_callers()
 
@@ -800,6 +802,7 @@ defmodule ReqLLM.StreamServer do
         | protocol_state: new_protocol_state,
           provider_state: new_provider_state
       })
+      |> reset_metadata_waiter_timeouts(stream_chunks)
 
     terminated? =
       Enum.any?(events, &termination_event?/1) or
@@ -1082,6 +1085,24 @@ defmodule ReqLLM.StreamServer do
     |> maybe_emit_stream_stop(metadata[:finish_reason] || :unknown)
   end
 
+  defp finalize_cancelled_stream(%{status: :done} = state), do: state
+  defp finalize_cancelled_stream(%{status: {:error, _reason}} = state), do: state
+
+  defp finalize_cancelled_stream(state) do
+    state = flush_protocol_state(state)
+
+    metadata =
+      state
+      |> extract_final_metadata()
+      |> Map.put(:finish_reason, :cancelled)
+
+    state
+    |> Map.put(:status, :done)
+    |> Map.put(:queue, :queue.new())
+    |> Map.put(:metadata, metadata)
+    |> maybe_emit_stream_stop(:cancelled)
+  end
+
   defp flush_protocol_state(state) do
     {events, new_protocol_state} = SSE.flush(state.protocol_state)
     terminated? = Enum.any?(events, &termination_event?/1)
@@ -1256,10 +1277,46 @@ defmodule ReqLLM.StreamServer do
 
   defp register_waiting_caller(state, from, type, timeout) do
     token = make_ref()
-    timer = Process.send_after(self(), {:caller_timeout, token}, timeout)
+    timer = start_waiting_caller_timer(token, timeout)
 
-    caller = %{from: from, type: type, token: token, timer: timer}
+    caller = %{from: from, type: type, token: token, timer: timer, timeout: timeout}
     %{state | waiting_callers: state.waiting_callers ++ [caller]}
+  end
+
+  defp reset_metadata_waiter_timeouts(state, chunks) do
+    if Enum.any?(chunks, &semantic_progress_chunk?/1) do
+      waiting_callers = Enum.map(state.waiting_callers, &reset_metadata_waiter_timeout/1)
+      %{state | waiting_callers: waiting_callers}
+    else
+      state
+    end
+  end
+
+  defp semantic_progress_chunk?(%StreamChunk{type: type})
+       when type in [:content, :thinking, :tool_call],
+       do: true
+
+  defp semantic_progress_chunk?(%StreamChunk{type: :meta, metadata: metadata})
+       when is_map(metadata) do
+    map_size(metadata) > 0 and
+      Map.get(metadata, :keepalive?) != true and Map.get(metadata, "keepalive?") != true
+  end
+
+  defp semantic_progress_chunk?(_chunk), do: false
+
+  defp reset_metadata_waiter_timeout(%{type: :metadata, timeout: timeout} = caller)
+       when is_integer(timeout) do
+    cancel_waiting_caller_timer(caller)
+    token = make_ref()
+    %{caller | token: token, timer: start_waiting_caller_timer(token, timeout)}
+  end
+
+  defp reset_metadata_waiter_timeout(caller), do: caller
+
+  defp start_waiting_caller_timer(_token, :infinity), do: nil
+
+  defp start_waiting_caller_timer(token, timeout) do
+    Process.send_after(self(), {:caller_timeout, token}, timeout)
   end
 
   defp pop_waiting_caller(state, token) do
@@ -1268,6 +1325,8 @@ defmodule ReqLLM.StreamServer do
 
     {List.first(matched), %{state | waiting_callers: remaining}}
   end
+
+  defp cancel_waiting_caller_timer(%{timer: nil}), do: :ok
 
   defp cancel_waiting_caller_timer(%{timer: timer}) do
     Process.cancel_timer(timer, async: true, info: false)

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -1038,14 +1038,7 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp finalize_stream(state) do
-    state = flush_protocol_state(state)
-
-    {flush_chunks, new_provider_state} =
-      if function_exported?(state.provider_mod, :flush_stream_state, 2) do
-        state.provider_mod.flush_stream_state(state.model, state.provider_state)
-      else
-        {[], state.provider_state}
-      end
+    state = state |> flush_protocol_state() |> flush_provider_state()
 
     extra_flush_chunks =
       if state.object_json_mode? do
@@ -1074,8 +1067,7 @@ defmodule ReqLLM.StreamServer do
 
     state =
       state
-      |> Map.put(:provider_state, new_provider_state)
-      |> then(&enqueue_chunks(flush_chunks ++ extra_flush_chunks, &1))
+      |> then(&enqueue_chunks(extra_flush_chunks, &1))
 
     metadata = extract_final_metadata(state)
 
@@ -1089,7 +1081,7 @@ defmodule ReqLLM.StreamServer do
   defp finalize_cancelled_stream(%{status: {:error, _reason}} = state), do: state
 
   defp finalize_cancelled_stream(state) do
-    state = flush_protocol_state(state)
+    state = state |> flush_protocol_state() |> flush_provider_state()
 
     metadata =
       state
@@ -1101,6 +1093,19 @@ defmodule ReqLLM.StreamServer do
     |> Map.put(:queue, :queue.new())
     |> Map.put(:metadata, metadata)
     |> maybe_emit_stream_stop(:cancelled)
+  end
+
+  defp flush_provider_state(state) do
+    {flush_chunks, new_provider_state} =
+      if function_exported?(state.provider_mod, :flush_stream_state, 2) do
+        state.provider_mod.flush_stream_state(state.model, state.provider_state)
+      else
+        {[], state.provider_state}
+      end
+
+    state
+    |> Map.put(:provider_state, new_provider_state)
+    |> then(&enqueue_chunks(flush_chunks, &1))
   end
 
   defp flush_protocol_state(state) do

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -68,7 +68,7 @@ defmodule ReqLLM.Streaming do
   ## Options
 
     * `:timeout` - HTTP request timeout in milliseconds (default: 30_000)
-    * `:metadata_timeout` - Metadata collection timeout in milliseconds (default: 300_000)
+    * `:metadata_timeout` - Maximum metadata inactivity in milliseconds, or `:infinity`
     * `:fixture_path` - Path for test fixture capture (testing only)
     * `:finch_name` - Finch pool name (default: ReqLLM.Finch)
 

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -82,6 +82,36 @@ defmodule ReqLLM.StreamServer.MetadataTest do
       StreamServer.cancel(server)
     end
 
+    test "cancellation replies to all metadata waiters with partial usage" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      usage = %{"prompt_tokens" => 10, "completion_tokens" => 5, "total_tokens" => 15}
+      payload = Jason.encode!(%{"usage" => usage})
+
+      StreamServer.http_event(server, {:data, "data: #{payload}\n\n"})
+
+      metadata_tasks =
+        for _index <- 1..2 do
+          Task.async(fn -> StreamServer.await_metadata(server, :infinity) end)
+        end
+
+      await_metadata_waiters(server, 2)
+
+      assert :ok = StreamServer.cancel(server)
+
+      results = Task.await_many(metadata_tasks)
+      assert length(results) == 2
+
+      Enum.each(results, fn result ->
+        assert {:ok, metadata} = result
+        assert metadata.finish_reason == :cancelled
+        assert metadata.usage.input_tokens == 10
+        assert metadata.usage.output_tokens == 5
+        assert metadata.usage.total_tokens == 15
+      end)
+    end
+
     test "stops after normal HTTP task completion once halt and metadata are delivered" do
       server = start_server()
       task = Task.async(fn -> Process.sleep(20) end)
@@ -183,5 +213,20 @@ defmodule ReqLLM.StreamServer.MetadataTest do
 
       StreamServer.cancel(server)
     end
+  end
+
+  defp await_metadata_waiters(server, expected_count, attempts \\ 50)
+
+  defp await_metadata_waiters(server, expected_count, attempts) when attempts > 0 do
+    if length(:sys.get_state(server).waiting_callers) >= expected_count do
+      :ok
+    else
+      Process.sleep(5)
+      await_metadata_waiters(server, expected_count, attempts - 1)
+    end
+  end
+
+  defp await_metadata_waiters(_server, _expected_count, 0) do
+    flunk("metadata waiters were not registered")
   end
 end

--- a/test/req_llm/stream_server/provider_test.exs
+++ b/test/req_llm/stream_server/provider_test.exs
@@ -69,8 +69,18 @@ defmodule ReqLLM.StreamServer.ProviderTest.ProviderWithState do
 
   def decode_stream_event(_, _model, provider_state), do: {[], provider_state}
 
-  def flush_stream_state(_model, %{count: count} = provider_state) do
-    {[StreamChunk.text("FLUSH:#{count}")], provider_state}
+  def flush_stream_state(model, %{count: count} = provider_state) do
+    flush_chunks =
+      case model.extra do
+        %{test_pid: test_pid} ->
+          send(test_pid, {:provider_flushed, count})
+          [StreamChunk.text("FLUSH:#{count}"), StreamChunk.meta(%{provider_flush_count: count})]
+
+        _other ->
+          [StreamChunk.text("FLUSH:#{count}")]
+      end
+
+    {flush_chunks, provider_state}
   end
 
   def prepare_request(_op, _model, _data, _opts), do: {:error, :not_implemented}
@@ -229,6 +239,28 @@ defmodule ReqLLM.StreamServer.ProviderTest do
       assert flush_chunk == StreamChunk.text("FLUSH:2")
     end
 
+    test "flushes provider state before cancellation metadata" do
+      model = %LLMDB.Model{
+        provider: ProviderWithState,
+        id: "test",
+        extra: %{test_pid: self()}
+      }
+
+      server = start_server(provider_mod: ProviderWithState, model: model)
+      _task = mock_http_task(server)
+
+      StreamServer.http_event(server, {:data, "data: content\n\n"})
+
+      metadata_task = Task.async(fn -> StreamServer.await_metadata(server, :infinity) end)
+      await_metadata_waiter(server)
+
+      assert :ok = StreamServer.cancel(server)
+      assert {:ok, metadata} = Task.await(metadata_task)
+      assert_receive {:provider_flushed, 1}
+      assert metadata.finish_reason == :cancelled
+      assert metadata.provider_flush_count == 1
+    end
+
     test "handles provider without init_stream_state" do
       server = start_server()
       _task = mock_http_task(server)
@@ -368,5 +400,20 @@ defmodule ReqLLM.StreamServer.ProviderTest do
 
       StreamServer.cancel(server)
     end
+  end
+
+  defp await_metadata_waiter(server, attempts \\ 50)
+
+  defp await_metadata_waiter(server, attempts) when attempts > 0 do
+    if Enum.any?(:sys.get_state(server).waiting_callers, &(&1.type == :metadata)) do
+      :ok
+    else
+      Process.sleep(5)
+      await_metadata_waiter(server, attempts - 1)
+    end
+  end
+
+  defp await_metadata_waiter(_server, 0) do
+    flunk("metadata waiter was not registered")
   end
 end

--- a/test/req_llm/stream_server/streaming_test.exs
+++ b/test/req_llm/stream_server/streaming_test.exs
@@ -251,6 +251,35 @@ defmodule ReqLLM.StreamServer.StreamingTest do
       StreamServer.cancel(server)
     end
 
+    test "await_metadata/2 resets a finite timeout on semantic progress" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      metadata_task = Task.async(fn -> StreamServer.await_metadata(server, 250) end)
+
+      Process.sleep(150)
+
+      StreamServer.http_event(
+        server,
+        {:data, ~s(data: {"choices": [{"delta": {"content": "one"}}]}\n\n)}
+      )
+
+      Process.sleep(150)
+
+      StreamServer.http_event(
+        server,
+        {:data, ~s(data: {"choices": [{"delta": {"content": "two"}}]}\n\n)}
+      )
+
+      Process.sleep(150)
+      StreamServer.http_event(server, :done)
+
+      assert {:ok, metadata} = Task.await(metadata_task, 500)
+      assert metadata.finish_reason == :incomplete
+
+      StreamServer.cancel(server)
+    end
+
     test "next/2 returns structured timeout when transport error arrives late" do
       server = start_server()
       _task = mock_http_task(server)


### PR DESCRIPTION
## Summary

- finalize active streams as cancelled before `StreamServer` shutdown
- reply to every registered metadata waiter with explicit `finish_reason: :cancelled` metadata
- preserve partial usage and accumulated message metadata on cancellation
- support `metadata_timeout: :infinity`
- make finite metadata timeouts inactivity watchdogs that reset on semantic stream progress
- document the progress-aware timeout behavior and add cancellation, partial-usage, infinity, active-stream, and stalled-stream coverage

## Root cause

Cancellation stopped the `StreamServer` normally without replying to metadata waiters, so their `GenServer.call/3` exited and `MetadataHandle` replaced the result with an empty map. Finite metadata timeouts were also registered once at stream start, making them absolute lifetime limits even while content, reasoning, tool, or usage events continued arriving.

## Validation

- `mix test`: 3,537 passed, 11 skipped, 144 excluded
- focused StreamServer metadata and streaming suites: 27 passed
- `mix quality`: passed formatting, warnings-as-errors compilation, Credo strict, and Dialyzer with zero errors

Closes #816