### PR TITLE
fix(streaming): enforce high-watermark backpressure

### DIFF
--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -54,9 +54,13 @@ defmodule ReqLLM.StreamServer do
 
   ## Backpressure
 
-  When the internal queue exceeds `high_watermark`, the server delays replying to
-  `{:http_event, {:data, _}}` messages until consumers drain the queue via `next/2`.
-  This provides natural backpressure without dropping events.
+  When the number of decoded public chunks in the internal queue reaches
+  `high_watermark`, the server delays replying to the producing
+  `{:http_event, {:data, _}}` call until consumers drain the queue below the
+  watermark via `next/2`. Each transport data event is processed atomically, so
+  one event that decodes to multiple chunks can exceed the watermark by the
+  chunks from that event. No later transport event is acknowledged or processed
+  while the producer is suspended.
   """
 
   use GenServer
@@ -99,6 +103,8 @@ defmodule ReqLLM.StreamServer do
     high_watermark: 500,
     headers: [],
     http_status: nil,
+    blocked_http_event: nil,
+    pending_http_calls: :queue.new(),
     waiting_callers: [],
     object_json_mode?: false,
     object_acc: [],
@@ -125,7 +131,8 @@ defmodule ReqLLM.StreamServer do
     * `:provider_mod` - Provider module implementing ReqLLM.Provider behavior (required)
     * `:model` - ReqLLM.Model struct (required)
     * `:fixture_path` - Optional path for fixture capture
-    * `:high_watermark` - Queue size limit for backpressure (default: 500)
+    * `:high_watermark` - Positive decoded public-chunk queue bound for backpressure
+      (default: 500)
 
   ## Examples
 
@@ -139,6 +146,7 @@ defmodule ReqLLM.StreamServer do
   def start_link(opts) do
     provider_mod = Keyword.fetch!(opts, :provider_mod)
     model = Keyword.fetch!(opts, :model)
+    high_watermark = validate_high_watermark!(Keyword.get(opts, :high_watermark, 500))
 
     provider_state =
       if function_exported?(provider_mod, :init_stream_state, 1) do
@@ -158,7 +166,7 @@ defmodule ReqLLM.StreamServer do
           :completion_cleanup_after,
           Application.get_env(:req_llm, :stream_completion_cleanup_after, 30_000)
         ),
-      high_watermark: Keyword.get(opts, :high_watermark, 500)
+      high_watermark: high_watermark
     }
 
     GenServer.start_link(__MODULE__, state, opts)
@@ -315,7 +323,7 @@ defmodule ReqLLM.StreamServer do
   """
   @spec http_event(server(), term()) :: :ok
   def http_event(server, event) do
-    GenServer.call(server, {:http_event, event})
+    GenServer.call(server, {:http_event, event}, :infinity)
   end
 
   @doc """
@@ -405,18 +413,15 @@ defmodule ReqLLM.StreamServer do
   end
 
   @impl GenServer
-  def handle_call({:http_event, event}, _from, %{telemetry_pending?: true} = state) do
-    {:reply, :ok, %{state | pending_http_events: state.pending_http_events ++ [event]}}
+  def handle_call({:http_event, event}, from, %{blocked_http_event: nil} = state) do
+    {reply, new_state} = apply_http_event(event, state)
+    finish_http_event_call(event, from, reply, new_state)
   end
 
   @impl GenServer
-  def handle_call({:http_event, event}, _from, state) do
-    {:reply, reply, new_state} = process_http_event(event, state)
-
-    case finalize_lifecycle(new_state) do
-      {:stop, final_state} -> {:stop, :normal, reply, final_state}
-      {:continue, final_state} -> {:reply, reply, final_state}
-    end
+  def handle_call({:http_event, event}, from, state) do
+    pending_http_calls = :queue.in({from, event}, state.pending_http_calls)
+    {:noreply, %{state | pending_http_calls: pending_http_calls}}
   end
 
   @impl GenServer
@@ -425,7 +430,7 @@ defmodule ReqLLM.StreamServer do
 
     case dequeue_chunk(state) do
       {:ok, chunk, new_state} ->
-        {:reply, {:ok, chunk}, new_state}
+        reply_with_lifecycle({:ok, chunk}, resume_http_event_callers(new_state))
 
       {:empty, new_state} ->
         case state.status do
@@ -537,6 +542,7 @@ defmodule ReqLLM.StreamServer do
       state
       |> Map.put(:telemetry, telemetry_context)
       |> drain_pending_http_events()
+      |> resume_http_event_callers()
 
     case finalize_lifecycle(new_state) do
       {:stop, final_state} -> {:stop, :normal, :ok, final_state}
@@ -586,7 +592,11 @@ defmodule ReqLLM.StreamServer do
 
   @impl GenServer
   def handle_info({:EXIT, pid, reason}, %{http_task: pid} = state) do
-    new_state = state |> process_http_task_exit(reason) |> reply_to_waiting_callers()
+    new_state =
+      state
+      |> process_http_task_exit(reason)
+      |> release_http_event_callers()
+      |> reply_to_waiting_callers()
 
     case finalize_lifecycle(new_state) do
       {:stop, final_state} -> {:stop, :normal, final_state}
@@ -609,7 +619,11 @@ defmodule ReqLLM.StreamServer do
 
   @impl GenServer
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{http_task: pid} = state) do
-    new_state = state |> process_http_task_exit(reason) |> reply_to_waiting_callers()
+    new_state =
+      state
+      |> process_http_task_exit(reason)
+      |> release_http_event_callers()
+      |> reply_to_waiting_callers()
 
     case finalize_lifecycle(new_state) do
       {:stop, final_state} -> {:stop, :normal, final_state}
@@ -662,6 +676,115 @@ defmodule ReqLLM.StreamServer do
   end
 
   ## Private Functions
+
+  defp validate_high_watermark!(high_watermark)
+       when is_integer(high_watermark) and high_watermark > 0,
+       do: high_watermark
+
+  defp validate_high_watermark!(high_watermark) do
+    raise ArgumentError,
+          ":high_watermark must be a positive integer, got: #{inspect(high_watermark)}"
+  end
+
+  defp apply_http_event(event, %{telemetry_pending?: true} = state) do
+    {:ok, %{state | pending_http_events: state.pending_http_events ++ [event]}}
+  end
+
+  defp apply_http_event(event, state) do
+    {:reply, reply, new_state} = process_http_event(event, state)
+    {reply, new_state}
+  end
+
+  defp finish_http_event_call(event, from, reply, state) do
+    if backpressure_required?(event, state) do
+      {:noreply, %{state | blocked_http_event: {from, reply}}}
+    else
+      reply_with_lifecycle(reply, state)
+    end
+  end
+
+  defp reply_with_lifecycle(reply, state) do
+    case finalize_lifecycle(state) do
+      {:stop, final_state} -> {:stop, :normal, reply, final_state}
+      {:continue, final_state} -> {:reply, reply, final_state}
+    end
+  end
+
+  defp backpressure_required?({:data, _chunk}, state) do
+    active_stream?(state) and buffered_chunk_count(state) >= state.high_watermark
+  end
+
+  defp backpressure_required?(_event, _state), do: false
+
+  defp active_stream?(%{status: :done}), do: false
+  defp active_stream?(%{status: {:error, _reason}}), do: false
+  defp active_stream?(_state), do: true
+
+  defp buffered_chunk_count(state) do
+    :queue.len(state.queue) + pending_telemetry_data_count(state)
+  end
+
+  defp pending_telemetry_data_count(%{telemetry_pending?: true} = state) do
+    Enum.count(state.pending_http_events, &match?({:data, _chunk}, &1))
+  end
+
+  defp pending_telemetry_data_count(_state), do: 0
+
+  defp resume_http_event_callers(%{blocked_http_event: nil} = state) do
+    drain_pending_http_calls(state)
+  end
+
+  defp resume_http_event_callers(state) do
+    if active_stream?(state) and buffered_chunk_count(state) >= state.high_watermark do
+      state
+    else
+      {from, reply} = state.blocked_http_event
+      GenServer.reply(from, reply)
+
+      state
+      |> Map.put(:blocked_http_event, nil)
+      |> drain_pending_http_calls()
+    end
+  end
+
+  defp drain_pending_http_calls(%{blocked_http_event: nil} = state) do
+    case :queue.out(state.pending_http_calls) do
+      {{:value, {from, event}}, pending_http_calls} ->
+        {reply, new_state} =
+          apply_http_event(event, %{state | pending_http_calls: pending_http_calls})
+
+        cond do
+          not active_stream?(new_state) ->
+            GenServer.reply(from, reply)
+            release_http_event_callers(new_state)
+
+          backpressure_required?(event, new_state) ->
+            %{new_state | blocked_http_event: {from, reply}}
+
+          true ->
+            GenServer.reply(from, reply)
+            drain_pending_http_calls(new_state)
+        end
+
+      {:empty, _pending_http_calls} ->
+        state
+    end
+  end
+
+  defp drain_pending_http_calls(state), do: state
+
+  defp release_http_event_callers(state) do
+    case state.blocked_http_event do
+      nil -> :ok
+      {from, reply} -> GenServer.reply(from, reply)
+    end
+
+    state.pending_http_calls
+    |> :queue.to_list()
+    |> Enum.each(fn {from, _event} -> GenServer.reply(from, :ok) end)
+
+    %{state | blocked_http_event: nil, pending_http_calls: :queue.new()}
+  end
 
   defp process_http_event({:status, status}, state) do
     new_state = %{state | http_status: status}
@@ -1338,6 +1461,8 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp cleanup_resources(state) do
+    state = release_http_event_callers(state)
+
     # Kill HTTP task if running
     if state.http_task && Process.alive?(state.http_task) do
       Process.exit(state.http_task, :cancelled)

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -60,7 +60,9 @@ defmodule ReqLLM.StreamServer do
   watermark via `next/2`. Each transport data event is processed atomically, so
   one event that decodes to multiple chunks can exceed the watermark by the
   chunks from that event. No later transport event is acknowledged or processed
-  while the producer is suspended.
+  while the producer is suspended. Before telemetry setup completes, the first
+  data event is held so its decoded chunk count can be evaluated against the
+  watermark instead of estimating capacity from raw transport reads.
   """
 
   use GenServer
@@ -711,7 +713,7 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp backpressure_required?({:data, _chunk}, state) do
-    active_stream?(state) and buffered_chunk_count(state) >= state.high_watermark
+    active_stream?(state) and backpressure_saturated?(state)
   end
 
   defp backpressure_required?(_event, _state), do: false
@@ -720,22 +722,18 @@ defmodule ReqLLM.StreamServer do
   defp active_stream?(%{status: {:error, _reason}}), do: false
   defp active_stream?(_state), do: true
 
-  defp buffered_chunk_count(state) do
-    :queue.len(state.queue) + pending_telemetry_data_count(state)
-  end
+  defp backpressure_saturated?(%{telemetry_pending?: true}), do: true
 
-  defp pending_telemetry_data_count(%{telemetry_pending?: true} = state) do
-    Enum.count(state.pending_http_events, &match?({:data, _chunk}, &1))
+  defp backpressure_saturated?(state) do
+    :queue.len(state.queue) >= state.high_watermark
   end
-
-  defp pending_telemetry_data_count(_state), do: 0
 
   defp resume_http_event_callers(%{blocked_http_event: nil} = state) do
     drain_pending_http_calls(state)
   end
 
   defp resume_http_event_callers(state) do
-    if active_stream?(state) and buffered_chunk_count(state) >= state.high_watermark do
+    if active_stream?(state) and backpressure_saturated?(state) do
       state
     else
       {from, reply} = state.blocked_http_event

--- a/test/req_llm/stream_server/concurrency_test.exs
+++ b/test/req_llm/stream_server/concurrency_test.exs
@@ -80,42 +80,40 @@ defmodule ReqLLM.StreamServer.ConcurrencyTest do
       StreamServer.cancel(server)
     end
 
-    test "concurrent consumers with backpressure" do
+    test "consumer demand releases a backpressured producer one chunk at a time" do
       server = start_server(high_watermark: 1)
-      _task = mock_http_task(server)
 
       sse_data1 = ~s(data: {"choices": [{"delta": {"content": "one"}}]}\n\n)
       sse_data2 = ~s(data: {"choices": [{"delta": {"content": "two"}}]}\n\n)
       sse_data3 = ~s(data: {"choices": [{"delta": {"content": "three"}}]}\n\n)
 
-      assert :ok = GenServer.call(server, {:http_event, {:data, sse_data1}})
+      producer =
+        Task.async(fn ->
+          Enum.each([sse_data1, sse_data2, sse_data3], fn event ->
+            :ok = StreamServer.http_event(server, {:data, event})
+          end)
 
-      consumer1 = Task.async(fn -> StreamServer.next(server, 1000) end)
+          StreamServer.http_event(server, :done)
+        end)
 
-      :timer.sleep(10)
+      assert :ok = wait_for_backpressure(server)
 
-      assert :ok = GenServer.call(server, {:http_event, {:data, sse_data2}})
+      chunks =
+        for expected <- ["one", "two", "three"] do
+          consumer = Task.async(fn -> StreamServer.next(server, 1000) end)
+          assert {:ok, chunk} = Task.await(consumer)
+          assert chunk.text == expected
 
-      consumer2 = Task.async(fn -> StreamServer.next(server, 1000) end)
+          if expected != "three" do
+            assert :ok = wait_for_backpressure(server)
+          end
 
-      :timer.sleep(10)
+          chunk.text
+        end
 
-      assert :ok = GenServer.call(server, {:http_event, {:data, sse_data3}})
-
-      consumer3 = Task.async(fn -> StreamServer.next(server, 1000) end)
-
-      :timer.sleep(10)
-
-      assert :ok = GenServer.call(server, {:http_event, :done})
-
-      assert {:ok, chunk1} = Task.await(consumer1)
-      assert chunk1.text == "one"
-
-      assert {:ok, chunk2} = Task.await(consumer2)
-      assert chunk2.text == "two"
-
-      assert {:ok, chunk3} = Task.await(consumer3)
-      assert chunk3.text == "three"
+      assert chunks == ["one", "two", "three"]
+      assert :ok = Task.await(producer)
+      assert :halt = StreamServer.next(server, 100)
 
       StreamServer.cancel(server)
     end
@@ -136,6 +134,23 @@ defmodule ReqLLM.StreamServer.ConcurrencyTest do
       assert Process.alive?(server)
 
       StreamServer.cancel(server)
+    end
+  end
+
+  defp wait_for_backpressure(server, attempts \\ 100)
+
+  defp wait_for_backpressure(_server, 0) do
+    flunk("StreamServer did not apply backpressure")
+  end
+
+  defp wait_for_backpressure(server, attempts) do
+    state = :sys.get_state(server)
+
+    if state.blocked_http_event && :queue.len(state.queue) == 1 do
+      :ok
+    else
+      Process.sleep(10)
+      wait_for_backpressure(server, attempts - 1)
     end
   end
 end

--- a/test/req_llm/stream_server/core_test.exs
+++ b/test/req_llm/stream_server/core_test.exs
@@ -30,6 +30,12 @@ defmodule ReqLLM.StreamServer.CoreTest do
       assert :ok = StreamServer.cancel(server)
     end
 
+    test "requires a positive high watermark" do
+      assert_raise ArgumentError, ":high_watermark must be a positive integer, got: 0", fn ->
+        start_server(high_watermark: 0)
+      end
+    end
+
     test "handles HTTP task attachment and monitoring" do
       server = start_server()
       task = mock_http_task(server)

--- a/test/req_llm/stream_server/streaming_test.exs
+++ b/test/req_llm/stream_server/streaming_test.exs
@@ -24,45 +24,103 @@ defmodule ReqLLM.StreamServer.StreamingTest do
   end
 
   describe "backpressure handling" do
-    test "applies backpressure when queue exceeds high_watermark" do
-      server = start_server(high_watermark: 2)
-      _task = mock_http_task(server)
+    test "bounds queued chunks and fixture data until consumer demand resumes" do
+      server = start_server(high_watermark: 1, fixture_path: "unused-stream-fixture.json")
+      parent = self()
 
-      for i <- 1..5 do
-        sse_data = ~s(data: {"choices": [{"delta": {"content": "#{i}"}}]}\n\n)
-        GenServer.call(server, {:http_event, {:data, sse_data}})
-      end
+      events =
+        for text <- ["one", "two", "three"] do
+          {text, ~s(data: {"choices": [{"delta": {"content": "#{text}"}}]}\n\n)}
+        end
 
-      assert {:ok, chunk1} = StreamServer.next(server, 100)
-      assert chunk1.text == "1"
+      producer =
+        Task.async(fn ->
+          Enum.each(events, fn {text, event} ->
+            send(parent, {:producer_sending, text})
+            :ok = StreamServer.http_event(server, {:data, event})
+            send(parent, {:producer_acknowledged, text})
+          end)
+        end)
 
-      assert {:ok, chunk2} = StreamServer.next(server, 100)
-      assert chunk2.text == "2"
+      expected_raw_bytes =
+        Enum.reduce(events, 0, fn {text, event}, raw_bytes ->
+          assert_receive {:producer_sending, ^text}
+          expected_raw_bytes = raw_bytes + byte_size(event)
+          assert :ok = wait_for_backpressure(server, expected_raw_bytes)
+          refute_receive {:producer_acknowledged, ^text}, 25
+
+          assert {:ok, chunk} = StreamServer.next(server, 100)
+          assert chunk.text == text
+          assert_receive {:producer_acknowledged, ^text}
+
+          expected_raw_bytes
+        end)
+
+      assert expected_raw_bytes ==
+               Enum.sum(Enum.map(events, fn {_text, event} -> byte_size(event) end))
+
+      assert :ok = Task.await(producer)
+      assert :ok = StreamServer.http_event(server, :done)
+      assert :halt = StreamServer.next(server, 100)
 
       StreamServer.cancel(server)
     end
 
-    test "resumes processing after queue drains below watermark" do
+    test "cancellation releases a suspended producer" do
       server = start_server(high_watermark: 1)
-      _task = mock_http_task(server)
+      first = ~s(data: {"choices": [{"delta": {"content": "first"}}]}\n\n)
+      second = ~s(data: {"choices": [{"delta": {"content": "second"}}]}\n\n)
+      first_producer = Task.async(fn -> StreamServer.http_event(server, {:data, first}) end)
 
-      sse_data1 = ~s(data: {"choices": [{"delta": {"content": "First"}}]}\n\n)
-      sse_data2 = ~s(data: {"choices": [{"delta": {"content": "Second"}}]}\n\n)
+      assert :ok = wait_for_backpressure(server)
 
-      assert :ok = GenServer.call(server, {:http_event, {:data, sse_data1}})
+      second_producer = Task.async(fn -> StreamServer.http_event(server, {:data, second}) end)
+      assert :ok = wait_for_pending_http_call(server)
 
-      data_task =
-        Task.async(fn ->
-          GenServer.call(server, {:http_event, {:data, sse_data2}})
+      assert :ok = StreamServer.cancel(server)
+      assert :ok = Task.await(first_producer)
+      assert :ok = Task.await(second_producer)
+    end
+
+    test "consumer termination releases a suspended producer" do
+      server = start_server(high_watermark: 1)
+
+      consumer =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
         end)
 
-      assert {:ok, chunk} = StreamServer.next(server, 100)
-      assert chunk.text == "First"
+      assert :ok = StreamServer.monitor_consumer(server, consumer)
 
-      assert :ok = Task.await(data_task)
+      event = ~s(data: {"choices": [{"delta": {"content": "blocked"}}]}\n\n)
+      producer = Task.async(fn -> StreamServer.http_event(server, {:data, event}) end)
+      server_ref = Process.monitor(server)
+
+      assert :ok = wait_for_backpressure(server)
+      Process.exit(consumer, :cancelled)
+
+      assert :ok = Task.await(producer)
+      assert_receive {:DOWN, ^server_ref, :process, ^server, :normal}
+    end
+
+    test "telemetry deferral cannot bypass the watermark" do
+      server = start_server(high_watermark: 1)
+      :sys.replace_state(server, &%{&1 | telemetry_pending?: true})
+
+      event = ~s(data: {"choices": [{"delta": {"content": "deferred"}}]}\n\n)
+      producer = Task.async(fn -> StreamServer.http_event(server, {:data, event}) end)
+
+      assert :ok = wait_for_telemetry_backpressure(server)
+      assert nil == Task.yield(producer, 25)
+
+      assert :ok = StreamServer.set_telemetry_context(server, nil)
+      assert nil == Task.yield(producer, 25)
 
       assert {:ok, chunk} = StreamServer.next(server, 100)
-      assert chunk.text == "Second"
+      assert chunk.text == "deferred"
+      assert :ok = Task.await(producer)
 
       StreamServer.cancel(server)
     end
@@ -301,6 +359,59 @@ defmodule ReqLLM.StreamServer.StreamingTest do
       assert {:error, :transport_timeout} = StreamServer.next(server, 100)
 
       StreamServer.cancel(server)
+    end
+  end
+
+  defp wait_for_backpressure(server, expected_raw_bytes \\ nil, attempts \\ 100)
+
+  defp wait_for_backpressure(_server, _expected_raw_bytes, 0) do
+    flunk("StreamServer did not apply backpressure")
+  end
+
+  defp wait_for_backpressure(server, expected_raw_bytes, attempts) do
+    state = :sys.get_state(server)
+
+    raw_bytes_match? = is_nil(expected_raw_bytes) or state.raw_bytes == expected_raw_bytes
+
+    if state.blocked_http_event && :queue.len(state.queue) == 1 && raw_bytes_match? do
+      :ok
+    else
+      Process.sleep(10)
+      wait_for_backpressure(server, expected_raw_bytes, attempts - 1)
+    end
+  end
+
+  defp wait_for_pending_http_call(server, attempts \\ 100)
+
+  defp wait_for_pending_http_call(_server, 0) do
+    flunk("StreamServer did not retain the pending HTTP call")
+  end
+
+  defp wait_for_pending_http_call(server, attempts) do
+    state = :sys.get_state(server)
+
+    if :queue.len(state.pending_http_calls) == 1 do
+      :ok
+    else
+      Process.sleep(10)
+      wait_for_pending_http_call(server, attempts - 1)
+    end
+  end
+
+  defp wait_for_telemetry_backpressure(server, attempts \\ 100)
+
+  defp wait_for_telemetry_backpressure(_server, 0) do
+    flunk("StreamServer did not backpressure deferred telemetry events")
+  end
+
+  defp wait_for_telemetry_backpressure(server, attempts) do
+    state = :sys.get_state(server)
+
+    if state.blocked_http_event && length(state.pending_http_events) == 1 do
+      :ok
+    else
+      Process.sleep(10)
+      wait_for_telemetry_backpressure(server, attempts - 1)
     end
   end
 end

--- a/test/req_llm/stream_server/streaming_test.exs
+++ b/test/req_llm/stream_server/streaming_test.exs
@@ -106,10 +106,18 @@ defmodule ReqLLM.StreamServer.StreamingTest do
     end
 
     test "telemetry deferral cannot bypass the watermark" do
-      server = start_server(high_watermark: 1)
+      server = start_server(high_watermark: 2)
       :sys.replace_state(server, &%{&1 | telemetry_pending?: true})
 
-      event = ~s(data: {"choices": [{"delta": {"content": "deferred"}}]}\n\n)
+      event = """
+      data: {"choices": [{"delta": {"content": "one"}}]}
+
+      data: {"choices": [{"delta": {"content": "two"}}]}
+
+      data: {"choices": [{"delta": {"content": "three"}}]}
+
+      """
+
       producer = Task.async(fn -> StreamServer.http_event(server, {:data, event}) end)
 
       assert :ok = wait_for_telemetry_backpressure(server)
@@ -119,8 +127,15 @@ defmodule ReqLLM.StreamServer.StreamingTest do
       assert nil == Task.yield(producer, 25)
 
       assert {:ok, chunk} = StreamServer.next(server, 100)
-      assert chunk.text == "deferred"
+      assert chunk.text == "one"
+      assert nil == Task.yield(producer, 25)
+
+      assert {:ok, chunk} = StreamServer.next(server, 100)
+      assert chunk.text == "two"
       assert :ok = Task.await(producer)
+
+      assert {:ok, chunk} = StreamServer.next(server, 100)
+      assert chunk.text == "three"
 
       StreamServer.cancel(server)
     end

--- a/test/req_llm/stream_server/telemetry_test.exs
+++ b/test/req_llm/stream_server/telemetry_test.exs
@@ -161,18 +161,22 @@ defmodule ReqLLM.StreamServer.TelemetryTest do
 
     StreamServer.http_event(server, {:status, 200})
 
-    StreamServer.http_event(
-      server,
-      {:data, "data: #{Jason.encode!(%{"type" => "content", "text" => "answer"})}\n\n"}
-    )
+    producer =
+      Task.async(fn ->
+        StreamServer.http_event(
+          server,
+          {:data, "data: #{Jason.encode!(%{"type" => "content", "text" => "answer"})}\n\n"}
+        )
 
-    StreamServer.http_event(
-      server,
-      {:data, "data: #{Jason.encode!(%{"type" => "finish", "finish_reason" => "stop"})}\n\n"}
-    )
+        StreamServer.http_event(
+          server,
+          {:data, "data: #{Jason.encode!(%{"type" => "finish", "finish_reason" => "stop"})}\n\n"}
+        )
 
-    StreamServer.http_event(server, :done)
-    send(server, {:EXIT, task.pid, :normal})
+        StreamServer.http_event(server, :done)
+      end)
+
+    assert nil == Task.yield(producer, 25)
 
     refute_receive {:telemetry_event, [:req_llm, :request, :start], _, _}, 50
     refute_receive {:telemetry_event, [:req_llm, :request, :stop], _, _}, 50
@@ -188,6 +192,8 @@ defmodule ReqLLM.StreamServer.TelemetryTest do
       |> ReqLLM.Telemetry.start_request(%{})
 
     assert :ok = StreamServer.set_telemetry_context(server, telemetry_context)
+    assert :ok = Task.await(producer)
+    send(server, {:EXIT, task.pid, :normal})
     assert {:ok, metadata} = StreamServer.await_metadata(server, 500)
     assert metadata.finish_reason == :stop
 

--- a/test/support/vcr.ex
+++ b/test/support/vcr.ex
@@ -40,6 +40,7 @@ defmodule ReqLLM.Test.VCR do
       stream = VCR.replay_stream(transcript)
   """
 
+  alias ReqLLM.StreamServer
   alias ReqLLM.Test.{ChunkCollector, Transcript}
 
   @type provider :: atom()
@@ -244,16 +245,16 @@ defmodule ReqLLM.Test.VCR do
     Enum.each(events, fn event ->
       case event do
         {:status, code} ->
-          GenServer.call(server, {:http_event, {:status, code}})
+          StreamServer.http_event(server, {:status, code})
 
         {:headers, headers} ->
-          GenServer.call(server, {:http_event, {:headers, headers}})
+          StreamServer.http_event(server, {:headers, headers})
 
         {:data, binary} ->
-          GenServer.call(server, {:http_event, {:data, binary}})
+          StreamServer.http_event(server, {:data, binary})
 
         {:done, :ok} ->
-          GenServer.call(server, {:http_event, :done})
+          StreamServer.http_event(server, :done)
 
         _ ->
           :ok


### PR DESCRIPTION
## Summary

- suspend transport acknowledgements when decoded public chunks reach the configured high watermark
- preserve event order while retaining later producer calls and release suspended callers on cancellation, consumer death, or transport termination
- enforce the same contract for Finch and WebSocket streams, including telemetry deferral and fixture raw-data accumulation
- document the watermark unit and atomic transport-event semantics

## Validation

- `mix test` — 3,546 passed, 11 skipped, 144 excluded
- `mix test test/req_llm/stream_server` — 77 passed
- `mix test test/req_llm/streaming test/req_llm/streaming_test.exs` — 93 passed
- `mix quality`

Closes #821