### PR TITLE
feat: add evidence-backed model support tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ This approach gives you full control over the Req pipeline, allowing you to add 
 ## Documentation
 
 - [Compatibility Policy](COMPATIBILITY.md) – stable, experimental, deprecated, platform, and ReqLLM/Jido contracts
+- [Model Support Evidence](guides/model-support.md) – generated, surface-specific compatibility tiers
 - [Getting Started](guides/getting-started.md) – first call and basic concepts
 - [Configuration](guides/configuration.md) – timeouts, connection pools, and global settings
 - [Telemetry](guides/telemetry.md) – request lifecycle, reasoning lifecycle, payload capture

--- a/guides/fixture-testing.md
+++ b/guides/fixture-testing.md
@@ -75,6 +75,19 @@ Each model entry includes:
 
 The `priv/supported_models.json` file tracks which models have passing fixtures. This file is auto-generated and should not be manually edited.
 
+The versioned `priv/model_compat_scenarios.json` artifact preserves finer-grained
+evidence keyed by model, execution surface, and scenario. Each scenario keeps
+its proof level and observation history, including timestamps, fixture names,
+mode, status, errors, and the classified failure layer. The exact surface comes
+from the recorded fixture request URL, so a replay cannot silently move to a
+different provider API surface.
+
+Run `mix req_llm.model_support --generate` to regenerate the deterministic
+[`model support evidence reference`](model-support.md), and run
+`mix req_llm.model_support --check` to verify both generated files. Support tiers
+are descriptive compatibility-tool output only; ReqLLM continues to resolve
+models independently of this evidence.
+
 ### Comprehensive Test Macro
 
 Tests use the `ReqLLM.ProviderTest.Comprehensive` macro (in `test/support/provider_test/comprehensive.ex`), which generates up to 9 focused tests per model based on capabilities:

--- a/guides/mix-tasks.md
+++ b/guides/mix-tasks.md
@@ -353,6 +353,42 @@ The `priv/supported_models.json` file tracks validation status:
 }
 ```
 
+Scenario-level evidence is stored separately in
+`priv/model_compat_scenarios.json`. That versioned artifact records the model,
+exact execution surface inferred from the fixture request URL, scenario,
+proof level, observations, fixture names, and classified failure layer. It is
+used only by compatibility tooling and generated documentation; it never
+changes model resolution or request routing.
+
+## `mix req_llm.model_support`
+
+Inspect the conservative support tiers derived from current scenario evidence:
+
+```bash
+mix req_llm.model_support
+mix req_llm.model_support --model openai:gpt-4o-mini
+mix req_llm.model_compat --available --sample --support-tiers
+```
+
+Maintainers generate and verify the checked-in evidence reference with:
+
+```bash
+mix req_llm.model_support --generate
+mix req_llm.model_support --check
+```
+
+The generated [`model-support.md`](model-support.md) reference is deterministic
+for a given catalog and evidence snapshot. Tiers are surface-specific:
+
+- `first_class` requires current passing evidence for the entire operation baseline;
+- `best_effort` requires at least one current baseline pass but is incomplete;
+- `experimental` means evidence or current catalog declaration is missing or stale; and
+- `unsupported` includes an explicit reason such as a baseline failure layer or
+  an operation absent from current model metadata.
+
+Catalog presence alone is never evidence. These tiers do not act as a runtime
+allowlist.
+
 ### Example Output
 
 ```

--- a/guides/model-support.md
+++ b/guides/model-support.md
@@ -1,0 +1,813 @@
+# Model Support Evidence
+
+This file is generated from `priv/model_compat_scenarios.json` and the compiled
+compatibility scenario catalog. It is a tooling snapshot, not a runtime model
+allowlist, and it does not change whether ReqLLM can resolve or call a model.
+
+- Evidence schema: `1`
+- Snapshot evaluated at: `2026-06-12T21:58:25Z`
+- Freshness window: `90 days`
+
+## Conservative tier rules
+
+- **First-class**: every fixture-replay baseline scenario for this exact
+  execution surface has current passing evidence.
+- **Best-effort**: at least one baseline scenario has current passing evidence,
+  but the baseline is incomplete.
+- **Experimental**: evidence is missing, stale, or no fixture-replay baseline is
+  defined. Catalog presence alone never promotes a surface.
+- **Unsupported**: a required baseline scenario has explicit failing evidence;
+  the reason includes its classified failure layer.
+
+A recorded operation that current model metadata does not declare is unsupported
+for that operation. Evidence for a model absent from the current catalog remains
+experimental rather than becoming a support claim.
+
+These labels describe evidence for a model surface. They do not describe every
+provider-native feature and are not consulted by request routing.
+
+## Snapshot summary
+
+| Tier | Surfaces |
+| --- | ---: |
+| First-class | 46 |
+| Best-effort | 475 |
+| Experimental | 66 |
+| Unsupported | 103 |
+| **Total recorded surfaces** | **690** |
+
+## anthropic
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `claude-haiku-4-5-20251001` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:09:16Z | missing current evidence: context_append, streaming |
+| `claude-opus-4-1-20250805` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:11:25Z | missing current evidence: context_append, streaming |
+| `claude-opus-4-20250514` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:13:32Z | missing current evidence: context_append, streaming |
+| `claude-opus-4-5` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:20:43Z | missing current evidence: context_append, streaming |
+| `claude-opus-4-8` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:14:45Z | missing current evidence: context_append, streaming |
+| `claude-sonnet-4-20250514` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:16:20Z | missing current evidence: context_append, streaming |
+| `claude-sonnet-4-5-20250929` | `text` | `anthropic.messages` | text → text | Best-effort | 3/5 | 2026-05-29T17:17:58Z | missing current evidence: context_append, streaming |
+
+## cerebras
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `gpt-oss-120b` | `text` | `cerebras.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:27:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `llama3.1-8b` | `text` | `cerebras.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-29T23:27:04Z | surface declaration unknown |
+| `qwen-3-235b-a22b-instruct-2507` | `text` | `cerebras.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T23:27:04Z | basic failed at provider_drift |
+| `qwen-3-coder-480b` | `text` | `cerebras.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T23:27:04Z | basic failed at provider_drift |
+| `zai-glm-4.7` | `text` | `cerebras.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:27:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+
+## cohere
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `c4ai-aya-expanse-32b` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `c4ai-aya-expanse-8b` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `c4ai-aya-vision-32b` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `c4ai-aya-vision-8b` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-a-03-2025` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-a-reasoning-08-2025` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-a-translate-08-2025` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-a-vision-07-2025` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-r-08-2024` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-r-plus-08-2024` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-r7b-12-2024` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `command-r7b-arabic-02-2025` | `text` | `cohere.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:28:02Z | basic failed at assertion |
+| `rerank-english-v3.0` | `rerank` | `cohere.rerank` | text → ranked_documents | First-class | 1/1 | 2026-05-29T23:28:38Z | complete current baseline |
+| `rerank-multilingual-v3.0` | `rerank` | `cohere.rerank` | text → ranked_documents | First-class | 1/1 | 2026-05-29T23:28:38Z | complete current baseline |
+| `rerank-v3.5` | `rerank` | `cohere.rerank` | text → ranked_documents | First-class | 1/1 | 2026-05-29T23:28:38Z | complete current baseline |
+| `rerank-v4.0-fast` | `rerank` | `cohere.rerank` | text → ranked_documents | First-class | 1/1 | 2026-05-29T23:28:38Z | complete current baseline |
+| `rerank-v4.0-pro` | `rerank` | `cohere.rerank` | text → ranked_documents | First-class | 1/1 | 2026-05-29T23:28:38Z | complete current baseline |
+
+## elevenlabs
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `eleven_flash_v2_5` | `speech` | `elevenlabs.speech` | text → audio | First-class | 1/1 | 2026-05-29T23:29:10Z | complete current baseline |
+| `eleven_multilingual_v2` | `speech` | `elevenlabs.speech` | text → audio | First-class | 1/1 | 2026-05-29T23:29:10Z | complete current baseline |
+| `eleven_turbo_v2_5` | `speech` | `elevenlabs.speech` | text → audio | First-class | 1/1 | 2026-05-29T23:29:10Z | complete current baseline |
+| `eleven_v3` | `speech` | `elevenlabs.speech` | text → audio | First-class | 1/1 | 2026-05-29T23:29:10Z | complete current baseline |
+
+## fireworks_ai
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `accounts/fireworks/models/deepseek-v4-flash` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/deepseek-v4-pro` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/glm-5p1` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/gpt-oss-120b` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/gpt-oss-20b` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/kimi-k2p5` | `text` | `fireworks_ai.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:30:47Z | surface declaration unknown |
+| `accounts/fireworks/models/kimi-k2p6` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/minimax-m2p5` | `text` | `fireworks_ai.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:30:47Z | surface declaration unknown |
+| `accounts/fireworks/models/minimax-m2p7` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `accounts/fireworks/models/qwen3p6-plus` | `text` | `fireworks_ai.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:30:47Z | surface declaration unknown |
+| `accounts/fireworks/routers/glm-5p1-fast` | `text` | `fireworks_ai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:30:47Z | basic failed at provider_drift |
+| `accounts/fireworks/routers/kimi-k2p6-turbo` | `text` | `fireworks_ai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:30:47Z | missing current evidence: usage, token_limit, context_append, streaming |
+
+## github_copilot
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `gpt-4.1` | `text` | `github_copilot.chat_completions` | text → text | Best-effort | 1/5 | 2026-06-12T21:58:25Z | missing current evidence: usage, token_limit, context_append, streaming |
+
+## google
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `antigravity-preview-05-2026` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `aqa` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `deep-research-max-preview-04-2026` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `deep-research-preview-04-2026` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `deep-research-pro-preview-12-2025` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-1.5-flash` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
+| `gemini-1.5-pro` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
+| `gemini-2.0-flash` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-2.0-flash-exp` | `text` | `google.generate_content` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
+| `gemini-2.0-flash-lite` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-2.5-computer-use-preview-10-2025` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-2.5-flash` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-2.5-flash-image` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:27:26Z | complete current baseline |
+| `gemini-2.5-flash-lite` | `text` | `google.generate_content` | text, tool_result → structured_object, text, tool_call | First-class | 5/5 | 2026-05-30T01:01:43Z | complete current baseline |
+| `gemini-2.5-flash-native-audio-latest` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-2.5-flash-native-audio-preview-09-2025` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-2.5-flash-native-audio-preview-12-2025` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-2.5-pro` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-3-flash-preview` | `text` | `google.generate_content` | text, tool_result → reasoning, structured_object, text, tool_call | First-class | 5/5 | 2026-05-30T01:01:43Z | complete current baseline |
+| `gemini-3-pro-image` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:29:02Z | complete current baseline |
+| `gemini-3-pro-image-preview` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:28:39Z | complete current baseline |
+| `gemini-3-pro-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-3.1-flash-image` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:28:17Z | complete current baseline |
+| `gemini-3.1-flash-image-preview` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:27:52Z | complete current baseline |
+| `gemini-3.1-flash-lite` | `text` | `google.generate_content` | text, tool_result → reasoning, structured_object, text, tool_call | First-class | 5/5 | 2026-05-30T01:01:43Z | complete current baseline |
+| `gemini-3.1-flash-lite-preview` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-3.1-flash-live-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-3.1-pro-preview` | `text` | `google.generate_content` | document, text, tool_result → reasoning, structured_object, text, tool_call | First-class | 5/5 | 2026-05-30T01:01:43Z | complete current baseline |
+| `gemini-3.1-pro-preview-customtools` | `text` | `google.generate_content` | text, tool_result → reasoning, structured_object, text, tool_call | First-class | 5/5 | 2026-05-30T01:01:43Z | complete current baseline |
+| `gemini-3.5-flash` | `text` | `google.generate_content` | text, tool_result → reasoning, structured_object, text, tool_call | First-class | 5/5 | 2026-06-10T21:03:14Z | complete current baseline |
+| `gemini-embedding-001` | `embedding` | `google.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T01:02:06Z | missing current evidence: embed_usage, embed_batch |
+| `gemini-embedding-2` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | operation not declared |
+| `gemini-embedding-2-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-flash-latest` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-pro-latest` | `text` | `google.generate_content` | text → text | First-class | 5/5 | 2026-05-30T01:01:43Z | complete current baseline |
+| `gemini-robotics-er-1.5-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `gemini-robotics-er-1.6-preview` | `text` | `google.generate_content` | text → text | Best-effort | 1/5 | 2026-05-30T01:01:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `imagen-4.0-fast-generate-001` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:29:31Z | complete current baseline |
+| `imagen-4.0-generate-001` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:29:18Z | complete current baseline |
+| `imagen-4.0-ultra-generate-001` | `image` | `google.image` | text → image | First-class | 1/1 | 2026-05-29T22:29:47Z | complete current baseline |
+| `lyria-3-clip-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `lyria-3-pro-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `nano-banana-pro-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at assertion |
+| `text-embedding-004` | `embedding` | `google.unrecorded_embedding` | text → embedding | Experimental | 0/3 | 2026-05-30T01:02:06Z | surface declaration unknown |
+| `veo-2.0-generate-001` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
+| `veo-3.0-fast-generate-001` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
+| `veo-3.0-generate-001` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
+| `veo-3.1-fast-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `veo-3.1-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `veo-3.1-lite-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+
+## groq
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `allam-2-7b` | `text` | `groq.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:26:10Z | surface declaration unknown |
+| `groq/compound` | `text` | `groq.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:26:10Z | basic failed at provider_drift |
+| `groq/compound-mini` | `text` | `groq.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:26:10Z | basic failed at provider_drift |
+| `llama-3.1-8b-instant` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `llama-3.3-70b-versatile` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `llama3-8b-8192` | `text` | `groq.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-29T23:26:10Z | surface declaration unknown |
+| `meta-llama/llama-4-maverick-17b-128e-instruct` | `text` | `groq.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:26:10Z | surface declaration unknown |
+| `meta-llama/llama-prompt-guard-2-22m` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-prompt-guard-2-86m` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2-instruct-0905` | `text` | `groq.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:26:10Z | surface declaration unknown |
+| `openai/gpt-oss-120b` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-20b` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-safeguard-20b` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-32b` | `text` | `groq.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:26:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `whisper-large-v3` | `transcription` | `groq.transcription` | audio → text | First-class | 1/1 | 2026-05-29T23:26:29Z | complete current baseline |
+| `whisper-large-v3-turbo` | `transcription` | `groq.transcription` | audio → text | First-class | 1/1 | 2026-05-29T23:26:29Z | complete current baseline |
+
+## minimax
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `MiniMax-M2.1` | `text` | `minimax.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T16:18:48Z | basic failed at provider_drift |
+
+## openai
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `babbage-002` | `text` | `openai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T19:05:19Z | basic failed at provider_drift |
+| `chat-latest` | `text` | `openai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T21:30:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `chatgpt-image-latest` | `image` | `openai.image` | text → image | First-class | 1/1 | 2026-05-29T21:24:36Z | complete current baseline |
+| `davinci-002` | `text` | `openai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T19:05:29Z | basic failed at provider_drift |
+| `gpt-4-0125-preview` | `text` | `openai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T19:05:48Z | basic failed at provider_drift |
+| `gpt-4.1-2025-04-14` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:57:28Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-4.1-mini` | `text` | `openai.unrecorded_text` | text → text | Best-effort | 1/5 | 2026-05-29T18:43:47Z | missing current evidence: basic, usage, token_limit, streaming |
+| `gpt-4.1-mini-2025-04-14` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:57:38Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-4o-2024-08-06` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:57:48Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-4o-2024-11-20` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:57:58Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-4o-mini` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T16:16:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-4o-mini-transcribe` | `transcription` | `openai.transcription` | audio → text | First-class | 1/1 | 2026-05-29T21:19:21Z | complete current baseline |
+| `gpt-4o-mini-transcribe-2025-03-20` | `transcription` | `openai.transcription` | audio → text | First-class | 1/1 | 2026-05-29T21:23:21Z | complete current baseline |
+| `gpt-4o-mini-transcribe-2025-12-15` | `transcription` | `openai.transcription` | audio → text | First-class | 1/1 | 2026-05-29T21:23:38Z | complete current baseline |
+| `gpt-4o-mini-tts` | `speech` | `openai.speech` | text → audio | First-class | 1/1 | 2026-05-29T21:17:40Z | complete current baseline |
+| `gpt-4o-mini-tts-2025-12-15` | `speech` | `openai.speech` | text → audio | First-class | 1/1 | 2026-05-29T21:17:57Z | complete current baseline |
+| `gpt-4o-transcribe` | `transcription` | `openai.transcription` | audio → text | First-class | 1/1 | 2026-05-29T21:20:10Z | complete current baseline |
+| `gpt-4o-transcribe-diarize` | `transcription` | `openai.transcription` | audio → text | First-class | 1/1 | 2026-05-29T21:23:56Z | complete current baseline |
+| `gpt-5-2025-08-07` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:58:08Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5-mini-2025-08-07` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:58:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5-nano` | `text` | `openai.unrecorded_text` | text → structured_object | Experimental | 0/5 | 2026-05-29T18:43:47Z | missing or stale evidence |
+| `gpt-5-nano-2025-08-07` | `text` | `openai.responses` | text → text | Best-effort | 2/5 | 2026-05-29T19:19:08Z | missing current evidence: usage, token_limit, context_append |
+| `gpt-5-pro` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:59:05Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5-pro-2025-10-06` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:59:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5-search-api` | `text` | `openai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T19:09:22Z | basic failed at provider_drift |
+| `gpt-5-search-api-2025-10-14` | `text` | `openai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T19:09:31Z | basic failed at provider_drift |
+| `gpt-5.1` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:00:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.1-2025-11-13` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:00:26Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.2` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:00:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.2-2025-12-11` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:00:43Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.2-chat-latest` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:00:53Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.2-pro` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:01:09Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.2-pro-2025-12-11` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:01:31Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.3-chat-latest` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:05:58Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.3-codex` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:06:08Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.3-codex-spark` | `text` | `openai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T21:26:57Z | basic failed at provider_drift |
+| `gpt-5.4` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:06:26Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-2026-03-05` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:06:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-mini` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:06:44Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-mini-2026-03-17` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:06:53Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-nano` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:07:01Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-nano-2026-03-17` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:07:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-pro` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:07:49Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.4-pro-2026-03-05` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:08:23Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.5` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:08:33Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.5-2026-04-23` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:08:42Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.5-pro` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:08:53Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-5.5-pro-2026-04-23` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:09:14Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-audio` | `text` | `openai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T21:37:41Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-audio-mini` | `text` | `openai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T21:37:57Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gpt-image-1-mini` | `image` | `openai.image` | text → image | First-class | 1/1 | 2026-05-29T21:25:04Z | complete current baseline |
+| `gpt-image-1.5` | `image` | `openai.image` | text → image | First-class | 1/1 | 2026-05-29T20:45:07Z | complete current baseline |
+| `gpt-image-2` | `image` | `openai.image` | text → image | First-class | 1/1 | 2026-05-29T21:25:32Z | complete current baseline |
+| `gpt-image-2-2026-04-21` | `image` | `openai.image` | text → image | First-class | 1/1 | 2026-05-29T21:26:05Z | complete current baseline |
+| `gpt-realtime-whisper` | `transcription` | `openai.unrecorded_transcription` | audio → text | Unsupported | 0/1 | 2026-05-29T21:20:41Z | transcription_basic failed at assertion |
+| `o3-2025-04-16` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:58:41Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `o3-pro` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T18:59:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `o3-pro-2025-06-10` | `text` | `openai.responses` | text → text | Best-effort | 1/5 | 2026-05-29T19:00:08Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `tts-1` | `speech` | `openai.speech` | text → audio | First-class | 1/1 | 2026-05-29T20:40:07Z | complete current baseline |
+| `tts-1-1106` | `speech` | `openai.speech` | text → audio | First-class | 1/1 | 2026-05-29T21:18:14Z | complete current baseline |
+| `tts-1-hd` | `speech` | `openai.speech` | text → audio | First-class | 1/1 | 2026-05-29T21:18:32Z | complete current baseline |
+| `tts-1-hd-1106` | `speech` | `openai.speech` | text → audio | First-class | 1/1 | 2026-05-29T21:18:50Z | complete current baseline |
+| `whisper-1` | `transcription` | `openai.transcription` | audio → text | First-class | 1/1 | 2026-05-29T20:44:37Z | complete current baseline |
+
+## openrouter
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `aion-labs/aion-1.0` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:24:39Z | surface declaration unknown |
+| `aion-labs/aion-1.0-mini` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:24:39Z | surface declaration unknown |
+| `aion-labs/aion-2.0` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:39Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `aion-labs/aion-rp-llama-3.1-8b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:39Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `amazon/nova-2-lite-v1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:13:28Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `amazon/nova-lite-v1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:13:28Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `amazon/nova-micro-v1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:13:28Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `amazon/nova-premier-v1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:13:28Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `amazon/nova-pro-v1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:13:28Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `arcee-ai/coder-large` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:13:54Z | basic failed at provider_drift |
+| `arcee-ai/maestro-reasoning` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:13:54Z | surface declaration unknown |
+| `arcee-ai/spotlight` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:13:54Z | surface declaration unknown |
+| `arcee-ai/trinity-large-thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:13:54Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `arcee-ai/trinity-mini` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:13:54Z | surface declaration unknown |
+| `arcee-ai/virtuoso-large` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:13:54Z | basic failed at provider_drift |
+| `baai/bge-base-en-v1.5` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `baai/bge-large-en-v1.5` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `baai/bge-m3` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `baidu/ernie-4.5-21b-a3b` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:14:36Z | surface declaration unknown |
+| `baidu/ernie-4.5-21b-a3b-thinking` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:14:36Z | surface declaration unknown |
+| `baidu/ernie-4.5-300b-a47b` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:14:36Z | surface declaration unknown |
+| `baidu/ernie-4.5-vl-28b-a3b` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:14:36Z | surface declaration unknown |
+| `baidu/ernie-4.5-vl-424b-a47b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:14:36Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance-seed/seed-1.6` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:07Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance-seed/seed-1.6-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:07Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance-seed/seed-2.0-lite` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:07Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance-seed/seed-2.0-mini` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:07Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `cohere/command-a` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:25Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `cohere/command-r-08-2024` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:25Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `cohere/command-r-plus-08-2024` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:25Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `cohere/command-r7b-12-2024` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:25Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-chat` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-chat-v3-0324` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-r1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-r1-0528` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-r1-distill-llama-70b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-r1-distill-qwen-32b` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:35:21Z | surface declaration unknown |
+| `deepseek/deepseek-v3.2` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v3.2-exp` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v3.2-speciale` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-29T23:35:21Z | surface declaration unknown |
+| `deepseek/deepseek-v4-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v4-flash:free` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-29T23:35:21Z | surface declaration unknown |
+| `deepseek/deepseek-v4-pro` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:35:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.0-flash-001` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:24:06Z | surface declaration unknown |
+| `google/gemini-2.0-flash-lite-001` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:24:06Z | surface declaration unknown |
+| `google/gemini-2.5-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:06Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-flash-lite` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:06Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-flash-lite-preview-09-2025` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:24:06Z | surface declaration unknown |
+| `google/gemini-2.5-pro` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:06Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-pro-preview` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:06Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-pro-preview-05-06` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:06Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3-flash-preview` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-flash-lite` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-flash-lite-preview` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-pro-preview` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-pro-preview-customtools` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.5-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:15:55Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-embedding-001` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `google/gemini-embedding-2-preview` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `google/gemma-2-27b-it` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemma-3-4b-it` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemma-3n-e4b-it` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemma-4-26b-a4b-it` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemma-4-26b-a4b-it:free` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:42:35Z | basic failed at provider_drift |
+| `google/gemma-4-31b-it` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemma-4-31b-it:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `ibm-granite/granite-4.0-h-micro` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:20:36Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `ibm-granite/granite-4.1-8b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:20:36Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inception/mercury-2` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:20:46Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ling-2.6-1t` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:16:15Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ling-2.6-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:16:15Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ring-2.6-1t` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:16:15Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inflection/inflection-3-pi` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:54Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inflection/inflection-3-productivity` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:24:54Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `intfloat/e5-base-v2` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `intfloat/e5-large-v2` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `intfloat/multilingual-e5-large` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `liquid/lfm-2-24b-a2b` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:16:50Z | surface declaration unknown |
+| `liquid/lfm-2.5-1.2b-instruct:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:16:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `liquid/lfm-2.5-1.2b-thinking:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:16:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mancer/weaver` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:25:07Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-3-70b-instruct` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:37:04Z | surface declaration unknown |
+| `meta-llama/llama-3-8b-instruct` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:37:04Z | surface declaration unknown |
+| `meta-llama/llama-3.1-70b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-3.1-8b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-3.2-11b-vision-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-3.2-1b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-3.2-3b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-3.2-3b-instruct:free` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:37:04Z | basic failed at provider_drift |
+| `meta-llama/llama-3.3-70b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-4-maverick` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-4-scout` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta-llama/llama-guard-3-8b` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-29T23:37:04Z | surface declaration unknown |
+| `meta-llama/llama-guard-4-12b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:37:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `microsoft/phi-4` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:17:09Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `microsoft/phi-4-mini-instruct` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:17:09Z | surface declaration unknown |
+| `microsoft/wizardlm-2-8x22b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:17:09Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:59Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2-her` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:59Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:59Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:59Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.5:free` | `text` | `openrouter.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-29T23:42:59Z | surface declaration unknown |
+| `minimax/minimax-m2.7` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:59Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/codestral-2508` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/codestral-embed-2505` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `mistralai/devstral-2512` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/devstral-medium` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:38:18Z | surface declaration unknown |
+| `mistralai/devstral-small` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:38:18Z | surface declaration unknown |
+| `mistralai/ministral-14b-2512` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/ministral-3b-2512` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/ministral-8b-2512` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-7b-instruct-v0.1` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:38:18Z | surface declaration unknown |
+| `mistralai/mistral-embed-2312` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `mistralai/mistral-large` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-large-2407` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-large-2411` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:38:18Z | surface declaration unknown |
+| `mistralai/mistral-large-2512` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-medium-3` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-medium-3-5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-medium-3.1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-nemo` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-saba` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-small-24b-instruct-2501` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-small-2603` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mixtral-8x22b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/pixtral-large-2411` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:38:18Z | surface declaration unknown |
+| `mistralai/voxtral-small-24b-2507` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:38:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2-0905` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2.5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2.6` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:21Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2.6:free` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:45:21Z | surface declaration unknown |
+| `morph/morph-v3-fast` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:20:57Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `morph/morph-v3-large` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:20:57Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nex-agi/deepseek-v3.1-nex-n1` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:21:08Z | surface declaration unknown |
+| `nousresearch/hermes-2-pro-llama-3-8b` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:18:40Z | surface declaration unknown |
+| `nousresearch/hermes-3-llama-3.1-405b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:18:40Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nousresearch/hermes-3-llama-3.1-405b:free` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:18:40Z | basic failed at provider_drift |
+| `nousresearch/hermes-3-llama-3.1-70b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:18:40Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nousresearch/hermes-4-70b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:18:40Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/llama-3.3-nemotron-super-49b-v1.5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/llama-nemotron-embed-vl-1b-v2:free` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `nvidia/nemotron-3-nano-30b-a3b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/nemotron-3-nano-30b-a3b:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/nemotron-3-super-120b-a12b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/nemotron-3-super-120b-a12b:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/nemotron-nano-12b-v2-vl:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia/nemotron-nano-9b-v2:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-4o-mini` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T16:17:31Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-120b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:45Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-120b:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:45Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-20b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:45Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-20b:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:45Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-oss-safeguard-20b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:45:45Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/text-embedding-3-large` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `openai/text-embedding-3-small` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `openai/text-embedding-ada-002` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `openrouter/auto` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:23:22Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openrouter/bodybuilder` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:23:22Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openrouter/free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:23:22Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openrouter/owl-alpha` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:23:22Z | surface declaration unknown |
+| `openrouter/pareto-code` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:23:22Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `perplexity/pplx-embed-v1-0.6b` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `perplexity/pplx-embed-v1-4b` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `perplexity/sonar` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `perplexity/sonar-deep-research` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:19:52Z | basic failed at assertion |
+| `perplexity/sonar-pro` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `perplexity/sonar-pro-search` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `perplexity/sonar-reasoning-pro` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `poolside/laguna-m.1:free` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:21:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `poolside/laguna-xs.2:free` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:21:35Z | surface declaration unknown |
+| `qwen/qwen-2.5-72b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:21:54Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen-2.5-7b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:21:54Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen-2.5-coder-32b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:21:54Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen-plus` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:22:16Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen-plus-2025-07-28` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:22:16Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen-plus-2025-07-28:thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:22:16Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-14b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-235b-a22b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-235b-a22b-2507` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-235b-a22b-thinking-2507` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-30b-a3b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-30b-a3b-instruct-2507` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-30b-a3b-thinking-2507` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-32b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-8b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-coder-30b-a3b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-coder-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-coder-next` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-coder-plus` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-embedding-4b` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `qwen/qwen3-embedding-8b` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `qwen/qwen3-max-thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-next-80b-a3b-instruct:free` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:42:04Z | basic failed at provider_drift |
+| `qwen/qwen3-next-80b-a3b-thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-235b-a22b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-235b-a22b-thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-30b-a3b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-30b-a3b-thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-32b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-8b-instruct` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-8b-thinking` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-122b-a10b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-27b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-35b-a3b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-397b-a17b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-9b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-flash-02-23` | `text` | `openrouter.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:42:04Z | basic failed at provider_drift |
+| `qwen/qwen3.5-plus-02-15` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-plus-20260420` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-27b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-35b-a3b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-max-preview` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-plus` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.7-max` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:42:04Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `rekaai/reka-edge` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:21:19Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `sao10k/l3-euryale-70b` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:25:35Z | surface declaration unknown |
+| `sao10k/l3-lunaris-8b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:25:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `sao10k/l3.1-70b-hanami-x1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:25:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `sao10k/l3.1-euryale-70b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:25:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `sao10k/l3.3-euryale-70b` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:25:35Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `sentence-transformers/all-minilm-l12-v2` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `sentence-transformers/all-minilm-l6-v2` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `sentence-transformers/all-mpnet-base-v2` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `sentence-transformers/multi-qa-mpnet-base-dot-v1` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `sentence-transformers/paraphrase-minilm-l6-v2` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `thenlper/gte-base` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `thenlper/gte-large` | `embedding` | `openrouter.embedding` | text → embedding | Best-effort | 1/3 | 2026-05-30T00:56:13Z | missing current evidence: embed_usage, embed_batch |
+| `x-ai/grok-3-mini` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:19:11Z | surface declaration unknown |
+| `x-ai/grok-3-mini-beta` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:19:11Z | surface declaration unknown |
+| `x-ai/grok-4.20` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:11Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `x-ai/grok-4.20-multi-agent` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:11Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `x-ai/grok-4.3` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:11Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `x-ai/grok-build-0.1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:19:11Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `xiaomi/mimo-v2-flash` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:22:50Z | surface declaration unknown |
+| `xiaomi/mimo-v2-omni` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:22:50Z | surface declaration unknown |
+| `xiaomi/mimo-v2-pro` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:22:50Z | surface declaration unknown |
+| `xiaomi/mimo-v2.5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:22:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `xiaomi/mimo-v2.5-pro` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:22:50Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4-32b` | `text` | `openrouter.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:44:10Z | surface declaration unknown |
+| `z-ai/glm-4.5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.5-air` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.5v` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.6` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.6v` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.7` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.7-flash` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5-turbo` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5.1` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5v-turbo` | `text` | `openrouter.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:44:10Z | missing current evidence: usage, token_limit, context_append, streaming |
+
+## venice
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `aion-labs-aion-2-0` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `arcee-trinity-large-thinking` | `text` | `venice.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:55:12Z | surface declaration unknown |
+| `claude-opus-4-5` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `claude-opus-4-6` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `claude-opus-4-6-fast` | `text` | `venice.chat_completions` | text → text | Experimental | 0/5 | 2026-05-29T23:55:12Z | surface declaration unknown |
+| `claude-opus-4-7` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `claude-opus-4-7-fast` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `claude-sonnet-4-5` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `claude-sonnet-4-6` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek-v3.2` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek-v4-flash` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek-v4-pro` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-3-1-pro-preview` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-3-5-flash` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemini-3-flash-preview` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `gemma-4-uncensored` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google-gemma-3-27b-it` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google-gemma-4-26b-a4b-it` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google-gemma-4-31b-it` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-20` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-20-multi-agent` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-3` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-build-0-1` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `hermes-3-llama-3.1-405b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `kimi-k2-5` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `kimi-k2-6` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `llama-3.2-3b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `llama-3.3-70b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mercury-2` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax-m25` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax-m27` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistral-small-2603` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistral-small-3-2-24b-instruct` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia-nemotron-3-nano-30b-a3b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `nvidia-nemotron-cascade-2-30b-a3b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `olafangensan-glm-4.7-flash-heretic` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-4o-2024-11-20` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-4o-mini-2024-07-18` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-52` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-52-codex` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-53-codex` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-54` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-54-mini` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-54-pro` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-55` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-55-pro` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai-gpt-oss-120b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen-3-6-plus` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen-3-7-max` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-235b-a22b-instruct-2507` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-235b-a22b-thinking-2507` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-5-35b-a3b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-5-397b-a17b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-5-9b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-6-27b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-coder-480b-a35b-instruct-turbo` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-next-80b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen3-vl-235b-a22b` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `venice-uncensored-1-2` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `venice-uncensored-role-play` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai-glm-5-turbo` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai-glm-5v-turbo` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `zai-org-glm-4.6` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `zai-org-glm-4.7` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `zai-org-glm-4.7-flash` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `zai-org-glm-5` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `zai-org-glm-5-1` | `text` | `venice.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:55:12Z | missing current evidence: usage, token_limit, context_append, streaming |
+
+## xai
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `grok-2` | `text` | `xai.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:06:18Z | surface declaration unknown |
+| `grok-2-1212` | `text` | `xai.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:06:18Z | surface declaration unknown |
+| `grok-3` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-3-mini` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-3-mini-fast` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-3-mini-fast-latest` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-3-mini-latest` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-0709` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-1-fast-non-reasoning` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-1-fast-reasoning` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-fast` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-fast-non-reasoning` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4-fast-reasoning` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4.20-0309-non-reasoning` | `text` | `xai.chat_completions` | text → structured_object, text, tool_call | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4.20-0309-reasoning` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4.20-multi-agent-0309` | `text` | `xai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:06:18Z | basic failed at provider_drift |
+| `grok-4.20-non-reasoning` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4.3` | `text` | `xai.chat_completions` | text → structured_object, text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-4.3` | `text` | `xai.responses` | text → text | Experimental | 0/5 | 2026-05-29T23:12:24Z | missing or stale evidence |
+| `grok-4.3` | `text` | `xai.unrecorded_text` | text → text | Best-effort | 1/5 | 2026-05-29T23:08:12Z | missing current evidence: basic, usage, token_limit, context_append |
+| `grok-beta` | `text` | `xai.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:06:18Z | surface declaration unknown |
+| `grok-build-0.1` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-code-fast-1` | `text` | `xai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T01:06:18Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `grok-imagine-image` | `image` | `xai.image` | text → image | First-class | 1/1 | 2026-05-30T01:06:56Z | complete current baseline |
+| `grok-imagine-image-pro` | `image` | `xai.image` | text → image | First-class | 1/1 | 2026-05-30T01:06:56Z | complete current baseline |
+| `grok-imagine-image-quality` | `image` | `xai.image` | text → image | First-class | 1/1 | 2026-05-30T01:06:56Z | complete current baseline |
+| `grok-imagine-video` | `text` | `xai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:06:18Z | basic failed at provider_drift |
+
+## zai
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `glm-4.5` | `text` | `zai.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-4.5-air` | `text` | `zai.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-4.5-flash` | `text` | `zai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:33:31Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `glm-4.5v` | `text` | `zai.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-4.6` | `text` | `zai.chat_completions` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-4.6v` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-4.7` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-4.7-flash` | `text` | `zai.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T23:33:31Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `glm-4.7-flashx` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-5` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-5-turbo` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-5.1` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+| `glm-5v-turbo` | `text` | `zai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-29T23:33:31Z | basic failed at provider_drift |
+
+## zai_coder
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `glm-4.5-flash` | `text` | `zai_coder.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-29T16:28:19Z | missing current evidence: usage, token_limit, context_append, streaming |
+
+## zai_coding_plan
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `glm-4.5-air` | `text` | `zai_coding_plan.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:11:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `glm-4.7` | `text` | `zai_coding_plan.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:11:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `glm-5-turbo` | `text` | `zai_coding_plan.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:11:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `glm-5.1` | `text` | `zai_coding_plan.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:11:52Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `glm-5v-turbo` | `text` | `zai_coding_plan.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:11:52Z | basic failed at provider_drift |
+
+## zenmux
+
+| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |
+| --- | --- | --- | --- | --- | ---: | --- | --- |
+| `anthropic/claude-3.5-haiku` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `anthropic/claude-3.7-sonnet` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-haiku-4.5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `anthropic/claude-opus-4` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-opus-4.1` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-opus-4.5` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-opus-4.6` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-opus-4.7` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-opus-4.8` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `anthropic/claude-sonnet-4` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-sonnet-4.5` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `anthropic/claude-sonnet-4.6` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `baidu/ernie-5.0-thinking-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `baidu/ernie-5.1` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `baidu/ernie-x1.1-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance/doubao-seed-1.8` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance/doubao-seed-2.0-code` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance/doubao-seed-2.0-lite` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance/doubao-seed-2.0-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance/doubao-seed-2.0-pro` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `bytedance/doubao-seed-code` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-chat` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-chat-v3.1` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-r1-0528` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-reasoner` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v3.2` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v3.2-exp` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v4-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `deepseek/deepseek-v4-pro` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-flash-lite` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-2.5-pro` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3-flash-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-flash-lite` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-flash-lite-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.1-pro-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemini-3.5-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `google/gemma-3-12b-it` | `text` | `zenmux.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:10:17Z | surface declaration unknown |
+| `inclusionai/ling-1t` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ling-2.6-1t` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ling-2.6-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/llada2.1-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ring-1t` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `inclusionai/ring-2.6-1t` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `kuaishou/kat-coder-pro-v2` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta/llama-3.3-70b-instruct` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `meta/llama-4-scout-17b-16e-instruct` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2-her` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.1` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.5-lightning` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.7` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `minimax/minimax-m2.7-highspeed` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `mistralai/mistral-large-2512` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `moonshotai/kimi-k2-0905` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `moonshotai/kimi-k2-thinking` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `moonshotai/kimi-k2-thinking-turbo` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `moonshotai/kimi-k2.5` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `moonshotai/kimi-k2.6` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/chat-latest` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-4` | `text` | `zenmux.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:10:17Z | surface declaration unknown |
+| `openai/gpt-4.1` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-4.1-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-4.1-nano` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-4o` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-4o-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5-chat` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5-codex` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `openai/gpt-5-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5-nano` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5-pro` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.1` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.1-chat` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.1-codex` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.1-codex-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.2` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.2-chat` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.2-codex` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.2-pro` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `openai/gpt-5.3-chat` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.3-codex` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.4` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.4-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.4-nano` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.4-pro` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `openai/gpt-5.5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/gpt-5.5-pro` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `openai/o1` | `text` | `zenmux.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:10:17Z | surface declaration unknown |
+| `openai/o4-mini` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `openai/text-embedding-3-large` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `openai/text-embedding-3-small` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `qwen/qwen3-14b` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-235b-a22b-2507` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-235b-a22b-thinking-2507` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-coder` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-coder-plus` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-max` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3-vl-plus` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.5-plus` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-max-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.6-plus` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `qwen/qwen3.7-max` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `sapiens-ai/agnes-1.5-flash` | `text` | `zenmux.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:10:17Z | surface declaration unknown |
+| `sapiens-ai/agnes-1.5-lite` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `sapiens-ai/agnes-1.5-pro` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `sapiens-ai/agnes-2.0-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `stepfun/step-3` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at transport |
+| `stepfun/step-3.5-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `stepfun/step-3.5-flash-free` | `text` | `zenmux.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T00:10:17Z | surface declaration unknown |
+| `tencent/hunyuan-2.0-thinking` | `text` | `zenmux.chat_completions` | text → text | Experimental | 0/5 | 2026-05-30T00:10:17Z | surface declaration unknown |
+| `tencent/hy3-preview` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `volcengine/doubao-seed-1.8` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `volcengine/doubao-seed-2.0-code` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `volcengine/doubao-seed-2.0-lite` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `volcengine/doubao-seed-2.0-mini` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `volcengine/doubao-seed-2.0-pro` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `volcengine/doubao-seed-code` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `x-ai/grok-4` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `x-ai/grok-4-fast` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `x-ai/grok-4.1-fast` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `x-ai/grok-4.1-fast-non-reasoning` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `x-ai/grok-4.2-fast` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `x-ai/grok-4.2-fast-non-reasoning` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `x-ai/grok-4.3` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `x-ai/grok-code-fast-1` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at provider_drift |
+| `xiaomi/mimo-v2-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `xiaomi/mimo-v2-omni` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `xiaomi/mimo-v2-pro` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `xiaomi/mimo-v2.5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `xiaomi/mimo-v2.5-pro` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.5-air` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.6` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.6v` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.6v-flash` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.6v-flash-free` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.7` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-4.7-flash-free` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at transport |
+| `z-ai/glm-4.7-flashx` | `text` | `zenmux.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T00:10:17Z | basic failed at transport |
+| `z-ai/glm-5` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5-turbo` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5.1` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+| `z-ai/glm-5v-turbo` | `text` | `zenmux.chat_completions` | text → text | Best-effort | 1/5 | 2026-05-30T00:10:17Z | missing current evidence: usage, token_limit, context_append, streaming |
+

--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -1165,7 +1165,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   defp evidence_support_text(nil, _provider, _model, _selected_operation), do: ""
 
   defp evidence_support_text(evidence, provider, model, selected_operation) do
-    operation = if selected_operation == :all, do: model["type"], else: selected_operation
+    operation = support_operation(model, selected_operation)
     model_spec = "#{provider}:#{model["id"]}"
 
     declared? =
@@ -1182,6 +1182,13 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
     IO.ANSI.faint() <> " [support: #{support.tier}]" <> IO.ANSI.reset()
   end
+
+  @doc false
+  def support_operation(model, :all) do
+    ReqLLM.ModelOperation.normalize(model["type"])
+  end
+
+  def support_operation(_model, selected_operation), do: selected_operation
 
   defp print_model_status(model, _spec, status) do
     tier_color =

--- a/lib/mix/tasks/model_compat.ex
+++ b/lib/mix/tasks/model_compat.ex
@@ -55,6 +55,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   ## Flags
 
       --available        List all models from models.dev API registry (no implementation filter)
+      --support-tiers    Annotate --available output with evidence-derived support tiers
       --sample           Further reduce to sample subset (see :sample_* config or fallback)
       --type TYPE        Operation type: text, embedding, image, speech, transcription, rerank, ocr, or all
       --record           Re-record fixtures (live API calls)
@@ -74,7 +75,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
 
   use Mix.Task
 
-  alias ReqLLM.Compatibility.ScenarioCatalog
+  alias ReqLLM.Compatibility.{Evidence, ScenarioCatalog}
 
   @preferred_cli_env :test
 
@@ -88,6 +89,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
         switches: [
           sample: :boolean,
           available: :boolean,
+          support_tiers: :boolean,
           type: :string,
           record: :boolean,
           record_all: :boolean,
@@ -163,6 +165,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     operation = parse_operation_type(opts[:type])
     sample_specs = if opts[:sample], do: default_specs_for_operation(operation)
     implemented_providers = get_implemented_providers()
+    evidence = if opts[:support_tiers], do: Evidence.load!()
 
     Mix.shell().info("\n#{header(opts[:sample])}\n")
 
@@ -200,7 +203,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
         )
 
         Enum.each(filtered, fn model ->
-          print_model_with_status(model, provider, state)
+          print_model_with_status(model, provider, state, evidence, operation)
         end)
 
         Mix.shell().info("")
@@ -542,6 +545,8 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
         true -> nil
       end
 
+    failure_layer = if status == :pass, do: nil, else: Evidence.classify_failure(error || output)
+
     %{
       provider: provider,
       model_id: model_id,
@@ -551,6 +556,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
       failed: failed,
       total: total,
       error: error,
+      failure_layer: failure_layer,
       fixtures: fixtures,
       scenario: scenario
     }
@@ -596,6 +602,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
           "scenario" => result.scenario,
           "status" => Atom.to_string(result.status),
           "fixtures" => result.fixtures,
+          "failure_layer" => result.failure_layer,
           "error" => result.error
         }
       end)
@@ -614,6 +621,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
       failed: Enum.reduce(results, 0, &(&1.failed + &2)),
       total: Enum.reduce(results, 0, &(&1.total + &2)),
       error: if(errors == [], do: nil, else: Enum.join(errors, "\n")),
+      failure_layer: nil,
       fixtures:
         results
         |> Enum.flat_map(& &1.fixtures)
@@ -1119,7 +1127,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     end
   end
 
-  defp print_model_with_status(model, provider, state) do
+  defp print_model_with_status(model, provider, state, evidence, selected_operation) do
     model_spec = "#{provider}:#{model["id"]}"
     model_id = model["id"]
     has_fixtures = has_fixtures?(provider, model_id)
@@ -1149,7 +1157,30 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
     tier_text =
       if model["tier"], do: " #{tier_color}(#{model["tier"]})#{IO.ANSI.reset()}", else: ""
 
-    Mix.shell().info("  #{status_icon} #{model["id"]}#{tier_text}")
+    support_text = evidence_support_text(evidence, provider, model, selected_operation)
+
+    Mix.shell().info("  #{status_icon} #{model["id"]}#{tier_text}#{support_text}")
+  end
+
+  defp evidence_support_text(nil, _provider, _model, _selected_operation), do: ""
+
+  defp evidence_support_text(evidence, provider, model, selected_operation) do
+    operation = if selected_operation == :all, do: model["type"], else: selected_operation
+    model_spec = "#{provider}:#{model["id"]}"
+
+    declared? =
+      case LLMDB.model(model_spec) do
+        {:ok, resolved} -> ReqLLM.ModelOperation.supported?(resolved, operation)
+        _error -> false
+      end
+
+    support =
+      Evidence.support_status(evidence, model_spec, operation,
+        declared?: declared?,
+        as_of: DateTime.utc_now()
+      )
+
+    IO.ANSI.faint() <> " [support: #{support.tier}]" <> IO.ANSI.reset()
   end
 
   defp print_model_status(model, _spec, status) do
@@ -1499,66 +1530,33 @@ defmodule Mix.Tasks.ReqLlm.ModelCompat do
   defp save_scenario_state(results, run_ts, opts) do
     priv_dir = :code.priv_dir(:req_llm)
     path = Path.join(priv_dir, "model_compat_scenarios.json")
-
-    existing =
-      case File.read(path) do
-        {:ok, content} -> Jason.decode!(content)
-        _ -> %{}
-      end
-
-    ts = DateTime.to_iso8601(run_ts)
     mode = if opts[:record_all] || opts[:record], do: "record", else: "replay"
 
+    surface_resolver = fn model_spec, operation, fixtures ->
+      Evidence.fixture_surface(fixture_path_root(), model_spec, operation, fixtures)
+    end
+
+    existing =
+      case Evidence.load(path, surface_resolver: surface_resolver) do
+        {:ok, evidence} ->
+          evidence
+
+        {:error, :enoent} ->
+          Evidence.migrate(%{})
+
+        {:error, reason} ->
+          raise ArgumentError, "cannot load compatibility evidence: #{inspect(reason)}"
+      end
+
     new_state =
-      Enum.reduce(results, existing, fn result, acc ->
-        scenarios = Map.get(result, :scenarios) || scenario_entries_for_result(result)
+      Evidence.record(existing, results, run_ts, mode, surface_resolver: surface_resolver)
 
-        Enum.reduce(scenarios, acc, fn scenario, scenario_acc ->
-          put_scenario_state(scenario_acc, result.model_spec, scenario, ts, mode)
-        end)
-      end)
-
-    json = Jason.encode!(new_state, pretty: true)
+    json = Evidence.canonical_json(new_state)
 
     case File.read(path) do
       {:ok, prev} when prev == json -> :ok
       _ -> File.write!(path, json)
     end
-  end
-
-  defp scenario_entries_for_result(%{scenario: nil}), do: []
-
-  defp scenario_entries_for_result(result) do
-    [
-      %{
-        "scenario" => result.scenario,
-        "status" => Atom.to_string(result.status),
-        "fixtures" => result.fixtures,
-        "error" => result.error
-      }
-    ]
-  end
-
-  defp put_scenario_state(state, model_spec, scenario, ts, mode) do
-    scenario_name = scenario["scenario"]
-
-    model_state =
-      state
-      |> Map.get(model_spec, %{})
-      |> Map.put_new("scenarios", %{})
-
-    scenario_state = %{
-      "status" => scenario["status"],
-      "last_checked" => ts,
-      "mode" => mode,
-      "fixtures" => scenario["fixtures"] || [],
-      "error" => scenario["error"]
-    }
-
-    updated_model_state =
-      put_in(model_state, ["scenarios", scenario_name], scenario_state)
-
-    Map.put(state, model_spec, updated_model_state)
   end
 
   defp build_sorted_json(state) do

--- a/lib/mix/tasks/model_support.ex
+++ b/lib/mix/tasks/model_support.ex
@@ -1,0 +1,102 @@
+defmodule Mix.Tasks.ReqLlm.ModelSupport do
+  @shortdoc "Inspect or generate evidence-backed model support tiers"
+  @moduledoc """
+  Inspect evidence-backed support tiers without changing model resolution.
+
+      mix req_llm.model_support
+      mix req_llm.model_support --model openai:gpt-4o-mini
+      mix req_llm.model_support --generate
+      mix req_llm.model_support --check
+  """
+
+  use Mix.Task
+
+  alias ReqLLM.Compatibility.{Evidence, SupportReference}
+
+  @impl Mix.Task
+  def run(args) do
+    Application.ensure_all_started(:req_llm)
+
+    {opts, _positional, invalid} =
+      OptionParser.parse(args,
+        strict: [generate: :boolean, check: :boolean, model: :string]
+      )
+
+    if invalid != [], do: Mix.raise("Invalid options: #{inspect(invalid)}")
+
+    cond do
+      opts[:generate] -> generate(load_source_evidence())
+      opts[:check] -> check(load_source_evidence())
+      opts[:model] -> print_model(Evidence.load!(), opts[:model])
+      true -> print_summary(Evidence.load!())
+    end
+  end
+
+  @doc false
+  def evidence_path, do: Path.expand("priv/model_compat_scenarios.json")
+
+  @doc false
+  def reference_path, do: Path.expand("guides/model-support.md")
+
+  defp load_source_evidence do
+    Evidence.load!(evidence_path(), surface_resolver: surface_resolver())
+  end
+
+  defp generate(evidence) do
+    evidence =
+      evidence
+      |> Evidence.resolve_surfaces(surface_resolver())
+      |> Evidence.annotate_declarations()
+
+    Evidence.write!(evidence_path(), evidence)
+    File.write!(reference_path(), SupportReference.render(evidence))
+    Mix.shell().info("Generated #{evidence_path()} and #{reference_path()}")
+  end
+
+  defp check(evidence) do
+    expected_evidence = Evidence.canonical_json(evidence)
+    expected_reference = SupportReference.render(evidence)
+
+    with {:ok, ^expected_evidence} <- File.read(evidence_path()),
+         {:ok, ^expected_reference} <- File.read(reference_path()) do
+      Mix.shell().info("Compatibility evidence and support reference are current")
+    else
+      _mismatch -> Mix.raise("Compatibility evidence or support reference is not generated")
+    end
+  end
+
+  defp print_summary(evidence) do
+    rows = SupportReference.rows(evidence, as_of: DateTime.utc_now())
+    counts = Enum.frequencies_by(rows, & &1.status.tier)
+
+    Mix.shell().info(
+      "Evidence schema #{evidence["schema_version"]} (#{evidence["generated_at"]})"
+    )
+
+    Mix.shell().info("Recorded models: #{map_size(evidence["models"] || %{})}")
+    Mix.shell().info("First-class surfaces: #{Map.get(counts, :first_class, 0)}")
+    Mix.shell().info("Best-effort surfaces: #{Map.get(counts, :best_effort, 0)}")
+    Mix.shell().info("Experimental surfaces: #{Map.get(counts, :experimental, 0)}")
+    Mix.shell().info("Unsupported surfaces: #{Map.get(counts, :unsupported, 0)}")
+  end
+
+  defp print_model(evidence, model_spec) do
+    statuses = Evidence.model_surface_statuses(evidence, model_spec, as_of: DateTime.utc_now())
+
+    if statuses == [] do
+      Mix.shell().info("#{model_spec}: experimental (missing evidence)")
+    else
+      Enum.each(statuses, fn status ->
+        Mix.shell().info("#{model_spec} #{status.surface}: #{status.tier} (#{status.reason})")
+      end)
+    end
+  end
+
+  defp surface_resolver do
+    fixture_root = Path.expand("test/support/fixtures")
+
+    fn model_spec, operation, fixtures ->
+      Evidence.fixture_surface(fixture_root, model_spec, operation, fixtures)
+    end
+  end
+end

--- a/lib/mix/tasks/model_support.ex
+++ b/lib/mix/tasks/model_support.ex
@@ -43,10 +43,7 @@ defmodule Mix.Tasks.ReqLlm.ModelSupport do
   end
 
   defp generate(evidence) do
-    evidence =
-      evidence
-      |> Evidence.resolve_surfaces(surface_resolver())
-      |> Evidence.annotate_declarations()
+    evidence = refresh_evidence(evidence)
 
     Evidence.write!(evidence_path(), evidence)
     File.write!(reference_path(), SupportReference.render(evidence))
@@ -54,6 +51,7 @@ defmodule Mix.Tasks.ReqLlm.ModelSupport do
   end
 
   defp check(evidence) do
+    evidence = refresh_evidence(evidence)
     expected_evidence = Evidence.canonical_json(evidence)
     expected_reference = SupportReference.render(evidence)
 
@@ -63,6 +61,13 @@ defmodule Mix.Tasks.ReqLlm.ModelSupport do
     else
       _mismatch -> Mix.raise("Compatibility evidence or support reference is not generated")
     end
+  end
+
+  @doc false
+  def refresh_evidence(evidence) do
+    evidence
+    |> Evidence.resolve_surfaces(surface_resolver())
+    |> Evidence.annotate_declarations(packaged_catalog_resolver())
   end
 
   defp print_summary(evidence) do
@@ -97,6 +102,33 @@ defmodule Mix.Tasks.ReqLlm.ModelSupport do
 
     fn model_spec, operation, fixtures ->
       Evidence.fixture_surface(fixture_root, model_spec, operation, fixtures)
+    end
+  end
+
+  defp packaged_catalog_resolver do
+    case LLMDB.Loader.load(custom: %{}) do
+      {:ok, snapshot} ->
+        direct_models =
+          Map.new(snapshot.models_by_key, fn {{provider, model_id}, model} ->
+            {"#{provider}:#{model_id}", model}
+          end)
+
+        alias_models =
+          Map.new(snapshot.aliases_by_key, fn {{provider, alias_id}, model_id} ->
+            {"#{provider}:#{alias_id}", Map.fetch!(snapshot.models_by_key, {provider, model_id})}
+          end)
+
+        models_by_spec = Map.merge(direct_models, alias_models)
+
+        fn model_spec ->
+          case Map.fetch(models_by_spec, model_spec) do
+            {:ok, model} -> {:ok, model}
+            :error -> {:error, :unknown_model}
+          end
+        end
+
+      {:error, reason} ->
+        raise ArgumentError, "cannot load packaged LLMDB catalog: #{inspect(reason)}"
     end
   end
 end

--- a/lib/req_llm/compatibility/evidence.ex
+++ b/lib/req_llm/compatibility/evidence.ex
@@ -1,0 +1,881 @@
+defmodule ReqLLM.Compatibility.Evidence do
+  @moduledoc """
+  Versioned compatibility evidence for models, execution surfaces, and scenarios.
+
+  Evidence is tooling metadata. It does not participate in model resolution or
+  request routing.
+  """
+
+  alias ReqLLM.Compatibility.ScenarioCatalog
+
+  @schema_version 1
+  @freshness_days 90
+  @failure_layers ~w(resolution planning encoding transport decoding materialization assertion provider_drift)
+
+  @type tier :: :first_class | :best_effort | :experimental | :unsupported
+
+  @doc "Returns the current evidence schema version."
+  @spec schema_version() :: pos_integer()
+  def schema_version, do: @schema_version
+
+  @doc "Returns the default evidence freshness window in days."
+  @spec freshness_days() :: pos_integer()
+  def freshness_days, do: @freshness_days
+
+  @doc "Returns the supported failure-layer names."
+  @spec failure_layers() :: [binary()]
+  def failure_layers, do: @failure_layers
+
+  @doc "Loads and migrates compatibility evidence from disk."
+  @spec load(Path.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def load(path \\ default_path(), opts \\ []) do
+    with {:ok, content} <- File.read(path),
+         {:ok, decoded} <- Jason.decode(content) do
+      {:ok, migrate(decoded, opts)}
+    end
+  end
+
+  @doc "Loads compatibility evidence or raises."
+  @spec load!(Path.t(), keyword()) :: map()
+  def load!(path \\ default_path(), opts \\ []) do
+    case load(path, opts) do
+      {:ok, evidence} ->
+        evidence
+
+      {:error, reason} ->
+        raise ArgumentError, "cannot load compatibility evidence: #{inspect(reason)}"
+    end
+  end
+
+  @doc "Migrates legacy scenario state into the current evidence schema."
+  @spec migrate(map(), keyword()) :: map()
+  def migrate(evidence, opts \\ [])
+
+  def migrate(%{"schema_version" => @schema_version, "models" => models} = evidence, _opts)
+      when is_map(models) do
+    evidence
+  end
+
+  def migrate(%{"schema_version" => version}, _opts) do
+    raise ArgumentError,
+          "unsupported compatibility evidence schema version: #{inspect(version)}"
+  end
+
+  def migrate(legacy, opts) when is_map(legacy) do
+    surface_resolver = Keyword.get(opts, :surface_resolver, &default_surface_resolver/3)
+
+    models =
+      legacy
+      |> Enum.sort_by(fn {model_spec, _state} -> model_spec end)
+      |> Enum.reduce(%{}, fn {model_spec, model_state}, acc ->
+        Map.put(acc, model_spec, migrate_legacy_model(model_spec, model_state, surface_resolver))
+      end)
+
+    %{
+      "schema_version" => @schema_version,
+      "generated_at" => latest_checked_at(models),
+      "models" => models
+    }
+  end
+
+  @doc "Records scenario results without discarding prior observations."
+  @spec record(map(), [map()], DateTime.t(), binary(), keyword()) :: map()
+  def record(evidence, results, %DateTime{} = checked_at, mode, opts \\ [])
+      when is_list(results) and is_binary(mode) do
+    surface_resolver = Keyword.get(opts, :surface_resolver, &default_surface_resolver/3)
+    checked_at = checked_at |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+    models =
+      Enum.reduce(results, evidence["models"] || %{}, fn result, acc ->
+        record_result(acc, result, checked_at, mode, surface_resolver)
+      end)
+
+    evidence
+    |> Map.put("schema_version", @schema_version)
+    |> Map.put("generated_at", checked_at)
+    |> Map.put("models", models)
+  end
+
+  @doc "Reindexes recorded scenarios from their fixture-backed execution surfaces."
+  @spec resolve_surfaces(map(), (binary(), atom(), [binary()] -> binary() | nil)) :: map()
+  def resolve_surfaces(evidence, surface_resolver) when is_function(surface_resolver, 3) do
+    models =
+      evidence
+      |> Map.get("models", %{})
+      |> Map.new(fn {model_spec, model} ->
+        {provider, _model_id} = split_model_spec(model_spec)
+
+        surfaces =
+          model
+          |> Map.get("surfaces", %{})
+          |> Enum.reduce(%{}, fn {existing_surface_id, surface}, acc ->
+            operation = operation_atom!(surface["operation"])
+
+            surface
+            |> Map.get("scenarios", %{})
+            |> Enum.reduce(acc, fn {scenario_id, scenario}, scenario_acc ->
+              fixtures = scenario_fixtures(scenario)
+
+              surface_id =
+                surface_resolver.(model_spec, operation, fixtures) ||
+                  normalize_unrecorded_surface(existing_surface_id, provider, operation)
+
+              merge_surface_scenario(
+                scenario_acc,
+                surface_id,
+                provider,
+                operation,
+                scenario_id,
+                scenario
+              )
+            end)
+          end)
+
+        {model_spec, Map.put(model, "surfaces", surfaces)}
+      end)
+
+    Map.put(evidence, "models", models)
+  end
+
+  @doc "Annotates recorded surfaces with current catalog operation declarations."
+  @spec annotate_declarations(map(), (binary() -> {:ok, LLMDB.Model.t()} | {:error, term()})) ::
+          map()
+  def annotate_declarations(evidence, resolver \\ &LLMDB.model/1) when is_function(resolver, 1) do
+    models =
+      evidence
+      |> Map.get("models", %{})
+      |> Map.new(fn {model_spec, model} ->
+        {catalog_status, declared_operations} = declared_operations(resolver.(model_spec))
+
+        surfaces =
+          model
+          |> Map.get("surfaces", %{})
+          |> Map.new(fn {surface_id, surface} ->
+            declaration =
+              surface_declaration(surface["operation"], catalog_status, declared_operations)
+
+            {surface_id, Map.put(surface, "declaration", declaration)}
+          end)
+
+        annotated =
+          model
+          |> Map.put("catalog_status", catalog_status)
+          |> Map.put("declared_operations", declared_operations)
+          |> Map.put("surfaces", surfaces)
+
+        {model_spec, annotated}
+      end)
+
+    Map.put(evidence, "models", models)
+  end
+
+  @doc "Writes evidence as deterministic, recursively key-sorted JSON."
+  @spec write!(Path.t(), map()) :: :ok
+  def write!(path, evidence) do
+    File.write!(path, canonical_json(evidence))
+  end
+
+  @doc "Encodes evidence as deterministic, recursively key-sorted JSON."
+  @spec canonical_json(map()) :: binary()
+  def canonical_json(evidence) do
+    evidence
+    |> ordered()
+    |> Jason.encode!(pretty: true)
+    |> Kernel.<>("\n")
+  end
+
+  @doc "Returns the evidence-derived status for one declared operation."
+  @spec support_status(map(), binary(), atom(), keyword()) :: map()
+  def support_status(evidence, model_spec, operation, opts \\ [])
+      when is_binary(model_spec) and is_atom(operation) do
+    if Keyword.get(opts, :declared?, true) do
+      statuses =
+        evidence
+        |> surface_entries(model_spec)
+        |> Enum.filter(fn {_surface_id, surface} ->
+          surface["operation"] == Atom.to_string(operation)
+        end)
+        |> Enum.map(fn {surface_id, surface} ->
+          surface_status(surface_id, surface, operation, opts)
+        end)
+
+      aggregate_operation_status(operation, statuses)
+    else
+      status(:unsupported, :operation_not_declared, operation, [], [], nil)
+    end
+  end
+
+  @doc "Returns evidence-derived statuses for every recorded surface of a model."
+  @spec model_surface_statuses(map(), binary(), keyword()) :: [map()]
+  def model_surface_statuses(evidence, model_spec, opts \\ []) when is_binary(model_spec) do
+    evidence
+    |> surface_entries(model_spec)
+    |> Enum.map(fn {surface_id, surface} ->
+      operation = operation_atom!(surface["operation"])
+      surface_status(surface_id, surface, operation, opts)
+    end)
+    |> Enum.sort_by(& &1.surface)
+  end
+
+  @doc "Classifies a failed execution into a stable compatibility layer."
+  @spec classify_failure(binary() | nil) :: binary() | nil
+  def classify_failure(nil), do: nil
+
+  def classify_failure(error) when is_binary(error) do
+    normalized = String.downcase(error)
+
+    cond do
+      contains_any?(normalized, [
+        "unknown model",
+        "model not found",
+        "could not resolve",
+        "no models match"
+      ]) ->
+        "resolution"
+
+      contains_any?(normalized, [
+        "no replayable",
+        "execution plan",
+        "planning",
+        "no matching compatibility tests"
+      ]) ->
+        "planning"
+
+      contains_any?(normalized, ["encode", "encoding", "request body", "invalid schema"]) ->
+        "encoding"
+
+      contains_any?(normalized, ["decode", "decoding", "invalid json", "parse response"]) ->
+        "decoding"
+
+      contains_any?(normalized, [
+        "materializ",
+        "response builder",
+        "responsebuilder",
+        "assemble response"
+      ]) ->
+        "materialization"
+
+      contains_any?(normalized, [
+        "timed out",
+        "timeout",
+        "econn",
+        "connection",
+        "finch",
+        "mint.transport"
+      ]) ->
+        "transport"
+
+      contains_any?(normalized, [
+        "provider response",
+        "status 4",
+        "status 5",
+        "http 4",
+        "http 5",
+        "rate limit"
+      ]) ->
+        "provider_drift"
+
+      true ->
+        "assertion"
+    end
+  end
+
+  @doc "Resolves a stable execution-surface ID from recorded fixture request URLs."
+  @spec fixture_surface(Path.t(), binary(), atom(), [binary()]) :: binary() | nil
+  def fixture_surface(fixture_root, model_spec, operation, fixtures)
+      when is_binary(model_spec) and is_atom(operation) and is_list(fixtures) do
+    {provider, model_id} = split_model_spec(model_spec)
+
+    families =
+      fixtures
+      |> Enum.flat_map(&fixture_urls(fixture_root, provider, model_id, &1))
+      |> Enum.map(&surface_family(&1, operation))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    case families do
+      [] -> nil
+      families -> "#{provider}.#{Enum.join(families, "+")}"
+    end
+  end
+
+  @doc "Returns the default checked-in evidence path."
+  @spec default_path() :: Path.t()
+  def default_path do
+    :req_llm
+    |> :code.priv_dir()
+    |> Path.join("model_compat_scenarios.json")
+  end
+
+  defp migrate_legacy_model(model_spec, model_state, surface_resolver) do
+    {provider, model_id} = split_model_spec(model_spec)
+    scenarios = if is_map(model_state), do: model_state["scenarios"] || %{}, else: %{}
+
+    surfaces =
+      scenarios
+      |> Enum.sort_by(fn {scenario_id, _state} -> scenario_id end)
+      |> Enum.reduce(%{}, fn {scenario_id, scenario_state}, acc ->
+        metadata = scenario_metadata(scenario_id)
+        operation = metadata.operation
+        fixtures = scenario_state["fixtures"] || []
+
+        surface_id =
+          surface_resolver.(model_spec, operation, fixtures) ||
+            fallback_surface(provider, operation)
+
+        observation = legacy_observation(scenario_state)
+
+        put_surface_observation(
+          acc,
+          surface_id,
+          provider,
+          operation,
+          scenario_id,
+          metadata.proof,
+          observation
+        )
+      end)
+
+    model = %{
+      "provider" => provider,
+      "model" => model_id,
+      "surfaces" => surfaces
+    }
+
+    legacy_metadata =
+      if is_map(model_state), do: Map.drop(model_state, ["scenarios"]), else: %{}
+
+    maybe_put(model, "legacy_metadata", legacy_metadata)
+  end
+
+  defp legacy_observation(scenario_state) do
+    error = scenario_state["error"]
+    status = scenario_state["status"] || "fail"
+
+    observation = %{
+      "status" => status,
+      "checked_at" => scenario_state["last_checked"],
+      "mode" => scenario_state["mode"] || "unknown",
+      "fixtures" => scenario_state["fixtures"] || [],
+      "failure_layer" => if(status == "pass", do: nil, else: classify_failure(error)),
+      "error" => error
+    }
+
+    legacy_metadata =
+      Map.drop(scenario_state, ["status", "last_checked", "mode", "fixtures", "error"])
+
+    maybe_put(observation, "legacy_metadata", legacy_metadata)
+  end
+
+  defp record_result(models, result, checked_at, mode, surface_resolver) do
+    model_spec = result.model_spec
+    {provider, model_id} = split_model_spec(model_spec)
+
+    model =
+      Map.get(models, model_spec, %{
+        "provider" => provider,
+        "model" => model_id,
+        "surfaces" => %{}
+      })
+
+    scenarios = Map.get(result, :scenarios) || result_scenarios(result)
+
+    surfaces =
+      Enum.reduce(scenarios, model["surfaces"] || %{}, fn scenario, acc ->
+        record_scenario(
+          acc,
+          model_spec,
+          provider,
+          scenario,
+          checked_at,
+          mode,
+          surface_resolver
+        )
+      end)
+
+    Map.put(models, model_spec, Map.put(model, "surfaces", surfaces))
+  end
+
+  defp result_scenarios(%{scenario: nil}), do: []
+
+  defp result_scenarios(result) do
+    [
+      %{
+        "scenario" => result.scenario,
+        "status" => Atom.to_string(result.status),
+        "fixtures" => result.fixtures,
+        "failure_layer" => result.failure_layer,
+        "error" => result.error
+      }
+    ]
+  end
+
+  defp record_scenario(
+         surfaces,
+         model_spec,
+         provider,
+         scenario,
+         checked_at,
+         mode,
+         surface_resolver
+       ) do
+    scenario_id = scenario["scenario"]
+    metadata = scenario_metadata(scenario_id)
+    fixtures = scenario["fixtures"] || []
+    resolved_surface = surface_resolver.(model_spec, metadata.operation, fixtures)
+    existing_surface = find_scenario_surface(surfaces, scenario_id)
+
+    validate_surface_change!(existing_surface, resolved_surface, scenario_id, model_spec, mode)
+
+    surface_id =
+      resolved_surface || existing_surface || fallback_surface(provider, metadata.operation)
+
+    status = scenario["status"]
+    error = scenario["error"]
+
+    observation = %{
+      "status" => status,
+      "checked_at" => checked_at,
+      "mode" => mode,
+      "fixtures" => fixtures,
+      "failure_layer" =>
+        if(status == "pass", do: nil, else: scenario["failure_layer"] || classify_failure(error)),
+      "error" => error
+    }
+
+    put_surface_observation(
+      surfaces,
+      surface_id,
+      provider,
+      metadata.operation,
+      scenario_id,
+      metadata.proof,
+      observation
+    )
+  end
+
+  defp validate_surface_change!(nil, _resolved_surface, _scenario_id, _model_spec, _mode), do: :ok
+  defp validate_surface_change!(_existing_surface, nil, _scenario_id, _model_spec, _mode), do: :ok
+
+  defp validate_surface_change!(surface, surface, _scenario_id, _model_spec, _mode), do: :ok
+
+  defp validate_surface_change!(existing, resolved, scenario_id, model_spec, "replay") do
+    raise ArgumentError,
+          "compatibility replay surface changed for #{model_spec} scenario #{scenario_id}: " <>
+            "recorded #{existing}, replayed #{resolved}"
+  end
+
+  defp validate_surface_change!(_existing, _resolved, _scenario_id, _model_spec, _mode), do: :ok
+
+  defp put_surface_observation(
+         surfaces,
+         surface_id,
+         provider,
+         operation,
+         scenario_id,
+         proof,
+         observation
+       ) do
+    surface =
+      Map.get(surfaces, surface_id, %{
+        "provider" => provider,
+        "operation" => Atom.to_string(operation),
+        "scenarios" => %{}
+      })
+
+    scenario =
+      surface
+      |> Map.get("scenarios", %{})
+      |> Map.get(scenario_id, %{"proof" => Atom.to_string(proof), "observations" => []})
+
+    observations =
+      scenario
+      |> Map.get("observations", [])
+      |> Enum.reject(&(&1["checked_at"] == observation["checked_at"]))
+      |> Kernel.++([observation])
+      |> Enum.sort_by(&(&1["checked_at"] || ""))
+
+    scenarios =
+      surface
+      |> Map.get("scenarios", %{})
+      |> Map.put(
+        scenario_id,
+        scenario
+        |> Map.put("proof", Atom.to_string(proof))
+        |> Map.put("observations", observations)
+      )
+
+    Map.put(surfaces, surface_id, Map.put(surface, "scenarios", scenarios))
+  end
+
+  defp find_scenario_surface(surfaces, scenario_id) do
+    Enum.find_value(surfaces, fn {surface_id, surface} ->
+      if Map.has_key?(surface["scenarios"] || %{}, scenario_id), do: surface_id
+    end)
+  end
+
+  defp surface_entries(evidence, model_spec) do
+    evidence
+    |> get_in(["models", model_spec, "surfaces"])
+    |> case do
+      surfaces when is_map(surfaces) ->
+        Enum.sort_by(surfaces, fn {surface_id, _} -> surface_id end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp surface_status(surface_id, surface, operation, opts) do
+    declaration = Keyword.get(opts, :declaration, surface["declaration"] || "declared")
+
+    if declaration == "declared" do
+      evidence_surface_status(surface_id, surface, operation, opts)
+    else
+      declaration_status(surface_id, surface, operation, declaration)
+    end
+  end
+
+  defp evidence_surface_status(surface_id, surface, operation, opts) do
+    as_of = normalize_datetime(Keyword.get(opts, :as_of, DateTime.utc_now()))
+    freshness_days = Keyword.get(opts, :freshness_days, @freshness_days)
+    required = ScenarioCatalog.baseline_scenarios(operation)
+
+    latest =
+      surface
+      |> Map.get("scenarios", %{})
+      |> Map.new(fn {scenario_id, scenario} -> {scenario_id, latest_observation(scenario)} end)
+      |> Map.reject(fn {_scenario_id, observation} -> is_nil(observation) end)
+
+    required_observations = Map.take(latest, required)
+
+    failure =
+      Enum.find(required, fn scenario_id ->
+        match?(%{"status" => "fail"}, required_observations[scenario_id])
+      end)
+
+    fresh_passes =
+      required
+      |> Enum.filter(fn scenario_id ->
+        case required_observations[scenario_id] do
+          %{"status" => "pass", "checked_at" => checked_at} ->
+            fresh?(checked_at, as_of, freshness_days)
+
+          _ ->
+            false
+        end
+      end)
+
+    missing = required -- fresh_passes
+    latest_checked = latest_checked_at_from_observations(Map.values(latest))
+
+    cond do
+      required == [] ->
+        status(
+          :experimental,
+          :no_fixture_backed_baseline,
+          operation,
+          required,
+          missing,
+          surface_id,
+          checked_at: latest_checked
+        )
+
+      failure ->
+        observation = required_observations[failure]
+
+        status(:unsupported, :baseline_failure, operation, required, missing, surface_id,
+          checked_at: latest_checked,
+          scenario: failure,
+          failure_layer: observation["failure_layer"] || "assertion"
+        )
+
+      missing == [] ->
+        status(:first_class, :complete_current_baseline, operation, required, [], surface_id,
+          checked_at: latest_checked
+        )
+
+      fresh_passes != [] ->
+        status(:best_effort, :partial_current_baseline, operation, required, missing, surface_id,
+          checked_at: latest_checked
+        )
+
+      map_size(latest) == 0 ->
+        status(:experimental, :missing_evidence, operation, required, required, surface_id)
+
+      true ->
+        status(
+          :experimental,
+          :missing_or_stale_evidence,
+          operation,
+          required,
+          missing,
+          surface_id,
+          checked_at: latest_checked
+        )
+    end
+  end
+
+  defp declaration_status(surface_id, surface, operation, "not_declared") do
+    required = ScenarioCatalog.baseline_scenarios(operation)
+
+    status(:unsupported, :operation_not_declared, operation, required, required, surface_id,
+      checked_at: surface_latest_checked_at(surface)
+    )
+  end
+
+  defp declaration_status(surface_id, surface, operation, _declaration) do
+    required = ScenarioCatalog.baseline_scenarios(operation)
+
+    status(:experimental, :surface_declaration_unknown, operation, required, required, surface_id,
+      checked_at: surface_latest_checked_at(surface)
+    )
+  end
+
+  defp aggregate_operation_status(operation, []) do
+    required = ScenarioCatalog.baseline_scenarios(operation)
+    status(:experimental, :missing_evidence, operation, required, required, nil)
+  end
+
+  defp aggregate_operation_status(_operation, statuses) do
+    Enum.max_by(statuses, &tier_rank(&1.tier))
+  end
+
+  defp tier_rank(:first_class), do: 0
+  defp tier_rank(:best_effort), do: 1
+  defp tier_rank(:experimental), do: 2
+  defp tier_rank(:unsupported), do: 3
+
+  defp status(tier, reason, operation, required, missing, surface, extra \\ []) do
+    %{
+      tier: tier,
+      reason: reason,
+      operation: operation,
+      surface: surface,
+      required_scenarios: required,
+      missing_scenarios: missing,
+      checked_at: Keyword.get(extra, :checked_at),
+      scenario: Keyword.get(extra, :scenario),
+      failure_layer: Keyword.get(extra, :failure_layer)
+    }
+  end
+
+  defp latest_observation(%{"observations" => observations}) when is_list(observations) do
+    Enum.max_by(observations, &(&1["checked_at"] || ""), fn -> nil end)
+  end
+
+  defp latest_observation(_scenario), do: nil
+
+  defp fresh?(nil, _as_of, _freshness_days), do: false
+
+  defp fresh?(checked_at, as_of, freshness_days) do
+    checked_at = normalize_datetime(checked_at)
+    age = DateTime.diff(as_of, checked_at, :second)
+    age >= 0 and age <= freshness_days * 86_400
+  rescue
+    _error -> false
+  end
+
+  defp normalize_datetime(%DateTime{} = datetime), do: datetime
+
+  defp normalize_datetime(datetime) when is_binary(datetime) do
+    case DateTime.from_iso8601(datetime) do
+      {:ok, parsed, _offset} ->
+        parsed
+
+      {:error, reason} ->
+        raise ArgumentError, "invalid evidence timestamp #{inspect(datetime)}: #{reason}"
+    end
+  end
+
+  defp latest_checked_at(models) do
+    models
+    |> Enum.flat_map(fn {_model_spec, model} ->
+      model
+      |> Map.get("surfaces", %{})
+      |> Enum.flat_map(fn {_surface_id, surface} ->
+        surface
+        |> Map.get("scenarios", %{})
+        |> Enum.flat_map(fn {_scenario_id, scenario} -> scenario["observations"] || [] end)
+      end)
+    end)
+    |> latest_checked_at_from_observations()
+  end
+
+  defp latest_checked_at_from_observations(observations) do
+    observations
+    |> Enum.map(& &1["checked_at"])
+    |> Enum.reject(&is_nil/1)
+    |> Enum.max(fn -> nil end)
+  end
+
+  defp surface_latest_checked_at(surface) do
+    surface
+    |> Map.get("scenarios", %{})
+    |> Enum.flat_map(fn {_scenario_id, scenario} -> scenario["observations"] || [] end)
+    |> latest_checked_at_from_observations()
+  end
+
+  defp scenario_metadata(scenario_id) do
+    case ScenarioCatalog.fetch_scenario(scenario_id) do
+      {:ok, scenario} -> scenario
+      :error -> %{operation: :text, proof: :unknown}
+    end
+  end
+
+  defp operation_atom!(operation) when is_binary(operation) do
+    case Enum.find(ScenarioCatalog.operations(), &(Atom.to_string(&1.id) == operation)) do
+      %{id: id} -> id
+      nil -> raise ArgumentError, "unknown evidence operation: #{inspect(operation)}"
+    end
+  end
+
+  defp declared_operations({:ok, %LLMDB.Model{} = model}) do
+    operations =
+      ScenarioCatalog.operations()
+      |> Enum.map(& &1.id)
+      |> Enum.reject(&(&1 == :all))
+      |> Enum.filter(&ReqLLM.ModelOperation.supported?(model, &1))
+      |> Enum.map(&Atom.to_string/1)
+      |> Enum.sort()
+
+    {"present", operations}
+  end
+
+  defp declared_operations({:error, _reason}), do: {"missing", []}
+
+  defp surface_declaration(_operation, "missing", _declared_operations), do: "unknown"
+
+  defp surface_declaration(operation, "present", declared_operations) do
+    if operation in declared_operations, do: "declared", else: "not_declared"
+  end
+
+  defp split_model_spec(model_spec) do
+    case String.split(model_spec, ":", parts: 2) do
+      [provider, model_id] -> {provider, model_id}
+      [model_id] -> {"unknown", model_id}
+    end
+  end
+
+  defp fallback_surface(provider, operation), do: "#{provider}.unrecorded_#{operation}"
+  defp default_surface_resolver(_model_spec, _operation, _fixtures), do: nil
+
+  defp normalize_unrecorded_surface(surface_id, provider, operation) do
+    if surface_id == "#{provider}.#{operation}",
+      do: fallback_surface(provider, operation),
+      else: surface_id
+  end
+
+  defp fixture_urls(fixture_root, provider, model_id, fixture) do
+    path =
+      Path.join([
+        fixture_root,
+        provider,
+        fixture_model_dir(model_id),
+        "#{fixture}.json"
+      ])
+
+    with {:ok, content} <- File.read(path),
+         {:ok, fixture_data} <- Jason.decode(content) do
+      fixture_request_urls(fixture_data)
+    else
+      _error -> []
+    end
+  end
+
+  defp fixture_request_urls(%{"request" => %{"url" => url}}) when is_binary(url), do: [url]
+
+  defp fixture_request_urls(steps) when is_list(steps) do
+    Enum.flat_map(steps, &fixture_request_urls/1)
+  end
+
+  defp fixture_request_urls(_fixture_data), do: []
+
+  defp fixture_model_dir(model_id) do
+    model_id
+    |> String.replace("-", "_")
+    |> String.replace(".", "_")
+    |> String.replace(":", "_")
+    |> String.replace("/", "_")
+  end
+
+  defp surface_family(_url, operation) when operation != :text, do: Atom.to_string(operation)
+
+  defp surface_family(url, :text) do
+    path = String.downcase(URI.parse(url).path || "")
+
+    cond do
+      String.contains?(path, "/responses") -> "responses"
+      String.contains?(path, "/chat/completions") -> "chat_completions"
+      String.contains?(path, "/messages") -> "messages"
+      String.contains?(path, "generatecontent") -> "generate_content"
+      String.contains?(path, "/converse") -> "bedrock_converse"
+      String.contains?(path, "/invoke") -> "bedrock_invoke"
+      true -> "text"
+    end
+  end
+
+  defp contains_any?(value, candidates), do: Enum.any?(candidates, &String.contains?(value, &1))
+
+  defp scenario_fixtures(scenario) do
+    scenario
+    |> Map.get("observations", [])
+    |> Enum.flat_map(&(&1["fixtures"] || []))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp merge_surface_scenario(
+         surfaces,
+         surface_id,
+         provider,
+         operation,
+         scenario_id,
+         scenario
+       ) do
+    surface =
+      Map.get(surfaces, surface_id, %{
+        "provider" => provider,
+        "operation" => Atom.to_string(operation),
+        "scenarios" => %{}
+      })
+
+    scenarios = surface["scenarios"] || %{}
+
+    merged_scenario =
+      case Map.get(scenarios, scenario_id) do
+        nil -> scenario
+        existing -> merge_scenario_observations(existing, scenario)
+      end
+
+    Map.put(surfaces, surface_id, %{
+      surface
+      | "scenarios" => Map.put(scenarios, scenario_id, merged_scenario)
+    })
+  end
+
+  defp merge_scenario_observations(existing, incoming) do
+    observations =
+      (existing["observations"] || [])
+      |> Kernel.++(incoming["observations"] || [])
+      |> Enum.uniq_by(&{&1["checked_at"], &1["mode"], &1["status"]})
+      |> Enum.sort_by(&(&1["checked_at"] || ""))
+
+    existing
+    |> Map.merge(incoming)
+    |> Map.put("observations", observations)
+  end
+
+  defp maybe_put(map, _key, empty) when empty == %{}, do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp ordered(%{} = map) do
+    map
+    |> Enum.sort_by(fn {key, _value} -> to_string(key) end)
+    |> Enum.map(fn {key, value} -> {key, ordered(value)} end)
+    |> Jason.OrderedObject.new()
+  end
+
+  defp ordered(list) when is_list(list), do: Enum.map(list, &ordered/1)
+  defp ordered(value), do: value
+end

--- a/lib/req_llm/compatibility/scenario_catalog.ex
+++ b/lib/req_llm/compatibility/scenario_catalog.ex
@@ -505,6 +505,17 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
     end
   end
 
+  @doc "Returns fixture-replay baseline scenarios required for an operation support tier."
+  @spec baseline_scenarios(atom()) :: [binary()]
+  def baseline_scenarios(operation) when is_atom(operation) do
+    @scenarios
+    |> Enum.filter(fn scenario ->
+      scenario.operation == operation and scenario.applicability == :operation and
+        scenario.proof == :fixture_replay and scenario.providers == :all
+    end)
+    |> Enum.map(& &1.id)
+  end
+
   @doc "Returns the selected test file for a provider, operation, and optional scenario."
   @spec test_file(atom(), atom(), atom() | binary() | nil) :: binary()
   def test_file(provider, operation, scenario \\ nil) when is_atom(provider) do

--- a/lib/req_llm/compatibility/support_reference.ex
+++ b/lib/req_llm/compatibility/support_reference.ex
@@ -1,0 +1,206 @@
+defmodule ReqLLM.Compatibility.SupportReference do
+  @moduledoc """
+  Deterministic Markdown generation from compatibility catalog and evidence.
+  """
+
+  alias ReqLLM.Compatibility.{Evidence, ScenarioCatalog}
+
+  @doc "Renders the checked-in model support evidence reference."
+  @spec render(map(), keyword()) :: binary()
+  def render(evidence, opts \\ []) do
+    as_of = Keyword.get(opts, :as_of, evidence["generated_at"])
+    rows = rows(evidence, as_of: as_of)
+    counts = Enum.frequencies_by(rows, & &1.status.tier)
+
+    [
+      "# Model Support Evidence\n\n",
+      intro(evidence, as_of),
+      tier_definitions(),
+      summary(counts, length(rows)),
+      provider_tables(rows)
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  @doc "Returns deterministic model/surface rows used by the reference."
+  @spec rows(map(), keyword()) :: [map()]
+  def rows(evidence, opts \\ []) do
+    as_of = Keyword.get(opts, :as_of, evidence["generated_at"])
+
+    evidence
+    |> Map.get("models", %{})
+    |> Enum.flat_map(fn {model_spec, model} ->
+      statuses = Evidence.model_surface_statuses(evidence, model_spec, as_of: as_of)
+
+      Enum.map(statuses, fn status ->
+        surface = get_in(model, ["surfaces", status.surface]) || %{}
+
+        %{
+          model_spec: model_spec,
+          provider: model["provider"],
+          model: model["model"],
+          surface: status.surface,
+          operation: status.operation,
+          modalities: modalities(surface),
+          observed_scenarios: map_size(surface["scenarios"] || %{}),
+          status: status
+        }
+      end)
+    end)
+    |> Enum.sort_by(&{&1.provider, &1.model, &1.surface})
+  end
+
+  defp intro(evidence, as_of) do
+    """
+    This file is generated from `priv/model_compat_scenarios.json` and the compiled
+    compatibility scenario catalog. It is a tooling snapshot, not a runtime model
+    allowlist, and it does not change whether ReqLLM can resolve or call a model.
+
+    - Evidence schema: `#{evidence["schema_version"]}`
+    - Snapshot evaluated at: `#{as_of || "unknown"}`
+    - Freshness window: `#{Evidence.freshness_days()} days`
+
+    """
+  end
+
+  defp tier_definitions do
+    """
+    ## Conservative tier rules
+
+    - **First-class**: every fixture-replay baseline scenario for this exact
+      execution surface has current passing evidence.
+    - **Best-effort**: at least one baseline scenario has current passing evidence,
+      but the baseline is incomplete.
+    - **Experimental**: evidence is missing, stale, or no fixture-replay baseline is
+      defined. Catalog presence alone never promotes a surface.
+    - **Unsupported**: a required baseline scenario has explicit failing evidence;
+      the reason includes its classified failure layer.
+
+    A recorded operation that current model metadata does not declare is unsupported
+    for that operation. Evidence for a model absent from the current catalog remains
+    experimental rather than becoming a support claim.
+
+    These labels describe evidence for a model surface. They do not describe every
+    provider-native feature and are not consulted by request routing.
+
+    """
+  end
+
+  defp summary(counts, total) do
+    """
+    ## Snapshot summary
+
+    | Tier | Surfaces |
+    | --- | ---: |
+    | First-class | #{Map.get(counts, :first_class, 0)} |
+    | Best-effort | #{Map.get(counts, :best_effort, 0)} |
+    | Experimental | #{Map.get(counts, :experimental, 0)} |
+    | Unsupported | #{Map.get(counts, :unsupported, 0)} |
+    | **Total recorded surfaces** | **#{total}** |
+
+    """
+  end
+
+  defp provider_tables(rows) do
+    rows
+    |> Enum.group_by(& &1.provider)
+    |> Enum.sort_by(fn {provider, _rows} -> provider end)
+    |> Enum.map(fn {provider, provider_rows} ->
+      [
+        "## ",
+        provider,
+        "\n\n",
+        "| Model | Operation | Execution surface | Input → output | Tier | Baseline | Checked | Reason |\n",
+        "| --- | --- | --- | --- | --- | ---: | --- | --- |\n",
+        Enum.map(provider_rows, &row/1),
+        "\n"
+      ]
+    end)
+  end
+
+  defp row(row) do
+    status = row.status
+    passed = length(status.required_scenarios) - length(status.missing_scenarios)
+    baseline = "#{passed}/#{length(status.required_scenarios)}"
+
+    [
+      "| `",
+      markdown(row.model),
+      "` | `",
+      Atom.to_string(row.operation),
+      "` | `",
+      markdown(row.surface),
+      "` | ",
+      markdown(modality_text(row.modalities)),
+      " | ",
+      tier_text(status.tier),
+      " | ",
+      baseline,
+      " | ",
+      status.checked_at || "—",
+      " | ",
+      markdown(reason_text(status)),
+      " |\n"
+    ]
+  end
+
+  defp modalities(surface) do
+    scenarios = Map.keys(surface["scenarios"] || %{})
+
+    Enum.reduce(scenarios, %{input: MapSet.new(), output: MapSet.new()}, fn scenario_id, acc ->
+      case ScenarioCatalog.fetch_scenario(scenario_id) do
+        {:ok, scenario} ->
+          %{
+            input: MapSet.union(acc.input, MapSet.new(scenario.input_modalities)),
+            output: MapSet.union(acc.output, MapSet.new(scenario.output_modalities))
+          }
+
+        :error ->
+          acc
+      end
+    end)
+  end
+
+  defp modality_text(%{input: input, output: output}) do
+    "#{join_modalities(input)} → #{join_modalities(output)}"
+  end
+
+  defp join_modalities(modalities) do
+    modalities
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.sort()
+    |> Enum.join(", ")
+    |> case do
+      "" -> "unknown"
+      joined -> joined
+    end
+  end
+
+  defp tier_text(:first_class), do: "First-class"
+  defp tier_text(:best_effort), do: "Best-effort"
+  defp tier_text(:experimental), do: "Experimental"
+  defp tier_text(:unsupported), do: "Unsupported"
+
+  defp reason_text(%{reason: :complete_current_baseline}), do: "complete current baseline"
+
+  defp reason_text(%{reason: :partial_current_baseline, missing_scenarios: missing}) do
+    "missing current evidence: #{Enum.join(missing, ", ")}"
+  end
+
+  defp reason_text(%{
+         reason: :baseline_failure,
+         scenario: scenario,
+         failure_layer: failure_layer
+       }) do
+    "#{scenario} failed at #{failure_layer}"
+  end
+
+  defp reason_text(%{reason: :no_fixture_backed_baseline}), do: "no fixture-replay baseline"
+  defp reason_text(%{reason: :missing_evidence}), do: "missing evidence"
+  defp reason_text(%{reason: :missing_or_stale_evidence}), do: "missing or stale evidence"
+  defp reason_text(%{reason: :operation_not_declared}), do: "operation not declared"
+  defp reason_text(%{reason: :surface_declaration_unknown}), do: "surface declaration unknown"
+  defp reason_text(status), do: status.reason |> to_string() |> String.replace("_", " ")
+
+  defp markdown(value), do: value |> to_string() |> String.replace("|", "\\|")
+end

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule ReqLLM.MixProject do
           "guides/usage-and-billing.md",
           "guides/image-generation.md",
           "guides/model-metadata.md",
+          "guides/model-support.md",
           "guides/getting-started.livemd",
           "guides/image-generation.livemd",
           "guides/mix-tasks.md",
@@ -98,7 +99,8 @@ defmodule ReqLLM.MixProject do
             "guides/model-specs.md",
             "guides/usage-and-billing.md",
             "guides/image-generation.md",
-            "guides/model-metadata.md"
+            "guides/model-metadata.md",
+            "guides/model-support.md"
           ],
           Livebooks: [
             "guides/getting-started.livemd",

--- a/priv/model_compat_scenarios.json
+++ b/priv/model_compat_scenarios.json
@@ -1,9664 +1,23112 @@
 {
-  "zenmux:inclusionai/ring-2.6-1t": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "github_copilot:gpt-4.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-06-12T21:58:25Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:xiaomi/mimo-v2-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-vl-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:tencent/hunyuan-2.0-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/kimi-k2p5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-1.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:aion-labs/aion-1.0-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:39Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemma-3-4b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:ibm-granite/granite-4.0-h-micro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:20:36Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:zai-org-glm-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:minimax/minimax-m2.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:59Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-opus-4-6-fast": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-r1-distill-qwen-32b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-3.1-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.5-flash-lite-preview-09-2025": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.7-flashx": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:moonshotai/kimi-k2.6:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/kimi-k2p6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5-2025-08-07": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:58:08Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:microsoft/phi-4": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:17:09Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:whisper-large-v3": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T23:26:29Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-14b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.7-flashx": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"timeout\", status: nil, response",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.1-chat": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-sonnet-4-6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-realtime-whisper": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": "     ** (MatchError) no match of right hand side value:\n          %ReqLLM.Error.API.Request{",
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T21:20:41Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3.7-max": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.5-flash-native-audio-preview-12-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:bytedance/doubao-seed-1.8": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:arcee-trinity-large-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4o-transcribe-diarize": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T21:23:56Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:z-ai-glm-5-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-2": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-max": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4.1-mini-2025-04-14": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:57:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "anthropic:claude-haiku-4-5-20251001": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:09:16Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:09:16Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:09:16Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3.5-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:chatgpt-image-latest": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T21:24:36Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-coder-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:xiaomi/mimo-v2-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:google/gemini-2.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4.1-fast": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:xiaomi/mimo-v2-omni": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-small-2603": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-reasoner": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:google/gemini-2.5-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.0-flash-lite-001": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:perplexity/pplx-embed-v1-4b": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-4-scout": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-plus-02-15": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.5-flash-image": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:27:26Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.5-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:moonshotai/kimi-k2-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-5-search-api": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:09:22Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-30b-a3b-instruct-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-5-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:sentence-transformers/paraphrase-minilm-l6-v2": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5-nano": {
-    "scenarios": {
-      "object_streaming": {
-        "error": null,
-        "fixtures": [],
-        "last_checked": "2026-05-29T18:43:47Z",
-        "mode": "replay",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:moonshotai/kimi-k2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-code-fast-1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:minimax/minimax-m2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:59Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:morph/morph-v3-large": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:20:57Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:xiaomi/mimo-v2.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mancer/weaver": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:25:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-next-80b-a3b-instruct:free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-2.5-flash-native-audio-preview-09-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-4-0125-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:05:48Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:kuaishou/kat-coder-pro-v2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-guard-4-12b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-3-mini-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.0-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:grok-build-0-1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-3.7-sonnet": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "anthropic:claude-sonnet-4-5-20250929": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:17:58Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:17:58Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:17:58Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-2-1212": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:google/gemini-3.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:inclusionai/ring-1t": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-opus-4.1": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "cohere:rerank-multilingual-v3.0": {
-    "scenarios": {
-      "rerank_basic": {
-        "error": null,
-        "fixtures": [
-          "rerank_basic"
-        ],
-        "last_checked": "2026-05-29T23:28:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-large-2411": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai_coder:glm-4.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T16:28:19Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.2-chat": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:google/gemini-3.1-flash-lite-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4o-mini-tts": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T21:17:40Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-coder-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:moonshotai/kimi-k2.5": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:nvidia-nemotron-3-nano-30b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5-mini-2025-08-07": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:58:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-opus-4-7-fast": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:rekaai/reka-edge": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:19Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.5v": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/minimax-m2p7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-image-1-mini": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T21:25:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:xiaomi/mimo-v2.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baidu/ernie-4.5-21b-a3b-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:14:36Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.6v-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:gemini-3-flash-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sao10k/l3-euryale-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:25:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.2-3b-instruct:free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:x-ai/grok-4.20-multi-agent": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:11Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:x-ai/grok-3-mini": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:11Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "groq:whisper-large-v3-turbo": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T23:26:29Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-build-0.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-5": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "cohere:c4ai-aya-expanse-32b": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-5.2-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:01:09Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openai/gpt-oss-safeguard-20b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:45Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.5-flash-native-audio-latest": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:mistralai/devstral-medium": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:c4ai-aya-expanse-8b": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "venice:deepseek-v4-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.6": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:google/gemini-embedding-001": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openrouter/bodybuilder": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:23:22Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-v4-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3-flash-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:19:13Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_basic": {
-        "error": null,
-        "fixtures": [
-          "object_basic"
-        ],
-        "last_checked": "2026-05-29T22:22:15Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "reasoning": {
-        "error": null,
-        "fixtures": [
-          "reasoning_basic",
-          "reasoning_streaming"
-        ],
-        "last_checked": "2026-05-29T22:25:08Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:19:13Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:09:19Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_multi": {
-        "error": null,
-        "fixtures": [
-          "multi_tool"
-        ],
-        "last_checked": "2026-05-29T22:22:03Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_none": {
-        "error": null,
-        "fixtures": [
-          "no_tool"
-        ],
-        "last_checked": "2026-05-29T22:22:03Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_round_trip": {
-        "error": null,
-        "fixtures": [
-          "tool_round_trip_1",
-          "tool_round_trip_2"
-        ],
-        "last_checked": "2026-05-29T22:22:03Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:09:19Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai_coding_plan:glm-4.5-air": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:11:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-30b-a3b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nousresearch/hermes-3-llama-3.1-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:18:40Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-v3.2-exp": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baai/bge-base-en-v1.5": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-large": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baidu/ernie-4.5-300b-a47b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:14:36Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:bytedance/doubao-seed-2.0-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:perplexity/sonar-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4o-mini-transcribe": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T21:19:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5-nano": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-7b-instruct-v0.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:inflection/inflection-3-pi": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-r1-distill-llama-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:perplexity/pplx-embed-v1-0.6b": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.6-35b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:z-ai-glm-5v-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-nano-9b-v2:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:moonshotai/kimi-k2.6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4-1-fast-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/llama-3.3-nemotron-super-49b-v1.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-v3.2-exp": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/minimax-m2p5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-235b-a22b-instruct-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/llama-nemotron-embed-vl-1b-v2:free": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:moonshotai/kimi-k2-thinking-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:x-ai/grok-3-mini-beta": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:11Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:openai/text-embedding-3-small": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/o4-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "elevenlabs:eleven_multilingual_v2": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T23:29:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:minimax/minimax-m2.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:59Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sentence-transformers/all-minilm-l12-v2": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.2-chat-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:00:53Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-30b-a3b-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.6v-flash-free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4.1-fast-non-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.4-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/devstral-2512": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3.6-max-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:mercury-2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:tts-1-1106": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T21:18:14Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:06:44Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.4": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4-0709": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:poolside/laguna-xs.2:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-v3.2-speciale": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:minimax/minimax-m2.5:free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:59Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:arcee-ai/trinity-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4.2-fast-non-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cerebras:qwen-3-235b-a22b-instruct-2507": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:27:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "elevenlabs:eleven_flash_v2_5": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T23:29:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.0-flash-001": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-5-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nousresearch/hermes-3-llama-3.1-405b:free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:18:40Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:baidu/ernie-5.0-thinking-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-r1-0528": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.6v": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sao10k/l3-lunaris-8b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:25:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-small-24b-instruct-2501": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.4-pro": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:cohere/command-a": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:25Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:zai-org-glm-4.6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:amazon/nova-2-lite-v1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:28Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:mistralai/mistral-large-2512": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:command-r7b-arabic-02-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-1.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-pro-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:20:56Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:20:56Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:13:02Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:14:34Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:microsoft/phi-4-mini-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:17:09Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:davinci-002": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:05:29Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:openai/gpt-4.1-nano": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:bytedance/doubao-seed-code": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-audio": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T21:37:41Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5-codex": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zai:glm-4.5-air": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:sapiens-ai/agnes-1.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:arcee-ai/trinity-large-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-v3.2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/qwen3p6-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.2-11b-vision-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:liquid/lfm-2.5-1.2b-instruct:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:16:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/o1": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-4-maverick": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:ibm-granite/granite-4.1-8b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:20:36Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-medium-3.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:openai/gpt-oss-20b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:intfloat/e5-base-v2": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:lyria-3-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (500): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-235b-a22b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-235b-a22b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:hermes-3-llama-3.1-405b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-nano-2026-03-17": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:07:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-saba": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:babbage-002": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:05:19Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-r1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4-fast-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-5-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-imagine-video": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:openai/gpt-oss-20b:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:45Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-235b-a22b-thinking-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:o3-2025-04-16": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:58:41Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-opus-4.5": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-8b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:zai-org-glm-4.7-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:chat-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T21:30:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-imagine-image": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-30T01:06:56Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-code-fast-1": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-embedding-2": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "elevenlabs:eleven_v3": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T23:29:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-3-super-120b-a12b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.1-70b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-5v-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-235b-a22b-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baai/bge-large-en-v1.5": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:inflection/inflection-3-productivity": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/gpt-oss-20b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:xiaomi/mimo-v2-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-4o-mini-2024-07-18": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:venice-uncensored-1-2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/text-embedding-3-large": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-3.1-flash-live-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "venice:openai-gpt-55-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-8b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:moonshotai/kimi-k2-instruct-0905": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "groq:openai/gpt-oss-120b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-4o-2024-11-20": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-embedding-8b": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4-fast-non-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-embed-2312": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:59:05Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openai/text-embedding-3-large": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-next-80b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-chat": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-coder-next": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:perplexity/sonar": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5-nano-2025-08-07": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:58:31Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T19:19:08Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:sapiens-ai/agnes-1.5-lite": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2.5-lightning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:minimax-m27": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.3-70b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-2026-03-05": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:06:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-54": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:bytedance-seed/seed-1.6-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:c4ai-aya-vision-32b": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "anthropic:claude-opus-4-8": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:14:45Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:14:45Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:14:45Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4.3": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:llama3-8b-8192": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/glm-5p1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:moonshotai/kimi-k2.6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-v4-flash:free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:lyria-3-clip-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (500): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:openai/text-embedding-3-small": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen-plus-2025-07-28:thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:16Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openai/gpt-oss-120b:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:45Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4.20-0309-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:moonshotai/kimi-k2-0905": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:command-a-vision-07-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "anthropic:claude-sonnet-4-20250514": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:16:20Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:16:20Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:16:20Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:inclusionai/llada2.1-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.0-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-122b-a10b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-nano-12b-v2-vl:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:microsoft/wizardlm-2-8x22b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:17:09Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.6v": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3-pro-image": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:29:02Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3.1-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:19:54Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "multimodal_tool_result": {
-        "error": null,
-        "fixtures": [
-          "multimodal_tool_result_1",
-          "multimodal_tool_result_2"
-        ],
-        "last_checked": "2026-05-29T22:07:39Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_basic": {
-        "error": null,
-        "fixtures": [
-          "object_basic"
-        ],
-        "last_checked": "2026-05-29T22:23:33Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "reasoning": {
-        "error": null,
-        "fixtures": [
-          "reasoning_basic",
-          "reasoning_streaming"
-        ],
-        "last_checked": "2026-05-29T22:25:37Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:19:54Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:10:55Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_multi": {
-        "error": null,
-        "fixtures": [
-          "multi_tool"
-        ],
-        "last_checked": "2026-05-29T22:23:21Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_none": {
-        "error": null,
-        "fixtures": [
-          "no_tool"
-        ],
-        "last_checked": "2026-05-29T22:23:21Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_round_trip": {
-        "error": null,
-        "fixtures": [
-          "tool_round_trip_1",
-          "tool_round_trip_2"
-        ],
-        "last_checked": "2026-05-29T22:23:21Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:10:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.6-max-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai_coding_plan:glm-5-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:11:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-235b-a22b-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.2-pro-2025-12-11": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:01:31Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemma-4-26b-a4b-it:free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-embedding-001": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T01:02:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:volcengine/doubao-seed-2.0-lite": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:bytedance-seed/seed-2.0-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-27b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baai/bge-m3": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:inclusionai/ling-2.6-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-6-27b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-4.1-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.3-codex": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:06:08Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-3-mini-fast-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:inclusionai/ring-2.6-1t": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:16:15Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:amazon/nova-micro-v1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:28Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-embedding-4b": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sao10k/l3.3-euryale-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:25:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:command-a-translate-08-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "groq:groq/compound-mini": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:bytedance/doubao-seed-2.0-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:08:33Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sentence-transformers/multi-qa-mpnet-base-dot-v1": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:kimi-k2-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-chat-v3-0324": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3-8b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:perplexity/sonar-pro-search": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemma-4-26b-a4b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:openai/gpt-oss-safeguard-20b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:00:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:meta-llama/llama-4-maverick-17b-128e-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "xai:grok-4.20-0309-non-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_streaming_tool_strict": {
-        "error": null,
-        "fixtures": [
-          "object_streaming_tool_strict"
-        ],
-        "last_checked": "2026-05-29T23:13:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:xiaomi/mimo-v2-omni": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-robotics-er-1.5-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:tencent/hy3-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-embedding-2-preview": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-large-2512": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openrouter/auto": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:23:22Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:command-a-03-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-coder-30b-a3b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-flash-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openrouter/pareto-code": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:23:22Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:whisper-1": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T20:44:37Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:kimi-k2-6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:allam-2-7b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-sonnet-4": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "xai:grok-beta": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:aqa": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:mistralai/codestral-2508": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-3.1-pro-preview-customtools": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:x-ai/grok-4.3": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:11Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openai/gpt-oss-20b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:45Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-4.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-5v-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "cohere:command-r7b-12-2024": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:baidu/ernie-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-397b-a17b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sentence-transformers/all-minilm-l6-v2": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-guard-3-8b": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-5-pro-2025-10-06": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:59:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-3.1-flash-lite-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-opus-4.8": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:deepseek-v3.2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "anthropic:claude-opus-4-20250514": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:13:32Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:13:32Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:13:32Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4o-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T16:16:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.3-chat-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:05:58Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-54-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:cohere/command-r7b-12-2024": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:25Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:00:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/deepseek-v4-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-embedding-2-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:stepfun/step-3": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"timeout\", status: nil, response",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-r1-0528": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "anthropic:claude-opus-4-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:20:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:20:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:20:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.5v": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "anthropic:claude-opus-4-1-20250805": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T17:11:25Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T17:11:25Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T17:11:25Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:llama-3.2-3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/codestral-embed-2505": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-sonnet-4.6": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-3.1-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:19:28Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_basic": {
-        "error": null,
-        "fixtures": [
-          "object_basic"
-        ],
-        "last_checked": "2026-05-29T22:22:49Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "reasoning": {
-        "error": null,
-        "fixtures": [
-          "reasoning_basic",
-          "reasoning_streaming"
-        ],
-        "last_checked": "2026-05-29T22:25:20Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:19:28Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:09:53Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_multi": {
-        "error": null,
-        "fixtures": [
-          "multi_tool"
-        ],
-        "last_checked": "2026-05-29T22:22:38Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_none": {
-        "error": null,
-        "fixtures": [
-          "no_tool"
-        ],
-        "last_checked": "2026-05-29T22:22:38Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_round_trip": {
-        "error": null,
-        "fixtures": [
-          "tool_round_trip_1",
-          "tool_round_trip_2"
-        ],
-        "last_checked": "2026-05-29T22:22:38Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:09:53Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:groq/compound": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.3-codex": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:06:26Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:gemma-4-uncensored": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:stepfun/step-3.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nex-agi/deepseek-v3.1-nex-n1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:08Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.5-air": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/devstral-small": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:rerank-v4.0-pro": {
-    "scenarios": {
-      "rerank_basic": {
-        "error": null,
-        "fixtures": [
-          "rerank_basic"
-        ],
-        "last_checked": "2026-05-29T23:28:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-3-mini-fast": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "elevenlabs:eleven_turbo_v2_5": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T23:29:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/gpt-oss-120b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:grok-4-20": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.3-chat": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-4o-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:meta/llama-3.3-70b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.1-8b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:amazon/nova-pro-v1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:28Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:morph/morph-v3-fast": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:20:57Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/chat-latest": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:antigravity-preview-05-2026": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:google/gemma-4-31b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cerebras:qwen-3-coder-480b": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:27:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:x-ai/grok-4.20": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:11Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-opus-4-6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cerebras:zai-glm-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:27:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-next-80b-a3b-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:inclusionai/ling-2.6-1t": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:16:15Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:google-gemma-4-26b-a4b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:rerank-v4.0-fast": {
-    "scenarios": {
-      "rerank_basic": {
-        "error": null,
-        "fixtures": [
-          "rerank_basic"
-        ],
-        "last_checked": "2026-05-29T23:28:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen-2.5-coder-32b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3.1-flash-lite-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemma-2-27b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:deep-research-pro-preview-12-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "xai:grok-3": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen-2.5-72b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:sao10k/l3.1-euryale-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:25:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:mistral-small-2603": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:gemini-3-5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:thenlper/gte-large": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-max-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-mini-2026-03-17": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:06:53Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-audio-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T21:37:57Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:arcee-ai/spotlight": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:54Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "venice:qwen3-5-9b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-4o": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-coder": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-v4-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-medium-3": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:veo-3.1-fast-generate-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:google/gemma-4-31b-it:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:veo-3.0-generate-001": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-3-super-120b-a12b:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-53-codex": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.7-max": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen-2.5-7b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-opus-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:sentence-transformers/all-mpnet-base-v2": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.2-pro": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-9b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:tts-1-hd-1106": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T21:18:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-vl-235b-a22b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:zai-org-glm-5-1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-30b-a3b-thinking-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.2-1b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-235b-a22b-thinking-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-235b-a22b-thinking-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-3-flash-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.6-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai_coding_plan:glm-5v-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:11:52Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:minimax/minimax-m2-her": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:59Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openai/gpt-4o-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T16:17:31Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-35b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:sapiens-ai/agnes-2.0-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.6-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:deep-research-preview-04-2026": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-32b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:volcengine/doubao-seed-2.0-mini": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "venice:minimax-m25": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:nano-banana-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-4o-transcribe": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T21:20:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:meta-llama/llama-prompt-guard-2-86m": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nousresearch/hermes-3-llama-3.1-405b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:18:40Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:text-embedding-004": {
-    "scenarios": {
-      "embed_basic": {
-        "error": "     Expected successful embedding, got error: %ReqLLM.Error.API.Request{reason: \"Provider response error (404): Google A",
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T01:02:06Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-4o-mini-transcribe-2025-12-15": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T21:23:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4o-2024-08-06": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:57:48Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4.1-2025-04-14": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:57:28Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:google/gemini-3.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-pro-2026-03-05": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:08:23Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.1-codex-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/ministral-3b-2512": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:command-r-08-2024": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:openai/gpt-oss-120b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:45Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.6v": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-4o-2024-11-20": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:57:58Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nousresearch/hermes-4-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:18:40Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:aion-labs/aion-rp-llama-3.1-8b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:39Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:veo-2.0-generate-001": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:google/gemini-2.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.3-codex-spark": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T21:26:57Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.5-pro-preview-05-06": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:meta-llama/llama-prompt-guard-2-22m": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3.1-pro-preview-customtools": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:20:18Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_basic": {
-        "error": null,
-        "fixtures": [
-          "object_basic"
-        ],
-        "last_checked": "2026-05-29T22:24:13Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "reasoning": {
-        "error": null,
-        "fixtures": [
-          "reasoning_basic",
-          "reasoning_streaming"
-        ],
-        "last_checked": "2026-05-29T22:25:51Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:20:18Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:11:54Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_multi": {
-        "error": null,
-        "fixtures": [
-          "multi_tool"
-        ],
-        "last_checked": "2026-05-29T22:24:02Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_none": {
-        "error": null,
-        "fixtures": [
-          "no_tool"
-        ],
-        "last_checked": "2026-05-29T22:24:02Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_round_trip": {
-        "error": null,
-        "fixtures": [
-          "tool_round_trip_1",
-          "tool_round_trip_2"
-        ],
-        "last_checked": "2026-05-29T22:24:02Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:11:54Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:amazon/nova-premier-v1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:28Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-opus-4.6": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-chat-v3.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-nano": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:07:01Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:inclusionai/ling-2.6-1t": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4.3": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_streaming_auto": {
-        "error": null,
-        "fixtures": [
-          "object_streaming_auto"
-        ],
-        "last_checked": "2026-05-29T23:12:59Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_streaming_json_schema": {
-        "error": null,
-        "fixtures": [
-          "object_streaming_json_schema"
-        ],
-        "last_checked": "2026-05-29T23:12:59Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:08:12Z",
-        "mode": "replay",
-        "status": "pass"
-      },
-      "streaming_error_handling": {
-        "error": null,
-        "fixtures": [
-          "streaming_truncated"
-        ],
-        "last_checked": "2026-05-29T23:12:59Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "web_search_basic": {
-        "error": null,
-        "fixtures": [
-          "web_search_basic"
-        ],
-        "last_checked": "2026-05-29T23:12:24Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "web_search_streaming": {
-        "error": null,
-        "fixtures": [
-          "web_search_streaming"
-        ],
-        "last_checked": "2026-05-29T23:12:24Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "x_search_streaming": {
-        "error": null,
-        "fixtures": [
-          "x_search_streaming"
-        ],
-        "last_checked": "2026-05-29T23:12:24Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:olafangensan-glm-4.7-flash-heretic": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:qwen/qwen3-32b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-haiku-4.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-3-nano-30b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.7-flash-free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"timeout\", status: nil, response",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "venice:venice-uncensored-role-play": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openrouter/free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:23:22Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baidu/ernie-4.5-vl-424b-a47b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:14:36Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.6-27b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:c4ai-aya-vision-8b": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:google/gemini-3-flash-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-55": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:inception/mercury-2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:20:46Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2-her": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-54-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:moonshotai/kimi-k2.5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:45:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:veo-3.1-lite-generate-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:sao10k/l3.1-70b-hanami-x1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:25:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:command-a-reasoning-08-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-5.2-2025-12-11": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:00:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:openai/text-embedding-ada-002": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:cohere/command-r-08-2024": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:25Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/routers/kimi-k2p6-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4-32b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:google-gemma-3-27b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:meta/llama-4-scout-17b-16e-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3.6-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:google-gemma-4-31b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:nvidia-nemotron-cascade-2-30b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-52-codex": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-5-35b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:zai-org-glm-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4-fast": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "groq:llama-3.1-8b-instant": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:llama-3.3-70b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:stepfun/step-3.5-flash-free": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:deep-research-max-preview-04-2026": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-v4-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:xiaomi/mimo-v2.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:volcengine/doubao-seed-1.8": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:openrouter/owl-alpha": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:23:22Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.5-2026-04-23": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:08:42Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:volcengine/doubao-seed-2.0-pro": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "minimax:MiniMax-M2.1": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T16:18:48Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-32b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4-1-fast-non-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemma-3n-e4b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:gemini-3-1-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5-search-api-2025-10-14": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:09:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:arcee-ai/coder-large": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:54Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-4o-mini-tts-2025-12-15": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T21:17:57Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/voxtral-small-24b-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.5-air": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3-pro-image-preview": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:28:39Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-4.1-mini": {
-    "scenarios": {
-      "context_append": {
-        "error": null,
-        "fixtures": [],
-        "last_checked": "2026-05-29T18:43:47Z",
-        "mode": "replay",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:volcengine/doubao-seed-2.0-code": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:gpt-4o-mini-transcribe-2025-03-20": {
-    "scenarios": {
-      "transcription_basic": {
-        "error": null,
-        "fixtures": [
-          "transcription_basic"
-        ],
-        "last_checked": "2026-05-29T21:23:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:arcee-ai/virtuoso-large": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:54Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-vl-8b-thinking": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:perplexity/sonar-reasoning-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:inclusionai/ling-1t": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5-chat": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.0-flash-exp": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-plus-20260420": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:deepseek/deepseek-v3.2": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-14b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:bytedance/doubao-seed-2.0-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:imagen-4.0-generate-001": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:29:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-medium-3-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4-fast": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:mistral-small-3-2-24b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:tts-1-hd": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T21:18:32Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.5-pro-2026-04-23": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:09:14Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.1-2025-11-13": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:00:26Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.4-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:07:49Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-image-2": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T21:25:32Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4.20-non-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:nvidia/nemotron-3-nano-30b-a3b:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baidu/ernie-4.5-21b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (502): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:14:36Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3-70b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:liquid/lfm-2.5-1.2b-thinking:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:16:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:deepseek-v4-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-coder-480b-a35b-instruct-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:xiaomi/mimo-v2.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-imagine-image-pro": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-30T01:06:56Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:bytedance-seed/seed-1.6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:minimax/minimax-m2.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:59Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cohere:rerank-v3.5": {
-    "scenarios": {
-      "rerank_basic": {
-        "error": null,
-        "fixtures": [
-          "rerank_basic"
-        ],
-        "last_checked": "2026-05-29T23:28:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.7-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-52": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:z-ai/glm-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:google/gemini-3.1-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mixtral-8x22b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:16Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:imagen-4.0-ultra-generate-001": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:29:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3.5-flash-02-23": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-5v-turbo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai_coding_plan:glm-5.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:11:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:meta-llama/llama-3.2-3b-instruct": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:37:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:intfloat/multilingual-e5-large": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/models/deepseek-v4-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.5-computer-use-preview-10-2025": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openai:o3-pro-2025-06-10": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:00:08Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:google/gemini-3.1-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-robotics-er-1.6-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:sapiens-ai/agnes-1.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-2.5-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:15:18Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_basic": {
-        "error": null,
-        "fixtures": [
-          "object_basic"
-        ],
-        "last_checked": "2026-05-29T22:21:40Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:18:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:08:36Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_multi": {
-        "error": null,
-        "fixtures": [
-          "multi_tool"
-        ],
-        "last_checked": "2026-05-29T22:21:33Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_none": {
-        "error": null,
-        "fixtures": [
-          "no_tool"
-        ],
-        "last_checked": "2026-05-29T22:21:33Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_round_trip": {
-        "error": null,
-        "fixtures": [
-          "tool_round_trip_1",
-          "tool_round_trip_2"
-        ],
-        "last_checked": "2026-05-29T22:21:33Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:08:36Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:grok-4-20-multi-agent": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-imagine-image-quality": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-30T01:06:56Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.6": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-5.5-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T19:08:53Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:aion-labs-aion-2-0": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-opus-4-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/ministral-14b-2512": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "cerebras:gpt-oss-120b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:27:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen-3-7-max": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-2.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3.5-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "context_append": {
-        "error": null,
-        "fixtures": [
-          "context_append_1",
-          "context_append_2"
-        ],
-        "last_checked": "2026-05-29T22:20:37Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "object_basic": {
-        "error": null,
-        "fixtures": [
-          "object_basic"
-        ],
-        "last_checked": "2026-06-10T21:03:14Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "reasoning": {
-        "error": null,
-        "fixtures": [
-          "reasoning_basic",
-          "reasoning_streaming"
-        ],
-        "last_checked": "2026-05-29T22:26:04Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "streaming": {
-        "error": null,
-        "fixtures": [
-          "streaming"
-        ],
-        "last_checked": "2026-05-29T22:20:37Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "token_limit": {
-        "error": null,
-        "fixtures": [
-          "token_limit"
-        ],
-        "last_checked": "2026-05-29T22:12:39Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_multi": {
-        "error": null,
-        "fixtures": [
-          "multi_tool"
-        ],
-        "last_checked": "2026-05-29T22:24:37Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_none": {
-        "error": null,
-        "fixtures": [
-          "no_tool"
-        ],
-        "last_checked": "2026-05-29T22:24:37Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "tool_round_trip": {
-        "error": null,
-        "fixtures": [
-          "tool_round_trip_1",
-          "tool_round_trip_2"
-        ],
-        "last_checked": "2026-05-29T22:24:37Z",
-        "mode": "record",
-        "status": "pass"
-      },
-      "usage": {
-        "error": null,
-        "fixtures": [
-          "usage"
-        ],
-        "last_checked": "2026-05-29T22:12:39Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:grok-4-3": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-3.5-haiku": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:moonshotai/kimi-k2-0905": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-v4-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-image-2-2026-04-21": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T21:26:05Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-sonnet-4.5": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:amazon/nova-lite-v1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:28Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3-235b-a22b-2507": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:x-ai/grok-4.2-fast": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:gemini-3-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "google:veo-3.0-fast-generate-001": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:poolside/laguna-m.1:free": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:21:35Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:tts-1": {
-    "scenarios": {
-      "speech_basic": {
-        "error": null,
-        "fixtures": [
-          "speech_basic"
-        ],
-        "last_checked": "2026-05-29T20:40:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-3.1-pro-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:55Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/pixtral-large-2411": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:baidu/ernie-4.5-vl-28b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (502): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:14:36Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:thenlper/gte-base": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-4": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-nemo": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2.7-highspeed": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:bytedance/doubao-seed-2.0-code": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:intfloat/e5-large-v2": {
-    "scenarios": {
-      "embed_basic": {
-        "error": null,
-        "fixtures": [
-          "embed_basic"
-        ],
-        "last_checked": "2026-05-30T00:56:13Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:openai-gpt-oss-120b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:deepseek/deepseek-chat": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:35:21Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "groq:llama-3.3-70b-versatile": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:26:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "fireworks_ai:accounts/fireworks/routers/glm-5p1-fast": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (503): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:30:47Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "cerebras:llama3.1-8b": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:27:04Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-coder-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-opus-4-7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:google/gemma-3-12b-it": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:aion-labs/aion-1.0": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:39Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:google/gemini-2.5-flash-lite": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:06Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-4.20-multi-agent-0309": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:perplexity/sonar-deep-research": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:52Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:x-ai/grok-build-0.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:19:11Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.4-nano": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-4.7-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.1-codex": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:qwen/qwen3.6-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:cohere/command-r-plus-08-2024": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:25Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zai:glm-4.5": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:33:31Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:mistralai/ministral-8b-2512": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3.1-flash-image-preview": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:27:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:claude-sonnet-4-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:gemini-3.1-flash-image": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:28:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:liquid/lfm-2-24b-a2b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:16:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "xai:grok-3-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:06:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:openai/gpt-5.2-codex": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:volcengine/doubao-seed-code": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "cohere:command-r-plus-08-2024": {
-    "scenarios": {
-      "basic": {
-        "error": "",
-        "fixtures": [],
-        "last_checked": "2026-05-29T23:28:02Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "cohere:rerank-english-v3.0": {
-    "scenarios": {
-      "rerank_basic": {
-        "error": null,
-        "fixtures": [
-          "rerank_basic"
-        ],
-        "last_checked": "2026-05-29T23:28:38Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:imagen-4.0-fast-generate-001": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T22:29:31Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:mistralai/mistral-large-2407": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:38:18Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:baidu/ernie-x1.1-preview": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:inclusionai/ling-2.6-flash": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:16:15Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:z-ai/glm-5": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:44:10Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen-plus-2025-07-28": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:16Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:xiaomi/mimo-v2-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:22:50Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:qwen/qwen3-30b-a3b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:42:04Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:aion-labs/aion-2.0": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:24:39Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen3-5-397b-a17b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:minimax/minimax-m2.1": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "venice:qwen-3-6-plus": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T23:55:12Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "zenmux:anthropic/claude-opus-4": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:10:17Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:nousresearch/hermes-2-pro-llama-3-8b": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:18:40Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "google:veo-3.1-generate-preview": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T01:01:43Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "zai_coding_plan:glm-4.7": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:11:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:gpt-image-1.5": {
-    "scenarios": {
-      "image_basic": {
-        "error": null,
-        "fixtures": [
-          "image_basic"
-        ],
-        "last_checked": "2026-05-29T20:45:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openai:o3-pro": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-29T18:59:52Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  },
-  "openrouter:arcee-ai/maestro-reasoning": {
-    "scenarios": {
-      "basic": {
-        "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:13:54Z",
-        "mode": "record",
-        "status": "fail"
-      }
-    }
-  },
-  "openrouter:bytedance-seed/seed-2.0-mini": {
-    "scenarios": {
-      "basic": {
-        "error": null,
-        "fixtures": [
-          "basic"
-        ],
-        "last_checked": "2026-05-30T00:15:07Z",
-        "mode": "record",
-        "status": "pass"
-      }
-    }
-  }
+  "generated_at": "2026-06-12T21:58:25Z",
+  "models": {
+    "anthropic:claude-haiku-4-5-20251001": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-haiku-4-5-20251001",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:09:16Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:09:16Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:09:16Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "anthropic:claude-opus-4-1-20250805": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-1-20250805",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:11:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:11:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:11:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "anthropic:claude-opus-4-20250514": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-20250514",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:13:32Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:13:32Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:13:32Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "anthropic:claude-opus-4-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-5",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:20:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:20:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:20:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "anthropic:claude-opus-4-8": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-8",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:14:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:14:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:14:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "anthropic:claude-sonnet-4-20250514": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-sonnet-4-20250514",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:16:20Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:16:20Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:16:20Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "anthropic:claude-sonnet-4-5-20250929": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-sonnet-4-5-20250929",
+      "provider": "anthropic",
+      "surfaces": {
+        "anthropic.messages": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "anthropic",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:17:58Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:17:58Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T17:17:58Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cerebras:gpt-oss-120b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-oss-120b",
+      "provider": "cerebras",
+      "surfaces": {
+        "cerebras.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cerebras",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:27:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cerebras:llama3.1-8b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "llama3.1-8b",
+      "provider": "cerebras",
+      "surfaces": {
+        "cerebras.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "cerebras",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:27:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cerebras:qwen-3-235b-a22b-instruct-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen-3-235b-a22b-instruct-2507",
+      "provider": "cerebras",
+      "surfaces": {
+        "cerebras.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cerebras",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:27:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cerebras:qwen-3-coder-480b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen-3-coder-480b",
+      "provider": "cerebras",
+      "surfaces": {
+        "cerebras.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cerebras",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:27:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cerebras:zai-glm-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "zai-glm-4.7",
+      "provider": "cerebras",
+      "surfaces": {
+        "cerebras.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cerebras",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:27:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:c4ai-aya-expanse-32b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "c4ai-aya-expanse-32b",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:c4ai-aya-expanse-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "c4ai-aya-expanse-8b",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:c4ai-aya-vision-32b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "c4ai-aya-vision-32b",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:c4ai-aya-vision-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "c4ai-aya-vision-8b",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-a-03-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-a-03-2025",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-a-reasoning-08-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-a-reasoning-08-2025",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-a-translate-08-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-a-translate-08-2025",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-a-vision-07-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-a-vision-07-2025",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-r-08-2024": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-r-08-2024",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-r-plus-08-2024": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-r-plus-08-2024",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-r7b-12-2024": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-r7b-12-2024",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:command-r7b-arabic-02-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "command-r7b-arabic-02-2025",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "cohere",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:02Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:rerank-english-v3.0": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "rerank"
+      ],
+      "model": "rerank-english-v3.0",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.rerank": {
+          "declaration": "declared",
+          "operation": "rerank",
+          "provider": "cohere",
+          "scenarios": {
+            "rerank_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "rerank_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:rerank-multilingual-v3.0": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "rerank"
+      ],
+      "model": "rerank-multilingual-v3.0",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.rerank": {
+          "declaration": "declared",
+          "operation": "rerank",
+          "provider": "cohere",
+          "scenarios": {
+            "rerank_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "rerank_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:rerank-v3.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "rerank"
+      ],
+      "model": "rerank-v3.5",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.rerank": {
+          "declaration": "declared",
+          "operation": "rerank",
+          "provider": "cohere",
+          "scenarios": {
+            "rerank_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "rerank_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:rerank-v4.0-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "rerank"
+      ],
+      "model": "rerank-v4.0-fast",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.rerank": {
+          "declaration": "declared",
+          "operation": "rerank",
+          "provider": "cohere",
+          "scenarios": {
+            "rerank_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "rerank_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "cohere:rerank-v4.0-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "rerank"
+      ],
+      "model": "rerank-v4.0-pro",
+      "provider": "cohere",
+      "surfaces": {
+        "cohere.rerank": {
+          "declaration": "declared",
+          "operation": "rerank",
+          "provider": "cohere",
+          "scenarios": {
+            "rerank_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:28:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "rerank_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "elevenlabs:eleven_flash_v2_5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "eleven_flash_v2_5",
+      "provider": "elevenlabs",
+      "surfaces": {
+        "elevenlabs.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "elevenlabs",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:29:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "elevenlabs:eleven_multilingual_v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "eleven_multilingual_v2",
+      "provider": "elevenlabs",
+      "surfaces": {
+        "elevenlabs.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "elevenlabs",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:29:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "elevenlabs:eleven_turbo_v2_5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "eleven_turbo_v2_5",
+      "provider": "elevenlabs",
+      "surfaces": {
+        "elevenlabs.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "elevenlabs",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:29:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "elevenlabs:eleven_v3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "eleven_v3",
+      "provider": "elevenlabs",
+      "surfaces": {
+        "elevenlabs.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "elevenlabs",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:29:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/deepseek-v4-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/deepseek-v4-flash",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/deepseek-v4-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/deepseek-v4-pro",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/glm-5p1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/glm-5p1",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/gpt-oss-120b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/gpt-oss-120b",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/gpt-oss-20b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/gpt-oss-20b",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/kimi-k2p5": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "accounts/fireworks/models/kimi-k2p5",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/kimi-k2p6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/kimi-k2p6",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/minimax-m2p5": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "accounts/fireworks/models/minimax-m2p5",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/minimax-m2p7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/models/minimax-m2p7",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/models/qwen3p6-plus": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "accounts/fireworks/models/qwen3p6-plus",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/routers/glm-5p1-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/routers/glm-5p1-fast",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (503): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "fireworks_ai:accounts/fireworks/routers/kimi-k2p6-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "accounts/fireworks/routers/kimi-k2p6-turbo",
+      "provider": "fireworks_ai",
+      "surfaces": {
+        "fireworks_ai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "fireworks_ai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:30:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "github_copilot:gpt-4.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4.1",
+      "provider": "github_copilot",
+      "surfaces": {
+        "github_copilot.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "github_copilot",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-06-12T21:58:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:antigravity-preview-05-2026": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "antigravity-preview-05-2026",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:aqa": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "aqa",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:deep-research-max-preview-04-2026": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deep-research-max-preview-04-2026",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:deep-research-preview-04-2026": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deep-research-preview-04-2026",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:deep-research-pro-preview-12-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deep-research-pro-preview-12-2025",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-1.5-flash": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "gemini-1.5-flash",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-1.5-pro": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "gemini-1.5-pro",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.0-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.0-flash",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.0-flash-exp": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "gemini-2.0-flash-exp",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.0-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.0-flash-lite",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-computer-use-preview-10-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-computer-use-preview-10-2025",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-flash",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-flash-image": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gemini-2.5-flash-image",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:27:26Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-flash-lite",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:15:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:21:40Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:18:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:08:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_multi": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:21:33Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multi_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_none": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:21:33Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "no_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_round_trip": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:21:33Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "tool_round_trip_1",
+                    "tool_round_trip_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:08:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-flash-native-audio-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-flash-native-audio-latest",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-flash-native-audio-preview-09-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-flash-native-audio-preview-09-2025",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-flash-native-audio-preview-12-2025": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-2.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-2.5-pro",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3-flash-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3-flash-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:19:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:15Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "reasoning": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:25:08Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "reasoning_basic",
+                    "reasoning_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:19:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:09:19Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_multi": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:03Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multi_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_none": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:03Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "no_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_round_trip": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:03Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "tool_round_trip_1",
+                    "tool_round_trip_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:09:19Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3-pro-image": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gemini-3-pro-image",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:29:02Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3-pro-image-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gemini-3-pro-image-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:28:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3-pro-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-flash-image": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gemini-3.1-flash-image",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:28:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-flash-image-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gemini-3.1-flash-image-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:27:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3.1-flash-lite",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:19:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:49Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "reasoning": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:25:20Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "reasoning_basic",
+                    "reasoning_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:19:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:09:53Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_multi": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multi_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_none": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "no_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_round_trip": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:22:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "tool_round_trip_1",
+                    "tool_round_trip_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:09:53Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-flash-lite-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3.1-flash-lite-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-flash-live-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3.1-flash-live-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3.1-pro-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:19:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "multimodal_tool_result": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:07:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multimodal_tool_result_1",
+                    "multimodal_tool_result_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:23:33Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "reasoning": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:25:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "reasoning_basic",
+                    "reasoning_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:19:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:10:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_multi": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:23:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multi_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_none": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:23:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "no_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_round_trip": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:23:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "tool_round_trip_1",
+                    "tool_round_trip_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:10:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.1-pro-preview-customtools": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3.1-pro-preview-customtools",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:20:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "reasoning": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:25:51Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "reasoning_basic",
+                    "reasoning_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:20:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:11:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_multi": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:02Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multi_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_none": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:02Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "no_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_round_trip": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:02Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "tool_round_trip_1",
+                    "tool_round_trip_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:11:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-3.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3.5-flash",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:20:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-06-10T21:03:14Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "reasoning": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:26:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "reasoning_basic",
+                    "reasoning_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:20:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:12:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_multi": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "multi_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_none": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "no_tool"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "tool_round_trip": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:24:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "tool_round_trip_1",
+                    "tool_round_trip_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:12:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-embedding-001": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "gemini-embedding-001",
+      "provider": "google",
+      "surfaces": {
+        "google.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "google",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:02:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-embedding-2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "gemini-embedding-2",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "not_declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-embedding-2-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-embedding-2-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-flash-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-flash-latest",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-pro-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-pro-latest",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:20:56Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "context_append_1",
+                    "context_append_2"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:20:56Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "token_limit": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:13:02Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "token_limit"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "usage": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:14:34Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "usage"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-robotics-er-1.5-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-robotics-er-1.5-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:gemini-robotics-er-1.6-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-robotics-er-1.6-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.generate_content": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:imagen-4.0-fast-generate-001": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "imagen-4.0-fast-generate-001",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:29:31Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:imagen-4.0-generate-001": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "imagen-4.0-generate-001",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:29:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:imagen-4.0-ultra-generate-001": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "imagen-4.0-ultra-generate-001",
+      "provider": "google",
+      "surfaces": {
+        "google.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "google",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T22:29:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:lyria-3-clip-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "lyria-3-clip-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (500): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:lyria-3-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "lyria-3-pro-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (500): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:nano-banana-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nano-banana-pro-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:text-embedding-004": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "text-embedding-004",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_embedding": {
+          "declaration": "unknown",
+          "operation": "embedding",
+          "provider": "google",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:02:06Z",
+                  "error": "     Expected successful embedding, got error: %ReqLLM.Error.API.Request{reason: \"Provider response error (404): Google A",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:veo-2.0-generate-001": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "veo-2.0-generate-001",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:veo-3.0-fast-generate-001": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "veo-3.0-fast-generate-001",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:veo-3.0-generate-001": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "veo-3.0-generate-001",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:veo-3.1-fast-generate-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "veo-3.1-fast-generate-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:veo-3.1-generate-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "veo-3.1-generate-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "google:veo-3.1-lite-generate-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "veo-3.1-lite-generate-preview",
+      "provider": "google",
+      "surfaces": {
+        "google.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "google",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:01:43Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:allam-2-7b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "allam-2-7b",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:groq/compound": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "groq/compound",
+      "provider": "groq",
+      "surfaces": {
+        "groq.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:groq/compound-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "groq/compound-mini",
+      "provider": "groq",
+      "surfaces": {
+        "groq.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:llama-3.1-8b-instant": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "llama-3.1-8b-instant",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:llama-3.3-70b-versatile": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "llama-3.3-70b-versatile",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:llama3-8b-8192": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "llama3-8b-8192",
+      "provider": "groq",
+      "surfaces": {
+        "groq.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:meta-llama/llama-4-maverick-17b-128e-instruct": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "meta-llama/llama-4-maverick-17b-128e-instruct",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:meta-llama/llama-prompt-guard-2-22m": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-prompt-guard-2-22m",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:meta-llama/llama-prompt-guard-2-86m": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-prompt-guard-2-86m",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:moonshotai/kimi-k2-instruct-0905": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "moonshotai/kimi-k2-instruct-0905",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:openai/gpt-oss-120b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-120b",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:openai/gpt-oss-20b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-20b",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:openai/gpt-oss-safeguard-20b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-safeguard-20b",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:qwen/qwen3-32b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-32b",
+      "provider": "groq",
+      "surfaces": {
+        "groq.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "groq",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:whisper-large-v3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "whisper-large-v3",
+      "provider": "groq",
+      "surfaces": {
+        "groq.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "groq",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:29Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "groq:whisper-large-v3-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "whisper-large-v3-turbo",
+      "provider": "groq",
+      "surfaces": {
+        "groq.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "groq",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:26:29Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "minimax:MiniMax-M2.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "MiniMax-M2.1",
+      "provider": "minimax",
+      "surfaces": {
+        "minimax.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "minimax",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T16:18:48Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:babbage-002": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "babbage-002",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:05:19Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:chat-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "chat-latest",
+      "provider": "openai",
+      "surfaces": {
+        "openai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:30:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:chatgpt-image-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "chatgpt-image-latest",
+      "provider": "openai",
+      "surfaces": {
+        "openai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "openai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:24:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:davinci-002": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "davinci-002",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:05:29Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4-0125-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4-0125-preview",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:05:48Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4.1-2025-04-14": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4.1-2025-04-14",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:57:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4.1-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4.1-mini",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "context_append": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:43:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [],
+                  "mode": "replay",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4.1-mini-2025-04-14": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4.1-mini-2025-04-14",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:57:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-2024-08-06": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4o-2024-08-06",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:57:48Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-2024-11-20": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4o-2024-11-20",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:57:58Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-4o-mini",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T16:16:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-mini-transcribe": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "gpt-4o-mini-transcribe",
+      "provider": "openai",
+      "surfaces": {
+        "openai.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:19:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-mini-transcribe-2025-03-20": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "gpt-4o-mini-transcribe-2025-03-20",
+      "provider": "openai",
+      "surfaces": {
+        "openai.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:23:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-mini-transcribe-2025-12-15": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "gpt-4o-mini-transcribe-2025-12-15",
+      "provider": "openai",
+      "surfaces": {
+        "openai.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:23:38Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-mini-tts": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "gpt-4o-mini-tts",
+      "provider": "openai",
+      "surfaces": {
+        "openai.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "openai",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:17:40Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-mini-tts-2025-12-15": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "gpt-4o-mini-tts-2025-12-15",
+      "provider": "openai",
+      "surfaces": {
+        "openai.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "openai",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:17:57Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-transcribe": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "gpt-4o-transcribe",
+      "provider": "openai",
+      "surfaces": {
+        "openai.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:20:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-4o-transcribe-diarize": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "gpt-4o-transcribe-diarize",
+      "provider": "openai",
+      "surfaces": {
+        "openai.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:23:56Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-2025-08-07": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-2025-08-07",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:58:08Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-mini-2025-08-07": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-mini-2025-08-07",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:58:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-nano": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-nano",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "object_streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:43:47Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [],
+                  "mode": "replay",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-nano-2025-08-07": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-nano-2025-08-07",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:58:31Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:19:08Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-pro",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:59:05Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-pro-2025-10-06": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-pro-2025-10-06",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:59:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-search-api": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-search-api",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:09:22Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5-search-api-2025-10-14": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5-search-api-2025-10-14",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:09:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.1",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:00:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.1-2025-11-13": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.1-2025-11-13",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:00:26Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.2",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:00:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.2-2025-12-11": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.2-2025-12-11",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:00:43Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.2-chat-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.2-chat-latest",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:00:53Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.2-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.2-pro",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:01:09Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.2-pro-2025-12-11": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.2-pro-2025-12-11",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:01:31Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.3-chat-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.3-chat-latest",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:05:58Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.3-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.3-codex",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:06:08Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.3-codex-spark": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.3-codex-spark",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:26:57Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:06:26Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-2026-03-05": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-2026-03-05",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:06:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-mini",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:06:44Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-mini-2026-03-17": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-mini-2026-03-17",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:06:53Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-nano": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-nano",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:07:01Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-nano-2026-03-17": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-nano-2026-03-17",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:07:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-pro",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:07:49Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.4-pro-2026-03-05": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.4-pro-2026-03-05",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:08:23Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.5",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:08:33Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.5-2026-04-23": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.5-2026-04-23",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:08:42Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.5-pro",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:08:53Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-5.5-pro-2026-04-23": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-5.5-pro-2026-04-23",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:09:14Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-audio": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-audio",
+      "provider": "openai",
+      "surfaces": {
+        "openai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:37:41Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-audio-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gpt-audio-mini",
+      "provider": "openai",
+      "surfaces": {
+        "openai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:37:57Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-image-1-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gpt-image-1-mini",
+      "provider": "openai",
+      "surfaces": {
+        "openai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "openai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:25:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-image-1.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gpt-image-1.5",
+      "provider": "openai",
+      "surfaces": {
+        "openai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "openai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T20:45:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-image-2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gpt-image-2",
+      "provider": "openai",
+      "surfaces": {
+        "openai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "openai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:25:32Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-image-2-2026-04-21": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "gpt-image-2-2026-04-21",
+      "provider": "openai",
+      "surfaces": {
+        "openai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "openai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:26:05Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:gpt-realtime-whisper": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "gpt-realtime-whisper",
+      "provider": "openai",
+      "surfaces": {
+        "openai.unrecorded_transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:20:41Z",
+                  "error": "     ** (MatchError) no match of right hand side value:\n          %ReqLLM.Error.API.Request{",
+                  "failure_layer": "assertion",
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:o3-2025-04-16": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "o3-2025-04-16",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:58:41Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:o3-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "o3-pro",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T18:59:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:o3-pro-2025-06-10": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "o3-pro-2025-06-10",
+      "provider": "openai",
+      "surfaces": {
+        "openai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T19:00:08Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:tts-1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "tts-1",
+      "provider": "openai",
+      "surfaces": {
+        "openai.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "openai",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T20:40:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:tts-1-1106": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "tts-1-1106",
+      "provider": "openai",
+      "surfaces": {
+        "openai.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "openai",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:18:14Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:tts-1-hd": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "tts-1-hd",
+      "provider": "openai",
+      "surfaces": {
+        "openai.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "openai",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:18:32Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:tts-1-hd-1106": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "speech"
+      ],
+      "model": "tts-1-hd-1106",
+      "provider": "openai",
+      "surfaces": {
+        "openai.speech": {
+          "declaration": "declared",
+          "operation": "speech",
+          "provider": "openai",
+          "scenarios": {
+            "speech_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T21:18:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "speech_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openai:whisper-1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "transcription"
+      ],
+      "model": "whisper-1",
+      "provider": "openai",
+      "surfaces": {
+        "openai.transcription": {
+          "declaration": "declared",
+          "operation": "transcription",
+          "provider": "openai",
+          "scenarios": {
+            "transcription_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T20:44:37Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "transcription_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:aion-labs/aion-1.0": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "aion-labs/aion-1.0",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:aion-labs/aion-1.0-mini": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "aion-labs/aion-1.0-mini",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:aion-labs/aion-2.0": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "aion-labs/aion-2.0",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:aion-labs/aion-rp-llama-3.1-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "aion-labs/aion-rp-llama-3.1-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:39Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:amazon/nova-2-lite-v1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "amazon/nova-2-lite-v1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:amazon/nova-lite-v1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "amazon/nova-lite-v1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:amazon/nova-micro-v1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "amazon/nova-micro-v1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:amazon/nova-premier-v1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "amazon/nova-premier-v1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:amazon/nova-pro-v1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "amazon/nova-pro-v1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:28Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:arcee-ai/coder-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "arcee-ai/coder-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:54Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:arcee-ai/maestro-reasoning": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "arcee-ai/maestro-reasoning",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:54Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:arcee-ai/spotlight": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "arcee-ai/spotlight",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:54Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:arcee-ai/trinity-large-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "arcee-ai/trinity-large-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:arcee-ai/trinity-mini": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "arcee-ai/trinity-mini",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:arcee-ai/virtuoso-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "arcee-ai/virtuoso-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:13:54Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baai/bge-base-en-v1.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "baai/bge-base-en-v1.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baai/bge-large-en-v1.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "baai/bge-large-en-v1.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baai/bge-m3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "baai/bge-m3",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baidu/ernie-4.5-21b-a3b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "baidu/ernie-4.5-21b-a3b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:14:36Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (502): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baidu/ernie-4.5-21b-a3b-thinking": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "baidu/ernie-4.5-21b-a3b-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:14:36Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baidu/ernie-4.5-300b-a47b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "baidu/ernie-4.5-300b-a47b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:14:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baidu/ernie-4.5-vl-28b-a3b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "baidu/ernie-4.5-vl-28b-a3b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:14:36Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (502): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:baidu/ernie-4.5-vl-424b-a47b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "baidu/ernie-4.5-vl-424b-a47b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:14:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:bytedance-seed/seed-1.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance-seed/seed-1.6",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:bytedance-seed/seed-1.6-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance-seed/seed-1.6-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:bytedance-seed/seed-2.0-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance-seed/seed-2.0-lite",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:bytedance-seed/seed-2.0-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance-seed/seed-2.0-mini",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:cohere/command-a": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "cohere/command-a",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:cohere/command-r-08-2024": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "cohere/command-r-08-2024",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:cohere/command-r-plus-08-2024": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "cohere/command-r-plus-08-2024",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:cohere/command-r7b-12-2024": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "cohere/command-r7b-12-2024",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:25Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-chat": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-chat",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-chat-v3-0324": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-chat-v3-0324",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-r1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-r1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-r1-0528": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-r1-0528",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-r1-distill-llama-70b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-r1-distill-llama-70b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-r1-distill-qwen-32b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "deepseek/deepseek-r1-distill-qwen-32b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-v3.2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v3.2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-v3.2-exp": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v3.2-exp",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-v3.2-speciale": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "deepseek/deepseek-v3.2-speciale",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-v4-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v4-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-v4-flash:free": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "deepseek/deepseek-v4-flash:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:deepseek/deepseek-v4-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v4-pro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:35:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.0-flash-001": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "google/gemini-2.0-flash-001",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.0-flash-lite-001": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "google/gemini-2.0-flash-lite-001",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.5-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-flash-lite",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.5-flash-lite-preview-09-2025": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "google/gemini-2.5-flash-lite-preview-09-2025",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-pro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.5-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-pro-preview",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-2.5-pro-preview-05-06": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-pro-preview-05-06",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:06Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-3-flash-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3-flash-preview",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-3.1-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-flash-lite",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-3.1-flash-lite-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-flash-lite-preview",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-3.1-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-pro-preview",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-3.1-pro-preview-customtools": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-pro-preview-customtools",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-3.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.5-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:15:55Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-embedding-001": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "google/gemini-embedding-001",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemini-embedding-2-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "google/gemini-embedding-2-preview",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-2-27b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-2-27b-it",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-3-4b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-3-4b-it",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-3n-e4b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-3n-e4b-it",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-4-26b-a4b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-4-26b-a4b-it",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-4-26b-a4b-it:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-4-26b-a4b-it:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-4-31b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-4-31b-it",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:google/gemma-4-31b-it:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemma-4-31b-it:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:ibm-granite/granite-4.0-h-micro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "ibm-granite/granite-4.0-h-micro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:20:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:ibm-granite/granite-4.1-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "ibm-granite/granite-4.1-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:20:36Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:inception/mercury-2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inception/mercury-2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:20:46Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:inclusionai/ling-2.6-1t": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ling-2.6-1t",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:16:15Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:inclusionai/ling-2.6-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ling-2.6-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:16:15Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:inclusionai/ring-2.6-1t": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ring-2.6-1t",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:16:15Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:inflection/inflection-3-pi": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inflection/inflection-3-pi",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:inflection/inflection-3-productivity": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inflection/inflection-3-productivity",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:24:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:intfloat/e5-base-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "intfloat/e5-base-v2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:intfloat/e5-large-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "intfloat/e5-large-v2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:intfloat/multilingual-e5-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "intfloat/multilingual-e5-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:liquid/lfm-2-24b-a2b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "liquid/lfm-2-24b-a2b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:16:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:liquid/lfm-2.5-1.2b-instruct:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "liquid/lfm-2.5-1.2b-instruct:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:16:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:liquid/lfm-2.5-1.2b-thinking:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "liquid/lfm-2.5-1.2b-thinking:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:16:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mancer/weaver": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mancer/weaver",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:25:07Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3-70b-instruct": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "meta-llama/llama-3-70b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3-8b-instruct": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "meta-llama/llama-3-8b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.1-70b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.1-70b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.1-8b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.1-8b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.2-11b-vision-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.2-11b-vision-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.2-1b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.2-1b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.2-3b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.2-3b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.2-3b-instruct:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.2-3b-instruct:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-3.3-70b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-3.3-70b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-4-maverick": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-4-maverick",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-4-scout": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-4-scout",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-guard-3-8b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "meta-llama/llama-guard-3-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:meta-llama/llama-guard-4-12b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta-llama/llama-guard-4-12b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:37:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:microsoft/phi-4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "microsoft/phi-4",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:17:09Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:microsoft/phi-4-mini-instruct": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "microsoft/phi-4-mini-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:17:09Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:microsoft/wizardlm-2-8x22b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "microsoft/wizardlm-2-8x22b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:17:09Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:minimax/minimax-m2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:minimax/minimax-m2-her": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2-her",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:minimax/minimax-m2.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:minimax/minimax-m2.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:minimax/minimax-m2.5:free": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "minimax/minimax-m2.5:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:59Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:minimax/minimax-m2.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.7",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/codestral-2508": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/codestral-2508",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/codestral-embed-2505": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "mistralai/codestral-embed-2505",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/devstral-2512": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/devstral-2512",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/devstral-medium": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "mistralai/devstral-medium",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/devstral-small": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "mistralai/devstral-small",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/ministral-14b-2512": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/ministral-14b-2512",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/ministral-3b-2512": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/ministral-3b-2512",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/ministral-8b-2512": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/ministral-8b-2512",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-7b-instruct-v0.1": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "mistralai/mistral-7b-instruct-v0.1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-embed-2312": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "mistralai/mistral-embed-2312",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-large-2407": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-large-2407",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-large-2411": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "mistralai/mistral-large-2411",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-large-2512": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-large-2512",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-medium-3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-medium-3",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-medium-3-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-medium-3-5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-medium-3.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-medium-3.1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-nemo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-nemo",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-saba": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-saba",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-small-24b-instruct-2501": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-small-24b-instruct-2501",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mistral-small-2603": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-small-2603",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/mixtral-8x22b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mixtral-8x22b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/pixtral-large-2411": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "mistralai/pixtral-large-2411",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:mistralai/voxtral-small-24b-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/voxtral-small-24b-2507",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:38:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:moonshotai/kimi-k2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:moonshotai/kimi-k2-0905": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2-0905",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:moonshotai/kimi-k2.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:moonshotai/kimi-k2.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2.6",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:moonshotai/kimi-k2.6:free": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "moonshotai/kimi-k2.6:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:21Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:morph/morph-v3-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "morph/morph-v3-fast",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:20:57Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:morph/morph-v3-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "morph/morph-v3-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:20:57Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nex-agi/deepseek-v3.1-nex-n1": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "nex-agi/deepseek-v3.1-nex-n1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:08Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nousresearch/hermes-2-pro-llama-3-8b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "nousresearch/hermes-2-pro-llama-3-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:18:40Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nousresearch/hermes-3-llama-3.1-405b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nousresearch/hermes-3-llama-3.1-405b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:18:40Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nousresearch/hermes-3-llama-3.1-405b:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nousresearch/hermes-3-llama-3.1-405b:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:18:40Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nousresearch/hermes-3-llama-3.1-70b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nousresearch/hermes-3-llama-3.1-70b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:18:40Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nousresearch/hermes-4-70b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nousresearch/hermes-4-70b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:18:40Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/llama-nemotron-embed-vl-1b-v2:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "nvidia/llama-nemotron-embed-vl-1b-v2:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-3-nano-30b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-3-nano-30b-a3b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-3-nano-30b-a3b:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-3-nano-30b-a3b:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-3-super-120b-a12b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-3-super-120b-a12b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-3-super-120b-a12b:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-3-super-120b-a12b:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-nano-12b-v2-vl:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-nano-12b-v2-vl:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:nvidia/nemotron-nano-9b-v2:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia/nemotron-nano-9b-v2:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/gpt-4o-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-4o-mini",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T16:17:31Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/gpt-oss-120b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-120b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/gpt-oss-120b:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-120b:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/gpt-oss-20b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-20b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/gpt-oss-20b:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-20b:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/gpt-oss-safeguard-20b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-oss-safeguard-20b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:45:45Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/text-embedding-3-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "openai/text-embedding-3-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/text-embedding-3-small": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "openai/text-embedding-3-small",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openai/text-embedding-ada-002": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "openai/text-embedding-ada-002",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openrouter/auto": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openrouter/auto",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:23:22Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openrouter/bodybuilder": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openrouter/bodybuilder",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:23:22Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openrouter/free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openrouter/free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:23:22Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openrouter/owl-alpha": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "openrouter/owl-alpha",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:23:22Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:openrouter/pareto-code": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openrouter/pareto-code",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:23:22Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/pplx-embed-v1-0.6b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "perplexity/pplx-embed-v1-0.6b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/pplx-embed-v1-4b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "perplexity/pplx-embed-v1-4b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/sonar": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "perplexity/sonar",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/sonar-deep-research": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "perplexity/sonar-deep-research",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:52Z",
+                  "error": "",
+                  "failure_layer": "assertion",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/sonar-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "perplexity/sonar-pro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/sonar-pro-search": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "perplexity/sonar-pro-search",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:perplexity/sonar-reasoning-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "perplexity/sonar-reasoning-pro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:poolside/laguna-m.1:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "poolside/laguna-m.1:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:poolside/laguna-xs.2:free": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "poolside/laguna-xs.2:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen-2.5-72b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen-2.5-72b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen-2.5-7b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen-2.5-7b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen-2.5-coder-32b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen-2.5-coder-32b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen-plus",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:16Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen-plus-2025-07-28": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen-plus-2025-07-28",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:16Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen-plus-2025-07-28:thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen-plus-2025-07-28:thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:16Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-14b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-14b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-235b-a22b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-235b-a22b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-235b-a22b-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-235b-a22b-2507",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-235b-a22b-thinking-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-235b-a22b-thinking-2507",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-30b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-30b-a3b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-30b-a3b-instruct-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-30b-a3b-instruct-2507",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-30b-a3b-thinking-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-30b-a3b-thinking-2507",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-32b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-32b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-coder-30b-a3b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-coder-30b-a3b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-coder-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-coder-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-coder-next": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-coder-next",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-coder-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-coder-plus",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-embedding-4b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "qwen/qwen3-embedding-4b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-embedding-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "qwen/qwen3-embedding-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-max-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-max-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-next-80b-a3b-instruct:free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-next-80b-a3b-instruct:free",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-next-80b-a3b-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-next-80b-a3b-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-235b-a22b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-235b-a22b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-235b-a22b-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-235b-a22b-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-30b-a3b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-30b-a3b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-30b-a3b-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-30b-a3b-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-32b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-32b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-8b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-8b-instruct",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3-vl-8b-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-8b-thinking",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-122b-a10b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-122b-a10b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-27b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-27b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-35b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-35b-a3b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-397b-a17b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-397b-a17b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-9b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-9b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-flash-02-23": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-flash-02-23",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-plus-02-15": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-plus-02-15",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.5-plus-20260420": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-plus-20260420",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.6-27b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-27b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.6-35b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-35b-a3b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.6-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.6-max-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-max-preview",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.6-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-plus",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:qwen/qwen3.7-max": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.7-max",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:42:04Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:rekaai/reka-edge": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "rekaai/reka-edge",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:21:19Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sao10k/l3-euryale-70b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "sao10k/l3-euryale-70b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:25:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sao10k/l3-lunaris-8b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sao10k/l3-lunaris-8b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:25:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sao10k/l3.1-70b-hanami-x1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sao10k/l3.1-70b-hanami-x1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:25:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sao10k/l3.1-euryale-70b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sao10k/l3.1-euryale-70b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:25:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sao10k/l3.3-euryale-70b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sao10k/l3.3-euryale-70b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:25:35Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sentence-transformers/all-minilm-l12-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "sentence-transformers/all-minilm-l12-v2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sentence-transformers/all-minilm-l6-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "sentence-transformers/all-minilm-l6-v2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sentence-transformers/all-mpnet-base-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "sentence-transformers/all-mpnet-base-v2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sentence-transformers/multi-qa-mpnet-base-dot-v1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:sentence-transformers/paraphrase-minilm-l6-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "sentence-transformers/paraphrase-minilm-l6-v2",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:thenlper/gte-base": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "thenlper/gte-base",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:thenlper/gte-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "embedding"
+      ],
+      "model": "thenlper/gte-large",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.embedding": {
+          "declaration": "declared",
+          "operation": "embedding",
+          "provider": "openrouter",
+          "scenarios": {
+            "embed_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:56:13Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "embed_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:x-ai/grok-3-mini": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "x-ai/grok-3-mini",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:11Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:x-ai/grok-3-mini-beta": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "x-ai/grok-3-mini-beta",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:11Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:x-ai/grok-4.20": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.20",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:11Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:x-ai/grok-4.20-multi-agent": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.20-multi-agent",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:11Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:x-ai/grok-4.3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.3",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:11Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:x-ai/grok-build-0.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-build-0.1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:19:11Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:xiaomi/mimo-v2-flash": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "xiaomi/mimo-v2-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:xiaomi/mimo-v2-omni": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "xiaomi/mimo-v2-omni",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:xiaomi/mimo-v2-pro": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "xiaomi/mimo-v2-pro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:xiaomi/mimo-v2.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:xiaomi/mimo-v2.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2.5-pro",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:22:50Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4-32b": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "z-ai/glm-4-32b",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.5-air": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.5-air",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.5v": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.5v",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.6",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.6v": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.6v",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.7",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-4.7-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.7-flash",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-5-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5-turbo",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5.1",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "openrouter:z-ai/glm-5v-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5v-turbo",
+      "provider": "openrouter",
+      "surfaces": {
+        "openrouter.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "openrouter",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:44:10Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:aion-labs-aion-2-0": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "aion-labs-aion-2-0",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:arcee-trinity-large-thinking": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "arcee-trinity-large-thinking",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-opus-4-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-5",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-opus-4-6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-6",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-opus-4-6-fast": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "claude-opus-4-6-fast",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-opus-4-7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-7",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-opus-4-7-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-opus-4-7-fast",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-sonnet-4-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-sonnet-4-5",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:claude-sonnet-4-6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "claude-sonnet-4-6",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:deepseek-v3.2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek-v3.2",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:deepseek-v4-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek-v4-flash",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:deepseek-v4-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek-v4-pro",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:gemini-3-1-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3-1-pro-preview",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:gemini-3-5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3-5-flash",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:gemini-3-flash-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemini-3-flash-preview",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:gemma-4-uncensored": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "gemma-4-uncensored",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:google-gemma-3-27b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google-gemma-3-27b-it",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:google-gemma-4-26b-a4b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google-gemma-4-26b-a4b-it",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:google-gemma-4-31b-it": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google-gemma-4-31b-it",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:grok-4-20": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-20",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:grok-4-20-multi-agent": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-20-multi-agent",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:grok-4-3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-3",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:grok-build-0-1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-build-0-1",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:hermes-3-llama-3.1-405b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "hermes-3-llama-3.1-405b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:kimi-k2-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "kimi-k2-5",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:kimi-k2-6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "kimi-k2-6",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:llama-3.2-3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "llama-3.2-3b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:llama-3.3-70b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "llama-3.3-70b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:mercury-2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mercury-2",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:minimax-m25": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax-m25",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:minimax-m27": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax-m27",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:mistral-small-2603": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistral-small-2603",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:mistral-small-3-2-24b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistral-small-3-2-24b-instruct",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:nvidia-nemotron-3-nano-30b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia-nemotron-3-nano-30b-a3b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:nvidia-nemotron-cascade-2-30b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "nvidia-nemotron-cascade-2-30b-a3b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:olafangensan-glm-4.7-flash-heretic": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "olafangensan-glm-4.7-flash-heretic",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-4o-2024-11-20": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-4o-2024-11-20",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-4o-mini-2024-07-18": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-4o-mini-2024-07-18",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-52": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-52",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-52-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-52-codex",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-53-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-53-codex",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-54": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-54",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-54-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-54-mini",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-54-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-54-pro",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-55": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-55",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-55-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-55-pro",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:openai-gpt-oss-120b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai-gpt-oss-120b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen-3-6-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen-3-6-plus",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen-3-7-max": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen-3-7-max",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-235b-a22b-instruct-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-235b-a22b-instruct-2507",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-235b-a22b-thinking-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-235b-a22b-thinking-2507",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-5-35b-a3b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-5-35b-a3b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-5-397b-a17b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-5-397b-a17b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-5-9b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-5-9b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-6-27b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-6-27b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-coder-480b-a35b-instruct-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-coder-480b-a35b-instruct-turbo",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-next-80b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-next-80b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:qwen3-vl-235b-a22b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen3-vl-235b-a22b",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:venice-uncensored-1-2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "venice-uncensored-1-2",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:venice-uncensored-role-play": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "venice-uncensored-role-play",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:z-ai-glm-5-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai-glm-5-turbo",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:z-ai-glm-5v-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai-glm-5v-turbo",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:zai-org-glm-4.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "zai-org-glm-4.6",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:zai-org-glm-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "zai-org-glm-4.7",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:zai-org-glm-4.7-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "zai-org-glm-4.7-flash",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:zai-org-glm-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "zai-org-glm-5",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "venice:zai-org-glm-5-1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "zai-org-glm-5-1",
+      "provider": "venice",
+      "surfaces": {
+        "venice.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "venice",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:55:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-2": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "grok-2",
+      "provider": "xai",
+      "surfaces": {
+        "xai.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-2-1212": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "grok-2-1212",
+      "provider": "xai",
+      "surfaces": {
+        "xai.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-3",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-3-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-3-mini",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-3-mini-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-3-mini-fast",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-3-mini-fast-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-3-mini-fast-latest",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-3-mini-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-3-mini-latest",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4-0709": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-0709",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4-1-fast-non-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-1-fast-non-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4-1-fast-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-1-fast-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-fast",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4-fast-non-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-fast-non-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4-fast-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4-fast-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4.20-0309-non-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4.20-0309-non-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_streaming_tool_strict": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:13:54Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_streaming_tool_strict"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4.20-0309-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4.20-0309-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4.20-multi-agent-0309": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4.20-multi-agent-0309",
+      "provider": "xai",
+      "surfaces": {
+        "xai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4.20-non-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4.20-non-reasoning",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-4.3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-4.3",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_streaming_auto": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:12:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_streaming_auto"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "object_streaming_json_schema": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:12:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "object_streaming_json_schema"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "streaming_error_handling": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:12:59Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "streaming_truncated"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        },
+        "xai.responses": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "web_search_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:12:24Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "web_search_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "web_search_streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:12:24Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "web_search_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            },
+            "x_search_streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:12:24Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "x_search_streaming"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        },
+        "xai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "streaming": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:08:12Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [],
+                  "mode": "replay",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-beta": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "grok-beta",
+      "provider": "xai",
+      "surfaces": {
+        "xai.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-build-0.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-build-0.1",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-code-fast-1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-code-fast-1",
+      "provider": "xai",
+      "surfaces": {
+        "xai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-imagine-image": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "grok-imagine-image",
+      "provider": "xai",
+      "surfaces": {
+        "xai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "xai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:56Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-imagine-image-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "grok-imagine-image-pro",
+      "provider": "xai",
+      "surfaces": {
+        "xai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "xai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:56Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-imagine-image-quality": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "image"
+      ],
+      "model": "grok-imagine-image-quality",
+      "provider": "xai",
+      "surfaces": {
+        "xai.image": {
+          "declaration": "declared",
+          "operation": "image",
+          "provider": "xai",
+          "scenarios": {
+            "image_basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:56Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "image_basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "xai:grok-imagine-video": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "grok-imagine-video",
+      "provider": "xai",
+      "surfaces": {
+        "xai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "xai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T01:06:18Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.5",
+      "provider": "zai",
+      "surfaces": {
+        "zai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.5-air": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.5-air",
+      "provider": "zai",
+      "surfaces": {
+        "zai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.5-flash",
+      "provider": "zai",
+      "surfaces": {
+        "zai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.5v": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.5v",
+      "provider": "zai",
+      "surfaces": {
+        "zai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.6",
+      "provider": "zai",
+      "surfaces": {
+        "zai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.6v": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.6v",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.7",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.7-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.7-flash",
+      "provider": "zai",
+      "surfaces": {
+        "zai.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-4.7-flashx": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.7-flashx",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-5-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5-turbo",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5.1",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai:glm-5v-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5v-turbo",
+      "provider": "zai",
+      "surfaces": {
+        "zai.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T23:33:31Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai_coder:glm-4.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.5-flash",
+      "provider": "zai_coder",
+      "surfaces": {
+        "zai_coder.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai_coder",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-29T16:28:19Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai_coding_plan:glm-4.5-air": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.5-air",
+      "provider": "zai_coding_plan",
+      "surfaces": {
+        "zai_coding_plan.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai_coding_plan",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:11:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai_coding_plan:glm-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-4.7",
+      "provider": "zai_coding_plan",
+      "surfaces": {
+        "zai_coding_plan.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai_coding_plan",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:11:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai_coding_plan:glm-5-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5-turbo",
+      "provider": "zai_coding_plan",
+      "surfaces": {
+        "zai_coding_plan.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai_coding_plan",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:11:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai_coding_plan:glm-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5.1",
+      "provider": "zai_coding_plan",
+      "surfaces": {
+        "zai_coding_plan.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai_coding_plan",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:11:52Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zai_coding_plan:glm-5v-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "glm-5v-turbo",
+      "provider": "zai_coding_plan",
+      "surfaces": {
+        "zai_coding_plan.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zai_coding_plan",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:11:52Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (429): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-3.5-haiku": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-3.5-haiku",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-3.7-sonnet": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-3.7-sonnet",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-haiku-4.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-haiku-4.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-opus-4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-opus-4",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-opus-4.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-opus-4.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-opus-4.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-opus-4.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-opus-4.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-opus-4.6",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-opus-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-opus-4.7",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-opus-4.8": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-opus-4.8",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-sonnet-4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-sonnet-4",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-sonnet-4.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-sonnet-4.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:anthropic/claude-sonnet-4.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "anthropic/claude-sonnet-4.6",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:baidu/ernie-5.0-thinking-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "baidu/ernie-5.0-thinking-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:baidu/ernie-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "baidu/ernie-5.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:baidu/ernie-x1.1-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "baidu/ernie-x1.1-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:bytedance/doubao-seed-1.8": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance/doubao-seed-1.8",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:bytedance/doubao-seed-2.0-code": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance/doubao-seed-2.0-code",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:bytedance/doubao-seed-2.0-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance/doubao-seed-2.0-lite",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:bytedance/doubao-seed-2.0-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance/doubao-seed-2.0-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:bytedance/doubao-seed-2.0-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance/doubao-seed-2.0-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:bytedance/doubao-seed-code": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "bytedance/doubao-seed-code",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-chat": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-chat",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-chat-v3.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-chat-v3.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-r1-0528": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-r1-0528",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-reasoner": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-reasoner",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-v3.2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v3.2",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-v3.2-exp": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v3.2-exp",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-v4-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v4-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:deepseek/deepseek-v4-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "deepseek/deepseek-v4-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-2.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-2.5-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-flash-lite",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-2.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-2.5-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-3-flash-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3-flash-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-3.1-flash-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-flash-lite",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-3.1-flash-lite-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-flash-lite-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-3.1-pro-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.1-pro-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemini-3.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "google/gemini-3.5-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:google/gemma-3-12b-it": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "google/gemma-3-12b-it",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:inclusionai/ling-1t": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ling-1t",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:inclusionai/ling-2.6-1t": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ling-2.6-1t",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:inclusionai/ling-2.6-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ling-2.6-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:inclusionai/llada2.1-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/llada2.1-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:inclusionai/ring-1t": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ring-1t",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:inclusionai/ring-2.6-1t": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "inclusionai/ring-2.6-1t",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:kuaishou/kat-coder-pro-v2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "kuaishou/kat-coder-pro-v2",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:meta/llama-3.3-70b-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta/llama-3.3-70b-instruct",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:meta/llama-4-scout-17b-16e-instruct": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "meta/llama-4-scout-17b-16e-instruct",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2-her": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2-her",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2.5-lightning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.5-lightning",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.7",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:minimax/minimax-m2.7-highspeed": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "minimax/minimax-m2.7-highspeed",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:mistralai/mistral-large-2512": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "mistralai/mistral-large-2512",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:moonshotai/kimi-k2-0905": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2-0905",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:moonshotai/kimi-k2-thinking": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2-thinking",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:moonshotai/kimi-k2-thinking-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2-thinking-turbo",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:moonshotai/kimi-k2.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:moonshotai/kimi-k2.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "moonshotai/kimi-k2.6",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/chat-latest": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/chat-latest",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-4": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "openai/gpt-4",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-4.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-4.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-4.1-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-4.1-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-4.1-nano": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-4.1-nano",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-4o": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-4o",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-4o-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-4o-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5-chat": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5-chat",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5-codex",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5-nano": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5-nano",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.1-chat": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.1-chat",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.1-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.1-codex",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.1-codex-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.1-codex-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.2": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.2",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.2-chat": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.2-chat",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.2-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.2-codex",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.2-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.2-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.3-chat": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.3-chat",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.3-codex": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.3-codex",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.4",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.4-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.4-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.4-nano": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.4-nano",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.4-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.4-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/gpt-5.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/gpt-5.5-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/o1": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "openai/o1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/o4-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/o4-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/text-embedding-3-large": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/text-embedding-3-large",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:openai/text-embedding-3-small": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "openai/text-embedding-3-small",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-14b": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-14b",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-235b-a22b-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-235b-a22b-2507",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-235b-a22b-thinking-2507": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-235b-a22b-thinking-2507",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-coder": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-coder",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-coder-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-coder-plus",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-max": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-max",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3-vl-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3-vl-plus",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3.5-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.5-plus",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3.6-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3.6-max-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-max-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3.6-plus": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.6-plus",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:qwen/qwen3.7-max": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "qwen/qwen3.7-max",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:sapiens-ai/agnes-1.5-flash": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "sapiens-ai/agnes-1.5-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:sapiens-ai/agnes-1.5-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sapiens-ai/agnes-1.5-lite",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:sapiens-ai/agnes-1.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sapiens-ai/agnes-1.5-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:sapiens-ai/agnes-2.0-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "sapiens-ai/agnes-2.0-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:stepfun/step-3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "stepfun/step-3",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"timeout\", status: nil, response",
+                  "failure_layer": "transport",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:stepfun/step-3.5-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "stepfun/step-3.5-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:stepfun/step-3.5-flash-free": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "stepfun/step-3.5-flash-free",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:tencent/hunyuan-2.0-thinking": {
+      "catalog_status": "missing",
+      "declared_operations": [],
+      "model": "tencent/hunyuan-2.0-thinking",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "unknown",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:tencent/hy3-preview": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "tencent/hy3-preview",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:volcengine/doubao-seed-1.8": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "volcengine/doubao-seed-1.8",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:volcengine/doubao-seed-2.0-code": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "volcengine/doubao-seed-2.0-code",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:volcengine/doubao-seed-2.0-lite": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "volcengine/doubao-seed-2.0-lite",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:volcengine/doubao-seed-2.0-mini": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "volcengine/doubao-seed-2.0-mini",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:volcengine/doubao-seed-2.0-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "volcengine/doubao-seed-2.0-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:volcengine/doubao-seed-code": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "volcengine/doubao-seed-code",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4-fast",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4.1-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.1-fast",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4.1-fast-non-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.1-fast-non-reasoning",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4.2-fast": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.2-fast",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (400): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4.2-fast-non-reasoning": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.2-fast-non-reasoning",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-4.3": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-4.3",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:x-ai/grok-code-fast-1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "x-ai/grok-code-fast-1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"Provider response error (404): ",
+                  "failure_layer": "provider_drift",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:xiaomi/mimo-v2-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:xiaomi/mimo-v2-omni": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2-omni",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:xiaomi/mimo-v2-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:xiaomi/mimo-v2.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:xiaomi/mimo-v2.5-pro": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "xiaomi/mimo-v2.5-pro",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.5-air": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.5-air",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.6": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.6",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.6v": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.6v",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.6v-flash": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.6v-flash",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.6v-flash-free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.6v-flash-free",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.7": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.7",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.7-flash-free": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.7-flash-free",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"timeout\", status: nil, response",
+                  "failure_layer": "transport",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-4.7-flashx": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-4.7-flashx",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.unrecorded_text": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": "     Expected {:ok, %ReqLLM.Response{}}, got: {:error, %ReqLLM.Error.API.Request{reason: \"timeout\", status: nil, response",
+                  "failure_layer": "transport",
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "fail"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-5": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-5-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5-turbo",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-5.1": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5.1",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    },
+    "zenmux:z-ai/glm-5v-turbo": {
+      "catalog_status": "present",
+      "declared_operations": [
+        "text"
+      ],
+      "model": "z-ai/glm-5v-turbo",
+      "provider": "zenmux",
+      "surfaces": {
+        "zenmux.chat_completions": {
+          "declaration": "declared",
+          "operation": "text",
+          "provider": "zenmux",
+          "scenarios": {
+            "basic": {
+              "observations": [
+                {
+                  "checked_at": "2026-05-30T00:10:17Z",
+                  "error": null,
+                  "failure_layer": null,
+                  "fixtures": [
+                    "basic"
+                  ],
+                  "mode": "record",
+                  "status": "pass"
+                }
+              ],
+              "proof": "fixture_replay"
+            }
+          }
+        }
+      }
+    }
+  },
+  "schema_version": 1
 }

--- a/test/mix/tasks/model_compat_test.exs
+++ b/test/mix/tasks/model_compat_test.exs
@@ -255,6 +255,18 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
     end
   end
 
+  describe "support_operation/2" do
+    test "normalizes inferred model types for all-operation discovery" do
+      assert ModelCompat.support_operation(%{"type" => "text"}, :all) == :text
+      assert ModelCompat.support_operation(%{"type" => "embedding"}, :all) == :embedding
+      assert ModelCompat.support_operation(%{"type" => "unknown"}, :all) == :unknown
+    end
+
+    test "preserves an explicitly selected operation" do
+      assert ModelCompat.support_operation(%{"type" => "embedding"}, :text) == :text
+    end
+  end
+
   describe "run/1" do
     test "raises clearly for unknown operation types" do
       Mix.Task.reenable("req_llm.model_compat")

--- a/test/mix/tasks/model_compat_test.exs
+++ b/test/mix/tasks/model_compat_test.exs
@@ -235,6 +235,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
       assert result.status == :fail
       assert result.total == 0
       assert result.error == "No matching compatibility tests executed"
+      assert result.failure_layer == "planning"
     end
 
     test "accepts successful invocations that execute a matching test" do
@@ -250,6 +251,7 @@ defmodule Mix.Tasks.ReqLlm.ModelCompatTest do
       assert result.status == :pass
       assert result.total == 1
       assert result.error == nil
+      assert result.failure_layer == nil
     end
   end
 

--- a/test/mix/tasks/model_support_test.exs
+++ b/test/mix/tasks/model_support_test.exs
@@ -19,6 +19,33 @@ defmodule Mix.Tasks.ReqLlm.ModelSupportTest do
     assert output =~ "Compatibility evidence and support reference are current"
   end
 
+  test "refreshes catalog declarations and fixture-backed surfaces before checking" do
+    evidence = ReqLLM.Compatibility.Evidence.load!(ModelSupport.evidence_path())
+
+    stale =
+      evidence
+      |> put_in(
+        ["models", "openai:gpt-4o-mini", "catalog_status"],
+        "missing"
+      )
+      |> put_in(
+        ["models", "openai:gpt-4o-mini", "surfaces", "openai.responses", "declaration"],
+        "unknown"
+      )
+
+    refreshed = ModelSupport.refresh_evidence(stale)
+
+    assert get_in(refreshed, ["models", "openai:gpt-4o-mini", "catalog_status"]) == "present"
+
+    assert get_in(refreshed, [
+             "models",
+             "openai:gpt-4o-mini",
+             "surfaces",
+             "openai.responses",
+             "declaration"
+           ]) == "declared"
+  end
+
   test "prints evidence-backed model surface status without changing resolution" do
     Mix.Task.reenable("req_llm.model_support")
     before_resolution = ReqLLM.model("openai:gpt-4o-mini")

--- a/test/mix/tasks/model_support_test.exs
+++ b/test/mix/tasks/model_support_test.exs
@@ -1,0 +1,43 @@
+defmodule Mix.Tasks.ReqLlm.ModelSupportTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.ReqLlm.ModelSupport
+
+  test "targets the checked-in evidence and reference artifacts" do
+    assert ModelSupport.evidence_path() == Path.expand("priv/model_compat_scenarios.json")
+    assert ModelSupport.reference_path() == Path.expand("guides/model-support.md")
+    assert File.exists?(ReqLLM.Compatibility.Evidence.default_path())
+  end
+
+  test "checks the deterministic evidence and reference artifacts" do
+    Mix.Task.reenable("req_llm.model_support")
+
+    output = capture_io(fn -> ModelSupport.run(["--check"]) end)
+
+    assert output =~ "Compatibility evidence and support reference are current"
+  end
+
+  test "prints evidence-backed model surface status without changing resolution" do
+    Mix.Task.reenable("req_llm.model_support")
+    before_resolution = ReqLLM.model("openai:gpt-4o-mini")
+
+    output =
+      capture_io(fn ->
+        ModelSupport.run(["--model", "openai:gpt-4o-mini"])
+      end)
+
+    assert output =~ "openai:gpt-4o-mini"
+    assert output =~ "openai.responses"
+    assert ReqLLM.model("openai:gpt-4o-mini") == before_resolution
+  end
+
+  test "rejects invalid options" do
+    Mix.Task.reenable("req_llm.model_support")
+
+    assert_raise Mix.Error, ~r/Invalid options/, fn ->
+      ModelSupport.run(["--unknown"])
+    end
+  end
+end

--- a/test/req_llm/compatibility/evidence_test.exs
+++ b/test/req_llm/compatibility/evidence_test.exs
@@ -89,6 +89,11 @@ defmodule ReqLLM.Compatibility.EvidenceTest do
       assert evidence["schema_version"] == 1
       assert map_size(evidence["models"]) == 688
       assert length(observations) == 769
+      assert Enum.frequencies_by(observations, & &1["status"]) == %{"fail" => 132, "pass" => 637}
+      assert Enum.frequencies_by(observations, & &1["mode"]) == %{"record" => 766, "replay" => 3}
+      assert Enum.sum(Enum.map(observations, &length(&1["fixtures"]))) == 773
+      assert Enum.count(observations, & &1["error"]) == 132
+      assert observations |> Enum.map(& &1["checked_at"]) |> Enum.uniq() |> length() == 173
       assert Evidence.canonical_json(evidence) == content
     end
   end

--- a/test/req_llm/compatibility/evidence_test.exs
+++ b/test/req_llm/compatibility/evidence_test.exs
@@ -1,0 +1,343 @@
+defmodule ReqLLM.Compatibility.EvidenceTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Compatibility.{Evidence, ScenarioCatalog, SupportReference}
+
+  @checked_at "2026-07-01T00:00:00Z"
+  @as_of ~U[2026-07-16 00:00:00Z]
+
+  describe "migration" do
+    test "versions legacy state without discarding observations or metadata" do
+      legacy = %{
+        "openai:gpt-4o-mini" => %{
+          "source" => "legacy",
+          "scenarios" => %{
+            "basic" => %{
+              "status" => "pass",
+              "last_checked" => @checked_at,
+              "mode" => "record",
+              "fixtures" => ["basic"],
+              "error" => nil,
+              "attempt" => 3
+            }
+          }
+        }
+      }
+
+      evidence =
+        Evidence.migrate(legacy,
+          surface_resolver: fn _model_spec, _operation, _fixtures -> "openai.responses" end
+        )
+
+      assert evidence["schema_version"] == 1
+      assert evidence["generated_at"] == @checked_at
+
+      assert %{
+               "provider" => "openai",
+               "model" => "gpt-4o-mini",
+               "legacy_metadata" => %{"source" => "legacy"}
+             } = evidence["models"]["openai:gpt-4o-mini"]
+
+      scenario =
+        get_in(evidence, [
+          "models",
+          "openai:gpt-4o-mini",
+          "surfaces",
+          "openai.responses",
+          "scenarios",
+          "basic"
+        ])
+
+      assert scenario["proof"] == "fixture_replay"
+
+      assert [
+               %{
+                 "status" => "pass",
+                 "checked_at" => @checked_at,
+                 "mode" => "record",
+                 "fixtures" => ["basic"],
+                 "failure_layer" => nil,
+                 "legacy_metadata" => %{"attempt" => 3}
+               }
+             ] = scenario["observations"]
+    end
+
+    test "keeps the current schema unchanged" do
+      evidence = %{"schema_version" => 1, "generated_at" => @checked_at, "models" => %{}}
+      assert Evidence.migrate(evidence) === evidence
+    end
+
+    test "rejects unknown schema versions instead of treating them as legacy state" do
+      assert_raise ArgumentError, ~r/unsupported compatibility evidence schema version: 2/, fn ->
+        Evidence.migrate(%{"schema_version" => 2, "models" => %{}})
+      end
+    end
+
+    test "checked-in migration preserves every legacy scenario observation" do
+      path = Path.expand("../../../priv/model_compat_scenarios.json", __DIR__)
+      content = File.read!(path)
+      evidence = Jason.decode!(content)
+
+      observations =
+        for {_model_spec, model} <- evidence["models"],
+            {_surface_id, surface} <- model["surfaces"],
+            {_scenario_id, scenario} <- surface["scenarios"],
+            observation <- scenario["observations"] do
+          observation
+        end
+
+      assert evidence["schema_version"] == 1
+      assert map_size(evidence["models"]) == 688
+      assert length(observations) == 769
+      assert Evidence.canonical_json(evidence) == content
+    end
+  end
+
+  describe "record/5" do
+    test "appends observations for the recorded execution surface" do
+      evidence = evidence_with_surface(%{"basic" => observation("pass")})
+      checked_at = ~U[2026-07-16 12:00:00Z]
+
+      result = %{
+        model_spec: "openai:gpt-4o-mini",
+        scenarios: [
+          %{
+            "scenario" => "basic",
+            "status" => "fail",
+            "fixtures" => ["basic"],
+            "failure_layer" => "assertion",
+            "error" => "expected response"
+          }
+        ]
+      }
+
+      updated =
+        Evidence.record(evidence, [result], checked_at, "replay",
+          surface_resolver: fn _model_spec, _operation, _fixtures -> "openai.responses" end
+        )
+
+      observations =
+        get_in(updated, [
+          "models",
+          "openai:gpt-4o-mini",
+          "surfaces",
+          "openai.responses",
+          "scenarios",
+          "basic",
+          "observations"
+        ])
+
+      assert Enum.map(observations, & &1["status"]) == ["pass", "fail"]
+      assert updated["generated_at"] == "2026-07-16T12:00:00Z"
+    end
+
+    test "rejects replay that follows a different execution surface" do
+      evidence = evidence_with_surface(%{"basic" => observation("pass")})
+
+      result = %{
+        model_spec: "openai:gpt-4o-mini",
+        scenarios: [
+          %{
+            "scenario" => "basic",
+            "status" => "pass",
+            "fixtures" => ["basic"],
+            "failure_layer" => nil,
+            "error" => nil
+          }
+        ]
+      }
+
+      assert_raise ArgumentError, ~r/replay surface changed/, fn ->
+        Evidence.record(evidence, [result], @as_of, "replay",
+          surface_resolver: fn _model_spec, _operation, _fixtures ->
+            "openai.chat_completions"
+          end
+        )
+      end
+    end
+  end
+
+  describe "support tiers" do
+    test "derives first-class only from a complete current baseline" do
+      scenarios =
+        :text
+        |> ScenarioCatalog.baseline_scenarios()
+        |> Map.new(&{&1, observation("pass")})
+
+      status =
+        scenarios
+        |> evidence_with_surface()
+        |> Evidence.support_status("openai:gpt-4o-mini", :text, as_of: @as_of)
+
+      assert status.tier == :first_class
+      assert status.reason == :complete_current_baseline
+      assert status.missing_scenarios == []
+    end
+
+    test "derives best-effort from partial current baseline evidence" do
+      status =
+        %{"basic" => observation("pass")}
+        |> evidence_with_surface()
+        |> Evidence.support_status("openai:gpt-4o-mini", :text, as_of: @as_of)
+
+      assert status.tier == :best_effort
+      assert status.reason == :partial_current_baseline
+      assert "streaming" in status.missing_scenarios
+    end
+
+    test "keeps missing and stale evidence experimental" do
+      empty_status =
+        Evidence.support_status(
+          %{"schema_version" => 1, "models" => %{}},
+          "openai:gpt-4o-mini",
+          :text,
+          as_of: @as_of
+        )
+
+      stale_status =
+        %{"basic" => observation("pass", "2025-01-01T00:00:00Z")}
+        |> evidence_with_surface()
+        |> Evidence.support_status("openai:gpt-4o-mini", :text, as_of: @as_of)
+
+      assert empty_status.tier == :experimental
+      assert empty_status.reason == :missing_evidence
+      assert stale_status.tier == :experimental
+      assert stale_status.reason == :missing_or_stale_evidence
+    end
+
+    test "derives unsupported with a classified baseline failure reason" do
+      status =
+        %{"basic" => observation("fail", @checked_at, "provider_drift")}
+        |> evidence_with_surface()
+        |> Evidence.support_status("openai:gpt-4o-mini", :text, as_of: @as_of)
+
+      assert status.tier == :unsupported
+      assert status.reason == :baseline_failure
+      assert status.scenario == "basic"
+      assert status.failure_layer == "provider_drift"
+    end
+
+    test "reports undeclared operations as unsupported without consulting evidence" do
+      status =
+        Evidence.support_status(
+          evidence_with_surface(%{"basic" => observation("pass")}),
+          "openai:gpt-4o-mini",
+          :image,
+          declared?: false,
+          as_of: @as_of
+        )
+
+      assert status.tier == :unsupported
+      assert status.reason == :operation_not_declared
+    end
+
+    test "keeps evidence for models missing from the current catalog experimental" do
+      evidence =
+        %{"basic" => observation("pass")}
+        |> evidence_with_surface()
+        |> Evidence.annotate_declarations(fn _model_spec -> {:error, :unknown_model} end)
+
+      status =
+        Evidence.support_status(evidence, "openai:gpt-4o-mini", :text, as_of: @as_of)
+
+      assert status.tier == :experimental
+      assert status.reason == :surface_declaration_unknown
+      assert status.checked_at == @checked_at
+    end
+  end
+
+  describe "failure classification and execution surfaces" do
+    test "classifies every stable failure layer" do
+      assert Evidence.classify_failure("unknown model") == "resolution"
+      assert Evidence.classify_failure("execution plan unavailable") == "planning"
+      assert Evidence.classify_failure("failed to encode request body") == "encoding"
+      assert Evidence.classify_failure("connection timed out") == "transport"
+      assert Evidence.classify_failure("failed to decode response") == "decoding"
+
+      assert Evidence.classify_failure("response builder materialization failed") ==
+               "materialization"
+
+      assert Evidence.classify_failure("expected true") == "assertion"
+      assert Evidence.classify_failure("Provider response error (404)") == "provider_drift"
+
+      assert Evidence.failure_layers() ==
+               ~w(resolution planning encoding transport decoding materialization assertion provider_drift)
+    end
+
+    test "derives the exact wire surface from recorded fixture URLs" do
+      root = Path.expand("../../support/fixtures", __DIR__)
+
+      assert Evidence.fixture_surface(root, "openai:gpt-4o-mini", :text, ["basic"]) ==
+               "openai.responses"
+
+      assert Evidence.fixture_surface(
+               root,
+               "anthropic:claude-sonnet-4-5-20250929",
+               :text,
+               ["web_fetch_basic"]
+             ) == "anthropic.messages"
+    end
+  end
+
+  describe "deterministic output" do
+    test "canonical JSON recursively sorts keys" do
+      first = %{"models" => %{"b" => %{}, "a" => %{}}, "schema_version" => 1}
+      second = %{"schema_version" => 1, "models" => %{"a" => %{}, "b" => %{}}}
+
+      assert Evidence.canonical_json(first) == Evidence.canonical_json(second)
+      assert Evidence.canonical_json(first) =~ ~s("a": {})
+    end
+
+    test "support reference is deterministic and catalog-derived" do
+      evidence = evidence_with_surface(%{"basic" => observation("pass")})
+
+      first = SupportReference.render(evidence, as_of: @as_of)
+      second = SupportReference.render(evidence, as_of: @as_of)
+
+      assert first == second
+      assert first =~ "openai.responses"
+      assert first =~ "text → text"
+      assert first =~ "Best-effort"
+    end
+  end
+
+  defp evidence_with_surface(scenarios) do
+    scenario_entries =
+      Map.new(scenarios, fn {scenario_id, observation} ->
+        {scenario_id,
+         %{
+           "proof" => "fixture_replay",
+           "observations" => [observation]
+         }}
+      end)
+
+    %{
+      "schema_version" => 1,
+      "generated_at" => @checked_at,
+      "models" => %{
+        "openai:gpt-4o-mini" => %{
+          "provider" => "openai",
+          "model" => "gpt-4o-mini",
+          "surfaces" => %{
+            "openai.responses" => %{
+              "provider" => "openai",
+              "operation" => "text",
+              "scenarios" => scenario_entries
+            }
+          }
+        }
+      }
+    }
+  end
+
+  defp observation(status, checked_at \\ @checked_at, failure_layer \\ nil) do
+    %{
+      "status" => status,
+      "checked_at" => checked_at,
+      "mode" => "replay",
+      "fixtures" => ["basic"],
+      "failure_layer" => failure_layer,
+      "error" => if(status == "pass", do: nil, else: "failure")
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- version compatibility evidence by model, exact execution surface, and scenario while preserving all 769 legacy observations
- derive conservative, explainable support tiers for compatibility tooling and generate a deterministic model/modality/surface reference
- classify failures by execution layer and prevent fixture replay from silently changing recorded surfaces
- expose tiers through opt-in discovery output and a read-only `mix req_llm.model_support` task without changing model resolution or routing

## Backward compatibility

This is V1-additive. Existing runtime APIs, model resolution, provider routing, and default `mix req_llm.model_compat --available` output are unchanged. Support tiers are opt-in tooling metadata only; missing or stale evidence cannot promote support.

## Validation

- `mix test` — 3,643 passed, 11 skipped, 145 excluded
- `mix quality`
- `mix req_llm.model_support --check`
- `MIX_ENV=test mix req_llm.model_support --check`
- `mix req_llm.model_compat openai:gpt-4o-mini --scenario basic`
- `mix docs`
- `mix hex.build --unpack --output /tmp/req_llm-issue-836-package`

Closes #836