### PR TITLE
fix(streaming): classify terminal failures

### DIFF
--- a/lib/req_llm/error.ex
+++ b/lib/req_llm/error.ex
@@ -57,7 +57,16 @@ defmodule ReqLLM.Error do
   defmodule API.Request do
     @moduledoc "Error for API request failures, HTTP errors, and network issues."
     use Splode.Error,
-      fields: [:reason, :status, :response_body, :request_body, :cause, :headers],
+      fields: [
+        :reason,
+        :status,
+        :response_body,
+        :request_body,
+        :cause,
+        :headers,
+        :provider_code,
+        :retryable
+      ],
       class: :api
 
     @spec message(map()) :: String.t()

--- a/lib/req_llm/step/error.ex
+++ b/lib/req_llm/step/error.ex
@@ -115,7 +115,10 @@ defmodule ReqLLM.Step.Error do
       status: exception.status,
       response_body: exception.response_body,
       request_body: exception.request_body || request.body,
-      cause: exception.cause
+      cause: exception.cause,
+      headers: exception.headers,
+      provider_code: exception.provider_code,
+      retryable: exception.retryable
     )
   end
 

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -69,6 +69,7 @@ defmodule ReqLLM.StreamServer do
 
   alias ReqLLM.MapAccess
   alias ReqLLM.StreamChunk
+  alias ReqLLM.Streaming.Failure
   alias ReqLLM.Streaming.SSE
 
   require Logger
@@ -99,6 +100,7 @@ defmodule ReqLLM.StreamServer do
     stream_requested?: false,
     metadata_delivered?: false,
     halt_delivered?: false,
+    error_delivered?: false,
     completion_cleanup_after: 30_000,
     completion_cleanup_timer: nil,
     completion_cleanup_token: nil,
@@ -445,7 +447,12 @@ defmodule ReqLLM.StreamServer do
             end
 
           {:error, reason} ->
-            {:reply, {:error, reason}, new_state}
+            error_state = %{new_state | error_delivered?: true}
+
+            case finalize_lifecycle(error_state) do
+              {:stop, final_state} -> {:stop, :normal, {:error, reason}, final_state}
+              {:continue, final_state} -> {:reply, {:error, reason}, final_state}
+            end
 
           _ ->
             {:noreply, register_waiting_caller(new_state, from, :next, timeout)}
@@ -563,7 +570,13 @@ defmodule ReqLLM.StreamServer do
   end
 
   def handle_call({:await_metadata, _timeout}, _from, %{status: {:error, reason}} = state) do
-    {:reply, {:error, reason}, state}
+    metadata = error_metadata(state, reason)
+    new_state = %{state | metadata: metadata, metadata_delivered?: true}
+
+    case finalize_lifecycle(new_state) do
+      {:stop, final_state} -> {:stop, :normal, {:ok, metadata}, final_state}
+      {:continue, final_state} -> {:reply, {:ok, metadata}, final_state}
+    end
   end
 
   def handle_call({:await_metadata, timeout}, from, state) do
@@ -804,6 +817,10 @@ defmodule ReqLLM.StreamServer do
     {:reply, :ok, new_state}
   end
 
+  defp process_http_event({:data, _chunk}, %{status: {:error, _reason}} = state) do
+    {:reply, :ok, state}
+  end
+
   defp process_http_event({:data, chunk}, state) do
     if state.http_status && state.http_status >= 400 do
       error = build_http_error(state.http_status, chunk, state.headers)
@@ -820,9 +837,17 @@ defmodule ReqLLM.StreamServer do
     end
   end
 
+  defp process_http_event(:done, %{status: {:error, _reason}} = state) do
+    {:reply, :ok, state}
+  end
+
   defp process_http_event(:done, state) do
     new_state = finalize_stream_with_fixture(state) |> reply_to_waiting_callers()
     {:reply, :ok, new_state}
+  end
+
+  defp process_http_event({:error, _reason}, %{status: {:error, _existing}} = state) do
+    {:reply, :ok, state}
   end
 
   defp process_http_event({:error, reason}, state) do
@@ -832,6 +857,11 @@ defmodule ReqLLM.StreamServer do
       |> maybe_emit_stream_exception(reason)
       |> reply_to_waiting_callers()
 
+    {:reply, :ok, new_state}
+  end
+
+  defp process_http_event({:cancelled, _reason}, state) do
+    new_state = state |> finalize_cancelled_stream() |> reply_to_waiting_callers()
     {:reply, :ok, new_state}
   end
 
@@ -868,6 +898,7 @@ defmodule ReqLLM.StreamServer do
   defp store_pending_http_exit(state, _reason), do: state
 
   defp process_http_task_exit(%{status: :done} = state, _reason), do: state
+  defp process_http_task_exit(%{status: {:error, _reason}} = state, _exit_reason), do: state
 
   defp process_http_task_exit(state, reason) when reason in [:normal, :shutdown] do
     finalize_stream_with_fixture(state)
@@ -1335,6 +1366,13 @@ defmodule ReqLLM.StreamServer do
     Map.delete(meta, :terminal?)
   end
 
+  defp error_metadata(state, reason) do
+    state
+    |> extract_final_metadata()
+    |> Map.put(:finish_reason, :error)
+    |> Map.put(:error, reason)
+  end
+
   defp reply_to_waiting_callers(state) do
     {replied_callers, remaining_callers} =
       Enum.split_with(state.waiting_callers, fn caller ->
@@ -1372,7 +1410,7 @@ defmodule ReqLLM.StreamServer do
 
       {{:empty, _}, {:error, reason}} ->
         GenServer.reply(from, {:error, reason})
-        state
+        %{state | error_delivered?: true}
 
       {{:empty, _}, _} ->
         GenServer.reply(from, {:error, :unexpected_empty_queue})
@@ -1391,8 +1429,9 @@ defmodule ReqLLM.StreamServer do
          %{status: {:error, reason}} = state
        ) do
     cancel_waiting_caller_timer(caller)
-    GenServer.reply(from, {:error, reason})
-    state
+    metadata = error_metadata(state, reason)
+    GenServer.reply(from, {:ok, metadata})
+    %{state | metadata: metadata, metadata_delivered?: true}
   end
 
   defp reply_to_caller(%{from: from, type: :metadata} = caller, state) do
@@ -1469,10 +1508,15 @@ defmodule ReqLLM.StreamServer do
     cancel_completion_cleanup(state)
   end
 
-  defp ready_to_stop?(state) do
-    state.status == :done and state.metadata_delivered? and state.halt_delivered? and
-      :queue.is_empty(state.queue)
+  defp ready_to_stop?(%{status: :done} = state) do
+    state.metadata_delivered? and state.halt_delivered? and :queue.is_empty(state.queue)
   end
+
+  defp ready_to_stop?(%{status: {:error, _reason}} = state) do
+    state.metadata_delivered? and state.error_delivered? and :queue.is_empty(state.queue)
+  end
+
+  defp ready_to_stop?(_state), do: false
 
   defp finalize_lifecycle(state) do
     cond do
@@ -1488,10 +1532,14 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp should_schedule_completion_cleanup?(state) do
-    state.status == :done and state.metadata_delivered? and not state.stream_requested? and
+    terminal_status?(state.status) and state.metadata_delivered? and not state.stream_requested? and
       not state.halt_delivered? and is_integer(state.completion_cleanup_after) and
       state.completion_cleanup_after >= 0
   end
+
+  defp terminal_status?(:done), do: true
+  defp terminal_status?({:error, _reason}), do: true
+  defp terminal_status?(_status), do: false
 
   defp ensure_completion_cleanup_timer(%{completion_cleanup_timer: nil} = state) do
     token = make_ref()
@@ -1512,33 +1560,7 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp build_http_error(status, chunk, headers) do
-    case Jason.decode(chunk) do
-      {:ok, %{"error" => error_data}} when is_map(error_data) ->
-        message = Map.get(error_data, "message", "HTTP #{status}")
-
-        ReqLLM.Error.API.Request.exception(
-          reason: message,
-          status: status,
-          response_body: error_data,
-          headers: headers
-        )
-
-      {:ok, decoded} ->
-        ReqLLM.Error.API.Request.exception(
-          reason: "HTTP #{status}",
-          status: status,
-          response_body: decoded,
-          headers: headers
-        )
-
-      {:error, _} ->
-        ReqLLM.Error.API.Request.exception(
-          reason: "HTTP #{status}",
-          status: status,
-          response_body: chunk,
-          headers: headers
-        )
-    end
+    Failure.api_error(status, chunk, headers)
   end
 
   # Normalize streaming usage data from provider format to ReqLLM format
@@ -1577,7 +1599,17 @@ defmodule ReqLLM.StreamServer do
   defp maybe_emit_stream_exception(%{telemetry: nil} = state, _reason), do: state
 
   defp maybe_emit_stream_exception(%{telemetry: telemetry} = state, reason) do
-    %{state | telemetry: ReqLLM.Telemetry.exception_request(telemetry, reason)}
+    usage = state.metadata[:usage]
+
+    telemetry =
+      ReqLLM.Telemetry.exception_request(telemetry, reason,
+        http_status: state.http_status,
+        usage: usage,
+        builtin_tool_timing: state.builtin_tool_timing,
+        emit_token_usage?: is_map(usage)
+      )
+
+    %{state | telemetry: telemetry}
   end
 
   defp maybe_put_request_id(meta, nil), do: meta

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -99,8 +99,7 @@ defmodule ReqLLM.StreamServer do
     metadata: %{},
     stream_requested?: false,
     metadata_delivered?: false,
-    halt_delivered?: false,
-    error_delivered?: false,
+    terminal_delivered?: false,
     completion_cleanup_after: 30_000,
     completion_cleanup_timer: nil,
     completion_cleanup_token: nil,
@@ -371,7 +370,10 @@ defmodule ReqLLM.StreamServer do
   ## Returns
 
     * `{:ok, metadata}` - Final stream metadata
-    * `{:error, reason}` - Error occurred or timeout
+    * `{:error, :timeout}` - Metadata was not available before the timeout
+
+  Failed streams return `{:ok, metadata}` with `:finish_reason` set to `:error`
+  and the structured failure under `:error`.
 
   ## Examples
 
@@ -439,17 +441,17 @@ defmodule ReqLLM.StreamServer do
       {:empty, new_state} ->
         case state.status do
           :done ->
-            halted_state = %{new_state | halt_delivered?: true}
+            terminal_state = %{new_state | terminal_delivered?: true}
 
-            case finalize_lifecycle(halted_state) do
+            case finalize_lifecycle(terminal_state) do
               {:stop, final_state} -> {:stop, :normal, :halt, final_state}
               {:continue, final_state} -> {:reply, :halt, final_state}
             end
 
           {:error, reason} ->
-            error_state = %{new_state | error_delivered?: true}
+            terminal_state = %{new_state | terminal_delivered?: true}
 
-            case finalize_lifecycle(error_state) do
+            case finalize_lifecycle(terminal_state) do
               {:stop, final_state} -> {:stop, :normal, {:error, reason}, final_state}
               {:continue, final_state} -> {:reply, {:error, reason}, final_state}
             end
@@ -561,22 +563,11 @@ defmodule ReqLLM.StreamServer do
 
   @impl GenServer
   def handle_call({:await_metadata, _timeout}, _from, %{status: :done} = state) do
-    new_state = %{state | metadata_delivered?: true}
-
-    case finalize_lifecycle(new_state) do
-      {:stop, final_state} -> {:stop, :normal, {:ok, final_state.metadata}, final_state}
-      {:continue, final_state} -> {:reply, {:ok, final_state.metadata}, final_state}
-    end
+    reply_with_metadata(state)
   end
 
-  def handle_call({:await_metadata, _timeout}, _from, %{status: {:error, reason}} = state) do
-    metadata = error_metadata(state, reason)
-    new_state = %{state | metadata: metadata, metadata_delivered?: true}
-
-    case finalize_lifecycle(new_state) do
-      {:stop, final_state} -> {:stop, :normal, {:ok, metadata}, final_state}
-      {:continue, final_state} -> {:reply, {:ok, metadata}, final_state}
-    end
+  def handle_call({:await_metadata, _timeout}, _from, %{status: {:error, _reason}} = state) do
+    reply_with_metadata(state)
   end
 
   def handle_call({:await_metadata, timeout}, from, state) do
@@ -648,11 +639,11 @@ defmodule ReqLLM.StreamServer do
 
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    case {MapSet.member?(state.consumer_refs, ref), state.status} do
-      {true, :done} ->
+    case {MapSet.member?(state.consumer_refs, ref), terminal_status?(state.status)} do
+      {true, true} ->
         {:noreply, %{state | consumer_refs: MapSet.delete(state.consumer_refs, ref)}}
 
-      {true, _status} ->
+      {true, false} ->
         new_state =
           %{state | consumer_refs: MapSet.delete(state.consumer_refs, ref)}
           |> finalize_cancelled_stream()
@@ -661,7 +652,7 @@ defmodule ReqLLM.StreamServer do
 
         {:stop, :normal, new_state}
 
-      {false, _status} ->
+      {false, _terminal?} ->
         {:noreply, state}
     end
   end
@@ -797,6 +788,10 @@ defmodule ReqLLM.StreamServer do
     %{state | blocked_http_event: nil, pending_http_calls: :queue.new()}
   end
 
+  defp process_http_event(_event, %{status: {:error, _reason}} = state) do
+    {:reply, :ok, state}
+  end
+
   defp process_http_event({:status, status}, state) do
     new_state = %{state | http_status: status}
     {:reply, :ok, new_state}
@@ -817,18 +812,13 @@ defmodule ReqLLM.StreamServer do
     {:reply, :ok, new_state}
   end
 
-  defp process_http_event({:data, _chunk}, %{status: {:error, _reason}} = state) do
-    {:reply, :ok, state}
-  end
-
   defp process_http_event({:data, chunk}, state) do
     if state.http_status && state.http_status >= 400 do
       error = build_http_error(state.http_status, chunk, state.headers)
 
       new_state =
         state
-        |> Map.put(:status, {:error, error})
-        |> maybe_emit_stream_exception(error)
+        |> finalize_failed_stream(error)
         |> reply_to_waiting_callers()
 
       {:reply, :ok, new_state}
@@ -837,24 +827,15 @@ defmodule ReqLLM.StreamServer do
     end
   end
 
-  defp process_http_event(:done, %{status: {:error, _reason}} = state) do
-    {:reply, :ok, state}
-  end
-
   defp process_http_event(:done, state) do
     new_state = finalize_stream_with_fixture(state) |> reply_to_waiting_callers()
     {:reply, :ok, new_state}
   end
 
-  defp process_http_event({:error, _reason}, %{status: {:error, _existing}} = state) do
-    {:reply, :ok, state}
-  end
-
   defp process_http_event({:error, reason}, state) do
     new_state =
       state
-      |> Map.put(:status, {:error, reason})
-      |> maybe_emit_stream_exception(reason)
+      |> finalize_failed_stream(reason)
       |> reply_to_waiting_callers()
 
     {:reply, :ok, new_state}
@@ -909,9 +890,7 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp process_http_task_exit(state, reason) do
-    state
-    |> Map.put(:status, {:error, {:http_task_failed, reason}})
-    |> maybe_emit_stream_exception({:http_task_failed, reason})
+    finalize_failed_stream(state, {:http_task_failed, reason})
   end
 
   defp parse_protocol_events(chunk, state) do
@@ -1373,6 +1352,24 @@ defmodule ReqLLM.StreamServer do
     |> Map.put(:error, reason)
   end
 
+  defp finalize_failed_stream(state, reason) do
+    metadata = error_metadata(state, reason)
+
+    state
+    |> Map.put(:status, {:error, reason})
+    |> Map.put(:metadata, metadata)
+    |> maybe_emit_stream_exception(reason)
+  end
+
+  defp reply_with_metadata(state) do
+    new_state = %{state | metadata_delivered?: true}
+
+    case finalize_lifecycle(new_state) do
+      {:stop, final_state} -> {:stop, :normal, {:ok, final_state.metadata}, final_state}
+      {:continue, final_state} -> {:reply, {:ok, final_state.metadata}, final_state}
+    end
+  end
+
   defp reply_to_waiting_callers(state) do
     {replied_callers, remaining_callers} =
       Enum.split_with(state.waiting_callers, fn caller ->
@@ -1406,11 +1403,11 @@ defmodule ReqLLM.StreamServer do
 
       {{:empty, _}, :done} ->
         GenServer.reply(from, :halt)
-        %{state | halt_delivered?: true}
+        %{state | terminal_delivered?: true}
 
       {{:empty, _}, {:error, reason}} ->
         GenServer.reply(from, {:error, reason})
-        %{state | error_delivered?: true}
+        %{state | terminal_delivered?: true}
 
       {{:empty, _}, _} ->
         GenServer.reply(from, {:error, :unexpected_empty_queue})
@@ -1426,12 +1423,11 @@ defmodule ReqLLM.StreamServer do
 
   defp reply_to_caller(
          %{from: from, type: :metadata} = caller,
-         %{status: {:error, reason}} = state
+         %{status: {:error, _reason}} = state
        ) do
     cancel_waiting_caller_timer(caller)
-    metadata = error_metadata(state, reason)
-    GenServer.reply(from, {:ok, metadata})
-    %{state | metadata: metadata, metadata_delivered?: true}
+    GenServer.reply(from, {:ok, state.metadata})
+    %{state | metadata_delivered?: true}
   end
 
   defp reply_to_caller(%{from: from, type: :metadata} = caller, state) do
@@ -1508,15 +1504,10 @@ defmodule ReqLLM.StreamServer do
     cancel_completion_cleanup(state)
   end
 
-  defp ready_to_stop?(%{status: :done} = state) do
-    state.metadata_delivered? and state.halt_delivered? and :queue.is_empty(state.queue)
+  defp ready_to_stop?(state) do
+    terminal_status?(state.status) and state.metadata_delivered? and state.terminal_delivered? and
+      :queue.is_empty(state.queue)
   end
-
-  defp ready_to_stop?(%{status: {:error, _reason}} = state) do
-    state.metadata_delivered? and state.error_delivered? and :queue.is_empty(state.queue)
-  end
-
-  defp ready_to_stop?(_state), do: false
 
   defp finalize_lifecycle(state) do
     cond do
@@ -1533,7 +1524,7 @@ defmodule ReqLLM.StreamServer do
 
   defp should_schedule_completion_cleanup?(state) do
     terminal_status?(state.status) and state.metadata_delivered? and not state.stream_requested? and
-      not state.halt_delivered? and is_integer(state.completion_cleanup_after) and
+      not state.terminal_delivered? and is_integer(state.completion_cleanup_after) and
       state.completion_cleanup_after >= 0
   end
 

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -315,7 +315,8 @@ defmodule ReqLLM.Streaming do
     Stream.resource(
       fn ->
         :ok = StreamServer.monitor_consumer(server_pid, self())
-        %{server: server_pid, exhausted?: false}
+        failure_ref = make_ref()
+        %{server: server_pid, exhausted?: false, failure_ref: failure_ref}
       end,
       fn %{server: server} = state ->
         case StreamServer.next(server, timeout) do
@@ -326,14 +327,18 @@ defmodule ReqLLM.Streaming do
             {:halt, %{state | exhausted?: true}}
 
           {:error, reason} ->
+            Process.put(state.failure_ref, true)
+
             raise %ReqLLM.Error.API.Stream{
               reason: "Stream failed: #{inspect(reason)}",
               cause: reason
             }
         end
       end,
-      fn %{exhausted?: exhausted?} ->
-        if not exhausted? do
+      fn state ->
+        failed? = Process.delete(state.failure_ref) == true
+
+        if not state.exhausted? and not failed? do
           cancel.()
         end
       end

--- a/lib/req_llm/streaming/failure.ex
+++ b/lib/req_llm/streaming/failure.ex
@@ -1,0 +1,198 @@
+defmodule ReqLLM.Streaming.Failure do
+  @moduledoc false
+
+  require Logger
+
+  @retryable_transport_reasons [:closed, :timeout, :econnrefused, :pool_not_available]
+
+  @type category :: :api | :transport | :cancelled | :unknown
+  @type classification :: %{
+          category: category(),
+          provider_code: term() | nil,
+          retryable: boolean(),
+          severity: Logger.level() | nil,
+          status: non_neg_integer() | nil,
+          transport_reason: term() | nil
+        }
+  @type api_error :: %ReqLLM.Error.API.Request{}
+
+  @spec classify(term()) :: classification()
+  def classify(%ReqLLM.Error.API.Request{status: status} = error) when is_integer(status) do
+    %{
+      category: :api,
+      provider_code: error.provider_code || provider_code(error.response_body),
+      retryable: boolean_or_default(error.retryable, retryable_status?(status)),
+      severity: :warning,
+      status: status,
+      transport_reason: nil
+    }
+  end
+
+  def classify(%ReqLLM.Error.API.Request{cause: cause}) when not is_nil(cause) do
+    classify(cause)
+  end
+
+  def classify(%Finch.TransportError{} = error) do
+    transport_classification(transport_reason(error))
+  end
+
+  def classify(%Mint.TransportError{reason: reason}) do
+    transport_classification(reason)
+  end
+
+  def classify(%Req.TransportError{reason: reason}) do
+    transport_classification(reason)
+  end
+
+  def classify(%Finch.Error{reason: reason}) do
+    transport_classification(reason)
+  end
+
+  def classify(reason) when reason in [:cancelled, :canceled] do
+    cancelled_classification()
+  end
+
+  def classify({wrapper, reason}) when wrapper in [:exit, :shutdown, :http_task_failed] do
+    case classify(reason) do
+      %{category: :unknown} -> unknown_classification()
+      classification -> classification
+    end
+  end
+
+  def classify(_reason), do: unknown_classification()
+
+  @spec log(term()) :: classification()
+  def log(reason) do
+    classification = classify(reason)
+    log_classification(classification, reason)
+    classification
+  end
+
+  @spec api_error(non_neg_integer(), term(), list()) :: api_error()
+  def api_error(status, body, headers) when is_integer(status) do
+    response_body = normalize_response_body(body)
+
+    ReqLLM.Error.API.Request.exception(
+      reason: error_message(response_body, status),
+      status: status,
+      response_body: unwrap_error(response_body),
+      headers: headers,
+      provider_code: provider_code(response_body),
+      retryable: retryable_status?(status)
+    )
+  end
+
+  @spec provider_code(term()) :: term() | nil
+  def provider_code(%{"error" => error}) when is_map(error), do: provider_code(error)
+  def provider_code(%{error: error}) when is_map(error), do: provider_code(error)
+  def provider_code(%{"code" => code}) when not is_nil(code), do: code
+  def provider_code(%{code: code}) when not is_nil(code), do: code
+  def provider_code(%{"type" => type}), do: type
+  def provider_code(%{type: type}), do: type
+  def provider_code(_body), do: nil
+
+  @spec retryable_status?(non_neg_integer()) :: boolean()
+  def retryable_status?(status) when status in [408, 409, 425, 429], do: true
+  def retryable_status?(status) when status in 500..599, do: true
+  def retryable_status?(_status), do: false
+
+  defp log_classification(%{category: :api} = classification, reason) do
+    Logger.warning(
+      "Streaming provider/API request failed: " <>
+        "status=#{classification.status}, " <>
+        "provider_code=#{inspect(classification.provider_code)}, " <>
+        "retryable=#{classification.retryable}, " <>
+        "reason=#{inspect(reason)}"
+    )
+  end
+
+  defp log_classification(%{category: :transport} = classification, reason) do
+    Logger.error(
+      "Finch streaming transport failed: " <>
+        "reason=#{inspect(classification.transport_reason)}, " <>
+        "retryable=#{classification.retryable}, " <>
+        "error=#{inspect(reason)}"
+    )
+  end
+
+  defp log_classification(%{category: :cancelled}, _reason), do: :ok
+
+  defp log_classification(%{category: :unknown}, reason) do
+    Logger.error("Streaming request failed: #{inspect(reason)}")
+  end
+
+  defp transport_classification(reason) do
+    %{
+      category: :transport,
+      provider_code: nil,
+      retryable: reason in @retryable_transport_reasons,
+      severity: :error,
+      status: nil,
+      transport_reason: reason
+    }
+  end
+
+  defp cancelled_classification do
+    %{
+      category: :cancelled,
+      provider_code: nil,
+      retryable: false,
+      severity: nil,
+      status: nil,
+      transport_reason: nil
+    }
+  end
+
+  defp unknown_classification do
+    %{
+      category: :unknown,
+      provider_code: nil,
+      retryable: false,
+      severity: :error,
+      status: nil,
+      transport_reason: nil
+    }
+  end
+
+  defp transport_reason(%Finch.TransportError{source: source, reason: reason}) do
+    case source do
+      %Mint.TransportError{reason: source_reason} -> source_reason
+      _ -> reason
+    end
+  end
+
+  defp normalize_response_body(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> decoded
+      {:error, _reason} -> body
+    end
+  end
+
+  defp normalize_response_body(body), do: body
+
+  defp error_message(%{"error" => error}, status) when is_map(error) do
+    error_message(error, status)
+  end
+
+  defp error_message(%{error: error}, status) when is_map(error) do
+    error_message(error, status)
+  end
+
+  defp error_message(%{"message" => message}, _status)
+       when is_binary(message) and message != "" do
+    message
+  end
+
+  defp error_message(%{message: message}, _status) when is_binary(message) and message != "" do
+    message
+  end
+
+  defp error_message(_body, status), do: "HTTP #{status}"
+
+  defp unwrap_error(%{"error" => error}) when is_map(error), do: error
+  defp unwrap_error(%{error: error}) when is_map(error), do: error
+  defp unwrap_error(body), do: body
+
+  defp boolean_or_default(value, _default) when is_boolean(value), do: value
+  defp boolean_or_default(_value, default), do: default
+end

--- a/lib/req_llm/streaming/failure.ex
+++ b/lib/req_llm/streaming/failure.ex
@@ -1,31 +1,24 @@
 defmodule ReqLLM.Streaming.Failure do
   @moduledoc false
 
+  alias ReqLLM.MapAccess
+
   require Logger
 
   @retryable_transport_reasons [:closed, :timeout, :econnrefused, :pool_not_available]
 
-  @type category :: :api | :transport | :cancelled | :unknown
-  @type classification :: %{
-          category: category(),
-          provider_code: term() | nil,
-          retryable: boolean(),
-          severity: Logger.level() | nil,
-          status: non_neg_integer() | nil,
-          transport_reason: term() | nil
-        }
+  @type classification ::
+          {:api, non_neg_integer(), term() | nil, boolean()}
+          | {:transport, term(), boolean()}
+          | :cancelled
+          | :unknown
   @type api_error :: %ReqLLM.Error.API.Request{}
 
   @spec classify(term()) :: classification()
   def classify(%ReqLLM.Error.API.Request{status: status} = error) when is_integer(status) do
-    %{
-      category: :api,
-      provider_code: error.provider_code || provider_code(error.response_body),
-      retryable: boolean_or_default(error.retryable, retryable_status?(status)),
-      severity: :warning,
-      status: status,
-      transport_reason: nil
-    }
+    provider_code = error.provider_code || provider_code(error.response_body)
+    retryable = boolean_or_default(error.retryable, retryable_status?(status))
+    {:api, status, provider_code, retryable}
   end
 
   def classify(%ReqLLM.Error.API.Request{cause: cause}) when not is_nil(cause) do
@@ -36,122 +29,70 @@ defmodule ReqLLM.Streaming.Failure do
     transport_classification(transport_reason(error))
   end
 
-  def classify(%Mint.TransportError{reason: reason}) do
+  def classify(%{__struct__: module, reason: reason})
+      when module in [Mint.TransportError, Req.TransportError, Finch.Error] do
     transport_classification(reason)
   end
 
-  def classify(%Req.TransportError{reason: reason}) do
-    transport_classification(reason)
+  def classify(reason) when reason in [:cancelled, :canceled], do: :cancelled
+
+  def classify({wrapper, reason})
+      when wrapper in [:error, :exit, :throw, :shutdown, :http_task_failed] do
+    classify(reason)
   end
 
-  def classify(%Finch.Error{reason: reason}) do
-    transport_classification(reason)
-  end
-
-  def classify(reason) when reason in [:cancelled, :canceled] do
-    cancelled_classification()
-  end
-
-  def classify({wrapper, reason}) when wrapper in [:exit, :shutdown, :http_task_failed] do
-    case classify(reason) do
-      %{category: :unknown} -> unknown_classification()
-      classification -> classification
-    end
-  end
-
-  def classify(_reason), do: unknown_classification()
+  def classify(_reason), do: :unknown
 
   @spec log(term()) :: classification()
   def log(reason) do
-    classification = classify(reason)
-    log_classification(classification, reason)
-    classification
+    case classify(reason) do
+      {:api, status, provider_code, retryable} = classification ->
+        Logger.warning(
+          "Streaming provider/API request failed: " <>
+            "status=#{status}, " <>
+            "provider_code=#{inspect(provider_code)}, " <>
+            "retryable=#{retryable}, " <>
+            "reason=#{inspect(reason)}"
+        )
+
+        classification
+
+      {:transport, transport_reason, retryable} = classification ->
+        Logger.error(
+          "Finch streaming transport failed: " <>
+            "reason=#{inspect(transport_reason)}, " <>
+            "retryable=#{retryable}, " <>
+            "error=#{inspect(reason)}"
+        )
+
+        classification
+
+      :cancelled ->
+        :cancelled
+
+      :unknown ->
+        Logger.error("Streaming request failed: #{inspect(reason)}")
+        :unknown
+    end
   end
 
-  @spec api_error(non_neg_integer(), term(), list()) :: api_error()
-  def api_error(status, body, headers) when is_integer(status) do
+  @spec api_error(non_neg_integer(), term(), list(), keyword()) :: api_error()
+  def api_error(status, body, headers, opts \\ []) when is_integer(status) do
     response_body = normalize_response_body(body)
+    error_body = error_body(response_body)
 
     ReqLLM.Error.API.Request.exception(
-      reason: error_message(response_body, status),
+      reason: error_message(error_body, status, Keyword.get(opts, :use_body_as_reason?, false)),
       status: status,
-      response_body: unwrap_error(response_body),
+      response_body: error_body,
       headers: headers,
-      provider_code: provider_code(response_body),
+      provider_code: provider_code(error_body),
       retryable: retryable_status?(status)
     )
   end
 
-  @spec provider_code(term()) :: term() | nil
-  def provider_code(%{"error" => error}) when is_map(error), do: provider_code(error)
-  def provider_code(%{error: error}) when is_map(error), do: provider_code(error)
-  def provider_code(%{"code" => code}) when not is_nil(code), do: code
-  def provider_code(%{code: code}) when not is_nil(code), do: code
-  def provider_code(%{"type" => type}), do: type
-  def provider_code(%{type: type}), do: type
-  def provider_code(_body), do: nil
-
-  @spec retryable_status?(non_neg_integer()) :: boolean()
-  def retryable_status?(status) when status in [408, 409, 425, 429], do: true
-  def retryable_status?(status) when status in 500..599, do: true
-  def retryable_status?(_status), do: false
-
-  defp log_classification(%{category: :api} = classification, reason) do
-    Logger.warning(
-      "Streaming provider/API request failed: " <>
-        "status=#{classification.status}, " <>
-        "provider_code=#{inspect(classification.provider_code)}, " <>
-        "retryable=#{classification.retryable}, " <>
-        "reason=#{inspect(reason)}"
-    )
-  end
-
-  defp log_classification(%{category: :transport} = classification, reason) do
-    Logger.error(
-      "Finch streaming transport failed: " <>
-        "reason=#{inspect(classification.transport_reason)}, " <>
-        "retryable=#{classification.retryable}, " <>
-        "error=#{inspect(reason)}"
-    )
-  end
-
-  defp log_classification(%{category: :cancelled}, _reason), do: :ok
-
-  defp log_classification(%{category: :unknown}, reason) do
-    Logger.error("Streaming request failed: #{inspect(reason)}")
-  end
-
   defp transport_classification(reason) do
-    %{
-      category: :transport,
-      provider_code: nil,
-      retryable: reason in @retryable_transport_reasons,
-      severity: :error,
-      status: nil,
-      transport_reason: reason
-    }
-  end
-
-  defp cancelled_classification do
-    %{
-      category: :cancelled,
-      provider_code: nil,
-      retryable: false,
-      severity: nil,
-      status: nil,
-      transport_reason: nil
-    }
-  end
-
-  defp unknown_classification do
-    %{
-      category: :unknown,
-      provider_code: nil,
-      retryable: false,
-      severity: :error,
-      status: nil,
-      transport_reason: nil
-    }
+    {:transport, reason, reason in @retryable_transport_reasons}
   end
 
   defp transport_reason(%Finch.TransportError{source: source, reason: reason}) do
@@ -170,28 +111,34 @@ defmodule ReqLLM.Streaming.Failure do
 
   defp normalize_response_body(body), do: body
 
-  defp error_message(%{"error" => error}, status) when is_map(error) do
-    error_message(error, status)
+  defp error_body(body) when is_map(body) do
+    case MapAccess.get(body, :error) do
+      error when is_map(error) -> error
+      _other -> body
+    end
   end
 
-  defp error_message(%{error: error}, status) when is_map(error) do
-    error_message(error, status)
+  defp error_body(body), do: body
+
+  defp error_message(body, status, _use_body_as_reason?) when is_map(body) do
+    case MapAccess.get(body, :message) do
+      message when is_binary(message) and message != "" -> message
+      _other -> "HTTP #{status}"
+    end
   end
 
-  defp error_message(%{"message" => message}, _status)
-       when is_binary(message) and message != "" do
-    message
+  defp error_message(body, _status, true) when is_binary(body) and body != "", do: body
+  defp error_message(_body, status, _use_body_as_reason?), do: "HTTP #{status}"
+
+  defp provider_code(body) when is_map(body) do
+    MapAccess.get(body, :code) || MapAccess.get(body, :type)
   end
 
-  defp error_message(%{message: message}, _status) when is_binary(message) and message != "" do
-    message
-  end
+  defp provider_code(_body), do: nil
 
-  defp error_message(_body, status), do: "HTTP #{status}"
-
-  defp unwrap_error(%{"error" => error}) when is_map(error), do: error
-  defp unwrap_error(%{error: error}) when is_map(error), do: error
-  defp unwrap_error(body), do: body
+  defp retryable_status?(status) when status in [408, 409, 425, 429], do: true
+  defp retryable_status?(status) when status in 500..599, do: true
+  defp retryable_status?(_status), do: false
 
   defp boolean_or_default(value, _default) when is_boolean(value), do: value
   defp boolean_or_default(_value, default), do: default

--- a/lib/req_llm/streaming/finch_client.ex
+++ b/lib/req_llm/streaming/finch_client.ex
@@ -215,7 +215,7 @@ defmodule ReqLLM.Streaming.FinchClient do
 
   defp forward_stream_failure(stream_server_pid, reason) do
     case Failure.log(reason) do
-      %{category: :cancelled} ->
+      :cancelled ->
         safe_http_event(stream_server_pid, {:cancelled, reason})
 
       _classification ->

--- a/lib/req_llm/streaming/finch_client.ex
+++ b/lib/req_llm/streaming/finch_client.ex
@@ -26,7 +26,7 @@ defmodule ReqLLM.Streaming.FinchClient do
   requests with proper authentication, headers, and request body formatting.
   """
 
-  alias ReqLLM.Streaming.{Fixtures, Retry}
+  alias ReqLLM.Streaming.{Failure, Fixtures, Retry}
   alias ReqLLM.Streaming.Fixtures.HTTPContext
   alias ReqLLM.StreamServer
 
@@ -195,23 +195,14 @@ defmodule ReqLLM.Streaming.FinchClient do
               :ok
 
             {:error, reason, _callback_acc} ->
-              Logger.error("Finch streaming failed: #{inspect(reason)}")
-              safe_http_event(stream_server_pid, {:error, reason})
-              {:error, reason}
+              forward_stream_failure(stream_server_pid, reason)
           end
         catch
           :exit, reason ->
-            Logger.error("Finch streaming task exited: #{inspect(reason)}")
-            safe_http_event(stream_server_pid, {:error, {:exit, reason}})
-            {:error, {:exit, reason}}
+            forward_stream_failure(stream_server_pid, {:exit, reason})
 
           kind, reason ->
-            Logger.error(
-              "Finch streaming task crashed (kind=#{inspect(kind)}): #{inspect(reason)}"
-            )
-
-            safe_http_event(stream_server_pid, {:error, {kind, reason}})
-            {:error, {kind, reason}}
+            forward_stream_failure(stream_server_pid, {kind, reason})
         end
       end)
 
@@ -220,6 +211,18 @@ defmodule ReqLLM.Streaming.FinchClient do
     error ->
       Logger.error("Failed to start streaming task: #{inspect(error)}")
       {:error, {:task_start_failed, error}}
+  end
+
+  defp forward_stream_failure(stream_server_pid, reason) do
+    case Failure.log(reason) do
+      %{category: :cancelled} ->
+        safe_http_event(stream_server_pid, {:cancelled, reason})
+
+      _classification ->
+        safe_http_event(stream_server_pid, {:error, reason})
+    end
+
+    {:error, reason}
   end
 
   @doc false

--- a/lib/req_llm/streaming/retry.ex
+++ b/lib/req_llm/streaming/retry.ex
@@ -70,26 +70,15 @@ defmodule ReqLLM.Streaming.Retry do
     wrapped_callback = fn event, wrapped_acc -> apply_callback(event, wrapped_acc, callback) end
 
     case stream_fun.(request, finch_name, initial_acc, wrapped_callback, stream_opts) do
-      {:ok, %{status: 429} = state} when attempt < max_retries ->
-        maybe_retry(params, attempt, state.callback_acc, :rate_limited, state)
-
-      {:ok, %{status: 429} = state} ->
-        deliver_http_failure(state, callback)
-
       {:ok, %{status: status} = state} when is_integer(status) and status >= 400 ->
-        deliver_http_failure(state, callback)
+        handle_http_failure(params, attempt, :rate_limited, state)
 
       {:ok, %{callback_acc: callback_acc}} ->
         {:ok, callback_acc}
 
-      {:error, reason, %{status: 429} = state} when attempt < max_retries ->
-        maybe_retry(params, attempt, state.callback_acc, reason, state)
-
-      {:error, _reason, %{status: 429} = state} ->
-        deliver_http_failure(state, callback)
-
-      {:error, _reason, %{status: status} = state} when is_integer(status) and status >= 400 ->
-        deliver_http_failure(state, callback)
+      {:error, reason, %{status: status} = state}
+      when is_integer(status) and status >= 400 ->
+        handle_http_failure(params, attempt, reason, state)
 
       {:error, reason, %{data_received?: false, callback_acc: callback_acc} = state}
       when attempt < max_retries ->
@@ -98,6 +87,20 @@ defmodule ReqLLM.Streaming.Retry do
       {:error, reason, %{callback_acc: callback_acc}} ->
         {:error, reason, callback_acc}
     end
+  end
+
+  defp handle_http_failure(
+         %{max_retries: max_retries} = params,
+         attempt,
+         reason,
+         %{status: 429} = state
+       )
+       when attempt < max_retries do
+    maybe_retry(params, attempt, state.callback_acc, reason, state)
+  end
+
+  defp handle_http_failure(%{callback: callback}, _attempt, _reason, state) do
+    deliver_http_failure(state, callback)
   end
 
   defp maybe_retry(%{max_retries: max_retries} = params, attempt, callback_acc, reason, state) do
@@ -168,10 +171,10 @@ defmodule ReqLLM.Streaming.Retry do
 
   defp classify_error(reason, _state) do
     case Failure.classify(reason) do
-      %{category: :transport, retryable: true, transport_reason: :pool_not_available} ->
+      {:transport, :pool_not_available, true} ->
         {:retry, 250}
 
-      %{category: :transport, retryable: true} ->
+      {:transport, _reason, true} ->
         {:retry, 0}
 
       _classification ->
@@ -235,7 +238,7 @@ defmodule ReqLLM.Streaming.Retry do
       |> Enum.reverse()
       |> IO.iodata_to_binary()
 
-    Failure.api_error(state.status, response_body, state.headers)
+    Failure.api_error(state.status, response_body, state.headers, use_body_as_reason?: true)
   end
 
   defp log_retry(reason, attempt, max_retries, delay_ms, status) do

--- a/lib/req_llm/streaming/retry.ex
+++ b/lib/req_llm/streaming/retry.ex
@@ -11,7 +11,7 @@ defmodule ReqLLM.Streaming.Retry do
 
   require Logger
 
-  @retryable_reasons [:closed, :timeout, :econnrefused]
+  alias ReqLLM.Streaming.Failure
 
   @type callback_acc :: term()
   @type callback :: (term(), callback_acc() -> callback_acc())
@@ -74,7 +74,10 @@ defmodule ReqLLM.Streaming.Retry do
         maybe_retry(params, attempt, state.callback_acc, :rate_limited, state)
 
       {:ok, %{status: 429} = state} ->
-        deliver_rate_limit_failure(state, callback)
+        deliver_http_failure(state, callback)
+
+      {:ok, %{status: status} = state} when is_integer(status) and status >= 400 ->
+        deliver_http_failure(state, callback)
 
       {:ok, %{callback_acc: callback_acc}} ->
         {:ok, callback_acc}
@@ -83,7 +86,10 @@ defmodule ReqLLM.Streaming.Retry do
         maybe_retry(params, attempt, state.callback_acc, reason, state)
 
       {:error, _reason, %{status: 429} = state} ->
-        deliver_rate_limit_failure(state, callback)
+        deliver_http_failure(state, callback)
+
+      {:error, _reason, %{status: status} = state} when is_integer(status) and status >= 400 ->
+        deliver_http_failure(state, callback)
 
       {:error, reason, %{data_received?: false, callback_acc: callback_acc} = state}
       when attempt < max_retries ->
@@ -97,7 +103,7 @@ defmodule ReqLLM.Streaming.Retry do
   defp maybe_retry(%{max_retries: max_retries} = params, attempt, callback_acc, reason, state) do
     case classify_error(reason, state) do
       {:retry, delay_ms} ->
-        log_retry(reason, attempt + 1, max_retries, delay_ms)
+        log_retry(reason, attempt + 1, max_retries, delay_ms, state.status)
 
         if delay_ms > 0 do
           Process.sleep(delay_ms)
@@ -110,8 +116,9 @@ defmodule ReqLLM.Streaming.Retry do
     end
   end
 
-  defp apply_callback({:status, 429}, wrapped_acc, _callback) do
-    %{wrapped_acc | status: 429}
+  defp apply_callback({:status, status}, wrapped_acc, _callback)
+       when is_integer(status) and status >= 400 do
+    %{wrapped_acc | status: status}
   end
 
   defp apply_callback({:status, status}, %{callback_acc: callback_acc} = wrapped_acc, callback) do
@@ -119,7 +126,12 @@ defmodule ReqLLM.Streaming.Retry do
     %{wrapped_acc | callback_acc: new_acc, status: status}
   end
 
-  defp apply_callback({:headers, headers}, %{status: 429} = wrapped_acc, _callback) do
+  defp apply_callback(
+         {:headers, headers},
+         %{status: status} = wrapped_acc,
+         _callback
+       )
+       when is_integer(status) and status >= 400 do
     %{wrapped_acc | headers: headers}
   end
 
@@ -130,9 +142,10 @@ defmodule ReqLLM.Streaming.Retry do
 
   defp apply_callback(
          {:data, chunk},
-         %{status: 429, error_body: error_body} = wrapped_acc,
+         %{status: status, error_body: error_body} = wrapped_acc,
          _callback
-       ) do
+       )
+       when is_integer(status) and status >= 400 do
     %{wrapped_acc | error_body: [chunk | error_body]}
   end
 
@@ -140,7 +153,8 @@ defmodule ReqLLM.Streaming.Retry do
     %{wrapped_acc | callback_acc: callback.(event, callback_acc), data_received?: true}
   end
 
-  defp apply_callback(:done, %{status: 429} = wrapped_acc, _callback) do
+  defp apply_callback(:done, %{status: status} = wrapped_acc, _callback)
+       when is_integer(status) and status >= 400 do
     wrapped_acc
   end
 
@@ -148,22 +162,21 @@ defmodule ReqLLM.Streaming.Retry do
     %{wrapped_acc | callback_acc: callback.(event, callback_acc)}
   end
 
-  defp classify_error(%Mint.TransportError{reason: reason}, _state)
-       when reason in @retryable_reasons,
-       do: {:retry, 0}
-
-  defp classify_error(%Req.TransportError{reason: reason}, _state)
-       when reason in @retryable_reasons,
-       do: {:retry, 0}
-
-  defp classify_error(%Finch.Error{reason: :pool_not_available}, _state), do: {:retry, 250}
-
   defp classify_error(_reason, %{status: 429} = state) do
     {:retry, extract_retry_after_delay(state.headers)}
   end
 
-  defp classify_error(_reason, _state) do
-    :no_retry
+  defp classify_error(reason, _state) do
+    case Failure.classify(reason) do
+      %{category: :transport, retryable: true, transport_reason: :pool_not_available} ->
+        {:retry, 250}
+
+      %{category: :transport, retryable: true} ->
+        {:retry, 0}
+
+      _classification ->
+        :no_retry
+    end
   end
 
   defp extract_retry_after_delay(headers) when is_list(headers) do
@@ -202,12 +215,12 @@ defmodule ReqLLM.Streaming.Retry do
 
   defp extract_retry_after_delay(_), do: 1000
 
-  defp deliver_rate_limit_failure(state, callback) do
+  defp deliver_http_failure(state, callback) do
     callback_acc =
-      callback.({:status, 429}, state.callback_acc)
+      callback.({:status, state.status}, state.callback_acc)
       |> maybe_emit_headers(callback, state.headers)
 
-    {:error, build_rate_limit_error(state), callback_acc}
+    {:error, build_http_error(state), callback_acc}
   end
 
   defp maybe_emit_headers(callback_acc, _callback, []), do: callback_acc
@@ -216,40 +229,17 @@ defmodule ReqLLM.Streaming.Retry do
     callback.({:headers, headers}, callback_acc)
   end
 
-  defp build_rate_limit_error(state) do
+  defp build_http_error(state) do
     response_body =
       state.error_body
       |> Enum.reverse()
       |> IO.iodata_to_binary()
-      |> decode_rate_limit_body()
 
-    reason =
-      case response_body do
-        %{"error" => %{"message" => message}} when is_binary(message) and message != "" -> message
-        %{"message" => message} when is_binary(message) and message != "" -> message
-        body when is_binary(body) and body != "" -> body
-        _ -> "HTTP 429"
-      end
-
-    ReqLLM.Error.API.Request.exception(
-      reason: reason,
-      status: 429,
-      response_body: response_body,
-      headers: state.headers
-    )
+    Failure.api_error(state.status, response_body, state.headers)
   end
 
-  defp decode_rate_limit_body(""), do: ""
-
-  defp decode_rate_limit_body(body) when is_binary(body) do
-    case Jason.decode(body) do
-      {:ok, decoded} -> decoded
-      {:error, _} -> body
-    end
-  end
-
-  defp log_retry(reason, attempt, max_retries, delay_ms) do
-    if delay_ms > 0 do
+  defp log_retry(reason, attempt, max_retries, delay_ms, status) do
+    if status == 429 do
       Logger.warning(
         "Retrying streaming request after rate limit (429), waiting #{delay_ms}ms " <>
           "(reason=#{inspect(reason)}, attempt=#{attempt}, max_retries=#{max_retries})"

--- a/lib/req_llm/telemetry.ex
+++ b/lib/req_llm/telemetry.ex
@@ -386,24 +386,41 @@ defmodule ReqLLM.Telemetry do
 
   def exception_request(%{request_stopped?: true} = context, _error, _opts), do: context
 
-  def exception_request(context, error, _opts) do
+  def exception_request(context, error, opts) do
     context = ensure_started(context, context.original_opts)
-    context = observe_error_reasoning(context, error)
+    usage = Keyword.get(opts, :usage)
+
+    context =
+      context
+      |> observe_error_reasoning(error)
+      |> observe_reasoning_usage(usage)
 
     :telemetry.execute(
       @request_exception_event,
       stop_measurements(context),
       request_metadata(context, %{
-        http_status: http_status_from_error(error),
+        http_status: Keyword.get(opts, :http_status) || http_status_from_error(error),
         finish_reason: :error,
-        usage: nil,
+        usage: usage,
         response_summary: response_summary(context.response_summary_state, context.operation),
         response_payload: nil,
+        builtin_tool_timing: Keyword.get(opts, :builtin_tool_timing),
         error: error
       })
     )
 
     maybe_emit_reasoning_stop(context, :error)
+
+    if Keyword.get(opts, :emit_token_usage?, false) do
+      emit_token_usage(context.model, usage,
+        request_id: context.request_id,
+        operation: context.operation,
+        mode: context.mode,
+        provider: context.model.provider,
+        transport: context.transport
+      )
+    end
+
     %{context | request_stopped?: true}
   end
 

--- a/test/req_llm/stream_server/core_test.exs
+++ b/test/req_llm/stream_server/core_test.exs
@@ -100,6 +100,34 @@ defmodule ReqLLM.StreamServer.CoreTest do
       StreamServer.cancel(server)
     end
 
+    test "keeps failed streams alive for metadata when consumer exits" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      consumer =
+        spawn(fn ->
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert :ok = StreamServer.monitor_consumer(server, consumer)
+      assert :ok = StreamServer.http_event(server, {:error, :connection_lost})
+
+      consumer_ref = Process.monitor(consumer)
+      send(consumer, :stop)
+      assert_receive {:DOWN, ^consumer_ref, :process, ^consumer, :normal}
+
+      Process.sleep(20)
+      assert Process.alive?(server)
+
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 100)
+      assert metadata.finish_reason == :error
+      assert metadata.error == :connection_lost
+
+      StreamServer.cancel(server)
+    end
+
     test "cancel is idempotent after StreamServer exits normally" do
       server = start_server()
       ref = Process.monitor(server)

--- a/test/req_llm/stream_server/error_handling_test.exs
+++ b/test/req_llm/stream_server/error_handling_test.exs
@@ -103,6 +103,7 @@ defmodule ReqLLM.StreamServer.ErrorHandlingTest do
       assert {:error, %ReqLLM.Error.API.Request{} = error} = StreamServer.next(server, 100)
       assert error.status == 500
       assert error.reason == "Internal server error"
+      assert error.retryable == true
 
       StreamServer.cancel(server)
     end
@@ -118,6 +119,7 @@ defmodule ReqLLM.StreamServer.ErrorHandlingTest do
       assert error.status == 404
       assert error.reason == "HTTP 404"
       assert error.response_body == "Not Found"
+      assert error.retryable == false
 
       StreamServer.cancel(server)
     end

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -70,16 +70,46 @@ defmodule ReqLLM.StreamServer.MetadataTest do
       StreamServer.cancel(server)
     end
 
-    test "await_metadata returns error on stream failure" do
+    test "await_metadata returns terminal error metadata on stream failure" do
       server = start_server()
       _task = mock_http_task(server)
 
       error_reason = {:request_failed, "Network error"}
       assert :ok = GenServer.call(server, {:http_event, {:error, error_reason}})
 
-      assert {:error, ^error_reason} = StreamServer.await_metadata(server, 100)
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 100)
+      assert metadata.error == error_reason
+      assert metadata.finish_reason == :error
 
       StreamServer.cancel(server)
+    end
+
+    test "stream failure metadata preserves partial content and observed usage" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      content = Jason.encode!(%{"choices" => [%{"delta" => %{"content" => "partial"}}]})
+      usage = Jason.encode!(%{"usage" => %{"prompt_tokens" => 4, "completion_tokens" => 2}})
+
+      StreamServer.http_event(server, {:data, "data: #{content}\n\n"})
+      StreamServer.http_event(server, {:data, "data: #{usage}\n\n"})
+
+      error = %Finch.TransportError{source: %Mint.TransportError{reason: :closed}}
+      StreamServer.http_event(server, {:error, error})
+
+      assert {:ok, content_chunk} = StreamServer.next(server, 100)
+      assert content_chunk.text == "partial"
+
+      assert {:ok, usage_chunk} = StreamServer.next(server, 100)
+      assert usage_chunk.metadata.usage["prompt_tokens"] == 4
+
+      assert {:ok, metadata} = StreamServer.await_metadata(server, 100)
+      assert metadata.error == error
+      assert metadata.finish_reason == :error
+      assert metadata.usage.input_tokens == 4
+      assert metadata.usage.output_tokens == 2
+
+      assert {:error, ^error} = StreamServer.next(server, 100)
     end
 
     test "cancellation replies to all metadata waiters with partial usage" do

--- a/test/req_llm/stream_server/metadata_test.exs
+++ b/test/req_llm/stream_server/metadata_test.exs
@@ -87,6 +87,7 @@ defmodule ReqLLM.StreamServer.MetadataTest do
     test "stream failure metadata preserves partial content and observed usage" do
       server = start_server()
       _task = mock_http_task(server)
+      server_ref = Process.monitor(server)
 
       content = Jason.encode!(%{"choices" => [%{"delta" => %{"content" => "partial"}}]})
       usage = Jason.encode!(%{"usage" => %{"prompt_tokens" => 4, "completion_tokens" => 2}})
@@ -110,6 +111,7 @@ defmodule ReqLLM.StreamServer.MetadataTest do
       assert metadata.usage.output_tokens == 2
 
       assert {:error, ^error} = StreamServer.next(server, 100)
+      assert_receive {:DOWN, ^server_ref, :process, ^server, :normal}, 100
     end
 
     test "cancellation replies to all metadata waiters with partial usage" do

--- a/test/req_llm/stream_server/telemetry_test.exs
+++ b/test/req_llm/stream_server/telemetry_test.exs
@@ -514,15 +514,32 @@ defmodule ReqLLM.StreamServer.TelemetryTest do
 
     assert :ok = StreamServer.set_telemetry_context(server, telemetry_context)
 
+    usage = %{"prompt_tokens" => 7, "completion_tokens" => 3, "total_tokens" => 10}
+
+    StreamServer.http_event(
+      server,
+      {:data,
+       "data: #{Jason.encode!(%{"type" => "meta", "usage" => usage, "reasoning_details" => []})}\n\n"}
+    )
+
     StreamServer.http_event(server, {:error, :boom})
 
-    assert {:error, :boom} = StreamServer.await_metadata(server, 200)
+    assert {:ok, metadata} = StreamServer.await_metadata(server, 200)
+    assert metadata.error == :boom
+    assert metadata.usage.input_tokens == 7
+    assert metadata.usage.output_tokens == 3
+
     assert_receive {:telemetry_event, [:req_llm, :request, :start], _, _}
     assert_receive {:telemetry_event, [:req_llm, :reasoning, :start], _, _}
     assert_receive {:telemetry_event, [:req_llm, :request, :exception], _, exception_meta}
     assert_receive {:telemetry_event, [:req_llm, :reasoning, :stop], _, reasoning_stop_meta}
+    assert_receive {:telemetry_event, [:req_llm, :token_usage], token_measurements, _}
     refute_receive {:telemetry_event, [:req_llm, :request, :stop], _, _}
     assert exception_meta.finish_reason == :error
+    assert exception_meta.usage.input_tokens == 7
+    assert exception_meta.usage.output_tokens == 3
+    assert token_measurements.tokens.input_tokens == 7
+    assert token_measurements.tokens.output_tokens == 3
     assert reasoning_stop_meta.milestone == :error
 
     StreamServer.cancel(server)

--- a/test/req_llm/streaming/failure_test.exs
+++ b/test/req_llm/streaming/failure_test.exs
@@ -18,16 +18,11 @@ defmodule ReqLLM.Streaming.FailureTest do
     assert error.retryable == true
     assert error.reason == "traffic queue wait expired"
 
-    assert %{
-             category: :api,
-             severity: :warning,
-             status: 429,
-             provider_code: "traffic_queue_timeout",
-             retryable: true
-           } = Failure.classify(error)
+    assert {:api, 429, "traffic_queue_timeout", true} = Failure.classify(error)
 
     log = capture_log(fn -> Failure.log(error) end)
 
+    assert log =~ "[warning]"
     assert log =~ "Streaming provider/API request failed"
     assert log =~ "status=429"
     assert log =~ "provider_code=\"traffic_queue_timeout\""
@@ -37,29 +32,31 @@ defmodule ReqLLM.Streaming.FailureTest do
   test "marks streamed 503 responses as retryable API failures" do
     error = Failure.api_error(503, ~s({"error":{"code":"overloaded"}}), [])
 
-    assert %{category: :api, status: 503, provider_code: "overloaded", retryable: true} =
-             Failure.classify(error)
+    assert {:api, 503, "overloaded", true} = Failure.classify(error)
+  end
+
+  test "preserves a plain-text provider response as the failure reason" do
+    error = Failure.api_error(429, "rate limit exceeded", [], use_body_as_reason?: true)
+
+    assert error.reason == "rate limit exceeded"
+    assert error.response_body == "rate limit exceeded"
   end
 
   test "classifies Finch errors backed by Mint as transport failures" do
     error = %Finch.TransportError{source: %Mint.TransportError{reason: :closed}}
 
-    assert %{
-             category: :transport,
-             severity: :error,
-             transport_reason: :closed,
-             retryable: true
-           } = Failure.classify(error)
+    assert {:transport, :closed, true} = Failure.classify(error)
+    assert {:transport, :closed, true} = Failure.classify({:error, error})
 
     log = capture_log(fn -> Failure.log(error) end)
 
+    assert log =~ "[error]"
     assert log =~ "Finch streaming transport failed"
     assert log =~ "reason=:closed"
   end
 
   test "treats expected cancellation as a non-logged terminal outcome" do
-    assert %{category: :cancelled, severity: nil, retryable: false} =
-             Failure.classify({:exit, :cancelled})
+    assert :cancelled = Failure.classify({:exit, :cancelled})
 
     assert capture_log(fn -> Failure.log({:exit, :cancelled}) end) == ""
   end

--- a/test/req_llm/streaming/failure_test.exs
+++ b/test/req_llm/streaming/failure_test.exs
@@ -1,0 +1,66 @@
+defmodule ReqLLM.Streaming.FailureTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias ReqLLM.Streaming.Failure
+
+  test "classifies structured HTTP failures as retryable provider/API failures" do
+    error =
+      Failure.api_error(
+        429,
+        ~s({"error":{"code":"traffic_queue_timeout","message":"traffic queue wait expired"}}),
+        [{"retry-after", "1"}]
+      )
+
+    assert error.status == 429
+    assert error.provider_code == "traffic_queue_timeout"
+    assert error.retryable == true
+    assert error.reason == "traffic queue wait expired"
+
+    assert %{
+             category: :api,
+             severity: :warning,
+             status: 429,
+             provider_code: "traffic_queue_timeout",
+             retryable: true
+           } = Failure.classify(error)
+
+    log = capture_log(fn -> Failure.log(error) end)
+
+    assert log =~ "Streaming provider/API request failed"
+    assert log =~ "status=429"
+    assert log =~ "provider_code=\"traffic_queue_timeout\""
+    refute log =~ "Finch streaming failed"
+  end
+
+  test "marks streamed 503 responses as retryable API failures" do
+    error = Failure.api_error(503, ~s({"error":{"code":"overloaded"}}), [])
+
+    assert %{category: :api, status: 503, provider_code: "overloaded", retryable: true} =
+             Failure.classify(error)
+  end
+
+  test "classifies Finch errors backed by Mint as transport failures" do
+    error = %Finch.TransportError{source: %Mint.TransportError{reason: :closed}}
+
+    assert %{
+             category: :transport,
+             severity: :error,
+             transport_reason: :closed,
+             retryable: true
+           } = Failure.classify(error)
+
+    log = capture_log(fn -> Failure.log(error) end)
+
+    assert log =~ "Finch streaming transport failed"
+    assert log =~ "reason=:closed"
+  end
+
+  test "treats expected cancellation as a non-logged terminal outcome" do
+    assert %{category: :cancelled, severity: nil, retryable: false} =
+             Failure.classify({:exit, :cancelled})
+
+    assert capture_log(fn -> Failure.log({:exit, :cancelled}) end) == ""
+  end
+end

--- a/test/req_llm/streaming/finch_client_test.exs
+++ b/test/req_llm/streaming/finch_client_test.exs
@@ -1,6 +1,8 @@
 defmodule ReqLLM.Streaming.FinchClientTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias ReqLLM.Context
   alias ReqLLM.Streaming.FinchClient
   alias ReqLLM.Streaming.Fixtures.HTTPContext
@@ -22,6 +24,24 @@ defmodule ReqLLM.Streaming.FinchClientTest do
 
       {:ok, conn} = Plug.Conn.chunk(conn, "data: [DONE]\n\n")
       conn
+    end
+
+    post "/rate_limit" do
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(
+        429,
+        ~s({"error":{"code":"traffic_queue_timeout","message":"traffic queue wait expired"}})
+      )
+    end
+
+    post "/unavailable" do
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(
+        503,
+        ~s({"error":{"code":"overloaded","message":"service unavailable"}})
+      )
     end
   end
 
@@ -536,20 +556,116 @@ defmodule ReqLLM.Streaming.FinchClientTest do
       {:ok, context} = Context.normalize("Test")
       model = %LLMDB.Model{provider: :test, id: "test"}
 
-      assert {:ok, task_pid, _http_context, _canonical_json} =
-               FinchClient.start_stream(
-                 LiveStreamProvider,
-                 model,
-                 context,
-                 [stream_url: "http://127.0.0.1:1/stream", max_retries: 0, receive_timeout: 10],
-                 stream_server
-               )
+      log =
+        capture_log(fn ->
+          assert {:ok, task_pid, _http_context, _canonical_json} =
+                   FinchClient.start_stream(
+                     LiveStreamProvider,
+                     model,
+                     context,
+                     [
+                       stream_url: "http://127.0.0.1:1/stream",
+                       max_retries: 0,
+                       receive_timeout: 10
+                     ],
+                     stream_server
+                   )
 
-      assert is_pid(task_pid)
+          assert is_pid(task_pid)
 
-      assert wait_until(fn ->
-               Enum.any?(EventStreamServer.events(stream_server), &match?({:error, _}, &1))
-             end)
+          assert wait_until(fn ->
+                   Enum.any?(EventStreamServer.events(stream_server), &match?({:error, _}, &1))
+                 end)
+        end)
+
+      assert log =~ "Finch streaming transport failed"
+      refute log =~ "Metadata collection failed"
+    end
+
+    test "classifies streamed 429 and 503 responses without false Finch errors" do
+      port = reserve_port()
+      start_supervised!({Bandit, plug: StreamingRouter, port: port})
+
+      {:ok, context} = Context.normalize("Test")
+      model = %LLMDB.Model{provider: :test, id: "test"}
+
+      for {path, status, provider_code} <- [
+            {"rate_limit", 429, "traffic_queue_timeout"},
+            {"unavailable", 503, "overloaded"}
+          ] do
+        {:ok, stream_server} = EventStreamServer.start_link()
+
+        log =
+          capture_log(fn ->
+            assert {:ok, task_pid, _http_context, _canonical_json} =
+                     FinchClient.start_stream(
+                       LiveStreamProvider,
+                       model,
+                       context,
+                       [
+                         stream_url: "http://127.0.0.1:#{port}/#{path}",
+                         max_retries: 0
+                       ],
+                       stream_server
+                     )
+
+            monitor_ref = Process.monitor(task_pid)
+            assert_receive {:DOWN, ^monitor_ref, :process, ^task_pid, :normal}, 1_000
+          end)
+
+        assert log =~ "Streaming provider/API request failed"
+        assert log =~ "status=#{status}"
+        assert log =~ "provider_code=\"#{provider_code}\""
+        refute log =~ "Finch streaming failed"
+        refute log =~ "Finch streaming transport failed"
+
+        assert Enum.any?(EventStreamServer.events(stream_server), fn
+                 {:error, %ReqLLM.Error.API.Request{} = error} ->
+                   error.status == status and error.provider_code == provider_code and
+                     error.retryable == true
+
+                 _event ->
+                   false
+               end)
+
+        GenServer.stop(stream_server)
+      end
+    end
+
+    test "keeps terminal metadata accessible after a streamed API failure" do
+      port = reserve_port()
+      start_supervised!({Bandit, plug: StreamingRouter, port: port})
+
+      {:ok, context} = Context.normalize("Test")
+      model = %LLMDB.Model{provider: :test, id: "test"}
+
+      log =
+        capture_log(fn ->
+          assert {:ok, stream_response} =
+                   ReqLLM.Streaming.start_stream(
+                     LiveStreamProvider,
+                     model,
+                     context,
+                     stream_url: "http://127.0.0.1:#{port}/unavailable",
+                     max_retries: 0
+                   )
+
+          assert_raise ReqLLM.Error.API.Stream, fn -> Enum.to_list(stream_response.stream) end
+          assert Process.alive?(stream_response.metadata_handle)
+
+          metadata =
+            ReqLLM.StreamResponse.MetadataHandle.await(stream_response.metadata_handle)
+
+          assert metadata.finish_reason == :error
+          assert metadata.error.status == 503
+          assert metadata.error.provider_code == "overloaded"
+
+          ReqLLM.StreamResponse.MetadataHandle.stop(stream_response.metadata_handle)
+        end)
+
+      assert length(Regex.scan(~r/Streaming provider\/API request failed/, log)) == 1
+      refute log =~ "Finch streaming failed"
+      refute log =~ "Metadata collection failed"
     end
 
     test "captures finch process exits as stream server errors" do

--- a/test/req_llm/streaming/retry_test.exs
+++ b/test/req_llm/streaming/retry_test.exs
@@ -230,7 +230,41 @@ defmodule ReqLLM.Streaming.RetryTest do
     assert error.status == 429
     assert error.reason == "Too many requests"
     assert error.headers == [{"retry-after", "0"}]
+    assert error.retryable == true
     assert Enum.reverse(events) == [{:status, 429}, {:headers, [{"retry-after", "0"}]}]
+  end
+
+  test "buffers a 503 response and returns one structured API failure" do
+    stream_fun = fn _request, _finch_name, acc, callback, _opts ->
+      acc = callback.({:status, 503}, acc)
+      acc = callback.({:headers, [{"content-type", "application/json"}]}, acc)
+      acc = callback.({:data, ~s({"error":{"code":"over)}, acc)
+      acc = callback.({:data, ~s(loaded","message":"try later"}})}, acc)
+      acc = callback.(:done, acc)
+      {:ok, acc}
+    end
+
+    callback = fn event, acc -> [event | acc] end
+
+    assert {:error, %ReqLLM.Error.API.Request{} = error, events} =
+             Retry.stream(
+               Finch.build(:post, "https://example.com/stream"),
+               ReqLLM.Finch,
+               [],
+               callback,
+               [max_retries: 0, receive_timeout: 1_000],
+               stream_fun
+             )
+
+    assert error.status == 503
+    assert error.reason == "try later"
+    assert error.provider_code == "overloaded"
+    assert error.retryable == true
+
+    assert Enum.reverse(events) == [
+             {:status, 503},
+             {:headers, [{"content-type", "application/json"}]}
+           ]
   end
 
   test "retries 429 errors returned from the streaming transport" do

--- a/test/req_llm/streaming/retry_test.exs
+++ b/test/req_llm/streaming/retry_test.exs
@@ -209,7 +209,7 @@ defmodule ReqLLM.Streaming.RetryTest do
       Agent.update(counter, &(&1 + 1))
       acc = callback.({:status, 429}, acc)
       acc = callback.({:headers, [{"retry-after", "0"}]}, acc)
-      acc = callback.({:data, ~s({"error":{"message":"Too many requests"}})}, acc)
+      acc = callback.({:data, "Too many requests"}, acc)
       acc = callback.(:done, acc)
       {:ok, acc}
     end
@@ -229,6 +229,7 @@ defmodule ReqLLM.Streaming.RetryTest do
     assert Agent.get(counter, & &1) == 2
     assert error.status == 429
     assert error.reason == "Too many requests"
+    assert error.response_body == "Too many requests"
     assert error.headers == [{"retry-after", "0"}]
     assert error.retryable == true
     assert Enum.reverse(events) == [{:status, 429}, {:headers, [{"retry-after", "0"}]}]


### PR DESCRIPTION
Closes #826

## Summary

- classify streamed HTTP responses separately from Finch/Mint transport failures
- attach HTTP status, provider error code, and retryability to structured request errors
- emit one canonical terminal failure log while treating cancellation as a distinct non-error outcome
- preserve partial content, usage metadata, and token telemetry across failure paths
- prevent normal task completion from overwriting an existing stream error

## Root cause

The Finch task logged every terminal `Retry.stream/6` error as a transport failure, even when the HTTP exchange completed with a structured provider response. The StreamServer metadata waiter then received the same reason as an independent failure and logged it again. A normal task exit could also finalize the server after the error and overwrite the terminal error state.

## Hardening

- simplify failure classification from repeated maps to tagged outcomes
- finalize terminal error metadata once and use one terminal-delivery lifecycle flag
- keep failed streams alive for metadata when a monitored consumer exits
- preserve plain-text provider failure reasons and classify wrapped transport exceptions
- retain the public function-enumerable stream contract

## Validation

- `mix test` — 3,577 passed, 11 skipped, 145 excluded
- focused streaming and StreamServer suite — 276 passed
- streaming orchestration integration suite — 11 passed
- `mix quality` — passed (format, warnings-as-errors compile, Credo, Dialyzer)
- fresh GitHub CI matrix — passed on all required Elixir/OTP combinations
- `git diff --check` — passed