### PR TITLE
test: consolidate compatibility scenarios

### DIFF
--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -123,8 +123,32 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   end
 
   @doc false
+  def scenarios_for_opts(opts, operation, provider) when is_atom(provider) do
+    scenarios = csv_values(opts[:scenario])
+
+    capability_scenarios =
+      opts[:capability]
+      |> csv_values()
+      |> Enum.flat_map(&capability_scenarios!(&1, provider))
+
+    operation_defaults = ScenarioCatalog.operation_defaults(operation, opts[:capability])
+
+    (scenarios ++ capability_scenarios ++ operation_defaults)
+    |> Enum.uniq()
+  end
+
+  @doc false
   def capability_scenarios!(capability) when is_binary(capability) do
     case ScenarioCatalog.scenarios_for_capability(capability) do
+      {:ok, scenarios} -> scenarios
+      :error -> Mix.raise("Unknown capability group: #{capability}")
+    end
+  end
+
+  @doc false
+  def capability_scenarios!(capability, provider)
+      when is_binary(capability) and is_atom(provider) do
+    case ScenarioCatalog.model_compat_scenarios_for_capability(capability, provider) do
       {:ok, scenarios} -> scenarios
       :error -> Mix.raise("Unknown capability group: #{capability}")
     end
@@ -316,10 +340,12 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     Mix.shell().info("----------------------------------------------------\n")
 
     models = load_registry()
-    specs = select_models(models, model_spec, opts)
+
+    selected_specs = select_models(models, model_spec, opts)
+    specs = filter_capability_specs(selected_specs, opts)
 
     if Enum.empty?(specs) do
-      Mix.raise("No models match spec: #{inspect(model_spec)}")
+      raise_for_empty_specs(selected_specs, model_spec, opts)
     end
 
     total_specs = length(specs)
@@ -360,10 +386,12 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     Mix.shell().info("----------------------------------------------------\n")
 
     models = load_registry()
-    specs = select_models(models, nil, opts)
+
+    selected_specs = select_models(models, nil, opts)
+    specs = filter_capability_specs(selected_specs, opts)
 
     if Enum.empty?(specs) do
-      Mix.raise("No models match spec")
+      raise_for_empty_specs(selected_specs, nil, opts)
     end
 
     total_specs = length(specs)
@@ -399,7 +427,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   end
 
   defp test_model(provider, model_id, opts) do
-    scenarios = scenarios_for_opts(opts, parse_operation_type(opts[:type]))
+    scenarios = scenarios_for_opts(opts, parse_operation_type(opts[:type]), provider)
 
     if Enum.empty?(scenarios) do
       run_test_invocation(provider, model_id, opts, nil)
@@ -500,11 +528,19 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   defp normalize_provider(provider) when is_atom(provider), do: provider
   defp normalize_provider(provider) when is_binary(provider), do: String.to_atom(provider)
 
-  defp parse_test_result(provider, model_id, output, exit_code, scenario) do
+  @doc false
+  def parse_test_result(provider, model_id, output, exit_code, scenario) do
     {passed, failed, total} = parse_exunit_summary(output)
 
-    status = if exit_code == 0 && failed == 0, do: :pass, else: :fail
+    status = if exit_code == 0 && failed == 0 && passed > 0, do: :pass, else: :fail
     fixtures = extract_fixtures(output)
+
+    error =
+      cond do
+        total == 0 -> "No matching compatibility tests executed"
+        failed > 0 or exit_code != 0 -> extract_error(output)
+        true -> nil
+      end
 
     %{
       provider: provider,
@@ -514,7 +550,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
       passed: passed,
       failed: failed,
       total: total,
-      error: if(failed > 0, do: extract_error(output)),
+      error: error,
       fixtures: fixtures,
       scenario: scenario
     }
@@ -594,6 +630,35 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
   end
+
+  defp filter_capability_specs(specs, opts) do
+    if csv_values(opts[:capability]) == [] do
+      specs
+    else
+      operation = parse_operation_type(opts[:type])
+
+      Enum.filter(specs, fn {provider, _model_id} ->
+        scenarios_for_opts(opts, operation, provider) != []
+      end)
+    end
+  end
+
+  @spec raise_for_empty_specs(list(), binary() | nil, keyword()) :: no_return()
+  defp raise_for_empty_specs(selected_specs, model_spec, opts) do
+    capabilities = csv_values(opts[:capability])
+
+    if selected_specs != [] and capabilities != [] do
+      Mix.raise(
+        "No replayable per-model scenarios apply to capability #{Enum.join(capabilities, ",")}" <>
+          model_spec_suffix(model_spec)
+      )
+    else
+      Mix.raise("No models match spec#{model_spec_suffix(model_spec)}")
+    end
+  end
+
+  defp model_spec_suffix(nil), do: ""
+  defp model_spec_suffix(model_spec), do: ": #{inspect(model_spec)}"
 
   defp max_concurrency(opts) do
     cond do

--- a/lib/req_llm/compatibility/scenario_catalog.ex
+++ b/lib/req_llm/compatibility/scenario_catalog.ex
@@ -14,7 +14,19 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
           required(:test_file) => binary() | :provider_directory
         }
   @type capability :: %{required(:id) => binary(), required(:operation) => atom()}
-  @type scenario :: %{required(:id) => binary(), required(:capability) => binary()}
+  @type scenario :: %{
+          required(:id) => binary(),
+          required(:capability) => binary(),
+          required(:operation) => atom(),
+          required(:input_modalities) => [atom()],
+          required(:output_modalities) => [atom()],
+          required(:requirements) => [atom()],
+          required(:transports) => [atom()],
+          required(:fixtures) => [binary()],
+          required(:proof) => atom(),
+          required(:applicability) => atom(),
+          required(:providers) => :all | [atom()]
+        }
   @type route :: %{
           required(:provider) => atom(),
           required(:scenario) => binary(),
@@ -49,44 +61,287 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
     %{id: "grounding_legacy", operation: :text},
     %{id: "multimodal_tool_result", operation: :text},
     %{id: "web_search", operation: :text},
-    %{id: "streaming_structured_output", operation: :text}
+    %{id: "web_fetch", operation: :text},
+    %{id: "logprobs", operation: :text},
+    %{id: "request_metadata", operation: :text},
+    %{id: "tool_id_compat", operation: :text},
+    %{id: "streaming_structured_output", operation: :text},
+    %{id: "azure_streaming_structured_output", operation: :text}
   ]
 
-  @scenarios [
-    %{id: "basic", capability: "core"},
-    %{id: "usage", capability: "core"},
-    %{id: "token_limit", capability: "core"},
-    %{id: "context_append", capability: "conversation"},
-    %{id: "streaming", capability: "streaming"},
-    %{id: "tool_none", capability: "tools"},
-    %{id: "tool_multi", capability: "tools"},
-    %{id: "tool_round_trip", capability: "tools"},
-    %{id: "object_basic", capability: "objects"},
-    %{id: "object_streaming", capability: "objects"},
-    %{id: "reasoning", capability: "reasoning"},
-    %{id: "embed_basic", capability: "embedding"},
-    %{id: "embed_usage", capability: "embedding"},
-    %{id: "embed_batch", capability: "embedding"},
-    %{id: "image_basic", capability: "image"},
-    %{id: "speech_basic", capability: "speech"},
-    %{id: "transcription_basic", capability: "transcription"},
-    %{id: "rerank_basic", capability: "rerank"},
-    %{id: "ocr_basic", capability: "ocr"},
-    %{id: "grounding_basic", capability: "grounding"},
-    %{id: "grounding_with_context", capability: "grounding"},
-    %{id: "grounding_streaming", capability: "grounding"},
-    %{id: "grounding_legacy", capability: "grounding_legacy"},
-    %{id: "multimodal_tool_result", capability: "multimodal_tool_result"},
-    %{id: "web_search_basic", capability: "web_search"},
-    %{id: "web_search_streaming", capability: "web_search"},
-    %{id: "x_search_streaming", capability: "web_search"},
-    %{id: "object_streaming_json_schema", capability: "streaming_structured_output"},
-    %{id: "object_streaming_tool_strict", capability: "streaming_structured_output"},
-    %{id: "object_streaming_auto", capability: "streaming_structured_output"},
-    %{id: "streaming_error_handling", capability: "streaming_structured_output"}
-  ]
+  @scenario_defaults %{
+    input_modalities: [:text],
+    output_modalities: [:text],
+    requirements: [],
+    transports: [:request_response],
+    proof: :fixture_replay,
+    applicability: :operation,
+    providers: :all
+  }
+
+  @scenario_specs Enum.map(
+                    [
+                      {"basic", "core", []},
+                      {"usage", "core", []},
+                      {"token_limit", "core", []},
+                      {"context_append", "conversation",
+                       fixtures: ["context_append_1", "context_append_2"]},
+                      {"streaming", "streaming", transports: [:server_sent_events]},
+                      {"tool_none", "tools",
+                       requirements: [:tool_calling],
+                       applicability: :model_features,
+                       fixtures: ["no_tool"]},
+                      {"tool_multi", "tools",
+                       output_modalities: [:text, :tool_call],
+                       requirements: [:tool_calling],
+                       applicability: :model_features,
+                       fixtures: ["multi_tool"]},
+                      {"tool_round_trip", "tools",
+                       input_modalities: [:text, :tool_result],
+                       output_modalities: [:text, :tool_call],
+                       requirements: [:tool_calling],
+                       applicability: :model_features,
+                       fixtures: ["tool_round_trip_1", "tool_round_trip_2"]},
+                      {"object_basic", "objects",
+                       output_modalities: [:structured_object],
+                       requirements: [:object_generation],
+                       applicability: :model_features},
+                      {"object_streaming", "objects",
+                       output_modalities: [:structured_object],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       applicability: :model_features},
+                      {"reasoning", "reasoning",
+                       output_modalities: [:text, :reasoning],
+                       requirements: [:reasoning],
+                       transports: [:request_response, :server_sent_events],
+                       applicability: :model_features,
+                       fixtures: ["reasoning_basic", "reasoning_streaming"]},
+                      {"embed_basic", "embedding",
+                       output_modalities: [:embedding], requirements: [:embedding]},
+                      {"embed_usage", "embedding",
+                       output_modalities: [:embedding, :usage],
+                       requirements: [:embedding],
+                       fixtures: ["embed_basic"]},
+                      {"embed_batch", "embedding",
+                       output_modalities: [:embedding], requirements: [:embedding]},
+                      {"image_basic", "image",
+                       output_modalities: [:image], requirements: [:image_generation]},
+                      {"speech_basic", "speech",
+                       output_modalities: [:audio], requirements: [:speech_generation]},
+                      {"transcription_basic", "transcription",
+                       input_modalities: [:audio], requirements: [:transcription]},
+                      {"rerank_basic", "rerank",
+                       output_modalities: [:ranked_documents], requirements: [:reranking]},
+                      {"ocr_basic", "ocr",
+                       input_modalities: [:document], requirements: [:ocr], proof: :declared},
+                      {"grounding_basic", "grounding",
+                       requirements: [:grounding], applicability: :focused, providers: [:google]},
+                      {"grounding_with_context", "grounding",
+                       requirements: [:grounding],
+                       applicability: :focused,
+                       providers: [:google],
+                       fixtures: ["grounding_context"]},
+                      {"grounding_streaming", "grounding",
+                       requirements: [:grounding],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:google]},
+                      {"grounding_legacy", "grounding_legacy",
+                       requirements: [:grounding],
+                       proof: :declared,
+                       applicability: :focused,
+                       providers: [:google]},
+                      {"multimodal_tool_result", "multimodal_tool_result",
+                       input_modalities: [:text, :document, :tool_result],
+                       output_modalities: [:text, :tool_call],
+                       requirements: [:multimodal_tool_result],
+                       applicability: :focused,
+                       providers: [:google],
+                       fixtures: ["multimodal_tool_result_1", "multimodal_tool_result_2"]},
+                      {"web_search_basic", "web_search",
+                       requirements: [:web_search],
+                       applicability: :focused,
+                       providers: [:anthropic, :openai, :xai]},
+                      {"web_search_streaming", "web_search",
+                       requirements: [:web_search],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:openai, :xai]},
+                      {"x_search_streaming", "web_search",
+                       requirements: [:web_search],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:xai]},
+                      {"object_streaming_json_schema", "streaming_structured_output",
+                       output_modalities: [:structured_object],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:anthropic, :azure, :xai]},
+                      {"object_streaming_tool_strict", "streaming_structured_output",
+                       output_modalities: [:structured_object, :tool_call],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:anthropic, :azure, :xai]},
+                      {"object_streaming_auto", "streaming_structured_output",
+                       output_modalities: [:structured_object],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:anthropic, :azure, :xai],
+                       fixtures: ["object_streaming_auto", "object_streaming_auto_with_tools"]},
+                      {"streaming_error_handling", "streaming_structured_output",
+                       output_modalities: [:structured_object],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       applicability: :focused,
+                       providers: [:azure, :xai],
+                       fixtures: ["streaming_truncated"]},
+                      {"web_fetch_basic", "web_fetch",
+                       requirements: [:web_fetch],
+                       applicability: :focused,
+                       providers: [:anthropic]},
+                      {"logprobs_non_streaming", "logprobs",
+                       output_modalities: [:text, :token_logprobs],
+                       requirements: [:logprobs],
+                       proof: :declared,
+                       applicability: :focused,
+                       providers: [:openai]},
+                      {"labels_basic", "request_metadata",
+                       requirements: [:request_labels],
+                       applicability: :focused,
+                       providers: [:google_vertex]},
+                      {"tool_id_compat_openai_passthrough", "tool_id_compat",
+                       input_modalities: [:text, :tool_call, :tool_result],
+                       requirements: [:cross_provider_tool_ids],
+                       proof: :live_only,
+                       applicability: :integration,
+                       providers: [:openai],
+                       fixtures: ["tool_call_id_compat_openai_passthrough"]},
+                      {"tool_id_compat_openai_to_anthropic", "tool_id_compat",
+                       input_modalities: [:text, :tool_call, :tool_result],
+                       requirements: [:cross_provider_tool_ids],
+                       proof: :live_only,
+                       applicability: :integration,
+                       providers: [:anthropic],
+                       fixtures: ["tool_call_id_compat_openai_to_anthropic"]},
+                      {"tool_id_compat_turn_boundary", "tool_id_compat",
+                       input_modalities: [:text, :tool_call],
+                       requirements: [:cross_provider_tool_ids],
+                       proof: :live_only,
+                       applicability: :integration,
+                       providers: [:anthropic],
+                       fixtures: []},
+                      {"object_streaming_claude_tool", "azure_streaming_structured_output",
+                       output_modalities: [:structured_object, :tool_call],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       proof: :declared,
+                       applicability: :focused,
+                       providers: [:azure]},
+                      {"object_streaming_claude_auto", "azure_streaming_structured_output",
+                       output_modalities: [:structured_object],
+                       requirements: [:streaming_object_generation],
+                       transports: [:server_sent_events],
+                       proof: :declared,
+                       applicability: :focused,
+                       providers: [:azure]}
+                    ],
+                    fn {id, capability, attrs} ->
+                      @scenario_defaults
+                      |> Map.merge(Map.new(attrs))
+                      |> Map.put(:id, id)
+                      |> Map.put(:capability, capability)
+                      |> Map.put_new(:fixtures, [id])
+                    end
+                  )
+
+  @scenarios Enum.map(@scenario_specs, fn scenario ->
+               capability = Enum.find(@capabilities, &(&1.id == scenario.capability))
+
+               @scenario_defaults
+               |> Map.merge(scenario)
+               |> Map.put(:operation, capability.operation)
+             end)
 
   @routes [
+    %{
+      provider: :openai,
+      scenario: "logprobs_non_streaming",
+      test_file: "test/coverage/openai/logprobs_test.exs"
+    },
+    %{
+      provider: :openai,
+      scenario: "web_search_basic",
+      test_file: "test/coverage/openai/web_search_test.exs"
+    },
+    %{
+      provider: :openai,
+      scenario: "web_search_streaming",
+      test_file: "test/coverage/openai/web_search_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      scenario: "web_fetch_basic",
+      test_file: "test/coverage/anthropic/web_fetch_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      scenario: "web_search_basic",
+      test_file: "test/coverage/anthropic/web_search_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      scenario: "object_streaming_json_schema",
+      test_file: "test/coverage/anthropic/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      scenario: "object_streaming_tool_strict",
+      test_file: "test/coverage/anthropic/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :anthropic,
+      scenario: "object_streaming_auto",
+      test_file: "test/coverage/anthropic/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      scenario: "object_streaming_json_schema",
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      scenario: "object_streaming_tool_strict",
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      scenario: "object_streaming_auto",
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      scenario: "streaming_error_handling",
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      scenario: "object_streaming_claude_tool",
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :azure,
+      scenario: "object_streaming_claude_auto",
+      test_file: "test/coverage/azure/streaming_structured_output_test.exs"
+    },
+    %{
+      provider: :google_vertex,
+      scenario: "labels_basic",
+      test_file: "test/coverage/google_vertex_gemini/labels_test.exs"
+    },
     %{
       provider: :google,
       scenario: "grounding_basic",
@@ -167,6 +422,45 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
   @spec routes() :: [route()]
   def routes, do: @routes
 
+  @doc "Returns metadata for a known scenario."
+  @spec fetch_scenario(atom() | binary()) :: {:ok, scenario()} | :error
+  def fetch_scenario(id) when is_atom(id) or is_binary(id) do
+    id = to_string(id)
+
+    case Enum.find(@scenarios, &(&1.id == id)) do
+      nil -> :error
+      scenario -> {:ok, scenario}
+    end
+  end
+
+  @doc "Returns metadata for a known scenario or raises for an unknown ID."
+  @spec fetch_scenario!(atom() | binary()) :: scenario()
+  def fetch_scenario!(id) when is_atom(id) or is_binary(id) do
+    case fetch_scenario(id) do
+      {:ok, scenario} -> scenario
+      :error -> raise ArgumentError, "unknown compatibility scenario: #{inspect(id)}"
+    end
+  end
+
+  @doc "Returns the ordered fixture contract for a known scenario."
+  @spec fixtures(atom() | binary()) :: [binary()]
+  def fixtures(id), do: fetch_scenario!(id).fixtures
+
+  @doc "Returns one fixture name from a scenario's ordered fixture contract."
+  @spec fixture!(atom() | binary(), non_neg_integer()) :: binary()
+  def fixture!(id, index \\ 0) when is_integer(index) and index >= 0 do
+    scenario = fetch_scenario!(id)
+
+    case Enum.fetch(scenario.fixtures, index) do
+      {:ok, fixture} ->
+        fixture
+
+      :error ->
+        raise ArgumentError,
+              "scenario #{inspect(scenario.id)} has no fixture at index #{index}"
+    end
+  end
+
   @doc "Returns ordered scenario IDs for a capability."
   @spec scenarios_for_capability(binary()) :: {:ok, [binary()]} | :error
   def scenarios_for_capability(capability) when is_binary(capability) do
@@ -174,6 +468,22 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
       {:ok,
        @scenarios
        |> Enum.filter(&(&1.capability == capability))
+       |> Enum.map(& &1.id)}
+    else
+      :error
+    end
+  end
+
+  @doc "Returns ordered per-model compatibility scenarios for a capability and provider."
+  @spec model_compat_scenarios_for_capability(binary(), atom()) ::
+          {:ok, [binary()]} | :error
+  def model_compat_scenarios_for_capability(capability, provider)
+      when is_binary(capability) and is_atom(provider) do
+    if Enum.any?(@capabilities, &(&1.id == capability)) do
+      {:ok,
+       @scenarios
+       |> Enum.filter(&(&1.capability == capability and provider_applicable?(&1, provider)))
+       |> Enum.reject(&(&1.applicability == :integration or &1.proof == :live_only))
        |> Enum.map(& &1.id)}
     else
       :error
@@ -212,6 +522,9 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
       if route.provider == provider and route.scenario == scenario, do: route.test_file
     end)
   end
+
+  defp provider_applicable?(%{providers: :all}, _provider), do: true
+  defp provider_applicable?(%{providers: providers}, provider), do: provider in providers
 
   @doc "Returns the established coverage test file for a provider operation."
   @spec operation_test_file(atom(), atom()) :: binary()

--- a/lib/req_llm/compatibility/scenario_catalog/validator.ex
+++ b/lib/req_llm/compatibility/scenario_catalog/validator.ex
@@ -1,8 +1,64 @@
 defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
   @moduledoc false
 
+  @operation_fields [:id, :test_file]
+  @capability_fields [:id, :operation]
+  @scenario_fields [
+    :id,
+    :capability,
+    :operation,
+    :input_modalities,
+    :output_modalities,
+    :requirements,
+    :transports,
+    :fixtures,
+    :proof,
+    :applicability,
+    :providers
+  ]
+
+  @modalities [
+    :audio,
+    :document,
+    :embedding,
+    :image,
+    :ranked_documents,
+    :reasoning,
+    :structured_object,
+    :text,
+    :token_logprobs,
+    :tool_call,
+    :tool_result,
+    :usage
+  ]
+  @requirements [
+    :cross_provider_tool_ids,
+    :embedding,
+    :grounding,
+    :image_generation,
+    :logprobs,
+    :multimodal_tool_result,
+    :object_generation,
+    :ocr,
+    :request_labels,
+    :reranking,
+    :speech_generation,
+    :streaming_object_generation,
+    :reasoning,
+    :tool_calling,
+    :transcription,
+    :web_fetch,
+    :web_search
+  ]
+  @transports [:request_response, :server_sent_events]
+  @proofs [:declared, :fixture_replay, :live_only]
+  @applicabilities [:focused, :integration, :model_features, :operation]
+
   @spec validate!([map()], [map()], [map()], [map()]) :: :ok
   def validate!(operations, capabilities, scenarios, routes) do
+    validate_fields!(operations, @operation_fields, :operation)
+    validate_fields!(capabilities, @capability_fields, :capability)
+    validate_fields!(scenarios, @scenario_fields, :scenario)
     validate_unique_ids!(operations, :operation)
     validate_unique_ids!(capabilities, :capability)
     validate_unique_ids!(scenarios, :scenario)
@@ -11,6 +67,25 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
     validate_scenarios!(capabilities, scenarios)
     validate_routes!(scenarios, routes)
     :ok
+  end
+
+  defp validate_fields!(entries, expected_fields, kind) do
+    expected = MapSet.new(expected_fields)
+
+    Enum.each(entries, fn entry ->
+      actual = entry |> Map.keys() |> MapSet.new()
+      missing = expected |> MapSet.difference(actual) |> MapSet.to_list() |> Enum.sort()
+      unknown = actual |> MapSet.difference(expected) |> MapSet.to_list() |> Enum.sort()
+      id = Map.get(entry, :id, :unknown)
+
+      if missing != [] do
+        raise ArgumentError, "#{kind} #{inspect(id)} missing fields: #{inspect(missing)}"
+      end
+
+      if unknown != [] do
+        raise ArgumentError, "#{kind} #{inspect(id)} has unknown fields: #{inspect(unknown)}"
+      end
+    end)
   end
 
   defp validate_unique_ids!(entries, kind) do
@@ -35,7 +110,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
     end
 
     Enum.each(operations, fn operation ->
-      test_file = Map.fetch!(operation, :test_file)
+      test_file = operation.test_file
 
       unless test_file == :provider_directory or
                (is_binary(test_file) and String.ends_with?(test_file, "_test.exs")) do
@@ -48,35 +123,107 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
     operation_ids = MapSet.new(operations, &Map.fetch!(&1, :id))
 
     Enum.each(capabilities, fn capability ->
-      id = Map.fetch!(capability, :id)
-      operation = Map.fetch!(capability, :operation)
-
-      unless is_binary(id) and MapSet.member?(operation_ids, operation) do
+      unless is_binary(capability.id) and capability.id != "" and
+               MapSet.member?(operation_ids, capability.operation) do
         raise ArgumentError, "invalid capability: #{inspect(capability)}"
       end
     end)
   end
 
   defp validate_scenarios!(capabilities, scenarios) do
-    capability_ids = MapSet.new(capabilities, &Map.fetch!(&1, :id))
+    capabilities_by_id = Map.new(capabilities, &{&1.id, &1})
 
     Enum.each(scenarios, fn scenario ->
-      id = Map.fetch!(scenario, :id)
-      capability = Map.fetch!(scenario, :capability)
-
-      unless is_binary(id) and MapSet.member?(capability_ids, capability) do
-        raise ArgumentError,
-              "scenario #{inspect(id)} references unknown capability #{inspect(capability)}"
-      end
+      validate_scenario!(scenario, capabilities_by_id)
     end)
   end
 
+  defp validate_scenario!(scenario, capabilities_by_id) do
+    capability = Map.get(capabilities_by_id, scenario.capability)
+
+    unless is_binary(scenario.id) and scenario.id != "" and not is_nil(capability) do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} references unknown capability #{inspect(scenario.capability)}"
+    end
+
+    unless scenario.operation == capability.operation do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} has incompatible operation #{inspect(scenario.operation)}"
+    end
+
+    validate_enum_list!(scenario, :input_modalities, @modalities, allow_empty?: false)
+    validate_enum_list!(scenario, :output_modalities, @modalities, allow_empty?: false)
+    validate_enum_list!(scenario, :requirements, @requirements, allow_empty?: true)
+    validate_enum_list!(scenario, :transports, @transports, allow_empty?: false)
+    validate_fixtures!(scenario)
+    validate_enum!(scenario, :proof, @proofs)
+    validate_enum!(scenario, :applicability, @applicabilities)
+    validate_providers!(scenario)
+
+    if scenario.proof == :fixture_replay and scenario.fixtures == [] do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} is missing its fixture contract"
+    end
+
+    if scenario.applicability == :model_features and scenario.requirements == [] do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} is missing model-feature requirements"
+    end
+  end
+
+  defp validate_enum_list!(scenario, field, allowed, opts) do
+    value = Map.fetch!(scenario, field)
+    allow_empty? = Keyword.fetch!(opts, :allow_empty?)
+
+    valid? =
+      is_list(value) and
+        (allow_empty? or value != []) and
+        value == Enum.uniq(value) and
+        Enum.all?(value, &(&1 in allowed))
+
+    unless valid? do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} has invalid #{field}: #{inspect(value)}"
+    end
+  end
+
+  defp validate_enum!(scenario, field, allowed) do
+    value = Map.fetch!(scenario, field)
+
+    unless value in allowed do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} has invalid #{field}: #{inspect(value)}"
+    end
+  end
+
+  defp validate_fixtures!(scenario) do
+    fixtures = scenario.fixtures
+
+    unless is_list(fixtures) and fixtures == Enum.uniq(fixtures) and
+             Enum.all?(fixtures, &(is_binary(&1) and &1 != "" and Path.basename(&1) == &1)) do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} has invalid fixtures: #{inspect(fixtures)}"
+    end
+  end
+
+  defp validate_providers!(%{providers: :all}), do: :ok
+
+  defp validate_providers!(scenario) do
+    providers = scenario.providers
+
+    unless is_list(providers) and providers != [] and providers == Enum.uniq(providers) and
+             Enum.all?(providers, &is_atom/1) do
+      raise ArgumentError,
+            "scenario #{inspect(scenario.id)} has invalid providers: #{inspect(providers)}"
+    end
+  end
+
   defp validate_routes!(scenarios, routes) do
-    scenario_ids = MapSet.new(scenarios, &Map.fetch!(&1, :id))
+    scenarios_by_id = Map.new(scenarios, &{&1.id, &1})
 
     route_keys =
       Enum.map(routes, fn route ->
-        validate_route!(route, scenario_ids)
+        validate_route!(route, scenarios_by_id)
         {Map.fetch!(route, :provider), Map.fetch!(route, :scenario)}
       end)
 
@@ -91,18 +238,22 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
     end
   end
 
-  defp validate_route!(route, scenario_ids) do
+  defp validate_route!(route, scenarios_by_id) do
     provider = Map.fetch!(route, :provider)
-    scenario = Map.fetch!(route, :scenario)
+    scenario_id = Map.fetch!(route, :scenario)
     test_file = Map.fetch!(route, :test_file)
+    scenario = Map.get(scenarios_by_id, scenario_id)
 
     valid? =
-      is_atom(provider) and MapSet.member?(scenario_ids, scenario) and is_binary(test_file) and
-        String.starts_with?(test_file, "test/coverage/") and
+      is_atom(provider) and not is_nil(scenario) and provider_applies?(scenario, provider) and
+        is_binary(test_file) and String.starts_with?(test_file, "test/coverage/") and
         String.ends_with?(test_file, "_test.exs")
 
     unless valid? do
       raise ArgumentError, "invalid scenario route: #{inspect(route)}"
     end
   end
+
+  defp provider_applies?(%{providers: :all}, _provider), do: true
+  defp provider_applies?(scenario, provider), do: provider in scenario.providers
 end

--- a/test/coverage/anthropic/streaming_structured_output_test.exs
+++ b/test/coverage/anthropic/streaming_structured_output_test.exs
@@ -35,12 +35,12 @@ defmodule ReqLLM.Coverage.Anthropic.StreamingStructuredOutputTest do
   end
 
   describe "streaming with json_schema mode" do
-    @tag scenario: :object_streaming_json_schema
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_json_schema)
 
     test "streams object with native output_format json_schema" do
       opts =
         fixture_opts(
-          "object_streaming_json_schema",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_json_schema),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 1000)
           |> Keyword.put(:provider_options, anthropic_structured_output_mode: :json_schema)
@@ -72,12 +72,12 @@ defmodule ReqLLM.Coverage.Anthropic.StreamingStructuredOutputTest do
   end
 
   describe "streaming with tool_strict mode" do
-    @tag scenario: :object_streaming_tool_strict
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_tool_strict)
 
     test "streams object with strict tool calling" do
       opts =
         fixture_opts(
-          "object_streaming_tool_strict",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_tool_strict),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 1000)
           |> Keyword.put(:provider_options, anthropic_structured_output_mode: :tool_strict)
@@ -105,12 +105,12 @@ defmodule ReqLLM.Coverage.Anthropic.StreamingStructuredOutputTest do
   end
 
   describe "streaming with auto mode" do
-    @tag scenario: :object_streaming_auto
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_auto)
 
     test "auto-selects json_schema when no other tools present" do
       opts =
         fixture_opts(
-          "object_streaming_auto",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_auto),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 1000)
           # Default mode is auto
@@ -142,7 +142,7 @@ defmodule ReqLLM.Coverage.Anthropic.StreamingStructuredOutputTest do
 
       opts =
         fixture_opts(
-          "object_streaming_auto_with_tools",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_auto, 1),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 1000)
           |> Keyword.put(:tools, [other_tool])

--- a/test/coverage/anthropic/web_fetch_test.exs
+++ b/test/coverage/anthropic/web_fetch_test.exs
@@ -14,11 +14,11 @@ defmodule ReqLLM.Coverage.Anthropic.WebFetchTest do
     :ok
   end
 
-  @tag scenario: :web_fetch_basic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:web_fetch_basic)
   @tag model: "claude-sonnet-4-5"
   test "web fetch retrieves and analyzes URL content" do
     opts =
-      fixture_opts("web_fetch_basic",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:web_fetch_basic),
         provider_options: [
           web_fetch: %{max_uses: 2}
         ]

--- a/test/coverage/anthropic/web_search_test.exs
+++ b/test/coverage/anthropic/web_search_test.exs
@@ -14,11 +14,11 @@ defmodule ReqLLM.Coverage.Anthropic.WebSearchTest do
     :ok
   end
 
-  @tag scenario: :web_search_basic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:web_search_basic)
   @tag model: "claude-sonnet-4-5"
   test "web search reports tool usage and cost" do
     opts =
-      fixture_opts("web_search_basic",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:web_search_basic),
         provider_options: [
           web_search: %{max_uses: 2}
         ]

--- a/test/coverage/azure/streaming_structured_output_test.exs
+++ b/test/coverage/azure/streaming_structured_output_test.exs
@@ -43,12 +43,12 @@ defmodule ReqLLM.Coverage.Azure.StreamingStructuredOutputTest do
   end
 
   describe "streaming with auto mode selection" do
-    @tag scenario: :object_streaming_auto
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_auto)
 
     test "auto-selects appropriate mode for OpenAI models (defaults to json_schema)" do
       opts =
         fixture_opts(
-          "object_streaming_auto",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_auto),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
         )
@@ -73,12 +73,12 @@ defmodule ReqLLM.Coverage.Azure.StreamingStructuredOutputTest do
   end
 
   describe "streaming with OpenAI models (json_schema mode)" do
-    @tag scenario: :object_streaming_json_schema
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_json_schema)
 
     test "streams object with native response_format json_schema" do
       opts =
         fixture_opts(
-          "object_streaming_json_schema",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_json_schema),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
         )
@@ -111,12 +111,12 @@ defmodule ReqLLM.Coverage.Azure.StreamingStructuredOutputTest do
   end
 
   describe "streaming with tool_strict mode" do
-    @tag scenario: :object_streaming_tool_strict
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_tool_strict)
 
     test "streams object with strict tool calling" do
       opts =
         fixture_opts(
-          "object_streaming_tool_strict",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_tool_strict),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
           |> Keyword.put(:provider_options, openai_structured_output_mode: :tool_strict)
@@ -154,13 +154,13 @@ defmodule ReqLLM.Coverage.Azure.StreamingStructuredOutputTest do
   end
 
   describe "streaming with Claude models (tool-based structured output)" do
-    @tag scenario: :object_streaming_claude_tool
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_claude_tool)
     @tag model_family: "anthropic"
 
     test "streams object using tool calling for Claude (json_schema not supported)" do
       opts =
         fixture_opts(
-          "object_streaming_claude_tool",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_claude_tool),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
         )
@@ -197,13 +197,13 @@ defmodule ReqLLM.Coverage.Azure.StreamingStructuredOutputTest do
   end
 
   describe "Claude auto mode selection" do
-    @tag scenario: :object_streaming_claude_auto
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_claude_auto)
     @tag model_family: "anthropic"
 
     test "auto-selects tool mode for Claude models (json_schema unavailable on Azure)" do
       opts =
         fixture_opts(
-          "object_streaming_claude_auto",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_claude_auto),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
         )
@@ -228,12 +228,12 @@ defmodule ReqLLM.Coverage.Azure.StreamingStructuredOutputTest do
   end
 
   describe "error handling in streaming" do
-    @tag scenario: :streaming_error_handling
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:streaming_error_handling)
 
     test "handles truncated stream gracefully" do
       opts =
         fixture_opts(
-          "streaming_truncated",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:streaming_error_handling),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 10)
         )

--- a/test/coverage/cross_provider/tool_call_id_compat_integration_test.exs
+++ b/test/coverage/cross_provider/tool_call_id_compat_integration_test.exs
@@ -23,9 +23,10 @@ defmodule ReqLLM.Coverage.CrossProvider.ToolCallIdCompatIntegrationTest do
   end
 
   @tag provider: "openai"
-  @tag scenario: :tool_id_compat_openai_passthrough
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:tool_id_compat_openai_passthrough)
   test "OpenAI request preserves OpenAI-style tool call IDs" do
-    fixture_name = "tool_call_id_compat_openai_passthrough"
+    fixture_name =
+      ReqLLM.Test.CompatibilityScenario.fixture!(:tool_id_compat_openai_passthrough)
 
     {:ok, response} =
       ReqLLM.generate_text(
@@ -44,9 +45,10 @@ defmodule ReqLLM.Coverage.CrossProvider.ToolCallIdCompatIntegrationTest do
   end
 
   @tag provider: "anthropic"
-  @tag scenario: :tool_id_compat_openai_to_anthropic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:tool_id_compat_openai_to_anthropic)
   test "Anthropic request sanitizes IDs from OpenAI-shaped context" do
-    fixture_name = "tool_call_id_compat_openai_to_anthropic"
+    fixture_name =
+      ReqLLM.Test.CompatibilityScenario.fixture!(:tool_id_compat_openai_to_anthropic)
 
     {:ok, response} =
       ReqLLM.generate_text(
@@ -67,7 +69,7 @@ defmodule ReqLLM.Coverage.CrossProvider.ToolCallIdCompatIntegrationTest do
   end
 
   @tag provider: "anthropic"
-  @tag scenario: :tool_id_compat_turn_boundary
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:tool_id_compat_turn_boundary)
   test "Anthropic rejects unresolved tool turns" do
     assert_raise ReqLLM.Error.Invalid.Parameter,
                  ~r/Switch providers only after appending tool results/,

--- a/test/coverage/google/grounding_test.exs
+++ b/test/coverage/google/grounding_test.exs
@@ -34,10 +34,10 @@ defmodule ReqLLM.Coverage.Google.GroundingTest do
     describe "#{model_spec}" do
       @describetag model: model_spec |> String.split(":", parts: 2) |> List.last()
 
-      @tag scenario: :grounding_basic
+      @tag ReqLLM.Test.CompatibilityScenario.tag!(:grounding_basic)
       test "grounding with enable: true" do
         opts =
-          fixture_opts("grounding_basic",
+          fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:grounding_basic),
             provider_options: [
               google_api_version: "v1beta",
               google_grounding: %{enable: true}
@@ -71,10 +71,10 @@ defmodule ReqLLM.Coverage.Google.GroundingTest do
         assert response.usage.cost.tools > 0
       end
 
-      @tag scenario: :grounding_with_context
+      @tag ReqLLM.Test.CompatibilityScenario.tag!(:grounding_with_context)
       test "grounding with conversation context" do
         opts =
-          fixture_opts("grounding_context",
+          fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:grounding_with_context),
             provider_options: [
               google_api_version: "v1beta",
               google_grounding: %{enable: true}
@@ -103,10 +103,10 @@ defmodule ReqLLM.Coverage.Google.GroundingTest do
         assert response.usage.cost.tools > 0
       end
 
-      @tag scenario: :grounding_streaming
+      @tag ReqLLM.Test.CompatibilityScenario.tag!(:grounding_streaming)
       test "grounding with streaming" do
         opts =
-          fixture_opts("grounding_streaming",
+          fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:grounding_streaming),
             stream: true,
             provider_options: [
               google_api_version: "v1beta",
@@ -136,10 +136,10 @@ defmodule ReqLLM.Coverage.Google.GroundingTest do
       end
 
       if String.contains?(@model_spec, "gemini-1.5") do
-        @tag scenario: :grounding_legacy
+        @tag ReqLLM.Test.CompatibilityScenario.tag!(:grounding_legacy)
         test "grounding with legacy dynamic_retrieval (Gemini 1.5)" do
           opts =
-            fixture_opts("grounding_legacy",
+            fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:grounding_legacy),
               provider_options: [
                 google_api_version: "v1beta",
                 google_grounding: %{

--- a/test/coverage/google/multimodal_tool_result_test.exs
+++ b/test/coverage/google/multimodal_tool_result_test.exs
@@ -26,7 +26,7 @@ defmodule ReqLLM.Coverage.Google.MultimodalToolResultTest do
     :ok
   end
 
-  @tag scenario: :multimodal_tool_result
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:multimodal_tool_result)
   @tag model: "gemini-3.1-pro-preview"
   test "tool result with PDF and accompanying text reaches the model" do
     pdf_bytes = File.read!(Path.join(File.cwd!(), "priv/examples/test.pdf"))
@@ -57,7 +57,7 @@ defmodule ReqLLM.Coverage.Google.MultimodalToolResultTest do
         @model_spec,
         "Call get_document with name=\"test.pdf\" to fetch the file, then quote the text it contains in full.",
         fixture_opts(
-          "multimodal_tool_result_1",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:multimodal_tool_result, 0),
           base_opts ++
             [
               tools: tools,
@@ -75,7 +75,10 @@ defmodule ReqLLM.Coverage.Google.MultimodalToolResultTest do
       ReqLLM.generate_text(
         @model_spec,
         ctx2,
-        fixture_opts("multimodal_tool_result_2", base_opts ++ [tools: tools])
+        fixture_opts(
+          ReqLLM.Test.CompatibilityScenario.fixture!(:multimodal_tool_result, 1),
+          base_opts ++ [tools: tools]
+        )
       )
 
     text = ReqLLM.Response.text(resp2) || ""

--- a/test/coverage/google_vertex_gemini/labels_test.exs
+++ b/test/coverage/google_vertex_gemini/labels_test.exs
@@ -41,7 +41,7 @@ defmodule ReqLLM.Coverage.GoogleVertexGemini.LabelsTest do
     describe "#{model_spec}" do
       @describetag model: model_spec |> String.split(":", parts: 2) |> List.last()
 
-      @tag scenario: :labels_basic
+      @tag ReqLLM.Test.CompatibilityScenario.tag!(:labels_basic)
       test "sends labels at the top level of the generateContent body" do
         labels = %{
           "team" => "engineering",
@@ -50,7 +50,8 @@ defmodule ReqLLM.Coverage.GoogleVertexGemini.LabelsTest do
         }
 
         opts =
-          ReqLLM.Test.Helpers.fixture_opts("labels_basic",
+          ReqLLM.Test.Helpers.fixture_opts(
+            ReqLLM.Test.CompatibilityScenario.fixture!(:labels_basic),
             provider_options: [labels: labels]
           )
 

--- a/test/coverage/openai/embedding_test.exs
+++ b/test/coverage/openai/embedding_test.exs
@@ -9,14 +9,17 @@ defmodule ReqLLM.Coverage.OpenAI.EmbeddingTest do
   use ReqLLM.ProviderTest.Embedding, provider: :openai
 
   @tag category: :embedding
-  @tag scenario: :embed_basic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:embed_basic)
   @tag model: "text-embedding-3-small"
   test "return_usage includes cost fields" do
     {:ok, %{usage: usage}} =
       ReqLLM.embed(
         "openai:text-embedding-3-small",
         "Hello world",
-        fixture_opts("embed_basic", return_usage: true)
+        fixture_opts(
+          ReqLLM.Test.CompatibilityScenario.fixture!(:embed_basic),
+          return_usage: true
+        )
       )
 
     assert usage.input_tokens > 0

--- a/test/coverage/openai/logprobs_test.exs
+++ b/test/coverage/openai/logprobs_test.exs
@@ -24,11 +24,11 @@ defmodule ReqLLM.Coverage.OpenAI.LogprobsTest do
     :ok
   end
 
-  @tag scenario: :logprobs_non_streaming
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:logprobs_non_streaming)
   @tag model: "gpt-3.5-turbo"
   test "logprobs are returned in provider_meta when requested" do
     opts =
-      fixture_opts("logprobs_non_streaming",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:logprobs_non_streaming),
         provider_options: [openai_logprobs: true]
       )
 
@@ -47,10 +47,10 @@ defmodule ReqLLM.Coverage.OpenAI.LogprobsTest do
     end)
   end
 
-  @tag scenario: :basic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:basic)
   @tag model: "gpt-3.5-turbo"
   test "logprobs are absent from provider_meta when not requested" do
-    opts = fixture_opts("basic")
+    opts = fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:basic))
 
     {:ok, response} = ReqLLM.generate_text(@model_spec, "Hello world!", opts)
 

--- a/test/coverage/openai/web_search_test.exs
+++ b/test/coverage/openai/web_search_test.exs
@@ -14,11 +14,11 @@ defmodule ReqLLM.Coverage.OpenAI.WebSearchTest do
     :ok
   end
 
-  @tag scenario: :web_search_basic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:web_search_basic)
   @tag model: "gpt-5-mini"
   test "web search reports tool usage and cost" do
     opts =
-      fixture_opts("web_search_basic",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:web_search_basic),
         tools: [%{"type" => "web_search"}]
       )
 
@@ -33,11 +33,11 @@ defmodule ReqLLM.Coverage.OpenAI.WebSearchTest do
     assert response.usage.cost.tools > 0
   end
 
-  @tag scenario: :web_search_streaming
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:web_search_streaming)
   @tag model: "gpt-5-mini"
   test "web search reports tool usage and cost with streaming" do
     opts =
-      fixture_opts("web_search_streaming",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:web_search_streaming),
         stream: true,
         tools: [%{"type" => "web_search"}]
       )

--- a/test/coverage/xai/streaming_structured_output_test.exs
+++ b/test/coverage/xai/streaming_structured_output_test.exs
@@ -31,12 +31,12 @@ defmodule ReqLLM.Coverage.XAI.StreamingStructuredOutputTest do
   end
 
   describe "streaming with json_schema mode (grok-4.3)" do
-    @tag scenario: :object_streaming_json_schema
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_json_schema)
 
     test "streams object with native response_format json_schema" do
       opts =
         fixture_opts(
-          "object_streaming_json_schema",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_json_schema),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
         )
@@ -69,12 +69,12 @@ defmodule ReqLLM.Coverage.XAI.StreamingStructuredOutputTest do
   end
 
   describe "streaming with tool_strict mode" do
-    @tag scenario: :object_streaming_tool_strict
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_tool_strict)
 
     test "streams object with strict tool calling fallback" do
       opts =
         fixture_opts(
-          "object_streaming_tool_strict",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_tool_strict),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
           |> Keyword.put(:provider_options, xai_structured_output_mode: :tool_strict)
@@ -112,12 +112,12 @@ defmodule ReqLLM.Coverage.XAI.StreamingStructuredOutputTest do
   end
 
   describe "streaming with auto mode selection" do
-    @tag scenario: :object_streaming_auto
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming_auto)
 
     test "auto-selects json_schema for current Grok models" do
       opts =
         fixture_opts(
-          "object_streaming_auto",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming_auto),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 500)
         )
@@ -140,12 +140,12 @@ defmodule ReqLLM.Coverage.XAI.StreamingStructuredOutputTest do
   end
 
   describe "error handling in streaming" do
-    @tag scenario: :streaming_error_handling
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:streaming_error_handling)
 
     test "handles interrupted stream gracefully" do
       opts =
         fixture_opts(
-          "streaming_truncated",
+          ReqLLM.Test.CompatibilityScenario.fixture!(:streaming_error_handling),
           param_bundles().deterministic
           |> Keyword.put(:max_tokens, 10)
         )

--- a/test/coverage/xai/web_search_test.exs
+++ b/test/coverage/xai/web_search_test.exs
@@ -14,11 +14,11 @@ defmodule ReqLLM.Coverage.XAI.WebSearchTest do
     :ok
   end
 
-  @tag scenario: :web_search_basic
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:web_search_basic)
   @tag model: "grok-4.3"
   test "web search reports tool usage and cost" do
     opts =
-      fixture_opts("web_search_basic",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:web_search_basic),
         xai_tools: [%{type: "web_search"}]
       )
 
@@ -33,11 +33,11 @@ defmodule ReqLLM.Coverage.XAI.WebSearchTest do
     assert response.usage.cost.tools > 0
   end
 
-  @tag scenario: :web_search_streaming
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:web_search_streaming)
   @tag model: "grok-4.3"
   test "web search reports tool usage and cost with streaming" do
     opts =
-      fixture_opts("web_search_streaming",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:web_search_streaming),
         stream: true,
         xai_tools: [%{type: "web_search"}]
       )
@@ -57,11 +57,11 @@ defmodule ReqLLM.Coverage.XAI.WebSearchTest do
     assert response.usage.cost.tools > 0
   end
 
-  @tag scenario: :x_search_streaming
+  @tag ReqLLM.Test.CompatibilityScenario.tag!(:x_search_streaming)
   @tag model: "grok-4.3"
   test "x search reports tool usage and cost with streaming" do
     opts =
-      fixture_opts("x_search_streaming",
+      fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:x_search_streaming),
         stream: true,
         xai_tools: [%{type: "x_search"}]
       )

--- a/test/mix/tasks/model_compat_test.exs
+++ b/test/mix/tasks/model_compat_test.exs
@@ -47,6 +47,14 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
                "web_search_streaming",
                "x_search_streaming"
              ]
+
+      assert ModelCompat.scenarios_for_opts([capability: "web_fetch"], :text) == [
+               "web_fetch_basic"
+             ]
+
+      assert ModelCompat.scenarios_for_opts([capability: "logprobs"], :text) == [
+               "logprobs_non_streaming"
+             ]
     end
 
     test "deduplicates combined scenario and capability values" do
@@ -75,6 +83,35 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
       assert_raise Mix.Error, ~r/Unknown capability group/, fn ->
         ModelCompat.scenarios_for_opts([capability: "unknown"], :text)
       end
+    end
+  end
+
+  describe "scenarios_for_opts/3" do
+    test "restricts focused capability scenarios to applicable providers" do
+      assert ModelCompat.scenarios_for_opts([capability: "web_fetch"], :text, :anthropic) == [
+               "web_fetch_basic"
+             ]
+
+      assert ModelCompat.scenarios_for_opts([capability: "web_fetch"], :text, :openai) == []
+    end
+
+    test "excludes live-only integration scenarios from per-model compatibility runs" do
+      assert ModelCompat.scenarios_for_opts([capability: "tool_id_compat"], :text, :openai) ==
+               []
+
+      assert ModelCompat.scenarios_for_opts(
+               [capability: "tool_id_compat"],
+               :text,
+               :anthropic
+             ) == []
+    end
+
+    test "preserves explicit scenario selection for compatibility" do
+      assert ModelCompat.scenarios_for_opts(
+               [scenario: "custom_scenario", capability: "web_fetch"],
+               :text,
+               :openai
+             ) == ["custom_scenario"]
     end
   end
 
@@ -132,6 +169,29 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
              ]
     end
 
+    test "routes consolidated focused scenarios through the catalog" do
+      assert ModelCompat.test_args_for(:openai, :text, "logprobs_non_streaming") == [
+               "test",
+               "test/coverage/openai/logprobs_test.exs",
+               "--only",
+               "scenario:logprobs_non_streaming"
+             ]
+
+      assert ModelCompat.test_args_for(:anthropic, :text, "web_fetch_basic") == [
+               "test",
+               "test/coverage/anthropic/web_fetch_test.exs",
+               "--only",
+               "scenario:web_fetch_basic"
+             ]
+
+      assert ModelCompat.test_args_for(:azure, :text, "object_streaming_claude_auto") == [
+               "test",
+               "test/coverage/azure/streaming_structured_output_test.exs",
+               "--only",
+               "scenario:object_streaming_claude_auto"
+             ]
+    end
+
     test "preserves operation-specific and unknown explicit scenario fallback routes" do
       assert ModelCompat.test_args_for(:openai, :embedding) == [
                "test",
@@ -158,6 +218,38 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
     test "parses result formatter summaries" do
       assert ModelCompat.parse_exunit_summary("Result: 1 passed, 9 excluded") == {1, 0, 1}
       assert ModelCompat.parse_exunit_summary("Result: 0/1 passed, 9 excluded") == {0, 1, 1}
+    end
+  end
+
+  describe "parse_test_result/5" do
+    test "rejects successful ExUnit exits that execute no matching tests" do
+      result =
+        ModelCompat.parse_test_result(
+          :openai,
+          "gpt-4o-mini",
+          "0 tests, 0 failures",
+          0,
+          "missing"
+        )
+
+      assert result.status == :fail
+      assert result.total == 0
+      assert result.error == "No matching compatibility tests executed"
+    end
+
+    test "accepts successful invocations that execute a matching test" do
+      result =
+        ModelCompat.parse_test_result(
+          :openai,
+          "gpt-4o-mini",
+          "1 test, 0 failures",
+          0,
+          "basic"
+        )
+
+      assert result.status == :pass
+      assert result.total == 1
+      assert result.error == nil
     end
   end
 

--- a/test/req_llm/compatibility/scenario_catalog_test.exs
+++ b/test/req_llm/compatibility/scenario_catalog_test.exs
@@ -31,16 +31,46 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
     "grounding_legacy" => ~w(grounding_legacy),
     "multimodal_tool_result" => ~w(multimodal_tool_result),
     "web_search" => ~w(web_search_basic web_search_streaming x_search_streaming),
+    "web_fetch" => ~w(web_fetch_basic),
+    "logprobs" => ~w(logprobs_non_streaming),
+    "request_metadata" => ~w(labels_basic),
+    "tool_id_compat" =>
+      ~w(tool_id_compat_openai_passthrough tool_id_compat_openai_to_anthropic tool_id_compat_turn_boundary),
     "streaming_structured_output" =>
-      ~w(object_streaming_json_schema object_streaming_tool_strict object_streaming_auto streaming_error_handling)
+      ~w(object_streaming_json_schema object_streaming_tool_strict object_streaming_auto streaming_error_handling),
+    "azure_streaming_structured_output" =>
+      ~w(object_streaming_claude_tool object_streaming_claude_auto)
   }
 
   describe "catalog" do
     test "represents every scenario once" do
       scenario_ids = Enum.map(ScenarioCatalog.scenarios(), & &1.id)
 
-      assert length(scenario_ids) == 31
+      assert length(scenario_ids) == 39
       assert length(scenario_ids) == MapSet.size(MapSet.new(scenario_ids))
+    end
+
+    test "exposes exact fixture contracts and applicability metadata" do
+      assert ScenarioCatalog.fixtures(:context_append) == [
+               "context_append_1",
+               "context_append_2"
+             ]
+
+      assert ScenarioCatalog.fixture!(:embed_usage) == "embed_basic"
+      assert ScenarioCatalog.fixture!(:multimodal_tool_result, 1) == "multimodal_tool_result_2"
+
+      assert %{
+               operation: :text,
+               requirements: [:tool_calling],
+               applicability: :model_features,
+               proof: :fixture_replay
+             } = ScenarioCatalog.fetch_scenario!(:tool_multi)
+
+      assert %{
+               input_modalities: [:audio],
+               output_modalities: [:text],
+               providers: :all
+             } = ScenarioCatalog.fetch_scenario!(:transcription_basic)
     end
 
     test "represents every canonical operation and its established route" do
@@ -65,6 +95,22 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
                Enum.find(ScenarioCatalog.capabilities(), &(&1.id == "embedding"))
     end
 
+    test "limits per-model capability scenarios to applicable providers and proof" do
+      assert ScenarioCatalog.model_compat_scenarios_for_capability("web_fetch", :anthropic) ==
+               {:ok, ["web_fetch_basic"]}
+
+      assert ScenarioCatalog.model_compat_scenarios_for_capability("web_fetch", :openai) ==
+               {:ok, []}
+
+      assert ScenarioCatalog.model_compat_scenarios_for_capability("tool_id_compat", :openai) ==
+               {:ok, []}
+
+      assert ScenarioCatalog.model_compat_scenarios_for_capability(
+               "tool_id_compat",
+               :anthropic
+             ) == {:ok, []}
+    end
+
     test "preserves provider-specific routes" do
       assert ScenarioCatalog.scenario_test_file(:google, "grounding_basic") ==
                "test/coverage/google/grounding_test.exs"
@@ -73,13 +119,59 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
                "test/coverage/xai/streaming_structured_output_test.exs"
 
       assert ScenarioCatalog.scenario_test_file(:google, "basic") == nil
+
+      assert ScenarioCatalog.scenario_test_file(:openai, :logprobs_non_streaming) ==
+               "test/coverage/openai/logprobs_test.exs"
+
+      assert ScenarioCatalog.scenario_test_file(:azure, :object_streaming_claude_auto) ==
+               "test/coverage/azure/streaming_structured_output_test.exs"
+    end
+
+    test "fixture-backed contracts have evidence and focused routes exist" do
+      fixture_files =
+        Path.expand("../../support/fixtures", __DIR__)
+        |> Path.join("**/*.json")
+        |> Path.wildcard()
+        |> Enum.map(&Path.basename(&1, ".json"))
+        |> MapSet.new()
+
+      for scenario <- ScenarioCatalog.scenarios(),
+          scenario.proof == :fixture_replay,
+          fixture <- scenario.fixtures do
+        assert MapSet.member?(fixture_files, fixture),
+               "missing fixture evidence for scenario #{scenario.id} fixture #{fixture}"
+      end
+
+      for route <- ScenarioCatalog.routes() do
+        assert File.exists?(route.test_file),
+               "missing focused coverage route for scenario #{route.scenario}: #{route.test_file}"
+      end
+    end
+
+    test "every current coverage scenario tag resolves through the catalog" do
+      sources =
+        Path.wildcard("test/coverage/**/*.exs") ++
+          Path.wildcard("test/support/provider_test/*.ex")
+
+      source = Enum.map_join(sources, "\n", &File.read!/1)
+      refute source =~ "@tag scenario:"
+
+      tagged_ids =
+        ~r/CompatibilityScenario\.tag!\(:(?<id>[a-z0-9_]+)\)/
+        |> Regex.scan(source, capture: :all_names)
+        |> List.flatten()
+        |> MapSet.new()
+
+      catalog_ids = ScenarioCatalog.scenarios() |> Enum.map(& &1.id) |> MapSet.new()
+
+      assert tagged_ids == catalog_ids
     end
   end
 
   describe "validation" do
     test "rejects duplicate scenario IDs" do
       capabilities = [%{id: "core", operation: :text}]
-      scenarios = [%{id: "basic", capability: "core"}, %{id: "basic", capability: "core"}]
+      scenarios = [scenario("basic"), scenario("basic")]
 
       assert_raise ArgumentError, ~r/duplicate scenario IDs/, fn ->
         ScenarioCatalog.validate!(@operations, capabilities, scenarios, [])
@@ -88,7 +180,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
 
     test "rejects unknown capabilities" do
       capabilities = [%{id: "core", operation: :text}]
-      scenarios = [%{id: "basic", capability: "missing"}]
+      scenarios = [scenario("basic", capability: "missing")]
 
       assert_raise ArgumentError, ~r/references unknown capability/, fn ->
         ScenarioCatalog.validate!(@operations, capabilities, scenarios, [])
@@ -97,12 +189,55 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
 
     test "rejects invalid routes" do
       capabilities = [%{id: "core", operation: :text}]
-      scenarios = [%{id: "basic", capability: "core"}]
+      scenarios = [scenario("basic")]
       routes = [%{provider: :openai, scenario: "unknown", test_file: "test/coverage/openai.exs"}]
 
       assert_raise ArgumentError, ~r/invalid scenario route/, fn ->
         ScenarioCatalog.validate!(@operations, capabilities, scenarios, routes)
       end
     end
+
+    test "identifies missing fixture contracts and unknown requirement tags" do
+      capabilities = [%{id: "core", operation: :text}]
+
+      assert_raise ArgumentError, ~r/scenario "basic" is missing its fixture contract/, fn ->
+        ScenarioCatalog.validate!(
+          @operations,
+          capabilities,
+          [scenario("basic", fixtures: [])],
+          []
+        )
+      end
+
+      assert_raise ArgumentError,
+                   ~r/scenario "basic" has invalid requirements: \[:unknown\]/,
+                   fn ->
+                     ScenarioCatalog.validate!(
+                       @operations,
+                       capabilities,
+                       [scenario("basic", requirements: [:unknown])],
+                       []
+                     )
+                   end
+    end
+  end
+
+  defp scenario(id, overrides \\ []) do
+    Map.merge(
+      %{
+        id: id,
+        capability: "core",
+        operation: :text,
+        input_modalities: [:text],
+        output_modalities: [:text],
+        requirements: [],
+        transports: [:request_response],
+        fixtures: [id],
+        proof: :fixture_replay,
+        applicability: :operation,
+        providers: :all
+      },
+      Map.new(overrides)
+    )
   end
 end

--- a/test/support/compatibility_scenario.ex
+++ b/test/support/compatibility_scenario.ex
@@ -1,0 +1,38 @@
+defmodule ReqLLM.Test.CompatibilityScenario do
+  @moduledoc """
+  Test-side access to the compiled compatibility scenario catalog.
+
+  Executable assertions remain in provider coverage tests. This module only
+  resolves their stable tags, fixture contracts, and model applicability.
+  """
+
+  alias ReqLLM.Compatibility.ScenarioCatalog
+  alias ReqLLM.ProviderTest.Comprehensive
+
+  @spec tag!(atom()) :: [{:scenario, atom()}]
+  def tag!(id) when is_atom(id) do
+    ScenarioCatalog.fetch_scenario!(id)
+    [scenario: id]
+  end
+
+  @spec fixture!(atom() | binary(), non_neg_integer()) :: binary()
+  def fixture!(id, index \\ 0), do: ScenarioCatalog.fixture!(id, index)
+
+  @spec applicable?(atom() | binary(), binary() | LLMDB.Model.t()) :: boolean()
+  def applicable?(id, model) do
+    scenario = ScenarioCatalog.fetch_scenario!(id)
+
+    case scenario.applicability do
+      :model_features -> Enum.all?(scenario.requirements, &supports?(&1, model))
+      _ -> true
+    end
+  end
+
+  defp supports?(:tool_calling, model), do: Comprehensive.supports_tool_calling?(model)
+  defp supports?(:object_generation, model), do: Comprehensive.supports_object_generation?(model)
+
+  defp supports?(:streaming_object_generation, model),
+    do: Comprehensive.supports_streaming_object_generation?(model)
+
+  defp supports?(:reasoning, model), do: Comprehensive.supports_reasoning?(model)
+end

--- a/test/support/provider_test/comprehensive.ex
+++ b/test/support/provider_test/comprehensive.ex
@@ -184,7 +184,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
         describe "#{model_spec}" do
           @describetag model: model_spec |> String.split(":", parts: 2) |> List.last()
 
-          @tag scenario: :basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:basic)
           test "basic generate_text (non-streaming)" do
             require Logger
 
@@ -203,12 +203,12 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             ReqLLM.generate_text(
               @model_spec,
               "Hello world!",
-              fixture_opts("basic", opts)
+              fixture_opts(ReqLLM.Test.CompatibilityScenario.fixture!(:basic), opts)
             )
             |> assert_basic_response()
           end
 
-          @tag scenario: :streaming
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:streaming)
           test "stream_text with system context and creative params" do
             require Logger
 
@@ -230,7 +230,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               ReqLLM.stream_text(
                 @model_spec,
                 context,
-                fixture_opts(@provider, "streaming", opts)
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:streaming),
+                  opts
+                )
               )
 
             assert %ReqLLM.StreamResponse{} = stream_response
@@ -259,7 +263,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             assert_streaming_usage(response.usage)
           end
 
-          @tag scenario: :token_limit
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:token_limit)
           @tag timeout: 600_000
           test "token limit constraints" do
             opts =
@@ -270,7 +274,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             case ReqLLM.generate_text(
                    @model_spec,
                    "Write a very long story about dragons and adventures",
-                   fixture_opts(@provider, "token_limit", opts)
+                   fixture_opts(
+                     @provider,
+                     ReqLLM.Test.CompatibilityScenario.fixture!(:token_limit),
+                     opts
+                   )
                  ) do
               {:ok, response} ->
                 assert_basic_response({:ok, response})
@@ -294,7 +302,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             end
           end
 
-          @tag scenario: :usage
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:usage)
           test "usage metrics and cost calculations" do
             require Logger
 
@@ -316,7 +324,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                 @model_spec,
                 "Hi there!",
                 fixture_opts(
-                  "usage",
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:usage),
                   Keyword.put(param_bundles().deterministic, :max_tokens, max_tokens)
                 )
               )
@@ -349,7 +357,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             end
           end
 
-          @tag scenario: :context_append
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:context_append)
           test "context append continues conversation" do
             ctx = ReqLLM.Context.new([user("Respond with a single word 'Hi'.")])
 
@@ -362,7 +370,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               ReqLLM.generate_text(
                 @model_spec,
                 ctx,
-                fixture_opts(@provider, "context_append_1", opts)
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:context_append, 0),
+                  opts
+                )
               )
 
             ctx2 = ReqLLM.Context.append(resp1.context, user("Hi again"))
@@ -371,7 +383,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               ReqLLM.generate_text(
                 @model_spec,
                 ctx2,
-                fixture_opts(@provider, "context_append_2", opts)
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:context_append, 1),
+                  opts
+                )
               )
 
             text = ReqLLM.Response.text(resp2) || ""
@@ -383,8 +399,8 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             assert resp2.message.role == :assistant
           end
 
-          if ReqLLM.ProviderTest.Comprehensive.supports_tool_calling?(model_spec) do
-            @tag scenario: :tool_multi
+          if ReqLLM.Test.CompatibilityScenario.applicable?(:tool_multi, model_spec) do
+            @tag ReqLLM.Test.CompatibilityScenario.tag!(:tool_multi)
             test "tool calling - multi-tool selection" do
               tools = [
                 ReqLLM.tool(
@@ -427,7 +443,10 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                 ReqLLM.generate_text(
                   @model_spec,
                   "What's the weather like in Paris, France?",
-                  fixture_opts("multi_tool", base_opts ++ [tools: tools])
+                  fixture_opts(
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:tool_multi),
+                    base_opts ++ [tools: tools]
+                  )
                 )
 
               case result do
@@ -448,7 +467,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               end
             end
 
-            @tag scenario: :tool_round_trip
+            @tag ReqLLM.Test.CompatibilityScenario.tag!(:tool_round_trip)
             test "tool calling - round trip execution" do
               tools = [
                 ReqLLM.tool(
@@ -479,7 +498,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                   @model_spec,
                   "Use the add tool to compute 2 + 3. After the tool result arrives, respond with 'sum=<value>'.",
                   fixture_opts(
-                    "tool_round_trip_1",
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:tool_round_trip, 0),
                     base_opts ++
                       [
                         tools: tools,
@@ -497,7 +516,10 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                 ReqLLM.generate_text(
                   @model_spec,
                   ctx2,
-                  fixture_opts("tool_round_trip_2", base_opts)
+                  fixture_opts(
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:tool_round_trip, 1),
+                    base_opts
+                  )
                 )
 
               text = ReqLLM.Response.text(resp2) || ""
@@ -506,7 +528,7 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               assert Enum.empty?(ReqLLM.Response.tool_calls(resp2))
             end
 
-            @tag scenario: :tool_none
+            @tag ReqLLM.Test.CompatibilityScenario.tag!(:tool_none)
             test "tool calling - no tool when inappropriate" do
               tools = [
                 ReqLLM.tool(
@@ -533,14 +555,17 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
               ReqLLM.generate_text(
                 @model_spec,
                 "Tell me a joke about cats",
-                fixture_opts("no_tool", base_opts ++ [tools: tools])
+                fixture_opts(
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:tool_none),
+                  base_opts ++ [tools: tools]
+                )
               )
               |> assert_basic_response()
             end
           end
 
-          if ReqLLM.ProviderTest.Comprehensive.supports_object_generation?(model_spec) do
-            @tag scenario: :object_basic
+          if ReqLLM.Test.CompatibilityScenario.applicable?(:object_basic, model_spec) do
+            @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_basic)
             test "object generation (non-streaming)" do
               schema = [
                 name: [type: :string, required: true, doc: "Person's full name"],
@@ -558,7 +583,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                   @model_spec,
                   "Generate a software engineer profile",
                   schema,
-                  fixture_opts(@provider, "object_basic", opts)
+                  fixture_opts(
+                    @provider,
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:object_basic),
+                    opts
+                  )
                 )
 
               assert %ReqLLM.Response{} = response
@@ -589,8 +618,8 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             end
           end
 
-          if ReqLLM.ProviderTest.Comprehensive.supports_streaming_object_generation?(model_spec) do
-            @tag scenario: :object_streaming
+          if ReqLLM.Test.CompatibilityScenario.applicable?(:object_streaming, model_spec) do
+            @tag ReqLLM.Test.CompatibilityScenario.tag!(:object_streaming)
             test "object generation (streaming)" do
               schema = [
                 name: [type: :string, required: true, doc: "Person's full name"],
@@ -608,7 +637,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                   @model_spec,
                   "Generate a software engineer profile",
                   schema,
-                  fixture_opts(@provider, "object_streaming", opts)
+                  fixture_opts(
+                    @provider,
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:object_streaming),
+                    opts
+                  )
                 )
 
               response =
@@ -646,8 +679,8 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
             end
           end
 
-          if ReqLLM.ProviderTest.Comprehensive.supports_reasoning?(model_spec) do
-            @tag scenario: :reasoning
+          if ReqLLM.Test.CompatibilityScenario.applicable?(:reasoning, model_spec) do
+            @tag ReqLLM.Test.CompatibilityScenario.tag!(:reasoning)
             test "reasoning/thinking tokens (non-streaming + streaming)" do
               dbug(
                 fn -> "\n[Comprehensive] model_spec=#{@model_spec}, test=reasoning" end,
@@ -675,7 +708,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                 ReqLLM.generate_text(
                   @model_spec,
                   prompt,
-                  fixture_opts(@provider, "reasoning_basic", base_opts)
+                  fixture_opts(
+                    @provider,
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:reasoning, 0),
+                    base_opts
+                  )
                 )
 
               assert %ReqLLM.Response{} = response
@@ -727,7 +764,11 @@ defmodule ReqLLM.ProviderTest.Comprehensive do
                 ReqLLM.stream_text(
                   @model_spec,
                   context,
-                  fixture_opts(@provider, "reasoning_streaming", stream_opts)
+                  fixture_opts(
+                    @provider,
+                    ReqLLM.Test.CompatibilityScenario.fixture!(:reasoning, 1),
+                    stream_opts
+                  )
                 )
 
               assert %ReqLLM.StreamResponse{} = stream_response

--- a/test/support/provider_test/embedding.ex
+++ b/test/support/provider_test/embedding.ex
@@ -48,7 +48,7 @@ defmodule ReqLLM.ProviderTest.Embedding do
 
         describe "#{model_spec}" do
           @tag category: :embedding
-          @tag scenario: :embed_basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:embed_basic)
           test "basic embedding generation" do
             dbug(
               fn -> "\n[Embedding] model_spec=#{@model_spec}, test=basic_embed" end,
@@ -59,7 +59,11 @@ defmodule ReqLLM.ProviderTest.Embedding do
               ReqLLM.embed(
                 @model_spec,
                 "Hello world",
-                fixture_opts(@provider, "embed_basic", [])
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:embed_basic),
+                  []
+                )
               )
 
             case result do
@@ -74,7 +78,7 @@ defmodule ReqLLM.ProviderTest.Embedding do
           end
 
           @tag category: :embedding
-          @tag scenario: :embed_usage
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:embed_usage)
           test "return_usage includes token counts" do
             dbug(
               fn -> "\n[Embedding] model_spec=#{@model_spec}, test=embed_basic_usage" end,
@@ -85,7 +89,11 @@ defmodule ReqLLM.ProviderTest.Embedding do
               ReqLLM.embed(
                 @model_spec,
                 "Hello world",
-                fixture_opts(@provider, "embed_basic", return_usage: true)
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:embed_usage),
+                  return_usage: true
+                )
               )
 
             case result do
@@ -106,7 +114,7 @@ defmodule ReqLLM.ProviderTest.Embedding do
           end
 
           @tag category: :embedding
-          @tag scenario: :embed_batch
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:embed_batch)
           test "batch embedding generation" do
             dbug(
               fn -> "\n[Embedding] model_spec=#{@model_spec}, test=batch_embed" end,
@@ -119,7 +127,11 @@ defmodule ReqLLM.ProviderTest.Embedding do
               ReqLLM.embed(
                 @model_spec,
                 texts,
-                fixture_opts(@provider, "embed_batch", [])
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:embed_batch),
+                  []
+                )
               )
 
             case result do

--- a/test/support/provider_test/image_generation.ex
+++ b/test/support/provider_test/image_generation.ex
@@ -35,14 +35,18 @@ defmodule ReqLLM.ProviderTest.ImageGeneration do
 
         describe "#{model_spec}" do
           @tag category: :image
-          @tag scenario: :image_basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:image_basic)
           @tag model: model_spec |> String.split(":", parts: 2) |> List.last()
           test "basic image generation" do
             {:ok, response} =
               ReqLLM.generate_image(
                 @model_spec,
                 ReqLLM.ProviderTest.ImageGeneration.prompt(@provider),
-                fixture_opts(@provider, "image_basic", [])
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:image_basic),
+                  []
+                )
               )
 
             images = ReqLLM.Response.images(response)

--- a/test/support/provider_test/ocr.ex
+++ b/test/support/provider_test/ocr.ex
@@ -37,13 +37,17 @@ defmodule ReqLLM.ProviderTest.OCR do
 
         describe "#{inspect(model_spec)}" do
           @tag category: :ocr
-          @tag scenario: :ocr_basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:ocr_basic)
           test "basic OCR extraction" do
             {:ok, result} =
               ReqLLM.ocr(
                 @model_spec,
                 ReqLLM.ProviderTest.OCR.tiny_pdf(),
-                fixture_opts(@provider, "ocr_basic", [])
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:ocr_basic),
+                  []
+                )
               )
 
             assert is_binary(result.markdown)

--- a/test/support/provider_test/rerank.ex
+++ b/test/support/provider_test/rerank.ex
@@ -35,13 +35,13 @@ defmodule ReqLLM.ProviderTest.Rerank do
 
         describe "#{model_spec}" do
           @tag category: :rerank
-          @tag scenario: :rerank_basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:rerank_basic)
           @tag model: model_spec |> String.split(":", parts: 2) |> List.last()
           test "basic rerank" do
             {:ok, response} =
               ReqLLM.rerank(
                 @model_spec,
-                fixture_opts(@provider, "rerank_basic",
+                fixture_opts(@provider, ReqLLM.Test.CompatibilityScenario.fixture!(:rerank_basic),
                   query: "capital of the United States",
                   documents: ["Carson City", "Washington, D.C.", "Saipan"],
                   top_n: 2

--- a/test/support/provider_test/speech.ex
+++ b/test/support/provider_test/speech.ex
@@ -35,7 +35,7 @@ defmodule ReqLLM.ProviderTest.Speech do
 
         describe "#{model_spec}" do
           @tag category: :speech
-          @tag scenario: :speech_basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:speech_basic)
           @tag model: model_spec |> String.split(":", parts: 2) |> List.last()
           test "basic speech generation" do
             {:ok, result} =
@@ -44,7 +44,7 @@ defmodule ReqLLM.ProviderTest.Speech do
                 "Hello, this is a short fixture test.",
                 fixture_opts(
                   @provider,
-                  "speech_basic",
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:speech_basic),
                   ReqLLM.ProviderTest.Speech.options(@provider)
                 )
               )

--- a/test/support/provider_test/transcription.ex
+++ b/test/support/provider_test/transcription.ex
@@ -37,14 +37,18 @@ defmodule ReqLLM.ProviderTest.Transcription do
 
         describe "#{model_spec}" do
           @tag category: :transcription
-          @tag scenario: :transcription_basic
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:transcription_basic)
           @tag model: model_spec |> String.split(":", parts: 2) |> List.last()
           test "basic audio transcription" do
             {:ok, result} =
               ReqLLM.transcribe(
                 @model_spec,
                 {:binary, ReqLLM.ProviderTest.Transcription.sample_audio(), "audio/wav"},
-                fixture_opts(@provider, "transcription_basic", language: "en")
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:transcription_basic),
+                  language: "en"
+                )
               )
 
             assert is_binary(result.text)


### PR DESCRIPTION
Closes #835

## Summary

- enrich the compiled compatibility catalog for all 39 current coverage scenarios
- centralize exact fixture contracts, feature requirements, transport/proof metadata, and focused routes
- make provider coverage tests resolve scenario tags, fixture names, and model applicability through the catalog
- add compile-time validation and fixture/route/source guardrails
- restrict capability replays to applicable providers and exclude live-only integration scenarios
- reject successful ExUnit exits that execute zero matching compatibility tests

## Backward compatibility

- no runtime generation, streaming, media, provider, or request-building code changes
- existing scenario IDs, ExUnit tags, request options, and fixture filenames are preserved
- no fixture files were modified or refreshed
- existing unknown explicit scenario fallback behavior remains intact

## Validation

- `mix test` — 3,620 passed, 11 skipped, 145 excluded
- `mix quality` — format, warnings-as-errors compile, Credo, and Dialyzer passed
- focused catalog and Mix-task tests — 34 passed
- replayed core text, tool round trip, structured output, embeddings, image, speech, transcription, and Anthropic web-fetch scenarios
- verified inapplicable `web_fetch` and live-only `tool_id_compat` capabilities fail before irrelevant provider tests are spawned
- `mix docs --formatter html`
- `mix hex.build --unpack`
