### PR TITLE
refactor: centralize compatibility scenario metadata

### DIFF
--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -74,46 +74,9 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
   use Mix.Task
 
-  @preferred_cli_env :test
-  @capability_scenarios %{
-    "core" => ~w(basic usage token_limit),
-    "conversation" => ~w(context_append),
-    "streaming" => ~w(streaming),
-    "tools" => ~w(tool_none tool_multi tool_round_trip),
-    "objects" => ~w(object_basic object_streaming),
-    "reasoning" => ~w(reasoning),
-    "embedding" => ~w(embed_basic embed_usage embed_batch),
-    "image" => ~w(image_basic),
-    "speech" => ~w(speech_basic),
-    "transcription" => ~w(transcription_basic),
-    "rerank" => ~w(rerank_basic),
-    "ocr" => ~w(ocr_basic),
-    "grounding" => ~w(grounding_basic grounding_with_context grounding_streaming),
-    "grounding_legacy" => ~w(grounding_legacy),
-    "multimodal_tool_result" => ~w(multimodal_tool_result),
-    "web_search" => ~w(web_search_basic web_search_streaming x_search_streaming),
-    "streaming_structured_output" =>
-      ~w(object_streaming_json_schema object_streaming_tool_strict object_streaming_auto streaming_error_handling)
-  }
+  alias ReqLLM.Compatibility.ScenarioCatalog
 
-  @scenario_test_files %{
-    google: %{
-      "grounding_basic" => "test/coverage/google/grounding_test.exs",
-      "grounding_with_context" => "test/coverage/google/grounding_test.exs",
-      "grounding_streaming" => "test/coverage/google/grounding_test.exs",
-      "grounding_legacy" => "test/coverage/google/grounding_test.exs",
-      "multimodal_tool_result" => "test/coverage/google/multimodal_tool_result_test.exs"
-    },
-    xai: %{
-      "web_search_basic" => "test/coverage/xai/web_search_test.exs",
-      "web_search_streaming" => "test/coverage/xai/web_search_test.exs",
-      "x_search_streaming" => "test/coverage/xai/web_search_test.exs",
-      "object_streaming_json_schema" => "test/coverage/xai/streaming_structured_output_test.exs",
-      "object_streaming_tool_strict" => "test/coverage/xai/streaming_structured_output_test.exs",
-      "object_streaming_auto" => "test/coverage/xai/streaming_structured_output_test.exs",
-      "streaming_error_handling" => "test/coverage/xai/streaming_structured_output_test.exs"
-    }
-  }
+  @preferred_cli_env :test
 
   @impl Mix.Task
   def run(args) do
@@ -153,15 +116,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
       |> csv_values()
       |> Enum.flat_map(&capability_scenarios!/1)
 
-    operation_capability = Atom.to_string(operation)
-
-    operation_defaults =
-      if opts[:capability] == operation_capability and
-           Map.has_key?(@capability_scenarios, operation_capability) do
-        Map.fetch!(@capability_scenarios, operation_capability)
-      else
-        []
-      end
+    operation_defaults = ScenarioCatalog.operation_defaults(operation, opts[:capability])
 
     (scenarios ++ capability_scenarios ++ operation_defaults)
     |> Enum.uniq()
@@ -169,7 +124,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
   @doc false
   def capability_scenarios!(capability) when is_binary(capability) do
-    case Map.fetch(@capability_scenarios, capability) do
+    case ScenarioCatalog.scenarios_for_capability(capability) do
       {:ok, scenarios} -> scenarios
       :error -> Mix.raise("Unknown capability group: #{capability}")
     end
@@ -529,9 +484,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   @doc false
   def test_args_for(provider, operation, scenario \\ nil) do
     provider = normalize_provider(provider)
-
-    args =
-      scenario_test_args(provider, scenario) || base_test_args(provider, operation)
+    args = ["test", ScenarioCatalog.test_file(provider, operation, scenario)]
 
     if scenario do
       args ++ ["--only", "scenario:#{scenario}"]
@@ -544,52 +497,8 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     test_args_for(provider, operation, scenario)
   end
 
-  defp scenario_test_args(_provider, nil), do: nil
-
-  defp scenario_test_args(provider, scenario) do
-    provider
-    |> then(&Map.get(@scenario_test_files, &1, %{}))
-    |> Map.get(to_string(scenario))
-    |> case do
-      nil -> nil
-      path -> ["test", path]
-    end
-  end
-
   defp normalize_provider(provider) when is_atom(provider), do: provider
   defp normalize_provider(provider) when is_binary(provider), do: String.to_atom(provider)
-
-  defp base_test_args(provider, :all) do
-    ["test", "test/coverage/#{provider}"]
-  end
-
-  defp base_test_args(provider, :embedding) do
-    ["test", "test/coverage/#{provider}/embedding_test.exs"]
-  end
-
-  defp base_test_args(provider, :image) do
-    ["test", "test/coverage/#{provider}/image_generation_test.exs"]
-  end
-
-  defp base_test_args(provider, :speech) do
-    ["test", "test/coverage/#{provider}/speech_test.exs"]
-  end
-
-  defp base_test_args(provider, :transcription) do
-    ["test", "test/coverage/#{provider}/transcription_test.exs"]
-  end
-
-  defp base_test_args(provider, :rerank) do
-    ["test", "test/coverage/#{provider}/rerank_test.exs"]
-  end
-
-  defp base_test_args(provider, :ocr) do
-    ["test", "test/coverage/#{provider}/ocr_test.exs"]
-  end
-
-  defp base_test_args(provider, :text) do
-    ["test", "test/coverage/#{provider}/comprehensive_test.exs"]
-  end
 
   defp parse_test_result(provider, model_id, output, exit_code, scenario) do
     {passed, failed, total} = parse_exunit_summary(output)

--- a/lib/req_llm/compatibility/scenario_catalog.ex
+++ b/lib/req_llm/compatibility/scenario_catalog.ex
@@ -1,0 +1,234 @@
+defmodule ReqLLM.Compatibility.ScenarioCatalog do
+  @moduledoc """
+  Compiled catalog of compatibility scenarios used by ReqLLM's test tooling.
+
+  The catalog centralizes capability membership, operation metadata, and
+  provider-specific test routing while preserving the established scenario and
+  command-line selection order.
+  """
+
+  alias ReqLLM.Compatibility.ScenarioCatalog.Validator
+
+  @type operation :: %{
+          required(:id) => atom(),
+          required(:test_file) => binary() | :provider_directory
+        }
+  @type capability :: %{required(:id) => binary(), required(:operation) => atom()}
+  @type scenario :: %{required(:id) => binary(), required(:capability) => binary()}
+  @type route :: %{
+          required(:provider) => atom(),
+          required(:scenario) => binary(),
+          required(:test_file) => binary()
+        }
+
+  @operations [
+    %{id: :text, test_file: "comprehensive_test.exs"},
+    %{id: :embedding, test_file: "embedding_test.exs"},
+    %{id: :image, test_file: "image_generation_test.exs"},
+    %{id: :speech, test_file: "speech_test.exs"},
+    %{id: :transcription, test_file: "transcription_test.exs"},
+    %{id: :rerank, test_file: "rerank_test.exs"},
+    %{id: :ocr, test_file: "ocr_test.exs"},
+    %{id: :all, test_file: :provider_directory}
+  ]
+
+  @capabilities [
+    %{id: "core", operation: :text},
+    %{id: "conversation", operation: :text},
+    %{id: "streaming", operation: :text},
+    %{id: "tools", operation: :text},
+    %{id: "objects", operation: :text},
+    %{id: "reasoning", operation: :text},
+    %{id: "embedding", operation: :embedding},
+    %{id: "image", operation: :image},
+    %{id: "speech", operation: :speech},
+    %{id: "transcription", operation: :transcription},
+    %{id: "rerank", operation: :rerank},
+    %{id: "ocr", operation: :ocr},
+    %{id: "grounding", operation: :text},
+    %{id: "grounding_legacy", operation: :text},
+    %{id: "multimodal_tool_result", operation: :text},
+    %{id: "web_search", operation: :text},
+    %{id: "streaming_structured_output", operation: :text}
+  ]
+
+  @scenarios [
+    %{id: "basic", capability: "core"},
+    %{id: "usage", capability: "core"},
+    %{id: "token_limit", capability: "core"},
+    %{id: "context_append", capability: "conversation"},
+    %{id: "streaming", capability: "streaming"},
+    %{id: "tool_none", capability: "tools"},
+    %{id: "tool_multi", capability: "tools"},
+    %{id: "tool_round_trip", capability: "tools"},
+    %{id: "object_basic", capability: "objects"},
+    %{id: "object_streaming", capability: "objects"},
+    %{id: "reasoning", capability: "reasoning"},
+    %{id: "embed_basic", capability: "embedding"},
+    %{id: "embed_usage", capability: "embedding"},
+    %{id: "embed_batch", capability: "embedding"},
+    %{id: "image_basic", capability: "image"},
+    %{id: "speech_basic", capability: "speech"},
+    %{id: "transcription_basic", capability: "transcription"},
+    %{id: "rerank_basic", capability: "rerank"},
+    %{id: "ocr_basic", capability: "ocr"},
+    %{id: "grounding_basic", capability: "grounding"},
+    %{id: "grounding_with_context", capability: "grounding"},
+    %{id: "grounding_streaming", capability: "grounding"},
+    %{id: "grounding_legacy", capability: "grounding_legacy"},
+    %{id: "multimodal_tool_result", capability: "multimodal_tool_result"},
+    %{id: "web_search_basic", capability: "web_search"},
+    %{id: "web_search_streaming", capability: "web_search"},
+    %{id: "x_search_streaming", capability: "web_search"},
+    %{id: "object_streaming_json_schema", capability: "streaming_structured_output"},
+    %{id: "object_streaming_tool_strict", capability: "streaming_structured_output"},
+    %{id: "object_streaming_auto", capability: "streaming_structured_output"},
+    %{id: "streaming_error_handling", capability: "streaming_structured_output"}
+  ]
+
+  @routes [
+    %{
+      provider: :google,
+      scenario: "grounding_basic",
+      test_file: "test/coverage/google/grounding_test.exs"
+    },
+    %{
+      provider: :google,
+      scenario: "grounding_with_context",
+      test_file: "test/coverage/google/grounding_test.exs"
+    },
+    %{
+      provider: :google,
+      scenario: "grounding_streaming",
+      test_file: "test/coverage/google/grounding_test.exs"
+    },
+    %{
+      provider: :google,
+      scenario: "grounding_legacy",
+      test_file: "test/coverage/google/grounding_test.exs"
+    },
+    %{
+      provider: :google,
+      scenario: "multimodal_tool_result",
+      test_file: "test/coverage/google/multimodal_tool_result_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "web_search_basic",
+      test_file: "test/coverage/xai/web_search_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "web_search_streaming",
+      test_file: "test/coverage/xai/web_search_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "x_search_streaming",
+      test_file: "test/coverage/xai/web_search_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "object_streaming_json_schema",
+      test_file: "test/coverage/xai/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "object_streaming_tool_strict",
+      test_file: "test/coverage/xai/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "object_streaming_auto",
+      test_file: "test/coverage/xai/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :xai,
+      scenario: "streaming_error_handling",
+      test_file: "test/coverage/xai/streaming_structured_output_test.exs"
+    }
+  ]
+
+  :ok = Validator.validate!(@operations, @capabilities, @scenarios, @routes)
+
+  @doc "Returns operation routing metadata in canonical operation order."
+  @spec operations() :: [operation()]
+  def operations, do: @operations
+
+  @doc "Returns the catalog's capability definitions in declaration order."
+  @spec capabilities() :: [capability()]
+  def capabilities, do: @capabilities
+
+  @doc "Returns the catalog's scenario definitions in selection order."
+  @spec scenarios() :: [scenario()]
+  def scenarios, do: @scenarios
+
+  @doc "Returns all provider-specific test routes."
+  @spec routes() :: [route()]
+  def routes, do: @routes
+
+  @doc "Returns ordered scenario IDs for a capability."
+  @spec scenarios_for_capability(binary()) :: {:ok, [binary()]} | :error
+  def scenarios_for_capability(capability) when is_binary(capability) do
+    if Enum.any?(@capabilities, &(&1.id == capability)) do
+      {:ok,
+       @scenarios
+       |> Enum.filter(&(&1.capability == capability))
+       |> Enum.map(& &1.id)}
+    else
+      :error
+    end
+  end
+
+  @doc "Returns the legacy default scenarios for a selected operation capability."
+  @spec operation_defaults(atom(), binary() | nil) :: [binary()]
+  def operation_defaults(operation, selected_capability) when is_atom(operation) do
+    operation_capability = Atom.to_string(operation)
+
+    case Enum.find(@capabilities, &(&1.id == operation_capability)) do
+      %{operation: ^operation} when selected_capability == operation_capability ->
+        {:ok, scenarios} = scenarios_for_capability(operation_capability)
+        scenarios
+
+      _ ->
+        []
+    end
+  end
+
+  @doc "Returns the selected test file for a provider, operation, and optional scenario."
+  @spec test_file(atom(), atom(), atom() | binary() | nil) :: binary()
+  def test_file(provider, operation, scenario \\ nil) when is_atom(provider) do
+    scenario_test_file(provider, scenario) || operation_test_file(provider, operation)
+  end
+
+  @doc "Returns the focused test file for a provider and scenario, if configured."
+  @spec scenario_test_file(atom(), atom() | binary() | nil) :: binary() | nil
+  def scenario_test_file(_provider, nil), do: nil
+
+  def scenario_test_file(provider, scenario) when is_atom(provider) do
+    scenario = to_string(scenario)
+
+    Enum.find_value(@routes, fn route ->
+      if route.provider == provider and route.scenario == scenario, do: route.test_file
+    end)
+  end
+
+  @doc "Returns the established coverage test file for a provider operation."
+  @spec operation_test_file(atom(), atom()) :: binary()
+  def operation_test_file(provider, operation) when is_atom(provider) do
+    case Enum.find(@operations, &(&1.id == operation)) do
+      %{test_file: :provider_directory} ->
+        "test/coverage/#{provider}"
+
+      %{test_file: test_file} ->
+        "test/coverage/#{provider}/#{test_file}"
+
+      nil ->
+        raise ArgumentError, "unknown compatibility operation: #{inspect(operation)}"
+    end
+  end
+
+  @doc false
+  @spec validate!([map()], [map()], [map()], [map()]) :: :ok
+  defdelegate validate!(operations, capabilities, scenarios, routes), to: Validator
+end

--- a/lib/req_llm/compatibility/scenario_catalog/validator.ex
+++ b/lib/req_llm/compatibility/scenario_catalog/validator.ex
@@ -1,0 +1,108 @@
+defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
+  @moduledoc false
+
+  @spec validate!([map()], [map()], [map()], [map()]) :: :ok
+  def validate!(operations, capabilities, scenarios, routes) do
+    validate_unique_ids!(operations, :operation)
+    validate_unique_ids!(capabilities, :capability)
+    validate_unique_ids!(scenarios, :scenario)
+    validate_operations!(operations)
+    validate_capabilities!(operations, capabilities)
+    validate_scenarios!(capabilities, scenarios)
+    validate_routes!(scenarios, routes)
+    :ok
+  end
+
+  defp validate_unique_ids!(entries, kind) do
+    duplicate_ids =
+      entries
+      |> Enum.map(&Map.fetch!(&1, :id))
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_id, count} -> count > 1 end)
+      |> Enum.map(&elem(&1, 0))
+
+    if duplicate_ids != [] do
+      raise ArgumentError, "duplicate #{kind} IDs: #{inspect(duplicate_ids)}"
+    end
+  end
+
+  defp validate_operations!(operations) do
+    operation_ids = Enum.map(operations, &Map.fetch!(&1, :id))
+
+    unless operation_ids == ReqLLM.ModelOperation.operations() do
+      raise ArgumentError,
+            "catalog operations must match ReqLLM.ModelOperation: #{inspect(operation_ids)}"
+    end
+
+    Enum.each(operations, fn operation ->
+      test_file = Map.fetch!(operation, :test_file)
+
+      unless test_file == :provider_directory or
+               (is_binary(test_file) and String.ends_with?(test_file, "_test.exs")) do
+        raise ArgumentError, "invalid operation route: #{inspect(operation)}"
+      end
+    end)
+  end
+
+  defp validate_capabilities!(operations, capabilities) do
+    operation_ids = MapSet.new(operations, &Map.fetch!(&1, :id))
+
+    Enum.each(capabilities, fn capability ->
+      id = Map.fetch!(capability, :id)
+      operation = Map.fetch!(capability, :operation)
+
+      unless is_binary(id) and MapSet.member?(operation_ids, operation) do
+        raise ArgumentError, "invalid capability: #{inspect(capability)}"
+      end
+    end)
+  end
+
+  defp validate_scenarios!(capabilities, scenarios) do
+    capability_ids = MapSet.new(capabilities, &Map.fetch!(&1, :id))
+
+    Enum.each(scenarios, fn scenario ->
+      id = Map.fetch!(scenario, :id)
+      capability = Map.fetch!(scenario, :capability)
+
+      unless is_binary(id) and MapSet.member?(capability_ids, capability) do
+        raise ArgumentError,
+              "scenario #{inspect(id)} references unknown capability #{inspect(capability)}"
+      end
+    end)
+  end
+
+  defp validate_routes!(scenarios, routes) do
+    scenario_ids = MapSet.new(scenarios, &Map.fetch!(&1, :id))
+
+    route_keys =
+      Enum.map(routes, fn route ->
+        validate_route!(route, scenario_ids)
+        {Map.fetch!(route, :provider), Map.fetch!(route, :scenario)}
+      end)
+
+    duplicate_routes =
+      route_keys
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_key, count} -> count > 1 end)
+      |> Enum.map(&elem(&1, 0))
+
+    if duplicate_routes != [] do
+      raise ArgumentError, "duplicate scenario routes: #{inspect(duplicate_routes)}"
+    end
+  end
+
+  defp validate_route!(route, scenario_ids) do
+    provider = Map.fetch!(route, :provider)
+    scenario = Map.fetch!(route, :scenario)
+    test_file = Map.fetch!(route, :test_file)
+
+    valid? =
+      is_atom(provider) and MapSet.member?(scenario_ids, scenario) and is_binary(test_file) and
+        String.starts_with?(test_file, "test/coverage/") and
+        String.ends_with?(test_file, "_test.exs")
+
+    unless valid? do
+      raise ArgumentError, "invalid scenario route: #{inspect(route)}"
+    end
+  end
+end

--- a/test/mix/tasks/model_compat_test.exs
+++ b/test/mix/tasks/model_compat_test.exs
@@ -57,6 +57,20 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
              ]
     end
 
+    test "preserves ordered operation-specific defaults" do
+      assert ModelCompat.scenarios_for_opts([capability: "embedding"], :embedding) == [
+               "embed_basic",
+               "embed_usage",
+               "embed_batch"
+             ]
+
+      assert ModelCompat.scenarios_for_opts([capability: "core"], :text) == [
+               "basic",
+               "usage",
+               "token_limit"
+             ]
+    end
+
     test "raises for unknown capabilities" do
       assert_raise Mix.Error, ~r/Unknown capability group/, fn ->
         ModelCompat.scenarios_for_opts([capability: "unknown"], :text)
@@ -115,6 +129,22 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
                "test/coverage/xai/streaming_structured_output_test.exs",
                "--only",
                "scenario:object_streaming_json_schema"
+             ]
+    end
+
+    test "preserves operation-specific and unknown explicit scenario fallback routes" do
+      assert ModelCompat.test_args_for(:openai, :embedding) == [
+               "test",
+               "test/coverage/openai/embedding_test.exs",
+               "--only",
+               "provider:openai"
+             ]
+
+      assert ModelCompat.test_args_for(:anthropic, :text, "custom_scenario") == [
+               "test",
+               "test/coverage/anthropic/comprehensive_test.exs",
+               "--only",
+               "scenario:custom_scenario"
              ]
     end
   end

--- a/test/req_llm/compatibility/scenario_catalog_test.exs
+++ b/test/req_llm/compatibility/scenario_catalog_test.exs
@@ -1,0 +1,108 @@
+defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Compatibility.ScenarioCatalog
+
+  @operations [
+    %{id: :text, test_file: "comprehensive_test.exs"},
+    %{id: :embedding, test_file: "embedding_test.exs"},
+    %{id: :image, test_file: "image_generation_test.exs"},
+    %{id: :speech, test_file: "speech_test.exs"},
+    %{id: :transcription, test_file: "transcription_test.exs"},
+    %{id: :rerank, test_file: "rerank_test.exs"},
+    %{id: :ocr, test_file: "ocr_test.exs"},
+    %{id: :all, test_file: :provider_directory}
+  ]
+
+  @capability_scenarios %{
+    "core" => ~w(basic usage token_limit),
+    "conversation" => ~w(context_append),
+    "streaming" => ~w(streaming),
+    "tools" => ~w(tool_none tool_multi tool_round_trip),
+    "objects" => ~w(object_basic object_streaming),
+    "reasoning" => ~w(reasoning),
+    "embedding" => ~w(embed_basic embed_usage embed_batch),
+    "image" => ~w(image_basic),
+    "speech" => ~w(speech_basic),
+    "transcription" => ~w(transcription_basic),
+    "rerank" => ~w(rerank_basic),
+    "ocr" => ~w(ocr_basic),
+    "grounding" => ~w(grounding_basic grounding_with_context grounding_streaming),
+    "grounding_legacy" => ~w(grounding_legacy),
+    "multimodal_tool_result" => ~w(multimodal_tool_result),
+    "web_search" => ~w(web_search_basic web_search_streaming x_search_streaming),
+    "streaming_structured_output" =>
+      ~w(object_streaming_json_schema object_streaming_tool_strict object_streaming_auto streaming_error_handling)
+  }
+
+  describe "catalog" do
+    test "represents every scenario once" do
+      scenario_ids = Enum.map(ScenarioCatalog.scenarios(), & &1.id)
+
+      assert length(scenario_ids) == 31
+      assert length(scenario_ids) == MapSet.size(MapSet.new(scenario_ids))
+    end
+
+    test "represents every canonical operation and its established route" do
+      assert ScenarioCatalog.operations() == @operations
+
+      assert ScenarioCatalog.operation_test_file(:openai, :text) ==
+               "test/coverage/openai/comprehensive_test.exs"
+
+      assert ScenarioCatalog.operation_test_file(:google, :all) == "test/coverage/google"
+    end
+
+    test "preserves capability selection order and operation metadata" do
+      actual =
+        Map.new(ScenarioCatalog.capabilities(), fn capability ->
+          {:ok, scenarios} = ScenarioCatalog.scenarios_for_capability(capability.id)
+          {capability.id, scenarios}
+        end)
+
+      assert actual == @capability_scenarios
+
+      assert %{operation: :embedding} =
+               Enum.find(ScenarioCatalog.capabilities(), &(&1.id == "embedding"))
+    end
+
+    test "preserves provider-specific routes" do
+      assert ScenarioCatalog.scenario_test_file(:google, "grounding_basic") ==
+               "test/coverage/google/grounding_test.exs"
+
+      assert ScenarioCatalog.scenario_test_file(:xai, :object_streaming_auto) ==
+               "test/coverage/xai/streaming_structured_output_test.exs"
+
+      assert ScenarioCatalog.scenario_test_file(:google, "basic") == nil
+    end
+  end
+
+  describe "validation" do
+    test "rejects duplicate scenario IDs" do
+      capabilities = [%{id: "core", operation: :text}]
+      scenarios = [%{id: "basic", capability: "core"}, %{id: "basic", capability: "core"}]
+
+      assert_raise ArgumentError, ~r/duplicate scenario IDs/, fn ->
+        ScenarioCatalog.validate!(@operations, capabilities, scenarios, [])
+      end
+    end
+
+    test "rejects unknown capabilities" do
+      capabilities = [%{id: "core", operation: :text}]
+      scenarios = [%{id: "basic", capability: "missing"}]
+
+      assert_raise ArgumentError, ~r/references unknown capability/, fn ->
+        ScenarioCatalog.validate!(@operations, capabilities, scenarios, [])
+      end
+    end
+
+    test "rejects invalid routes" do
+      capabilities = [%{id: "core", operation: :text}]
+      scenarios = [%{id: "basic", capability: "core"}]
+      routes = [%{provider: :openai, scenario: "unknown", test_file: "test/coverage/openai.exs"}]
+
+      assert_raise ArgumentError, ~r/invalid scenario route/, fn ->
+        ScenarioCatalog.validate!(@operations, capabilities, scenarios, routes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #834

## Summary

- add a compiled `ReqLLM.Compatibility.ScenarioCatalog` containing the existing scenario IDs, capability membership, canonical operations, operation test-file routing, and provider-specific routes
- validate duplicate IDs, operation drift, unknown capability references, malformed routes, and duplicate routes when the catalog compiles
- make `mix req_llm.model_compat` query the catalog for capability expansion, legacy operation defaults, and all test-file selection
- preserve unknown explicit `--scenario` fallback behavior and every existing selection order/test argument

## Design and simplification

This deliberately extracts only metadata already present on `main`. It does not adopt additional scenario modules or provider routes from the architecture branch.

The catalog adds declarative surface because later V1 evidence work needs one compiled source of truth. In exchange, the Mix task loses both hard-coded scenario maps and all eight operation-routing function clauses. Validation makes malformed catalog additions fail at compile time instead of silently changing replay selection.

## Backward compatibility

This is internal/additive for V1:

- no public generation API, struct, request, response, stream, error, provider callback, telemetry event, or fixture payload changes
- scenario IDs, capability expansion order, provider routes, operation routes, CLI arguments, and replay results remain unchanged
- unknown explicit scenarios continue to route to the operation's established coverage file
- no fixtures or generated compatibility-state files changed

## Validation

- `mix test test/req_llm/compatibility/scenario_catalog_test.exs test/mix/tasks/model_compat_test.exs` — 23 passed
- `mix req_llm.model_compat "openai:gpt-4o" --scenario basic` — passed from cached fixtures
- `mix req_llm.model_compat "google:gemini-2.5-flash" --scenario grounding_basic` — passed from cached fixtures
- `mix req_llm.model_compat "openai:text-embedding-3-small" --type embedding --capability embedding` — all three ordered embedding scenarios passed
- `mix test` — 3,609 passed, 11 skipped, 145 excluded
- `mix quality` — passed
- `mix hex.build --unpack` — passed; compiled catalog included in package