### PR TITLE
test: isolate public API stderr capture

### DIFF
--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -1,5 +1,5 @@
 defmodule ReqLLMTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag contract: :public_api
 


### PR DESCRIPTION
Closes #876

## Root cause

`ReqLLMTest` ran asynchronously while several tests used process-global `capture_io(:stderr, ...)`. Under CI seed `755286`, a concurrent Azure provider test emitted an unverified-model warning while the inline-model assertion owned `:stderr`, producing a false failure.

## Fix

Run `ReqLLMTest` synchronously so its exact stderr assertions are isolated from async test modules. The assertion remains strict and production warning behavior is unchanged.

## Compatibility

Test scheduling only. No production files, public APIs, request behavior, provider behavior, warning behavior, or serialized values change.

## Validation

- `mix test --seed 755286 --max-cases 8` — 3,600 passed, 11 skipped, 145 excluded
- `mix test --only contract:public_api` — 690 passed
- `mix quality` — passed
