### PR TITLE
fix(streaming): terminate metadata handles

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -942,8 +942,9 @@ defmodule ReqLLM do
   ## Performance Notes
 
   The stream is lazy and supports backpressure. Metadata collection happens
-  concurrently and won't block token delivery. Use cancellation for early
-  termination to free resources. High-concurrency streaming workloads can tune
+  concurrently and won't block token delivery. Use `ReqLLM.StreamResponse.close/1`
+  for early termination or after direct metadata access to free resources.
+  High-concurrency streaming workloads can tune
   Finch pool protocols with `:stream_pool_protocols`, capacity with
   `:stream_pool_size` and `:stream_pool_count`, shard selection with
   `:stream_pool_strategy`, and checkout behavior with `:stream_pool_timeout`

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -32,6 +32,7 @@ defmodule ReqLLM.StreamResponse do
 
   text = ReqLLM.StreamResponse.text(stream_response)
   usage = ReqLLM.StreamResponse.usage(stream_response)
+  :ok = ReqLLM.StreamResponse.close(stream_response)
   ```
 
   ### Backward compatibility
@@ -52,8 +53,8 @@ defmodule ReqLLM.StreamResponse do
   |> Stream.each(&IO.write/1)
   |> Stream.run()
 
-  # Cancel remaining work
-  stream_response.cancel.()
+  # Cancel remaining work and close the metadata handle
+  ReqLLM.StreamResponse.close(stream_response)
   ```
 
   ## Design Philosophy
@@ -385,6 +386,7 @@ defmodule ReqLLM.StreamResponse do
   - The stream is consumed exactly once (no double-consumption bugs)
   - All callbacks are optional - omitted callbacks are simply not invoked
   - The returned Response struct contains all accumulated data plus metadata
+  - The metadata handle is closed before this function returns
   """
   @spec process_stream(t(), keyword()) :: {:ok, Response.t()} | {:error, term()}
   def process_stream(%__MODULE__{} = stream_response, opts \\ []) do
@@ -411,6 +413,8 @@ defmodule ReqLLM.StreamResponse do
     error -> {:error, error}
   catch
     :exit, reason -> {:error, reason}
+  after
+    MetadataHandle.stop(stream_response.metadata_handle)
   end
 
   # Process stream chunks, invoking callbacks and collecting chunks
@@ -534,6 +538,20 @@ defmodule ReqLLM.StreamResponse do
     end
   end
 
+  @doc """
+  Closes a streaming response and releases its resources.
+
+  This operation cancels any remaining stream work and terminates the metadata
+  handle. It is safe to call more than once. After closing, metadata accessors
+  such as `usage/1` and `finish_reason/1` are no longer available.
+  """
+  @spec close(t()) :: :ok
+  def close(%__MODULE__{cancel: cancel, metadata_handle: handle}) do
+    cancel.()
+  after
+    MetadataHandle.stop(handle)
+  end
+
   defp normalize_finish_reason(reason) when is_atom(reason) do
     case reason do
       :tool_use -> :tool_calls
@@ -601,7 +619,7 @@ defmodule ReqLLM.StreamResponse do
 
   This function materializes the entire stream and awaits metadata collection,
   so it negates the streaming benefits. Use this only when backward compatibility
-  is required.
+  is required. The metadata handle is closed before this function returns.
   """
   @spec to_response(t()) :: {:ok, Response.t()} | {:error, term()}
   def to_response(%__MODULE__{} = stream_response) do
@@ -622,5 +640,7 @@ defmodule ReqLLM.StreamResponse do
     error -> {:error, error}
   catch
     :exit, reason -> {:error, reason}
+  after
+    MetadataHandle.stop(stream_response.metadata_handle)
   end
 end

--- a/lib/req_llm/stream_response/metadata_handle.ex
+++ b/lib/req_llm/stream_response/metadata_handle.ex
@@ -4,7 +4,7 @@ defmodule ReqLLM.StreamResponse.MetadataHandle do
 
   The handle starts a background process that runs the supplied fetch fun exactly once.
   Callers can await the metadata multiple times without causing repeated fetches or
-  task mailbox exhaustion.
+  task mailbox exhaustion. Call `stop/1` when the cached metadata is no longer needed.
   """
 
   use GenServer
@@ -26,32 +26,37 @@ defmodule ReqLLM.StreamResponse.MetadataHandle do
     end
   end
 
+  @doc """
+  Stops a metadata handle and any in-progress metadata collection.
+
+  This operation is idempotent and returns `:ok` when the handle has already stopped.
+  """
+  @spec stop(t()) :: :ok
+  def stop(handle) when is_pid(handle) do
+    GenServer.stop(handle)
+  catch
+    :exit, {:noproc, {GenServer, :stop, [^handle, :normal, :infinity]}} -> :ok
+  end
+
   @impl true
   def init(fetch_fun) do
-    state = %{fetch_fun: fetch_fun, metadata: :pending, waiters: []}
+    state = %{fetch_fun: fetch_fun, metadata: :pending, waiters: [], worker: nil}
     {:ok, state, {:continue, :collect_metadata}}
   end
 
   @impl true
   def handle_continue(:collect_metadata, %{fetch_fun: fetch_fun} = state) do
-    metadata =
-      try do
-        fetch_fun.()
-      rescue
-        error ->
-          Logger.warning(
-            "Metadata collection failed: #{Exception.format(:error, error, __STACKTRACE__)}"
-          )
+    parent = self()
 
-          %{}
-      catch
-        :exit, reason ->
-          Logger.warning("Metadata collection exited: #{inspect(reason)}")
-          %{}
-      end
+    worker =
+      :erlang.spawn_opt(
+        fn ->
+          send(parent, {:metadata_collected, self(), collect_metadata(fetch_fun)})
+        end,
+        [:link, :monitor]
+      )
 
-    Enum.each(state.waiters, &GenServer.reply(&1, {:ok, metadata}))
-    {:noreply, %{state | metadata: {:ready, metadata}, waiters: [], fetch_fun: nil}}
+    {:noreply, %{state | fetch_fun: nil, worker: worker}}
   end
 
   @impl true
@@ -61,5 +66,52 @@ defmodule ReqLLM.StreamResponse.MetadataHandle do
 
   def handle_call(:await, from, state) do
     {:noreply, %{state | waiters: [from | state.waiters]}}
+  end
+
+  @impl true
+  def handle_info(
+        {:metadata_collected, worker_pid, metadata},
+        %{worker: {worker_pid, monitor_ref}} = state
+      ) do
+    Process.demonitor(monitor_ref, [:flush])
+    {:noreply, metadata_ready(state, metadata)}
+  end
+
+  def handle_info(
+        {:DOWN, monitor_ref, :process, worker_pid, reason},
+        %{worker: {worker_pid, monitor_ref}} = state
+      ) do
+    Logger.warning("Metadata collection exited: #{inspect(reason)}")
+    {:noreply, metadata_ready(state, %{})}
+  end
+
+  @impl true
+  def terminate(_reason, %{worker: {worker_pid, monitor_ref}}) do
+    Process.unlink(worker_pid)
+    Process.demonitor(monitor_ref, [:flush])
+    Process.exit(worker_pid, :kill)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  defp collect_metadata(fetch_fun) do
+    fetch_fun.()
+  rescue
+    error ->
+      Logger.warning(
+        "Metadata collection failed: #{Exception.format(:error, error, __STACKTRACE__)}"
+      )
+
+      %{}
+  catch
+    :exit, reason ->
+      Logger.warning("Metadata collection exited: #{inspect(reason)}")
+      %{}
+  end
+
+  defp metadata_ready(state, metadata) do
+    Enum.each(state.waiters, &GenServer.reply(&1, {:ok, metadata}))
+    %{state | metadata: {:ready, metadata}, waiters: [], worker: nil}
   end
 end

--- a/lib/req_llm/stream_response/metadata_handle.ex
+++ b/lib/req_llm/stream_response/metadata_handle.ex
@@ -33,9 +33,12 @@ defmodule ReqLLM.StreamResponse.MetadataHandle do
   """
   @spec stop(t()) :: :ok
   def stop(handle) when is_pid(handle) do
-    GenServer.stop(handle)
-  catch
-    :exit, {:noproc, {GenServer, :stop, [^handle, :normal, :infinity]}} -> :ok
+    monitor_ref = Process.monitor(handle)
+    GenServer.cast(handle, :stop)
+
+    receive do
+      {:DOWN, ^monitor_ref, :process, ^handle, _reason} -> :ok
+    end
   end
 
   @impl true
@@ -66,6 +69,11 @@ defmodule ReqLLM.StreamResponse.MetadataHandle do
 
   def handle_call(:await, from, state) do
     {:noreply, %{state | waiters: [from | state.waiters]}}
+  end
+
+  @impl true
+  def handle_cast(:stop, state) do
+    {:stop, :normal, state}
   end
 
   @impl true

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -139,13 +139,9 @@ defmodule ReqLLM.Streaming do
         )
 
       receive_timeout = Keyword.get(opts, :receive_timeout, default_timeout)
-      stream = create_lazy_stream(server_pid, receive_timeout)
-
-      # Start metadata collection handle
       metadata_handle = start_metadata_handle(server_pid, opts)
-
-      # Create cancel function
-      cancel_fn = fn -> StreamServer.cancel(server_pid) end
+      cancel_fn = fn -> cancel_stream(server_pid, metadata_handle) end
+      stream = create_lazy_stream(server_pid, receive_timeout, cancel_fn)
 
       # Build StreamResponse
       stream_response = %StreamResponse{
@@ -315,7 +311,7 @@ defmodule ReqLLM.Streaming do
   end
 
   # Create lazy stream using Stream.resource that calls StreamServer.next/2
-  defp create_lazy_stream(server_pid, timeout) do
+  defp create_lazy_stream(server_pid, timeout, cancel) do
     Stream.resource(
       fn ->
         :ok = StreamServer.monitor_consumer(server_pid, self())
@@ -336,12 +332,18 @@ defmodule ReqLLM.Streaming do
             }
         end
       end,
-      fn %{server: server, exhausted?: exhausted?} ->
+      fn %{exhausted?: exhausted?} ->
         if not exhausted? do
-          StreamServer.cancel(server)
+          cancel.()
         end
       end
     )
+  end
+
+  defp cancel_stream(server_pid, metadata_handle) do
+    StreamServer.cancel(server_pid)
+  after
+    MetadataHandle.stop(metadata_handle)
   end
 
   defp start_metadata_handle(server_pid, opts) do

--- a/test/req_llm/integration/streaming_orchestration_test.exs
+++ b/test/req_llm/integration/streaming_orchestration_test.exs
@@ -90,6 +90,7 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
       assert function_exported?(ReqLLM.StreamResponse, :text, 1)
       assert function_exported?(ReqLLM.StreamResponse, :usage, 1)
       assert function_exported?(ReqLLM.StreamResponse, :finish_reason, 1)
+      assert function_exported?(ReqLLM.StreamResponse, :close, 1)
     end
   end
 
@@ -139,7 +140,7 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
         Streaming.start_stream(
           ReqLLM.Providers.OpenRouter,
           model,
-          Context.new("Hello"),
+          Context.new([Context.user("Hello")]),
           fixture: "streaming"
         )
 
@@ -163,7 +164,7 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
         Streaming.start_stream(
           ReqLLM.Providers.OpenRouter,
           model,
-          Context.new("Hello"),
+          Context.new([Context.user("Hello")]),
           fixture: "streaming",
           completion_cleanup_after: 20
         )
@@ -183,7 +184,7 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
         Streaming.start_stream(
           ReqLLM.Providers.OpenRouter,
           model,
-          Context.new("Hello"),
+          Context.new([Context.user("Hello")]),
           fixture: "streaming",
           completion_cleanup_after: 1_000
         )
@@ -208,7 +209,7 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
         Streaming.start_stream(
           ReqLLM.Providers.OpenRouter,
           model,
-          Context.new("Hello"),
+          Context.new([Context.user("Hello")]),
           fixture: "streaming"
         )
 
@@ -217,6 +218,22 @@ defmodule ReqLLM.Integration.StreamingOrchestrationTest do
       assert is_pid(stream_server_pid)
       assert [_chunk | _] = stream_response.stream |> Stream.take(1) |> Enum.to_list()
       assert wait_until(fn -> not Process.alive?(stream_server_pid) end)
+      refute Process.alive?(stream_response.metadata_handle)
+    end
+
+    test "explicit cancellation terminates the metadata handle" do
+      {:ok, model} = ReqLLM.model("openrouter:google/gemini-3-flash-preview")
+
+      {:ok, stream_response} =
+        Streaming.start_stream(
+          ReqLLM.Providers.OpenRouter,
+          model,
+          Context.new([Context.user("Hello")]),
+          fixture: "streaming"
+        )
+
+      assert :ok = stream_response.cancel.()
+      refute Process.alive?(stream_response.metadata_handle)
     end
   end
 

--- a/test/req_llm/stream_response_test.exs
+++ b/test/req_llm/stream_response_test.exs
@@ -68,7 +68,14 @@ defmodule ReqLLM.StreamResponseTest do
 
   import ReqLLM.StreamResponseTest.Helpers
 
-  alias ReqLLM.{Context, Response, StreamChunk, StreamResponse, ToolCall}
+  alias ReqLLM.{
+    Context,
+    Response,
+    StreamChunk,
+    StreamResponse,
+    StreamResponse.MetadataHandle,
+    ToolCall
+  }
 
   describe "struct validation and defaults" do
     test "exposes schema metadata" do
@@ -376,6 +383,8 @@ defmodule ReqLLM.StreamResponseTest do
 
       {:ok, response} = StreamResponse.to_response(stream_response)
 
+      refute Process.alive?(metadata_handle)
+
       # Verify Response struct structure
       assert %Response{} = response
       assert response.stream? == false
@@ -491,10 +500,13 @@ defmodule ReqLLM.StreamResponseTest do
           metadata_handle: create_metadata_handle(%{finish_reason: :stop})
         )
 
+      metadata_handle = stream_response.metadata_handle
+
       # Enum.to_list will raise, which to_response should catch
       result = StreamResponse.to_response(stream_response)
 
       assert {:error, %RuntimeError{message: "Stream processing failed"}} = result
+      refute Process.alive?(metadata_handle)
     end
 
     test "generates unique response IDs" do
@@ -507,6 +519,50 @@ defmodule ReqLLM.StreamResponseTest do
       assert response1.id != response2.id
       assert String.starts_with?(response1.id, "resp_")
       assert String.starts_with?(response2.id, "resp_")
+    end
+  end
+
+  describe "close/1 lifecycle" do
+    test "stops pending metadata collection and is idempotent" do
+      metadata_handle =
+        create_metadata_handle(fn ->
+          receive do
+            :finish -> %{finish_reason: :stop}
+          end
+        end)
+
+      stream_response = create_stream_response(metadata_handle: metadata_handle)
+
+      assert :ok = StreamResponse.close(stream_response)
+      refute Process.alive?(metadata_handle)
+      assert :ok = StreamResponse.close(stream_response)
+    end
+
+    test "preserves reusable metadata until explicitly closed" do
+      usage = %{input_tokens: 5, output_tokens: 10}
+      metadata_handle = create_metadata_handle(%{usage: usage, finish_reason: :stop})
+      stream_response = create_stream_response(metadata_handle: metadata_handle)
+
+      assert StreamResponse.usage(stream_response) == usage
+      assert StreamResponse.finish_reason(stream_response) == :stop
+      assert Process.alive?(metadata_handle)
+      assert :ok = StreamResponse.close(stream_response)
+      refute Process.alive?(metadata_handle)
+    end
+  end
+
+  describe "MetadataHandle lifecycle" do
+    test "stop/1 terminates an in-progress collector" do
+      metadata_handle =
+        create_metadata_handle(fn ->
+          receive do
+            :finish -> %{}
+          end
+        end)
+
+      assert :ok = MetadataHandle.stop(metadata_handle)
+      refute Process.alive?(metadata_handle)
+      assert :ok = MetadataHandle.stop(metadata_handle)
     end
   end
 
@@ -1043,6 +1099,7 @@ defmodule ReqLLM.StreamResponseTest do
       result = StreamResponse.process_stream(stream_response)
 
       assert {:error, ^error} = result
+      refute Process.alive?(metadata_handle)
     end
 
     test "returns {:error, reason} when stream encounters a transport error" do
@@ -1071,6 +1128,20 @@ defmodule ReqLLM.StreamResponseTest do
 
       assert {:error, %ReqLLM.Error.API.Stream{cause: %Mint.TransportError{reason: :closed}}} =
                result
+
+      refute Process.alive?(stream_response.metadata_handle)
+    end
+
+    test "releases metadata handles after repeated materialization" do
+      handles =
+        for _ <- 1..100 do
+          stream_response = create_stream_response(stream: [StreamChunk.text("complete")])
+
+          assert {:ok, %Response{}} = StreamResponse.process_stream(stream_response)
+          stream_response.metadata_handle
+        end
+
+      assert Enum.all?(handles, &(not Process.alive?(&1)))
     end
   end
 

--- a/test/req_llm/stream_response_test.exs
+++ b/test/req_llm/stream_response_test.exs
@@ -564,6 +564,35 @@ defmodule ReqLLM.StreamResponseTest do
       refute Process.alive?(metadata_handle)
       assert :ok = MetadataHandle.stop(metadata_handle)
     end
+
+    test "stop/1 is safe for concurrent callers" do
+      metadata_handle =
+        create_metadata_handle(fn ->
+          receive do
+            :finish -> %{}
+          end
+        end)
+
+      parent = self()
+
+      callers =
+        for _ <- 1..100 do
+          Task.async(fn ->
+            send(parent, {:ready, self()})
+
+            receive do
+              :stop -> MetadataHandle.stop(metadata_handle)
+            end
+          end)
+        end
+
+      caller_pids = Enum.map(callers, & &1.pid)
+      Enum.each(caller_pids, fn caller_pid -> assert_receive {:ready, ^caller_pid} end)
+      Enum.each(caller_pids, &send(&1, :stop))
+
+      assert Enum.map(callers, &Task.await(&1)) == List.duplicate(:ok, 100)
+      refute Process.alive?(metadata_handle)
+    end
   end
 
   describe "cancel function handling" do


### PR DESCRIPTION
## Summary

- add idempotent lifecycle APIs for closing `StreamResponse` and stopping `MetadataHandle`
- close metadata handles after `process_stream/2`, `to_response/1`, explicit cancellation, and partial stream consumption
- keep metadata reads reusable until callers explicitly close non-materialized responses
- make metadata collection independently stoppable so a blocked collector cannot prevent cleanup

## Root cause

`MetadataHandle` cached completed metadata in a GenServer indefinitely. Terminal materialization copied that metadata into a `Response` but never stopped the GenServer, while cancellation and stream resource cleanup only terminated the `StreamServer`.

## Impact

Completed, errored, cancelled, and partially consumed streams no longer retain permanent metadata processes. Existing callers can continue reading usage and finish reason repeatedly until they call `StreamResponse.close/1`.

## Validation

- `mix test` (3,566 passed, 11 skipped)
- `mix test test/req_llm/stream_response_test.exs` (96 passed)
- `mix test test/req_llm/integration/streaming_orchestration_test.exs --include integration` (11 passed)
- `mix quality`

Closes #824