### PR TITLE
docs: define ReqLLM 1.x compatibility boundaries

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,205 @@
+# ReqLLM 1.x Compatibility Policy
+
+ReqLLM 1.x evolves without requiring applications or third-party providers to
+rewrite working integrations. Internal architecture may change substantially,
+but stable observable behavior follows semantic versioning.
+
+This policy applies to the 1.x release line. The
+[V1 roadmap](ROADMAP_V1.md) describes planned compatible improvements, and the
+[V1 execution goal](V1_EXECUTION_GOAL.md) defines the evidence required before
+each roadmap pull request can merge.
+
+## Contract classifications
+
+Every supported surface is classified as stable, experimental, deprecated, or
+internal.
+
+### Stable
+
+A surface is stable when it is documented without an experimental or deprecated
+label. Stable contracts may gain additive behavior in a minor release, but an
+incompatible removal, rename, default change, or semantic replacement waits for
+a major release.
+
+Stable does not mean frozen. Internal implementation and private data may change
+when existing observable behavior remains compatible. A narrowly scoped bug fix
+may correct behavior that contradicts the documented contract or types, provided
+the change has regression evidence and does not introduce unrelated differences.
+
+### Experimental
+
+A surface is experimental only when its module, function, option, event, or
+guide explicitly says so. Experimental contracts may change or be removed in a
+minor release, but changes must still be intentional, documented, and tested.
+New public behavior is not implicitly experimental.
+
+Applications should isolate experimental use behind their own adapter. ReqLLM
+will prefer an additive migration path and warning when practical, especially
+when an experimental surface has meaningful adoption.
+
+### Deprecated
+
+A deprecated contract remains functional while users migrate. A deprecation
+must provide:
+
+- an actionable warning where runtime detection is practical;
+- the supported replacement and a migration example;
+- the release that introduced the deprecation;
+- the earliest release in which removal may occur; and
+- at least two minor releases of overlap before removal is considered.
+
+Stable runtime APIs are not removed during V1 merely because the overlap window
+has elapsed. Their removal belongs to a major release. The window creates a
+usable V1 bridge before that release.
+
+### Internal
+
+A surface is internal only when it is hidden from public documentation or
+explicitly documented as internal. File paths, private functions, intermediate
+maps, and module organization are not contracts by themselves.
+
+Visibility alone does not make an extension point internal. Documented provider
+callbacks, configuration, telemetry, and value shapes remain protected even
+when most applications use them indirectly.
+
+## Compatibility-protected contracts
+
+The following categories are stable unless their documentation explicitly
+classifies a particular surface otherwise.
+
+### Public functions and inputs
+
+- Documented facade and operation functions, their names, arities, bang
+  variants, defaults, and return tuples.
+- Accepted model forms, including `"provider:model"` strings, supported tuple
+  forms, full plain-map model specs, and `%LLMDB.Model{}` values.
+- Documented option names, types, precedence, and default behavior, including
+  provider-specific escape hatches.
+- The ability to use a full model specification without requiring LLMDB catalog
+  membership when enough routing metadata is present.
+
+Adding an opt-in function or option is compatible. Silently changing an existing
+default, precedence rule, or accepted input is not.
+
+### Results, values, and errors
+
+- Success and error tuple shapes, normalized content, usage, warnings, finish
+  reasons, provider metadata, and ordering.
+- Public struct modules, keys, defaults, equality behavior, `Map.from_struct/1`
+  output, `Inspect` representation, and Jason encoding.
+- Public error terms and fields plus the exception module and message raised by
+  bang functions.
+
+Richer information must use a computed projection, a new value, or an explicit
+opt-in return mode when adding fields would change an existing value's observable
+shape.
+
+### Streaming
+
+- The `StreamResponse.stream` and `StreamChunk` contract, element order and
+  meaning, and single-consumer behavior.
+- Terminal success and failure delivery, cancellation, timeout semantics,
+  metadata availability, and transport resource cleanup.
+- Semantic parity between a buffered stream and the equivalent non-streaming
+  operation where both surfaces support the same provider capability.
+
+A richer event view may project from the existing stream. V1 does not replace
+the legacy stream with a second independently consumable source.
+
+### Provider extensions
+
+- The documented `ReqLLM.Provider` callbacks and default implementations.
+- Provider registration, `:custom_providers`, inline model specs, and documented
+  request customization.
+- Callback inputs, return forms, option precedence, and routing behavior relied
+  upon by third-party provider modules.
+
+ReqLLM may introduce narrower internal seams, but the current provider behavior
+remains available through V1. A first-party refactor must include conformance
+evidence that an external provider would continue to work.
+
+### Configuration and telemetry
+
+- Documented application configuration, environment variables, per-request
+  options, precedence, defaults, and credential-source behavior.
+- Existing documented telemetry event names, metadata and measurement keys,
+  value types, meanings, units, and redaction behavior.
+
+New telemetry is additive. Existing events are not silently renamed or corrected
+in place when that would reinterpret a consumer's data. Provider-specific or
+detail events may use an experimental classification only when that status is
+explicit in their documentation.
+
+### Compatibility evidence
+
+- Public scenario identifiers, fixture naming and lookup rules, replay/live
+  behavior, semantic test tags, support-state meanings, and generated evidence
+  schemas.
+- Existing fixture request contracts outside the exact behavior being fixed.
+
+Recorded provider responses may be refreshed when a provider changes, but the
+pull request must distinguish provider drift from a library regression. Internal
+refactoring alone must not churn fixture payloads or support claims.
+
+## Elixir and OTP support
+
+The Elixir requirement in `mix.exs` and the versions exercised by GitHub CI are
+the source of truth for the supported toolchain. Toolchain support is managed
+independently from the ReqLLM API major version because language, OTP, security,
+dependency, and CI constraints have their own lifecycle.
+
+Raising the minimum Elixir or OTP version does not by itself require ReqLLM 2.0,
+but it is never treated as incidental maintenance. Except for an urgent security
+or ecosystem incompatibility, ReqLLM will:
+
+1. announce the intended minimum-version change at least one minor release in
+   advance;
+2. explain the EOL, security, dependency, or maintenance evidence behind it;
+3. keep the old version in CI during the notice window;
+4. include a concrete upgrade path in release notes; and
+5. change package metadata, CI coverage, and documentation together.
+
+Supporting an additional Elixir or OTP release is compatible when the existing
+matrix remains green.
+
+## ReqLLM and Jido ownership
+
+ReqLLM owns one model interaction. It resolves and validates the selected model,
+translates options, performs one request or stream, and normalizes provider data
+into responses, tool calls, usage, warnings, and errors. It may provide pure
+helpers that let a host append matched tool calls and results to a context.
+
+Jido or another application host owns orchestration across model interactions:
+
+- deciding whether and where a tool runs;
+- approvals and tool-execution policy;
+- appending application results and deciding whether to call a model again;
+- loop termination, step limits, model selection, and cross-call retry policy;
+- memory, checkpoints, resumption, delegation, and durable execution; and
+- sandbox creation, permissions, lifecycle, and cleanup.
+
+Concrete boundaries include:
+
+| Situation | ReqLLM owns | Jido or the host owns |
+| --- | --- | --- |
+| A response requests a tool | Decode and return a normalized tool call. | Approve, execute, reject, or defer it. |
+| A tool produced a result | Represent model-facing tool result content and offer pure context helpers. | Preserve application data and decide whether to make another model call. |
+| A provider returns a transient transport failure | Apply the documented retry behavior within the current operation. | Decide whether the workflow retries the completed model step or chooses another model. |
+| A caller cancels a stream | Stop the current operation and release transport resources. | Pause, resume, checkpoint, or terminate the larger workflow. |
+| A provider offers a native or server-side tool | Encode and decode the provider-scoped capability for one operation. | Decide whether the capability is allowed and how its effects fit the workflow. |
+
+ReqLLM core does not add an agent loop, approval engine, memory store, workflow
+checkpoint, delegation runtime, or Jido dependency. Optional integration code
+may adapt stable ReqLLM values for Jido without moving those responsibilities
+across the boundary.
+
+## Evaluating a V1 change
+
+Before merging a V1 change, identify every affected contract above and prove
+that behavior outside the accepted scope remains compatible. Exact request,
+serialization, error, exception, telemetry, and fixture assertions are required
+when those contracts are touched.
+
+If the valuable implementation cannot satisfy the V1 compatibility gate, narrow
+it to an additive bridge or move it to the V2 roadmap. Compatibility uncertainty
+is a reason to pause, not permission to guess.

--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ This approach gives you full control over the Req pipeline, allowing you to add 
 
 ## Documentation
 
+- [Compatibility Policy](COMPATIBILITY.md) – stable, experimental, deprecated, platform, and ReqLLM/Jido contracts
 - [Getting Started](guides/getting-started.md) – first call and basic concepts
 - [Configuration](guides/configuration.md) – timeouts, connection pools, and global settings
 - [Telemetry](guides/telemetry.md) – request lifecycle, reasoning lifecycle, payload capture
@@ -506,7 +507,10 @@ This approach gives you full control over the Req pipeline, allowing you to add 
 
 ## Roadmap & Status
 
-ReqLLM has now reached v1.0.0. The core API is stable and ready for production use. We're continuing to refine the library and would love community feedback as we plan the next set of improvements. If you run into anything or have suggestions, please open an issue or PR.
+ReqLLM has reached v1.0.0. Its [compatibility policy](COMPATIBILITY.md)
+protects the stable core API while the [roadmap](ROADMAP.md) evolves the library
+through conservative V1 improvements and separately justified V2 candidates.
+If you run into anything or have suggestions, please open an issue or PR.
 
 ### Test Coverage & Quality Commitment
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,10 @@ The [V1 execution goal](V1_EXECUTION_GOAL.md) defines the one-issue delivery
 loop, backward-compatibility merge gate, review and hardening standard, and
 completion criteria for the V1 backlog.
 
+The [ReqLLM 1.x compatibility policy](COMPATIBILITY.md) is the normative public
+contract for stable, experimental, deprecated, platform, and ReqLLM/Jido
+boundaries.
+
 The V1 roadmap records the review of 42 proposed issues covering Milestones 0–8.
 After auditing them against current `main`, 36 remain active one-pull-request
 tickets, three are already satisfied by current code, two were consolidated into

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,198 @@
+# ReqLLM Roadmap
+
+> Discussion draft — July 16, 2026
+
+ReqLLM should evolve in place. Its public API is useful, recognizable, and
+widely deployed; popularity makes compatibility and predictable migration more
+valuable than architectural purity. The default path is therefore additive
+ReqLLM 1.x releases backed by stronger conformance evidence. A formal V2 should
+happen only for a small set of high-return changes that cannot be delivered
+honestly behind the current API.
+
+This document is the roadmap index and shared product direction. Release-specific
+scope lives in:
+
+| Track | Compatibility posture | Roadmap | Master tracker |
+| --- | --- | --- | --- |
+| ReqLLM 1.x | Backward-compatible evolution | [ROADMAP_V1.md](ROADMAP_V1.md) | [#829](https://github.com/agentjido/req_llm/issues/829) |
+| ReqLLM 2.0 | Intentional, bounded breaking changes | [ROADMAP_V2.md](ROADMAP_V2.md) | [#830](https://github.com/agentjido/req_llm/issues/830) |
+
+The [V1 execution goal](V1_EXECUTION_GOAL.md) defines the one-issue delivery
+loop, backward-compatibility merge gate, review and hardening standard, and
+completion criteria for the V1 backlog.
+
+The V1 roadmap records the review of 42 proposed issues covering Milestones 0–8.
+After auditing them against current `main`, 36 remain active one-pull-request
+tickets, three are already satisfied by current code, two were consolidated into
+stronger tickets, and one speculative middleware framework was deferred.
+Execution takes one issue through merge and green post-merge checks before the
+next issue begins.
+
+## Product thesis
+
+ReqLLM should be the dependable Elixir model-runtime layer:
+
+- one small, stable API across providers and modalities;
+- explicit behavior when provider capabilities differ;
+- excellent errors, diagnostics, streaming, and observability;
+- composable model and tool contracts for Jido and other orchestration hosts;
+- provider-native escape hatches that do not contaminate the common API; and
+- replay-backed evidence for every support claim.
+
+The package should optimize for this boundary:
+
+```text
+ReqLLM: prompt -> one model interaction -> normalized result or tool calls
+Jido:   orchestration -> approvals -> memory -> checkpointing -> durability
+```
+
+A developer should not have to abandon the simple API as their application
+grows. ReqLLM's functional entry points and extension contracts remain the model
+boundary. Jido or another host composes those calls into agent loops and durable
+workflows.
+
+## Compatibility vocabulary
+
+- **V1 additive** — new API or internal behavior that does not invalidate
+  supported callers.
+- **V1 deprecation** — old behavior continues for a documented window with an
+  actionable replacement and warning.
+- **V1 bug fix** — documented or typed behavior was silently wrong. Correctness
+  wins, with a release note and regression test.
+- **V2 candidate** — a possible break that first needs an additive V1 migration
+  path and adoption evidence.
+- **V2 only** — removal or semantic replacement that must not ship in V1.
+
+Compatibility includes more than top-level function arities. Treat these as
+public contracts unless explicitly documented otherwise:
+
+- return tuple and exception behavior;
+- response, stream, message, tool, usage, and error shapes;
+- stream element semantics and cancellation behavior;
+- accepted model and option forms;
+- provider callbacks used by third-party integrations;
+- telemetry event names and metadata;
+- fixture names and compatibility-state semantics; and
+- documented configuration keys.
+
+Adding struct fields may compile cleanly while still changing map equality,
+`Map.from_struct/1`, `Inspect`, or JSON output. V1 therefore keeps existing
+public struct shapes and serializers stable unless richer data is returned
+through an explicitly opt-in value.
+
+## Target architecture
+
+The target is a thin compatibility facade over an inspectable planning and
+execution kernel:
+
+```mermaid
+flowchart LR
+    A["ReqLLM public facade"] --> B["Model resolution"]
+    B --> C["One internal request plan"]
+    C --> D["Existing provider adapters"]
+    D --> E["Provider wire and transport"]
+    E --> F["StreamChunk or event projection"]
+    F --> G["Existing accumulator and response builders"]
+    G --> H["Response, StreamResponse, and helpers"]
+    G --> I["Usage, warnings, timing, and telemetry"]
+```
+
+The boundaries mean:
+
+- **Request plan** is one internal, prescriptive value containing the resolved
+  model, operation, named API surface, normalized options, transport, and
+  warnings. Separate profile, mode, surface, and policy types are introduced
+  only if repeated implementation pressure proves they reduce complexity.
+- **Provider adapters** keep the current `ReqLLM.Provider` contract working
+  throughout V1.
+- **Provider seams** are extracted only where they remove measured duplication;
+  V1 does not create a protocol hierarchy for its own sake.
+- **Event projection** derives richer events from the one consumable stream; it
+  does not add a second independently consumed stream.
+- **Materialization** consolidates the existing `ChunkAccumulator` and
+  `ResponseBuilder` paths instead of introducing a parallel accumulator stack.
+- Compatibility evidence informs support claims and tests, never live runtime
+  routing.
+
+These internals can arrive while the existing facade and provider behavior
+remain available throughout V1.
+
+## What to harvest
+
+This roadmap combines four sources:
+
+1. the current ReqLLM 1.17 architecture and public API;
+2. reusable scenario work on origin/v2/reqllm-next-architecture at 893222c6;
+3. architecture experiments in the separate reqllm_next prototype; and
+4. ideas from Vercel AI SDK 7, released June 25, 2026.
+
+| Source | Keep | Do not copy directly |
+| --- | --- | --- |
+| Closed architecture branch | Reusable capability scenarios, stable fixtures, semantic tags, scenario-level evidence, generated modality coverage | The test-only registry/runtime split, duplicated Mix-task mappings, and a large hand-maintained taxonomy |
+| reqllm_next | Scenario contracts, explicit surface names, materializer tests, output-item experiments, support evidence, and focused provider slices | Its full profile/mode/surface/plan stack, a wholesale rewrite, a 230-module migration, mandatory compile-time manifests, a higher Elixir floor without product need, or Spec Led/Spark runtime requirements |
+| Vercel AI SDK 7 | Stable functional generation, structured outputs on text generation, rich stream parts, normalized tool contracts, timeouts, telemetry integrations, and provider metadata | Agent loops, approvals, workflow durability, JavaScript UI protocols, or experimental harness/sandbox abstractions in ReqLLM core |
+
+The closed branch should be mined commit by commit, not reopened or merged. The
+prototype is a design laboratory and executable reference, not the future
+package tree.
+
+## Decision rule for V2
+
+Do not create V2 merely because internals change. A proposed break must satisfy
+all of these:
+
+1. it removes silent wrongness, unlocks a major capability, or materially lowers
+   ongoing provider maintenance;
+2. an additive API would leave two confusing long-lived ways to do the same
+   thing;
+3. migration is mechanical and can be documented or checked automatically;
+4. a working V1 bridge has been available for at least two minor releases; and
+5. the accepted breaks form a coherent release rather than an isolated cleanup.
+
+Until that threshold is met, use adapters, opt-in policies, and deprecations.
+
+## Product metrics
+
+- percentage of first-class models with current scenario evidence;
+- buffered-stream versus non-stream semantic parity rate;
+- percentage of unsupported or ignored options producing a warning or error;
+- median time to diagnose fixture/live provider failures by layer;
+- provider additions that require shared-core branching;
+- deprecation adoption and remaining legacy call sites in public examples;
+- time to first working call from a new project;
+- percentage of errors with a remediation and correlation ID;
+- Jido integrations requiring no provider-specific response branching; and
+- compatibility issues per minor release.
+
+## Decisions needed
+
+1. Should the next year prioritize model-runtime reliability, the Jido extension
+   contract, or provider/modality breadth? Recommendation: reliability first,
+   Jido extensions second, breadth third.
+2. Is implementing ReqLLM.Provider a formally supported public extension surface
+   or package-internal despite being callable?
+3. Should V1 normalize structured-output failures to warnings, or preserve each
+   provider's current default while offering strict opt-in validation?
+4. Should a legacy StreamChunk projection remain for the full V2 release line?
+5. Should the Jido adapter live in Jido or a separately versioned optional
+   integration package? Recommendation: Jido unless release cadence proves
+   painful.
+6. Is two minor releases enough for deprecation, or should popular APIs receive
+   six months plus two minors?
+7. Which Elixir and OTP support window reflects the current user base?
+
+## External references
+
+The Vercel ideas were reviewed from official sources on July 16, 2026:
+
+- [AI SDK 7 announcement](https://vercel.com/blog/ai-sdk-7)
+- [AI SDK 7 detailed changelog](https://vercel.com/changelog/ai-sdk-7)
+- [AI SDK 7 migration guide](https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0)
+- [AI SDK tool calling](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling)
+- [AI SDK structured output](https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data)
+- [AI SDK streaming result](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text)
+
+The relevant lesson is not API-name parity or copying Vercel's agent runtime. It
+is the value of stable functional generation, rich tool/result contracts,
+timeouts, and observability beneath orchestration. ReqLLM should provide that
+model boundary; Jido should own the loop.

--- a/ROADMAP_V1.md
+++ b/ROADMAP_V1.md
@@ -1,0 +1,350 @@
+# ReqLLM 1.x Roadmap
+
+> Backward-compatible evolution — discussion draft, July 16, 2026
+
+[Back to the roadmap index](ROADMAP.md) ·
+[V1 execution goal](V1_EXECUTION_GOAL.md) ·
+[V2 roadmap](ROADMAP_V2.md) ·
+[Master tracking issue #829](https://github.com/agentjido/req_llm/issues/829)
+
+ReqLLM 1.x should evolve in place. New contracts are additive, internal
+architecture moves behind adapters, stricter behavior is opt-in, and removals or
+default changes wait for V2. The goal is a safer model runtime with a familiar
+facade, not a disguised rewrite.
+
+## V1 compatibility rules
+
+- Preserve generate_text/3, stream_text/3, generate_object/4,
+  stream_object/4, existing return tuples, and current model input forms.
+- Preserve Response, StreamResponse, StreamChunk, message, tool, usage, and
+  error semantics, including public struct keys/defaults, `Map.from_struct/1`,
+  `Inspect`, JSON output, public error terms, and bang exception behavior.
+- Keep the current provider behavior available through an adapter for all of V1.
+- Introduce opt-in strictness before changing a default.
+- Give every deprecation an actionable warning, migration example, target
+  release, and at least two minor releases before removal.
+- Treat silent loss or contradiction of documented input as a bug fix, with a
+  regression test and release note.
+- Keep agent loops, approvals, memory, durable execution, and retries across
+  model calls in Jido.
+
+## Milestones
+
+### Milestone 0 — Publish the compatibility promise
+
+Document stable, experimental, and deprecated contracts; lock the public facade
+and provider extension behavior with tests; expose evidence-based support tiers.
+
+**Exit:** users can tell what is stable, what is experimental, and what ReqLLM
+has actually verified.
+
+### Milestone 1 — Scenario-driven compatibility
+
+Harvest the reusable scenarios from origin/v2/reqllm-next-architecture into one
+compiled declarative catalog. Make tests, fixtures, Mix tasks, support evidence,
+and the generated coverage view share the same IDs and applicability rules.
+
+Replay stays the normal CI path. A sparse scheduled live lane detects provider
+drift without making routine CI credential-dependent.
+
+**Exit:** major runtime refactors can be measured against the same public
+scenarios before and after the change.
+
+### Milestone 2 — Deterministic planning behind the facade
+
+Normalize accepted model inputs correctly and introduce one small internal
+request-plan value with a named provider surface, normalized options, transport,
+and warnings. Route provider surfaces through it incrementally. Add namespaced
+provider options and harden the canonical reasoning options already present on
+`main` without removing legacy inputs.
+
+**Exit:** a request can be explained before execution, and invalid
+provider/feature/transport combinations fail before network I/O.
+
+### Milestone 3 — Canonical results and streaming
+
+Add canonical output projections and call metadata only where existing response
+values lose meaning. Add a tagged event projection over the one consumable
+legacy stream, consolidate the existing accumulator and response builders, and
+make total-call, request, idle, and cancellation semantics explicit without
+duplicating timeout controls.
+
+**Exit:** buffering a stream and making the equivalent non-streaming call
+produce semantically equivalent canonical results.
+
+### Milestone 4 — Structured output contracts
+
+Add text, object, array, choice, and JSON output descriptors to text generation.
+Keep generate_object and stream_object as convenience wrappers. Add explicit
+strict, warning, and permissive validation plus visible, bounded repair.
+
+**Exit:** a structured success cannot violate its declared final contract
+without an explicit permissive policy and warning.
+
+### Milestone 5 — Tool and orchestration extensions
+
+Harden the existing Tool, ToolCall, and ToolResult values, distinguish
+application results from model-facing result content, provide pure serializable
+continuation helpers, and document/test the public one-call host boundary.
+ReqLLM does not add a parallel invocation facade and never starts a follow-up
+model call.
+
+Jido owns loop termination, step limits, approvals, model/tool selection,
+cross-call retries, memory, checkpointing, resumption, delegation, durability,
+and sandbox lifecycle.
+
+**Exit:** Jido can drive and persist a provider-independent tool loop using
+stable ReqLLM contracts while ReqLLM remains a one-call runtime.
+
+### Milestone 6 — Provider extension ergonomics
+
+Move first-party providers into cohesive vertical slices and extract narrower
+wire, transport, and materialization seams only where current code demonstrates
+duplication. Harden and document the local provider registration already on
+`main`. Defer a general middleware framework, and consider a manifest only after
+plain module/data declarations demonstrate concrete limits.
+
+**Exit:** a compatible provider surface normally adds one focused slice and
+scenario evidence rather than branches throughout shared code.
+
+### Milestone 7 — Observability and developer experience
+
+Stabilize a small redacted telemetry core and its timings, then add doctor,
+sanitized plan/route diagnostics, and machine-readable deprecation/migration
+tooling. Provider-specific telemetry remains experimental unless real consumer
+evidence requires stability.
+
+**Exit:** common failures identify the failed layer, selected surface,
+remediation, and a safe correlation ID.
+
+### Milestone 8 — Files, media, realtime, and provider-native depth
+
+Add opt-in ownership and lifecycle to provider file references without changing
+legacy content parts, then expose transcription and speech metadata through
+opt-in detailed results. Harden OCR and realtime one family at a time while
+preserving exact legacy results and errors. Image and reranking result
+normalization already exists on `main`. Preserve operation entrypoints and
+dedicated result types without forcing every modality through chat.
+
+MCP and provider-trained tools stay provider-scoped or in optional packages.
+Realtime shares canonical events but leaves session orchestration to the
+application or Jido.
+
+**Exit:** a new modality reuses core contracts while retaining an explicit
+operation lifecycle.
+
+## Issue strategy
+
+Issue #829 is the only V1 master tracker. The audit considered all 42 proposed
+issues, #831 through #872. It leaves 36 active implementation issues; three are
+already satisfied by current `main`, two are consolidated into stronger issues,
+and one speculative framework is deferred. Each active issue maps to one pull
+request and one Conventional Commit squash title.
+
+The implementation backlog follows these rules:
+
+1. One issue closes through one pull request. The squash title is the changelog
+   unit.
+2. A pull request may include the contract, implementation, tests, fixtures, and
+   directly affected documentation for one coherent outcome.
+3. Group work only when it has one compatibility classification, rollback
+   boundary, and validation story.
+4. Keep separate issues for different provider surfaces, independent public API
+   features, and different media operations.
+5. Open backlog does not mean active execution. Work the dependency order and
+   take only one ticket through implementation, review, hardening, and merge at
+   a time.
+6. New scope beyond the 36 active tickets requires an explicit roadmap decision.
+7. If a ticket grows beyond one reviewable pull request, split or re-scope it
+   before implementation begins and record the decision in #829.
+
+Priority means:
+
+- **P0:** compatibility safety, evidence, and known correctness.
+- **P1:** planning, result, and streaming foundations.
+- **P2:** structured output and Jido-facing tool contracts.
+- **P3:** provider extensibility, observability, and developer experience.
+- **P4:** files, media, realtime, and provider-native depth.
+
+## Concrete ticket backlog
+
+### P0 — Compatibility safety and evidence
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 1 | [#831](https://github.com/agentjido/req_llm/issues/831) | Define compatibility and ReqLLM/Jido runtime boundaries | <code>docs: define ReqLLM 1.x compatibility boundaries</code> | — |
+| 2 | [#832](https://github.com/agentjido/req_llm/issues/832) | Inventory existing tests and fill public/provider-extension contract gaps | <code>test: lock ReqLLM public extension contracts</code> | #831 |
+| 3 | [#833](https://github.com/agentjido/req_llm/issues/833) | Stop silently discarding tuple model options | <code>fix: handle tuple model specification options</code> | #832 |
+| 4 | [#834](https://github.com/agentjido/req_llm/issues/834) | Introduce the compiled compatibility scenario catalog | <code>refactor: centralize compatibility scenario metadata</code> | #832 |
+| 5 | [#835](https://github.com/agentjido/req_llm/issues/835) | Consolidate current scenarios and fixture guardrails | <code>test: consolidate compatibility scenarios</code> | #834 |
+| 6 | [#836](https://github.com/agentjido/req_llm/issues/836) | Produce evidence-backed coverage and support tiers | <code>feat: add evidence-backed model support tiers</code> | #835 |
+| 7 | [#837](https://github.com/agentjido/req_llm/issues/837) | Add sparse live provider drift verification | <code>ci: add sparse live provider drift verification</code> | #836 |
+
+Issues #833 and #834 can proceed independently after #832. The #834 → #835 →
+#836 → #837 chain is intentionally sequential so catalog, evidence, and CI
+contracts are learned in order.
+
+### P1 — Planning and inputs
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 8 | [#838](https://github.com/agentjido/req_llm/issues/838) | Introduce one small deterministic internal request-plan value | <code>refactor: add internal request planning</code> | #832, #833 |
+| 9 | [#839](https://github.com/agentjido/req_llm/issues/839) | Route OpenAI Chat Completions and Responses selection through the plan | <code>refactor: plan OpenAI text requests</code> | #838 |
+| 10 | [#841](https://github.com/agentjido/req_llm/issues/841) | Route Anthropic Messages through the plan | <code>refactor: plan Anthropic Messages requests</code> | #838 |
+| 11 | [#842](https://github.com/agentjido/req_llm/issues/842) | Expose a small sanitized plan and route summary | <code>feat: add execution plan inspection</code> | #839, #841 |
+| 12 | [#843](https://github.com/agentjido/req_llm/issues/843) | Harden existing canonical reasoning translation and warnings | <code>fix: harden canonical reasoning options</code> | #838 |
+| 13 | [#844](https://github.com/agentjido/req_llm/issues/844) | Accept namespaced provider options beside the V1 legacy shape | <code>feat: add namespaced provider options</code> | #838 |
+
+The request plan stays one coherent internal contract. OpenAI owns both of its
+existing text API surfaces in one dispatcher, so they migrate together rather
+than through two overlapping pull requests. Anthropic remains a separate parity
+slice. Reasoning hardening and provider-option namespacing remain independently
+revertible.
+
+### P1 — Canonical results and streaming
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 14 | [#845](https://github.com/agentjido/req_llm/issues/845) | Add computed output and call-metadata projections without changing Response or legacy JSON | <code>feat: add model call projections</code> | #832 |
+| 15 | [#846](https://github.com/agentjido/req_llm/issues/846) | Add one canonical event projection without a second consumable stream | <code>feat: add canonical stream event projections</code> | #845 |
+| 16 | [#847](https://github.com/agentjido/req_llm/issues/847) | Consolidate OpenAI Chat Completions on the existing accumulator and response builder | <code>refactor: share OpenAI Chat Completions result materialization</code> | #839, #845, #846 |
+| 17 | [#848](https://github.com/agentjido/req_llm/issues/848) | Adopt shared materialization for OpenAI Responses | <code>refactor: share OpenAI Responses materialization</code> | #839, #847 |
+| 18 | [#849](https://github.com/agentjido/req_llm/issues/849) | Adopt shared materialization for Anthropic Messages | <code>refactor: share Anthropic Messages materialization</code> | #841, #847 |
+| 19 | [#850](https://github.com/agentjido/req_llm/issues/850) | Unify total-call, existing request-timeout, idle, cancellation, and terminal semantics | <code>feat: add model call timeout budgets</code> | #846 |
+
+Output items and call metadata form one result contract. The stream bridge is a
+separate public capability. Materializer adoption stays isolated by provider
+surface so each migration remains measurable and revertible.
+
+### P2 — Structured outputs, tools, and Jido extensions
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 20 | [#851](https://github.com/agentjido/req_llm/issues/851) | Add text, object, array, choice, and JSON output descriptors plus output contracts on text generation | <code>feat: add structured output contracts</code> | #845 |
+| 21 | [#852](https://github.com/agentjido/req_llm/issues/852) | Make existing extraction, repair, and final validation explicit without a general coercion framework | <code>feat: add visible structured output validation policies</code> | #851 |
+| 22 | [#853](https://github.com/agentjido/req_llm/issues/853) | Harden the existing Tool, ToolCall, and ToolResult exchange contracts | <code>feat: harden canonical tool exchange contracts</code> | #845 |
+| 23 | [#854](https://github.com/agentjido/req_llm/issues/854) | Add minimal pure helpers for appending matched tool calls and results to Context | <code>feat: add tool context continuation helpers</code> | #853 |
+| 24 | [#855](https://github.com/agentjido/req_llm/issues/855) | Document and test the existing one-call host boundary without a parallel facade | <code>docs: define the one-call host integration contract</code> | #846, #853, #854 |
+
+ReqLLM ends each operation after one model interaction. Issue #855 documents and
+tests the existing public host boundary but does not add a parallel facade, loop
+termination, approvals, memory, cross-call retries, checkpointing, durability,
+or a Jido runtime dependency.
+
+### P3 — Provider architecture and extensions
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 25 | [#856](https://github.com/agentjido/req_llm/issues/856) | Extract only measured OpenAI Chat Completions provider seams around current modules | <code>refactor: separate OpenAI Chat Completions provider seams</code> | #847 |
+| 26 | [#859](https://github.com/agentjido/req_llm/issues/859) | Decide from implementation evidence whether a provider extension manifest is earned | <code>docs: decide the provider extension manifest</code> | #832, #856 |
+
+Provider seams are proven on one reference surface before further migrations.
+Current `Providers.register/1`, `:custom_providers`, and inline model specs already
+cover local registration, so their remaining conformance belongs in #832 and
+planning/evidence tickets. A general middleware framework is deferred. The
+manifest decision is an evidence-backed architecture record, not a commitment
+to a compile-time framework.
+
+### P3 — Observability and developer experience
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 27 | [#860](https://github.com/agentjido/req_llm/issues/860) | Stabilize the small public telemetry core and classify all other events as experimental | <code>feat: stabilize ReqLLM runtime telemetry</code> | #838, #845, #846, #850 |
+| 28 | [#861](https://github.com/agentjido/req_llm/issues/861) | Add environment and configuration diagnostics through mix req_llm.doctor | <code>feat: add ReqLLM environment diagnostics</code> | #842 |
+| 29 | [#863](https://github.com/agentjido/req_llm/issues/863) | Add a deprecation ledger and only precise mechanical V2 migration checks | <code>feat: add the V2 migration audit</code> | #831, #844, #846, #852 |
+
+These tickets build on the telemetry and OpenTelemetry support already present
+in ReqLLM. A safe route and translated-option-key summary is part of #842;
+encoded request previews are deferred because they duplicate provider encoding
+and materially increase leak risk.
+
+### P4 — Files, media, realtime, and provider-native depth
+
+| Order | Issue | Outcome | Squash/PR title | Depends on |
+| ---: | --- | --- | --- | --- |
+| 30 | [#864](https://github.com/agentjido/req_llm/issues/864) | Add opt-in provider ownership without changing legacy ContentPart values or encoding | <code>feat: add owned provider file references</code> | #832 |
+| 31 | [#865](https://github.com/agentjido/req_llm/issues/865) | Add provider-scoped OpenAI file uploads without making uploads a universal abstraction | <code>feat: add OpenAI file uploads</code> | #864 |
+| 32 | [#867](https://github.com/agentjido/req_llm/issues/867) | Add opt-in transcription call metadata without expanding Transcription.Result | <code>feat: add transcription call metadata</code> | #832, #860 |
+| 33 | [#868](https://github.com/agentjido/req_llm/issues/868) | Add opt-in speech call metadata without expanding Speech.Result | <code>feat: add speech call metadata</code> | #832, #860 |
+| 34 | [#870](https://github.com/agentjido/req_llm/issues/870) | Harden OCR observability while preserving exact success, error, and bang behavior | <code>fix: harden OCR operation observability</code> | #832, #860 |
+| 35 | [#871](https://github.com/agentjido/req_llm/issues/871) | Map only exact realtime event overlap while preserving provider-native events | <code>refactor: normalize OpenAI realtime events</code> | #846, #853, #860 |
+| 36 | [#872](https://github.com/agentjido/req_llm/issues/872) | Define MCP, provider-native tool, and future operation boundaries | <code>docs: define provider-native integration boundaries</code> | #831, #853, #855, #864 |
+
+Each existing operation remains explicit. These tickets normalize shared result,
+usage, warning, and telemetry contracts without forcing every modality through
+chat or pulling orchestration into ReqLLM.
+
+## Streamlining audit of all 42 proposals
+
+The July 16 audit checked every issue against current `main`, the
+`reqllm_next` prototype, and the one-PR/backward-compatibility rules.
+
+| Original order | Issue | Disposition | Reason |
+| ---: | --- | --- | --- |
+| 1 | #831 | Keep | Compatibility and ReqLLM/Jido ownership must precede refactors. |
+| 2 | #832 | Narrow | Inventory existing tests and fill contract gaps instead of duplicating the suite. |
+| 3 | #833 | Keep | Accepted tuple defaults are currently discarded and need one boundary fix. |
+| 4 | #834 | Keep | Mechanical catalog extraction removes duplicated Mix-task routing. |
+| 5 | #835 | Keep | Scenario enrichment remains separate from the mechanical extraction. |
+| 6 | #836 | Narrow | Evidence comes first; support labels remain conservative tooling output. |
+| 7 | #837 | Keep | Sparse live drift detection complements replay without changing normal CI. |
+| 8 | #838 | Narrow | Use one request-plan value, not the prototype's profile/mode/surface/plan stack. |
+| 9 | #839 | Expand coherently | The existing OpenAI dispatcher owns Chat and Responses selection, so migrate both together. |
+| 10 | #840 | Consolidate into #839 | A second OpenAI surface-selection PR would duplicate the same dispatcher change. |
+| 11 | #841 | Keep | Anthropic is the useful non-OpenAI parity proof. |
+| 12 | #842 | Narrow | Expose a small experimental diagnostic map, not internal planner structs or raw bodies. |
+| 13 | #843 | Recast | Canonical reasoning options already exist; harden translation and warning propagation. |
+| 14 | #844 | Keep | Provider-keyed options are a useful additive bridge while flat provider options remain. |
+| 15 | #845 | Narrow | Add computed projections without changing Response fields, defaults, or legacy JSON. |
+| 16 | #846 | Narrow | Add an event projection over one stream, not a second consumable stream field. |
+| 17 | #847 | Recast | Consolidate the existing ChunkAccumulator and ResponseBuilder paths. |
+| 18 | #848 | Keep | The buffered OpenAI Responses decoder still diverges from its stream builder. |
+| 19 | #849 | Keep | The buffered Anthropic decoder still diverges from its stream builder. |
+| 20 | #850 | Narrow | Add total and idle semantics around existing request timeouts rather than duplicate knobs. |
+| 21 | #851 | Keep | Output descriptors are a high-value additive API aligned with the AI SDK. |
+| 22 | #852 | Narrow | Make current extraction/repair visible; avoid a general coercion or hidden model-repair framework. |
+| 23 | #853 | Recast | Harden the existing tool structs instead of creating parallel exchange types. |
+| 24 | #854 | Narrow | Add only matched-call/result helpers on top of existing Context operations. |
+| 25 | #855 | Recast | Document and test the public one-call boundary; the actual Jido adapter stays in Jido. |
+| 26 | #856 | Narrow | Extract measured seams from current OpenAI modules, not four new behavior hierarchies. |
+| 27 | #857 | Already satisfied | Providers.register/1, :custom_providers, inline models, docs, and tests are on main. |
+| 28 | #858 | Defer | A four-stage global/per-call middleware framework is speculative and would expand the V1 runtime surface. |
+| 29 | #859 | Keep | A later ADR can decide whether the prototype manifest earned its complexity. |
+| 30 | #860 | Narrow | Stabilize a small telemetry core and explicitly leave provider/detail events experimental. |
+| 31 | #861 | Keep | Read-only diagnostics directly improve support and onboarding. |
+| 32 | #862 | Consolidate into #842 | Route and option-key summaries are useful; encoded request previews duplicate encoding and raise leak risk. |
+| 33 | #863 | Narrow | Keep the ledger and only static checks with low false-positive risk. |
+| 34 | #864 | Recast | Add explicit ownership metadata only for opt-in references; legacy ContentPart values and encoding remain exact. |
+| 35 | #865 | Keep | OpenAI upload lifecycle is valuable and correctly provider-scoped. |
+| 36 | #866 | Already satisfied | Image APIs already return Response plus ContentPart, usage, provider metadata, and revised prompts. |
+| 37 | #867 | Recast | Return opt-in detailed metadata without expanding Transcription.Result. |
+| 38 | #868 | Recast | Return opt-in detailed metadata without expanding Speech.Result. |
+| 39 | #869 | Already satisfied | RerankResponse already preserves indices, sorting, batching, warnings, usage/cost, and telemetry. |
+| 40 | #870 | Recast | Preserve exact OCR success, error, and bang behavior while hardening internal classification, telemetry, and evidence. |
+| 41 | #871 | Narrow | Canonicalize only exact event overlap and retain OpenAI-native session semantics. |
+| 42 | #872 | Keep | The boundary document prevents provider-native depth from becoming an agent runtime. |
+
+## Execution cadence
+
+The [V1 execution goal](V1_EXECUTION_GOAL.md) is the delivery charter. Although
+the backlog records dependency opportunities, implementation is intentionally
+serial:
+
+1. Work the first open, unblocked issue in the priority order above.
+2. Take one issue through implementation, review, hardening, merge, and green
+   post-merge `main` checks before starting another.
+3. Pull the next unblocked active ticket from #831–#872 only after the current
+   delivery cycle is complete.
+4. Track completion and scope decisions in #829.
+5. Treat the 36 active tickets recorded above as the complete V1 roadmap. Any
+   issue beyond this set needs an explicit scope expansion recorded in #829.
+
+## V1 completion gates
+
+- All new contracts have executable public or conformance tests.
+- Legacy inputs and projections remain covered until V2.
+- Provider adoption occurs by named surface with before/after scenario parity.
+- No V1 ticket introduces a Jido runtime dependency or model-call loop.
+- Deprecations are present in the ledger and audit tooling.
+- V2 default changes remain opt-in throughout V1.
+- Support claims are derived from current evidence rather than catalog presence.

--- a/ROADMAP_V1.md
+++ b/ROADMAP_V1.md
@@ -3,6 +3,7 @@
 > Backward-compatible evolution — discussion draft, July 16, 2026
 
 [Back to the roadmap index](ROADMAP.md) ·
+[Compatibility policy](COMPATIBILITY.md) ·
 [V1 execution goal](V1_EXECUTION_GOAL.md) ·
 [V2 roadmap](ROADMAP_V2.md) ·
 [Master tracking issue #829](https://github.com/agentjido/req_llm/issues/829)

--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -1,0 +1,162 @@
+# ReqLLM 2.0 Roadmap
+
+> Intentional breaking changes — discussion draft, July 16, 2026
+
+[Back to the roadmap index](ROADMAP.md) ·
+[V1 roadmap](ROADMAP_V1.md) ·
+[Master tracking issue #830](https://github.com/agentjido/req_llm/issues/830)
+
+ReqLLM 2.0 is a controlled contract migration built on V1 bridges, not a port of
+the reqllm_next prototype. It acknowledges that the changes below break existing
+callers and limits the major release to breaks with clear user or maintenance
+return.
+
+## Scope
+
+### 1. Remove deprecated bang streaming APIs
+
+Remove stream_text! and stream_object!, which currently warn and return :ok
+instead of a stream.
+
+- **Why it is worth considering:** bang normally communicates exception
+  behavior, but these functions do not return a usable stream. Keeping them
+  creates a misleading API.
+- **V1 bridge:** stream_text/stream_object plus StreamResponse projections.
+- **Migration:** replace the bang function with its non-bang counterpart and
+  consume the returned StreamResponse.
+- **Success measure:** the migration audit finds no bang streaming calls in
+  ReqLLM examples or known first-party dependents.
+
+### 2. Make canonical tagged events the default raw stream
+
+Change the primary raw streaming contract from the four-type StreamChunk shape
+to canonical lifecycle and output events.
+
+- **Why it is worth considering:** tool calls, reasoning, sources, files,
+  warnings, cancellation, and provider metadata need explicit lifecycle
+  semantics. Continuing to overload a small chunk struct makes extensions
+  ambiguous.
+- **V1 bridge:** StreamResponse.events plus explicit text, item, event, and
+  legacy-chunk projections.
+- **Migration:** select the projection the consumer actually needs; consumers of
+  raw streams move to tagged events.
+- **Compatibility option:** retain an explicitly named legacy projection if its
+  maintenance cost remains small, but do not retain ambiguous .stream semantics.
+- **Success measure:** buffering canonical events and making the equivalent
+  non-streaming call produce semantically equivalent results.
+
+### 3. Replace the legacy provider extension behavior
+
+Make the stable V2 provider extension contract use explicit planning, semantic
+protocol, wire, transport, and response seams.
+
+- **Why it is worth considering:** the monolithic behavior couples request
+  intent, provider meaning, HTTP details, streaming, and materialization. The
+  coupling increases provider maintenance and parity drift.
+- **V1 bridge:** the legacy behavior remains supported through an adapter while
+  first-party providers move one surface at a time.
+- **Migration:** third-party providers adopt the narrower contracts with a
+  focused author guide and conformance suite.
+- **Gate:** survey actual third-party provider authors before freezing the V2
+  extension SDK.
+- **Success measure:** adding a compatible provider surface does not require
+  branching through shared execution code.
+
+### 4. Require namespaced provider options
+
+Reject ambiguous legacy flat provider options and require provider-keyed
+options.
+
+- **Why it is worth considering:** flat shapes can silently forward, collide,
+  or be ignored when callers change models.
+- **V1 bridge:** accept both shapes, normalize once, validate foreign keys, and
+  warn on legacy or conflicting input.
+- **Migration:** move provider-specific keys beneath the relevant provider name;
+  keep cross-provider options such as reasoning in the canonical option set.
+- **Success measure:** every unknown or foreign provider option produces a
+  deterministic error before I/O.
+
+### 5. Make strict final structured-output validation the default
+
+Return an error when the final materialized value violates its declared output
+contract unless the caller explicitly selects a permissive policy.
+
+- **Why it is worth considering:** a successful structured response that violates
+  its schema is silent wrongness and pushes provider-dependent validation into
+  every application.
+- **V1 bridge:** explicit strict, warning, and permissive/coercion policies;
+  structured warnings; final-value validation; bounded opt-in repair.
+- **Migration:** fix invalid schemas or explicitly request permissive behavior
+  where partial tolerance is intentional.
+- **Success measure:** no successful strict response violates its declared final
+  contract.
+
+## Bridge matrix
+
+| V2 break | Required V1 bridge | Minimum evidence before acceptance |
+| --- | --- | --- |
+| Remove bang streaming APIs | Non-bang APIs, projections, warnings, migration audit | Two minor releases and no first-party uses |
+| Canonical events become raw default | Event stream and explicit legacy projection | Stream/non-stream parity across anchor providers |
+| Replace provider behavior | Legacy adapter and first-party vertical slices | Ecosystem survey plus third-party conformance proof |
+| Require namespaced provider options | Dual-form normalization and warnings | Static audit and usage telemetry where available |
+| Strict validation becomes default | Explicit policies and structured warnings | Provider matrix for object/array/choice/JSON contracts |
+
+## Entry gates
+
+Every gate is required before a V2 release candidate:
+
+- each breaking item has shipped as an additive V1 bridge for at least two minor
+  releases;
+- public compatibility scenarios cover old and new behavior before default
+  changes;
+- each mechanical change has a migration guide and, where useful, a static Mix
+  task check;
+- third-party provider authors have been surveyed before the extension contract
+  freezes;
+- the release candidate passes the same model/surface/scenario evidence as the
+  latest V1 release;
+- the supported Elixir/OTP window comes from ecosystem need, not the prototype;
+  and
+- each break can be independently reverted during the release-candidate cycle.
+
+## Release sequencing
+
+1. Freeze the list of accepted breaks; additions after the first release
+   candidate wait for a later major.
+2. Publish a V1 migration release with all bridges, warnings, and audit tooling.
+3. Measure adoption for at least two V1 minor releases.
+4. Publish the V2 migration guide before the first release candidate.
+5. Land one breaking change per pull request so release history identifies the
+   exact contract change and rollback point.
+6. Run compatibility evidence after every breaking pull request.
+7. Release V2 only when all accepted changes and docs pass the entry gates.
+
+The V2 tracker may group the release, but implementation issues and pull requests
+must not combine multiple breaking changes.
+
+## Explicit non-goals
+
+- Do not move agent loops, approvals, memory, checkpointing, retries across model
+  calls, or durability into ReqLLM; those remain Jido concerns.
+- Do not remove tuple or plain-map model inputs solely for API purity.
+- Do not change Response.model to an LLMDB.Model when an additive resolved
+  profile field is sufficient.
+- Do not remove generate_object or stream_object; keep them as convenience
+  wrappers over the output contract.
+- Do not copy the reqllm_next module tree or require its development workflow as
+  ReqLLM runtime architecture.
+- Do not raise the Elixir requirement solely to match the prototype.
+- Do not bundle unrelated naming cleanups into the major release.
+- Do not treat a major version as permission for an unmeasured rewrite.
+
+## Decisions required before V2 planning
+
+1. Is the provider behavior a promised third-party extension API?
+2. Does the legacy StreamChunk projection remain for all of V2?
+3. Which structured-output policy should V1 use before strict becomes the V2
+   default?
+4. Is the deprecation window two minor releases, or six months plus two minors?
+5. Which Elixir and OTP versions must V2 support?
+
+Until the V1 bridges provide evidence for these decisions, V2 remains a bounded
+candidate roadmap rather than a release commitment.

--- a/V1_EXECUTION_GOAL.md
+++ b/V1_EXECUTION_GOAL.md
@@ -4,6 +4,7 @@
 
 [Roadmap index](ROADMAP.md) ·
 [V1 roadmap](ROADMAP_V1.md) ·
+[Compatibility policy](COMPATIBILITY.md) ·
 [V1 master tracker #829](https://github.com/agentjido/req_llm/issues/829)
 
 ## Goal

--- a/V1_EXECUTION_GOAL.md
+++ b/V1_EXECUTION_GOAL.md
@@ -1,0 +1,275 @@
+# ReqLLM V1 Execution Goal
+
+> Active execution charter — July 16, 2026
+
+[Roadmap index](ROADMAP.md) ·
+[V1 roadmap](ROADMAP_V1.md) ·
+[V1 master tracker #829](https://github.com/agentjido/req_llm/issues/829)
+
+## Goal
+
+Complete the ReqLLM V1 roadmap one issue at a time while preserving the
+behavior that existing applications and third-party providers rely on. Every
+issue must leave `main` at least as understandable, maintainable, and well
+tested as it was before the work began.
+
+Quality and backward compatibility are the primary constraints. Delivery speed,
+architectural novelty, and roadmap completion never justify weakening them.
+
+The desired end state is:
+
+- every active V1 issue is either merged or closed with an evidence-backed
+  disposition;
+- every merged issue is represented by one focused pull request and one clear
+  Conventional Commit in release history;
+- `main` passes the complete local quality suite and required GitHub checks;
+- public compatibility is protected by characterization, regression, and
+  conformance tests; and
+- the implementation is simpler, more cohesive, or easier to extend without
+  moving agent orchestration into ReqLLM.
+
+## Sources of truth
+
+- [ROADMAP_V1.md](ROADMAP_V1.md) defines the ordered backlog, dependencies,
+  compatibility posture, and intended squash titles.
+- [Issue #829](https://github.com/agentjido/req_llm/issues/829) records live
+  progress, dispositions, dependency changes, and scope decisions.
+- Each child issue defines the contract and acceptance criteria for its one
+  pull request.
+- GitHub Actions and the checked-out `main` branch define the current validation
+  baseline.
+
+The roadmap order is the default execution order. Start only the first open,
+unblocked issue. Do not implement multiple V1 issues in one branch or pull
+request, even when later work appears adjacent.
+
+## The one-issue delivery loop
+
+Repeat this loop until every active V1 roadmap issue has been addressed.
+
+### 1. Establish a clean baseline
+
+1. Fetch and prune the remote repository.
+2. Check out `main` and fast-forward it to `origin/main`.
+3. Confirm the working tree is clean.
+4. Confirm required GitHub checks on `main` are green.
+5. Run the smallest local baseline needed to distinguish a pre-existing failure
+   from a regression in the upcoming change.
+
+Do not build roadmap work on a red or ambiguous baseline. Investigate a failing
+baseline before creating the issue branch and record unrelated infrastructure
+failures explicitly.
+
+### 2. Revalidate the issue
+
+Before writing code:
+
+1. Confirm the issue is open, unblocked, and still matches current `main`.
+2. Read its dependencies, acceptance criteria, exclusions, and non-breaking
+   merge gate.
+3. Inspect the relevant implementation, tests, public documentation, types,
+   fixtures, telemetry, and provider callbacks.
+4. Write down the observable behavior that must remain unchanged.
+5. Reduce or clarify scope when the issue no longer fits one reviewable pull
+   request.
+
+If current `main` already satisfies the issue, close it with code and test
+evidence and update #829. If a safe V1 implementation is not possible, narrow
+the issue to an additive or internal change or move it to the V2 tracker. Do not
+force a breaking implementation merely to close a ticket.
+
+### 3. Create one focused branch
+
+Create `agent/issue-<number>-<short-description>` from the current
+`origin/main`. The branch contains only the selected issue. Preserve unrelated
+working-tree changes and do not carry planning-document edits into an
+implementation pull request.
+
+### 4. Characterize before changing
+
+Add or identify tests for every relevant legacy behavior before restructuring
+it. Prefer black-box assertions at public and provider-extension boundaries over
+tests that freeze incidental implementation details.
+
+Characterization is mandatory for changes to request encoding, response
+materialization, streaming, errors, timeouts, telemetry, fixtures, provider
+selection, or public structs. Golden assertions should be as exact as the
+contract requires.
+
+### 5. Implement the smallest complete change
+
+- Solve only the selected issue and its directly required documentation and
+  tests.
+- Prefer deleting duplication, consolidating existing paths, and naming current
+  concepts over introducing parallel abstractions.
+- Keep the existing public facade and provider behavior available throughout
+  V1.
+- Make new strictness, richer results, and provider-specific depth additive or
+  explicitly opt-in.
+- Do not add agent loops, cross-call retries, approvals, memory, checkpointing,
+  or durable orchestration to ReqLLM.
+- Do not edit `CHANGELOG.md`; the Conventional Commit is the release-history
+  unit.
+- Follow the repository rule forbidding comments inside function bodies.
+
+An implementation that increases conceptual surface without removing more
+complexity must justify that tradeoff in the pull request.
+
+### 6. Validate locally
+
+Run focused tests continuously, then run the broadest relevant validation before
+publishing:
+
+1. `mix format --check-formatted`
+2. focused unit, provider, streaming, fixture, or coverage tests for the change
+3. the full cached `mix test` suite
+4. `mix quality`
+5. relevant compatibility or model-coverage Mix tasks when scenario metadata,
+   fixtures, support evidence, or provider behavior changes
+
+Docs-only changes still require formatting, compilation, documentation checks
+where available, and enough of the test suite to prove links, examples, and
+types remain valid. Live provider calls are used only when the issue requires
+new live evidence and credentials are intentionally available; normal CI stays
+replay-based.
+
+### 7. Publish one ready pull request
+
+Stage only files belonging to the issue. Commit with the roadmap's Conventional
+Commit title, push the branch, and open a ready-for-review pull request against
+`main`.
+
+The pull request must:
+
+- close exactly one roadmap issue;
+- explain the problem, chosen design, user impact, and compatibility analysis;
+- list tests and commands run;
+- call out request, response, serialization, error, telemetry, fixture, and
+  provider-extension effects where relevant; and
+- contain no unrelated cleanup.
+
+### 8. Review and harden
+
+Perform a substantive merge-readiness review after publication. Review in this
+order:
+
+1. correctness and behavior regressions;
+2. missing or weak compatibility coverage;
+3. unnecessary architecture or avoidable duplication;
+4. merge conflicts and drift from `main`;
+5. GitHub checks and unresolved review threads.
+
+Apply `needs_work` whenever a blocker remains and remove `ready_to_merge`.
+Address every blocker on the pull-request branch, strengthen tests, rerun local
+validation, push the fixes, and review again. Apply `ready_to_merge` and remove
+`needs_work` only when the pull request is merge-clean, CI is green, coverage is
+appropriate for the risk, and no blocking comment remains.
+
+### 9. Merge and verify
+
+Squash-merge using the issue's Conventional Commit title and delete the remote
+branch only after all merge gates pass. Then:
+
+1. fast-forward the local `main` branch;
+2. verify the merge commit and issue closure;
+3. verify required post-merge checks on `main`;
+4. update #829 with the result and any scope decision; and
+5. remove stale local branches or worktrees when safe.
+
+Do not start the next issue until the merged change is green on `main`. A
+post-merge regression belongs to the current issue's delivery cycle and must be
+resolved before roadmap execution continues.
+
+## Backward-compatibility merge gate
+
+Every pull request must explicitly determine which of these contracts it
+touches and prove that untouched legacy behavior remains identical:
+
+| Contract | Required V1 evidence |
+| --- | --- |
+| Public functions | Existing names, arities, accepted inputs, defaults, return tuples, and bang behavior continue to work. |
+| Public values | Struct keys and defaults, equality, `Map.from_struct/1`, `Inspect`, and Jason output remain unchanged unless a new value is explicitly opt-in. |
+| Requests | Existing provider selection, option precedence, headers, body encoding, retry behavior, and fixture payloads remain exact outside the intended fix. |
+| Results | Response content, ordering, usage, warnings, provider metadata, and buffered/streamed parity remain compatible. |
+| Streams | Chunk order and meaning, single-consumer behavior, cancellation, terminal delivery, timeout semantics, and resource cleanup remain compatible. |
+| Errors | Public error terms and fields plus bang exception modules and messages remain exact unless the issue documents an intentional bug fix. |
+| Providers | Current `ReqLLM.Provider` callbacks, defaults, registration, inline model specs, and third-party adapters remain supported. |
+| Telemetry | Existing event names, metadata and measurement keys, value types, meanings, units, and redaction behavior remain stable. |
+| Evidence | Scenario IDs, fixture names, replay behavior, support-state semantics, and generated artifacts change only when the issue requires it. |
+| Platform | Supported Elixir and OTP versions compile and behave consistently; warnings, Dialyzer, and Credo remain clean. |
+
+Intentional correctness fixes must be narrowly tied to documented or typed
+behavior, carry a regression test, and avoid collateral request or response
+changes. When an issue cannot meet this table, it is a V2 candidate rather than
+a V1 merge.
+
+## Quality and simplification standard
+
+A roadmap pull request is successful only when it improves the system rather
+than merely relocating complexity. Prefer changes that:
+
+- remove duplicate branching or materialization paths;
+- make invalid states harder to represent internally;
+- isolate provider-specific behavior without widening the common API;
+- replace implicit behavior with inspectable data and precise warnings;
+- keep tests scenario-oriented and reusable across surfaces;
+- reduce the number of places required to add or repair a provider capability;
+- preserve a short, obvious path for the common call; and
+- make failure ownership and remediation clear.
+
+Track meaningful before-and-after evidence in the pull request: duplicated code
+removed, branches consolidated, fixtures unified, provider-specific cases
+isolated, or public behavior newly protected by tests. Raw line-count reduction
+is useful context, not a goal by itself.
+
+## Stop conditions
+
+Pause the current issue rather than merge when any of these is true:
+
+- required CI is red or missing;
+- the branch does not merge cleanly with current `main`;
+- a public compatibility effect is unknown or untested;
+- exact fixture, serialization, error, or telemetry behavior changed without an
+  accepted issue requirement;
+- a third-party provider could silently break;
+- the implementation needs more than one coherent rollback boundary;
+- a live-provider assertion is essential but cannot be established safely; or
+- review identified a correctness blocker that remains unresolved.
+
+Record the blocker in the issue and #829. Resume only when the evidence is
+available or the scope has been safely changed.
+
+## Definition of addressed
+
+An issue is addressed in exactly one of these ways:
+
+1. **Merged:** one focused pull request has passed all gates, landed on `main`,
+   closed the issue, and passed post-merge CI.
+2. **Already satisfied:** current `main` demonstrably meets the acceptance
+   criteria and the issue is closed with links to implementation and tests.
+3. **Consolidated:** the issue is a true duplicate whose complete scope is
+   represented by another V1 issue, with both issues and #829 cross-linked.
+4. **Moved out of V1:** compatibility analysis proves that the valuable form of
+   the work requires a breaking change; the rationale and V2 destination are
+   recorded before closing the V1 issue.
+5. **Not planned:** evidence shows the feature adds unjustified complexity or
+   violates the ReqLLM/Jido boundary, and the closure documents the alternative.
+
+Closing an issue without one of these evidence-backed outcomes does not count as
+roadmap progress.
+
+## Completion criteria
+
+The V1 execution goal is complete when:
+
+- all active child issues in ROADMAP_V1.md and #829 are addressed;
+- #829 contains the final disposition and pull request for every child issue;
+- no accepted V1 work remains hidden in a combined or follow-up pull request;
+- the complete cached test suite, `mix quality`, relevant compatibility tasks,
+  and required GitHub checks pass on current `main`;
+- compatibility evidence covers every new stable contract;
+- V2-only behavior remains opt-in, deprecated, or absent from V1;
+- ReqLLM still performs one model interaction per operation and Jido owns agent
+  orchestration; and
+- a final architecture review confirms that the resulting codebase is more
+  cohesive and no harder to extend than the baseline.

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,11 @@ defmodule ReqLLM.MixProject do
         main: "overview",
         extras: [
           {"README.md", title: "Overview", filename: "overview"},
+          "COMPATIBILITY.md",
+          "ROADMAP.md",
+          "ROADMAP_V1.md",
+          "ROADMAP_V2.md",
+          "V1_EXECUTION_GOAL.md",
           "CHANGELOG.md",
           "CONTRIBUTING.md",
           "guides/getting-started.md",
@@ -74,7 +79,14 @@ defmodule ReqLLM.MixProject do
         ],
         groups_for_extras: [
           Overview: [
-            "README.md"
+            "README.md",
+            "COMPATIBILITY.md"
+          ],
+          Roadmaps: [
+            "ROADMAP.md",
+            "ROADMAP_V1.md",
+            "ROADMAP_V2.md",
+            "V1_EXECUTION_GOAL.md"
           ],
           Guides: [
             "guides/getting-started.md",
@@ -250,7 +262,7 @@ defmodule ReqLLM.MixProject do
         "Website" => "https://agentjido.xyz"
       },
       files:
-        ~w(lib priv mix.exs LICENSE README.md CHANGELOG.md CONTRIBUTING.md AGENTS.md usage-rules.md guides .formatter.exs)
+        ~w(lib priv mix.exs LICENSE README.md COMPATIBILITY.md ROADMAP.md ROADMAP_V1.md ROADMAP_V2.md V1_EXECUTION_GOAL.md CHANGELOG.md CONTRIBUTING.md AGENTS.md usage-rules.md guides .formatter.exs)
     ]
   end
 


### PR DESCRIPTION
## Summary

- publish the ReqLLM 1.x compatibility policy and make it discoverable from README and HexDocs
- classify stable, experimental, deprecated, and internal contracts
- protect public functions, model inputs, values, serialization, errors, streams, provider extensions, configuration, telemetry, and compatibility evidence
- define a conservative Elixir/OTP support-change process
- make the ReqLLM/Jido one-call versus orchestration boundary concrete
- publish the V1/V2 roadmaps and serial one-issue execution charter

## Compatibility

Documentation and package metadata only. This change does not alter runtime code, public APIs, provider behavior, structs, serialization, errors, telemetry, fixtures, or dependencies.

The policy requires additive or opt-in V1 evolution, exact evidence for observable contracts, and V2 disposition when a valuable change cannot land compatibly.

## Validation

- `mix format --check-formatted`
- `mix docs -f html` — compatibility and roadmap pages rendered with working navigation
- `mix hex.build --unpack --output /tmp/req_llm-roadmap-package-873` — all linked policy and roadmap files included
- `mix test` — 3,577 passed, 11 skipped, 145 excluded
- `mix quality` — passed; Credo found no issues and Dialyzer reported zero errors
- baseline `main` CI was green at `a3010a75`

Closes #831.
Tracks #829.
Tracks #830.