### PR TITLE
fix: handle tuple model specification options

### DIFF
--- a/guides/model-specs.md
+++ b/guides/model-specs.md
@@ -56,6 +56,25 @@ Tuples also resolve through LLMDB, but let you keep the provider and model ID sp
 {:openai, id: "gpt-4o"}
 ```
 
+When a three-element tuple is passed directly to an operation, its keyword list supplies
+low-precedence defaults for options documented by that operation:
+
+```elixir
+model = {:anthropic, "claude-haiku-4-5", max_tokens: 512, temperature: 0.3}
+
+ReqLLM.generate_text(model, "Hello", temperature: 0.7)
+```
+
+Here `max_tokens: 512` is used and the explicit `temperature: 0.7` wins. An explicit
+`provider_options` value replaces a tuple's provider-options default as one option. Options
+that do not belong to the selected operation, invalid values, duplicate defaults, and
+operation-control or request-input keys are ignored with a warning rather than applied to
+the wrong request. Pass `on_unsupported: :ignore` on the call to suppress that warning.
+
+`ReqLLM.model/1` resolves only model identity. It returns the same `%LLMDB.Model{}` for
+equivalent two- and three-element tuples. The two-element keyword tuple remains an identity
+form; only the documented three-element tuple supplies operation defaults.
+
 ### 3. `%LLMDB.Model{}`
 
 This is the canonical explicit model contract in ReqLLM.

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -259,6 +259,10 @@ defmodule ReqLLM do
 
   ## Inline Models
 
+  Three-element tuple options are applied as low-precedence defaults when the tuple is
+  passed directly to an operation. Explicit operation options win. `model/1` resolves
+  only model identity, so equivalent two- and three-element tuples return the same model.
+
   For models not in the LLMDB catalog yet, use an inline model spec:
 
       model =

--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -204,6 +204,7 @@ defmodule ReqLLM.Embedding do
   def embed(model_spec, input, opts \\ [])
 
   def embed(model_spec, text, opts) when is_binary(text) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :embedding, opts)
     {return_usage, provider_opts} = Keyword.pop(opts, :return_usage, false)
 
     with {:ok, model} <- validate_model(model_spec),
@@ -234,6 +235,7 @@ defmodule ReqLLM.Embedding do
   end
 
   def embed(model_spec, texts, opts) when is_list(texts) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :embedding, opts)
     {return_usage, provider_opts} = Keyword.pop(opts, :return_usage, false)
 
     with {:ok, model} <- validate_model(model_spec),

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -514,6 +514,8 @@ defmodule ReqLLM.Generation do
           keyword()
         ) :: {:ok, ReqLLM.StreamResponse.t()} | {:error, term()}
   def stream_object(model_spec, messages, object_schema, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :object, opts)
+
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, compiled_schema} <- ReqLLM.Schema.compile(object_schema),

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -71,6 +71,8 @@ defmodule ReqLLM.Generation do
           keyword()
         ) :: {:ok, Response.t()} | {:error, term()}
   def generate_text(model_spec, messages, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :chat, opts)
+
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
@@ -146,6 +148,8 @@ defmodule ReqLLM.Generation do
           keyword()
         ) :: {:ok, ReqLLM.StreamResponse.t()} | {:error, term()}
   def stream_text(model_spec, messages, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :chat, opts)
+
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
@@ -244,6 +248,8 @@ defmodule ReqLLM.Generation do
           keyword()
         ) :: {:ok, Response.t()} | {:error, term()}
   def generate_object(model_spec, messages, object_schema, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :object, opts)
+
     opts_with_schema = fn compiled_schema ->
       Keyword.put(opts, :compiled_schema, compiled_schema)
     end

--- a/lib/req_llm/images.ex
+++ b/lib/req_llm/images.ex
@@ -138,6 +138,8 @@ defmodule ReqLLM.Images do
           keyword()
         ) :: {:ok, Response.t()} | {:error, term()}
   def generate_image(model_spec, prompt_or_messages, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :image, opts)
+
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, request} <-

--- a/lib/req_llm/model_input.ex
+++ b/lib/req_llm/model_input.ex
@@ -1,0 +1,108 @@
+defmodule ReqLLM.ModelInput do
+  @moduledoc false
+
+  @ambiguous_keys %{
+    chat: [:stream, :stream_transport, :defer_http_events_until_telemetry?, :on_finch_request],
+    object: [:stream, :stream_transport, :defer_http_events_until_telemetry?, :on_finch_request],
+    rerank: [:query, :documents]
+  }
+
+  @spec merge_tuple_defaults(ReqLLM.model_input(), atom(), keyword()) :: keyword()
+  def merge_tuple_defaults({provider, model_id, tuple_opts}, operation, call_opts)
+      when is_atom(provider) and is_binary(model_id) and is_list(call_opts) do
+    if Keyword.keyword?(tuple_opts) do
+      {defaults, ignored} = select_defaults(tuple_opts, operation)
+      warn_ignored(operation, ignored, tuple_opts, call_opts)
+      merge_defaults(defaults, call_opts)
+    else
+      warn_invalid_container(operation, call_opts)
+      call_opts
+    end
+  end
+
+  def merge_tuple_defaults(_model_input, _operation, call_opts), do: call_opts
+
+  defp select_defaults(tuple_opts, operation) do
+    schema = option_schema(operation).schema
+    ambiguous_keys = Map.get(@ambiguous_keys, operation, [])
+
+    tuple_opts
+    |> Enum.reduce({[], [], MapSet.new()}, fn {key, value}, {defaults, ignored, seen} ->
+      cond do
+        MapSet.member?(seen, key) ->
+          {defaults, [{key, :duplicate} | ignored], seen}
+
+        key in ambiguous_keys ->
+          {defaults, [{key, :ambiguous} | ignored], MapSet.put(seen, key)}
+
+        not Keyword.has_key?(schema, key) ->
+          {defaults, [{key, :unsupported} | ignored], MapSet.put(seen, key)}
+
+        valid_option?(key, value, schema) ->
+          {[{key, value} | defaults], ignored, MapSet.put(seen, key)}
+
+        true ->
+          {defaults, [{key, :invalid} | ignored], MapSet.put(seen, key)}
+      end
+    end)
+    |> then(fn {defaults, ignored, _seen} ->
+      {Enum.reverse(defaults), Enum.reverse(ignored)}
+    end)
+  end
+
+  defp valid_option?(key, value, schema) do
+    option_schema = NimbleOptions.new!([{key, Keyword.fetch!(schema, key)}])
+    match?({:ok, _validated}, NimbleOptions.validate([{key, value}], option_schema))
+  end
+
+  defp option_schema(:chat), do: ReqLLM.Generation.schema()
+  defp option_schema(:object), do: ReqLLM.Generation.schema()
+  defp option_schema(:embedding), do: ReqLLM.Embedding.schema()
+  defp option_schema(:image), do: ReqLLM.Images.schema()
+  defp option_schema(:transcription), do: ReqLLM.Transcription.schema()
+  defp option_schema(:speech), do: ReqLLM.Speech.schema()
+  defp option_schema(:rerank), do: ReqLLM.Rerank.schema()
+  defp option_schema(:ocr), do: ReqLLM.OCR.schema()
+
+  defp merge_defaults(defaults, call_opts) do
+    Keyword.merge(defaults, call_opts)
+  end
+
+  defp warn_ignored(_operation, [], _tuple_opts, _call_opts), do: :ok
+
+  defp warn_ignored(operation, ignored, tuple_opts, call_opts) do
+    if warning_enabled?(tuple_opts, call_opts) do
+      details = Enum.map_join(ignored, ", ", &format_ignored/1)
+
+      IO.warn(
+        "Ignoring tuple model defaults for #{operation}: #{details}. " <>
+          "Pass only documented #{operation} options; explicit call options take precedence."
+      )
+    end
+  end
+
+  defp warn_invalid_container(operation, call_opts) do
+    if warning_enabled?([], call_opts) do
+      IO.warn(
+        "Ignoring tuple model defaults for #{operation}: the third tuple element must be a keyword list."
+      )
+    end
+  end
+
+  defp warning_enabled?(tuple_opts, call_opts) do
+    policy =
+      Keyword.get(call_opts, :on_unsupported, Keyword.get(tuple_opts, :on_unsupported, :warn))
+
+    policy != :ignore
+  end
+
+  defp format_ignored({key, :duplicate}), do: "#{inspect(key)} is duplicated"
+
+  defp format_ignored({key, :ambiguous}),
+    do: "#{inspect(key)} is controlled by the operation boundary, not the model"
+
+  defp format_ignored({key, :unsupported}),
+    do: "#{inspect(key)} is not accepted by this operation"
+
+  defp format_ignored({key, :invalid}), do: "#{inspect(key)} has an invalid value"
+end

--- a/lib/req_llm/ocr.ex
+++ b/lib/req_llm/ocr.ex
@@ -32,6 +32,49 @@ defmodule ReqLLM.OCR do
 
   @type ocr_result :: %{markdown: String.t(), pages: [map()]}
 
+  @base_schema NimbleOptions.new!(
+                 include_images: [
+                   type: :boolean,
+                   default: true,
+                   doc: "Extract images as base64 data in the returned markdown"
+                 ],
+                 document_type: [
+                   type: :string,
+                   default: "application/pdf",
+                   doc: "MIME type for the document binary"
+                 ],
+                 pages: [
+                   type: {:list, :non_neg_integer},
+                   doc: "Zero-based page indexes to process"
+                 ],
+                 provider_options: [
+                   type: {:or, [:map, {:list, :any}]},
+                   doc: "Provider-specific options (keyword list or map)",
+                   default: []
+                 ],
+                 req_http_options: [
+                   type: {:or, [:map, {:list, :any}]},
+                   doc: "Req-specific options (keyword list or map)",
+                   default: []
+                 ],
+                 max_retries: [
+                   type: :non_neg_integer,
+                   default: 3,
+                   doc:
+                     "Maximum number of retry attempts for transient network errors. Set to 0 to disable retries."
+                 ],
+                 fixture: [
+                   type: {:or, [:string, {:tuple, [:atom, :string]}]},
+                   doc: "HTTP fixture for testing (provider inferred from model if string)"
+                 ]
+               )
+
+  @doc """
+  Returns the base OCR options schema.
+  """
+  @spec schema :: NimbleOptions.t()
+  def schema, do: @base_schema
+
   @doc """
   Validates that a model supports OCR operations.
   """
@@ -63,6 +106,7 @@ defmodule ReqLLM.OCR do
     * `opts` — Options:
       - `:include_images` — extract images as base64 in markdown (default `true`)
       - `:document_type` — MIME type hint (default `"application/pdf"`)
+      - `:pages` — zero-based page indexes to process
       - `:provider_options` — provider-specific options (e.g., `region`, `access_token`)
 
   ## Examples
@@ -75,6 +119,8 @@ defmodule ReqLLM.OCR do
   @spec ocr(String.t() | struct(), binary(), keyword()) ::
           {:ok, ocr_result()} | {:error, term()}
   def ocr(model_spec, document_binary, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :ocr, opts)
+
     with {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, request} <-

--- a/lib/req_llm/rerank.ex
+++ b/lib/req_llm/rerank.ex
@@ -125,6 +125,8 @@ defmodule ReqLLM.Rerank do
 
   @spec rerank(ReqLLM.model_input(), keyword()) :: {:ok, RerankResponse.t()} | {:error, term()}
   def rerank(model_spec, opts) when is_list(opts) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :rerank, opts)
+
     with :ok <- validate_query(Keyword.get(opts, :query)),
          :ok <- validate_documents(Keyword.get(opts, :documents)),
          :ok <- validate_batch_size(Keyword.get(opts, :batch_size)),

--- a/lib/req_llm/speech.ex
+++ b/lib/req_llm/speech.ex
@@ -136,6 +136,8 @@ defmodule ReqLLM.Speech do
           keyword()
         ) :: {:ok, Result.t()} | {:error, term()}
   def speak(model_spec, text, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :speech, opts)
+
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, request} <-

--- a/lib/req_llm/transcription.ex
+++ b/lib/req_llm/transcription.ex
@@ -132,6 +132,8 @@ defmodule ReqLLM.Transcription do
           keyword()
         ) :: {:ok, Result.t()} | {:error, term()}
   def transcribe(model_spec, audio, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :transcription, opts)
+
     with {:ok, audio_data, media_type} <- resolve_audio(audio),
          {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),

--- a/test/req_llm/tuple_model_options_test.exs
+++ b/test/req_llm/tuple_model_options_test.exs
@@ -1,5 +1,5 @@
 defmodule ReqLLM.TupleModelOptionsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag contract: :public_api
 
@@ -27,6 +27,18 @@ defmodule ReqLLM.TupleModelOptionsTest do
   end
 
   defmodule OCRHTTP do
+  end
+
+  defmodule CaptureStreamRequest do
+    @behaviour ReqLLM.FinchRequestAdapter
+
+    @impl true
+    def call(request) do
+      test_pid = Application.fetch_env!(:req_llm, :tuple_model_stream_test_pid)
+      body = request.body |> IO.iodata_to_binary() |> Jason.decode!()
+      send(test_pid, {:stream_request_body, body})
+      request
+    end
   end
 
   test "model/1 returns the same model for equivalent tuple identities" do
@@ -179,6 +191,50 @@ defmodule ReqLLM.TupleModelOptionsTest do
              )
 
     assert_body_delta(baseline, receive_body(ObjectHTTP), "temperature", 0.2)
+  end
+
+  test "streaming object tuple defaults change only the corresponding request key" do
+    previous_adapter = Application.get_env(:req_llm, :finch_request_adapter)
+    previous_test_pid = Application.get_env(:req_llm, :tuple_model_stream_test_pid)
+
+    on_exit(fn ->
+      Application.put_env(:req_llm, :finch_request_adapter, previous_adapter)
+      Application.put_env(:req_llm, :tuple_model_stream_test_pid, previous_test_pid)
+    end)
+
+    Application.put_env(:req_llm, :finch_request_adapter, CaptureStreamRequest)
+    Application.put_env(:req_llm, :tuple_model_stream_test_pid, self())
+
+    opts = [
+      api_key: "test-key",
+      base_url: "http://127.0.0.1:1/v1",
+      max_retries: 0
+    ]
+
+    schema = [name: [type: :string, required: true]]
+
+    assert {:ok, baseline_response} =
+             ReqLLM.stream_object(
+               {:openai, id: "gpt-4-0125-preview"},
+               "Return a person",
+               schema,
+               opts
+             )
+
+    assert_receive {:stream_request_body, baseline}
+    baseline_response.cancel.()
+
+    assert {:ok, tuple_response} =
+             ReqLLM.stream_object(
+               {:openai, "gpt-4-0125-preview", temperature: 0.2},
+               "Return a person",
+               schema,
+               opts
+             )
+
+    assert_receive {:stream_request_body, with_default}
+    assert_body_delta(baseline, with_default, "temperature", 0.2)
+    tuple_response.cancel.()
   end
 
   test "embedding tuple defaults change only the corresponding request key" do

--- a/test/req_llm/tuple_model_options_test.exs
+++ b/test/req_llm/tuple_model_options_test.exs
@@ -1,0 +1,445 @@
+defmodule ReqLLM.TupleModelOptionsTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :public_api
+
+  import ExUnit.CaptureIO
+
+  defmodule ChatHTTP do
+  end
+
+  defmodule ObjectHTTP do
+  end
+
+  defmodule EmbeddingHTTP do
+  end
+
+  defmodule ImageHTTP do
+  end
+
+  defmodule TranscriptionHTTP do
+  end
+
+  defmodule SpeechHTTP do
+  end
+
+  defmodule RerankHTTP do
+  end
+
+  defmodule OCRHTTP do
+  end
+
+  test "model/1 returns the same model for equivalent tuple identities" do
+    assert {:ok, two_element} = ReqLLM.model({:openai, id: "gpt-4-0125-preview"})
+
+    assert {:ok, three_element} =
+             ReqLLM.model({:openai, "gpt-4-0125-preview", temperature: 0.2})
+
+    assert two_element == three_element
+  end
+
+  test "two-element keyword tuples do not become operation defaults" do
+    call_opts = [temperature: 0.8]
+
+    assert ReqLLM.ModelInput.merge_tuple_defaults(
+             {:openai, id: "gpt-4-turbo", max_tokens: 64},
+             :chat,
+             call_opts
+           ) == call_opts
+  end
+
+  test "explicit call options override tuple defaults including provider options" do
+    tuple =
+      {:openai, "gpt-4-0125-preview",
+       temperature: 0.2, max_tokens: 64, provider_options: [service_tier: "auto", logprobs: false]}
+
+    call_opts = [temperature: 0.8, provider_options: [logprobs: true]]
+
+    assert ReqLLM.ModelInput.merge_tuple_defaults(tuple, :chat, call_opts) ==
+             [
+               max_tokens: 64,
+               temperature: 0.8,
+               provider_options: [logprobs: true]
+             ]
+
+    assert ReqLLM.ModelInput.merge_tuple_defaults(tuple, :chat, provider_options: []) ==
+             [temperature: 0.2, max_tokens: 64, provider_options: []]
+  end
+
+  test "wrong-operation, invalid, duplicate, and ambiguous tuple defaults stay non-fatal" do
+    tuple =
+      {:cohere, "rerank-v3.5",
+       query: "hidden query",
+       top_n: 2,
+       top_n: 1,
+       max_tokens_per_doc: 0,
+       api_secret: "must-not-appear"}
+
+    warning =
+      capture_io(:stderr, fn ->
+        merged =
+          ReqLLM.ModelInput.merge_tuple_defaults(
+            tuple,
+            :rerank,
+            query: "visible query",
+            documents: ["document"]
+          )
+
+        send(self(), {:merged_options, merged})
+      end)
+
+    assert_receive {:merged_options, [top_n: 2, query: "visible query", documents: ["document"]]}
+
+    assert warning =~ ":query is controlled by the operation boundary"
+    assert warning =~ ":top_n is duplicated"
+    assert warning =~ ":max_tokens_per_doc has an invalid value"
+    assert warning =~ ":api_secret is not accepted"
+    refute warning =~ "hidden query"
+    refute warning =~ "must-not-appear"
+  end
+
+  test "operation-control options do not become tuple defaults" do
+    warning =
+      capture_io(:stderr, fn ->
+        merged =
+          ReqLLM.ModelInput.merge_tuple_defaults(
+            {:openai, "gpt-4-0125-preview", stream: true, temperature: 0.2},
+            :chat,
+            []
+          )
+
+        send(self(), {:operation_options, merged})
+      end)
+
+    assert_receive {:operation_options, [temperature: 0.2]}
+    assert warning =~ ":stream is controlled by the operation boundary"
+  end
+
+  test "on_unsupported ignore suppresses tuple-default warnings" do
+    assert capture_io(:stderr, fn ->
+             assert ReqLLM.ModelInput.merge_tuple_defaults(
+                      {:openai, "text-embedding-3-small", temperature: 0.2},
+                      :embedding,
+                      on_unsupported: :ignore
+                    ) == [on_unsupported: :ignore]
+           end) == ""
+  end
+
+  test "chat tuple defaults change only the corresponding request key" do
+    stub_json(ChatHTTP, chat_response())
+    opts = openai_opts(ChatHTTP)
+
+    assert {:ok, _response} =
+             ReqLLM.generate_text({:openai, id: "gpt-4-0125-preview"}, "Hello", opts)
+
+    baseline = receive_body(ChatHTTP)
+
+    assert {:ok, _response} =
+             ReqLLM.generate_text(
+               {:openai, "gpt-4-0125-preview", temperature: 0.2},
+               "Hello",
+               opts
+             )
+
+    with_default = receive_body(ChatHTTP)
+    assert_body_delta(baseline, with_default, "temperature", 0.2)
+
+    assert {:ok, _response} =
+             ReqLLM.generate_text(
+               {:openai, "gpt-4-0125-preview", temperature: 0.2},
+               "Hello",
+               Keyword.put(opts, :temperature, 0.8)
+             )
+
+    explicit = receive_body(ChatHTTP)
+    assert_body_delta(baseline, explicit, "temperature", 0.8)
+  end
+
+  test "object tuple defaults change only the corresponding request key" do
+    stub_json(ObjectHTTP, object_response())
+    opts = openai_opts(ObjectHTTP)
+    schema = [name: [type: :string, required: true]]
+
+    assert {:ok, _response} =
+             ReqLLM.generate_object(
+               {:openai, id: "gpt-4-0125-preview"},
+               "Return a person",
+               schema,
+               opts
+             )
+
+    baseline = receive_body(ObjectHTTP)
+
+    assert {:ok, _response} =
+             ReqLLM.generate_object(
+               {:openai, "gpt-4-0125-preview", temperature: 0.2},
+               "Return a person",
+               schema,
+               opts
+             )
+
+    assert_body_delta(baseline, receive_body(ObjectHTTP), "temperature", 0.2)
+  end
+
+  test "embedding tuple defaults change only the corresponding request key" do
+    stub_json(EmbeddingHTTP, embedding_response())
+    opts = openai_opts(EmbeddingHTTP)
+
+    assert {:ok, _embedding} =
+             ReqLLM.embed({:openai, id: "text-embedding-3-small"}, "Hello", opts)
+
+    baseline = receive_body(EmbeddingHTTP)
+
+    assert {:ok, _embedding} =
+             ReqLLM.embed(
+               {:openai, "text-embedding-3-small", dimensions: 8},
+               "Hello",
+               opts
+             )
+
+    assert_body_delta(baseline, receive_body(EmbeddingHTTP), "dimensions", 8)
+  end
+
+  test "image tuple defaults change only the corresponding request key" do
+    stub_json(ImageHTTP, image_response())
+    opts = openai_opts(ImageHTTP)
+
+    assert {:ok, _response} =
+             ReqLLM.generate_image({:openai, id: "gpt-image-1.5"}, "A square", opts)
+
+    baseline = receive_body(ImageHTTP)
+
+    assert {:ok, _response} =
+             ReqLLM.generate_image(
+               {:openai, "gpt-image-1.5", size: "512x512"},
+               "A square",
+               opts
+             )
+
+    assert_body_delta(baseline, receive_body(ImageHTTP), "size", "512x512")
+  end
+
+  test "transcription tuple defaults change only the corresponding multipart field" do
+    stub_json(TranscriptionHTTP, transcription_response())
+    opts = openai_opts(TranscriptionHTTP)
+    audio = {:binary, "audio-bytes", "audio/mpeg"}
+
+    assert {:ok, _result} =
+             ReqLLM.transcribe({:openai, id: "whisper-1"}, audio, opts)
+
+    baseline = receive_body(TranscriptionHTTP)
+
+    assert {:ok, _result} =
+             ReqLLM.transcribe(
+               {:openai, "whisper-1", language: "en"},
+               audio,
+               opts
+             )
+
+    assert_body_delta(baseline, receive_body(TranscriptionHTTP), "language", "en")
+  end
+
+  test "speech tuple defaults change only the corresponding request key" do
+    stub_audio(SpeechHTTP)
+    opts = openai_opts(SpeechHTTP)
+
+    assert {:ok, _result} =
+             ReqLLM.speak({:openai, id: "tts-1"}, "Hello", opts)
+
+    baseline = receive_body(SpeechHTTP)
+
+    assert {:ok, _result} =
+             ReqLLM.speak(
+               {:openai, "tts-1", voice: "coral"},
+               "Hello",
+               opts
+             )
+
+    assert_body_delta(baseline, receive_body(SpeechHTTP), "voice", "coral")
+  end
+
+  test "rerank tuple defaults change only the corresponding request key" do
+    stub_json(RerankHTTP, rerank_response())
+
+    opts = [
+      query: "best document",
+      documents: ["one", "two"],
+      api_key: "test-key",
+      req_http_options: [plug: {Req.Test, RerankHTTP}]
+    ]
+
+    assert {:ok, _response} =
+             ReqLLM.rerank({:cohere, id: "rerank-v3.5"}, opts)
+
+    baseline = receive_body(RerankHTTP)
+
+    assert {:ok, _response} =
+             ReqLLM.rerank({:cohere, "rerank-v3.5", top_n: 1}, opts)
+
+    assert_body_delta(baseline, receive_body(RerankHTTP), "top_n", 1)
+  end
+
+  test "OCR tuple defaults change only the corresponding request key" do
+    stub_json(OCRHTTP, ocr_response())
+
+    opts = [
+      provider_options: [
+        access_token: "test-token",
+        project_id: "test-project",
+        region: "global"
+      ],
+      req_http_options: [plug: {Req.Test, OCRHTTP}]
+    ]
+
+    capture_io(:stderr, fn ->
+      assert {:ok, _result} =
+               ReqLLM.ocr(
+                 {:google_vertex, id: "mistral-ocr-2505"},
+                 "document",
+                 opts
+               )
+    end)
+
+    baseline = receive_body(OCRHTTP)
+
+    capture_io(:stderr, fn ->
+      assert {:ok, _result} =
+               ReqLLM.ocr(
+                 {:google_vertex, "mistral-ocr-2505", include_images: false},
+                 "document",
+                 opts
+               )
+    end)
+
+    assert_body_delta(baseline, receive_body(OCRHTTP), "include_image_base64", false)
+  end
+
+  test "unsupported tuple defaults do not alter an applicable operation request" do
+    stub_json(EmbeddingHTTP, embedding_response())
+    opts = openai_opts(EmbeddingHTTP)
+
+    assert {:ok, _embedding} =
+             ReqLLM.embed({:openai, id: "text-embedding-3-small"}, "Hello", opts)
+
+    baseline = receive_body(EmbeddingHTTP)
+
+    warning =
+      capture_io(:stderr, fn ->
+        assert {:ok, _embedding} =
+                 ReqLLM.embed(
+                   {:openai, "text-embedding-3-small", temperature: 0.2},
+                   "Hello",
+                   opts
+                 )
+      end)
+
+    assert warning =~ ":temperature is not accepted by this operation"
+    assert receive_body(EmbeddingHTTP) == baseline
+  end
+
+  defp openai_opts(owner) do
+    [api_key: "test-key", req_http_options: [plug: {Req.Test, owner}]]
+  end
+
+  defp stub_json(owner, response) do
+    test_pid = self()
+
+    Req.Test.stub(owner, fn conn ->
+      send(test_pid, {:request_body, owner, conn.body_params})
+      Req.Test.json(conn, response)
+    end)
+  end
+
+  defp stub_audio(owner) do
+    test_pid = self()
+
+    Req.Test.stub(owner, fn conn ->
+      send(test_pid, {:request_body, owner, conn.body_params})
+      Plug.Conn.send_resp(conn, 200, "audio-bytes")
+    end)
+  end
+
+  defp receive_body(owner) do
+    assert_receive {:request_body, ^owner, body}
+    body
+  end
+
+  defp assert_body_delta(baseline, with_default, key, value) do
+    baseline = normalize_body(baseline)
+    with_default = normalize_body(with_default)
+    assert with_default == Map.put(baseline, key, value)
+  end
+
+  defp normalize_body(%{"file" => %Plug.Upload{} = upload} = body) do
+    normalized_upload = upload |> Map.from_struct() |> Map.delete(:path)
+    Map.put(body, "file", normalized_upload)
+  end
+
+  defp normalize_body(body), do: body
+
+  defp chat_response do
+    %{
+      "id" => "chat-1",
+      "model" => "gpt-4-0125-preview",
+      "choices" => [
+        %{"message" => %{"role" => "assistant", "content" => "Hello"}, "finish_reason" => "stop"}
+      ],
+      "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2}
+    }
+  end
+
+  defp object_response do
+    %{
+      "id" => "object-1",
+      "model" => "gpt-4-0125-preview",
+      "choices" => [
+        %{
+          "message" => %{
+            "role" => "assistant",
+            "tool_calls" => [
+              %{
+                "id" => "call-1",
+                "type" => "function",
+                "function" => %{
+                  "name" => "structured_output",
+                  "arguments" => "{\"name\":\"Ada\"}"
+                }
+              }
+            ]
+          },
+          "finish_reason" => "tool_calls"
+        }
+      ],
+      "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2}
+    }
+  end
+
+  defp embedding_response do
+    %{
+      "data" => [%{"embedding" => [0.1, 0.2], "index" => 0, "object" => "embedding"}],
+      "model" => "text-embedding-3-small",
+      "object" => "list",
+      "usage" => %{"prompt_tokens" => 1, "total_tokens" => 1}
+    }
+  end
+
+  defp image_response do
+    %{"created" => 1, "data" => [%{"b64_json" => Base.encode64("image-bytes")}]}
+  end
+
+  defp transcription_response do
+    %{"text" => "Hello", "segments" => [], "language" => "en", "duration" => 1.0}
+  end
+
+  defp rerank_response do
+    %{
+      "id" => "rerank-1",
+      "results" => [%{"index" => 0, "relevance_score" => 0.9}],
+      "meta" => %{"billed_units" => %{"search_units" => 1}}
+    }
+  end
+
+  defp ocr_response do
+    %{"pages" => [%{"index" => 0, "markdown" => "Hello", "images" => []}]}
+  end
+end


### PR DESCRIPTION
Closes #833

## Summary

- apply valid three-element tuple model options as low-precedence defaults at each public operation boundary, including `stream_object/4`
- keep model identity resolution unchanged and prevent request inputs or streaming controls from becoming model defaults
- ignore invalid, duplicate, unsupported, or wrong-operation tuple defaults non-fatally with redacted warnings
- document precedence and add a base OCR option schema for the options OCR currently consumes
- prove exact request deltas for chat, object, object streaming, embedding, image, transcription, speech, rerank, and OCR

## Compatibility

This is a narrow V1 correctness fix. Strings, two-element tuples, maps, and `%LLMDB.Model{}` values remain no-ops in the new merger. `ReqLLM.model/1` still returns identical models for equivalent two- and three-element tuples. Explicit call options replace tuple defaults, and no public arity, provider callback, struct, serializer, stream element, or error payload changes.

## Validation

- `mix test test/req_llm/tuple_model_options_test.exs` — 16 passed
- `mix test --only contract:public_api` — 690 passed
- `mix test` — 3,600 passed, 11 skipped, 145 excluded
- `mix quality` — passed (format, warnings-as-errors compile, Credo, Dialyzer)
- GitHub CI and Jido Review — passed on `9a680447`
