### PR TITLE
ci: add sparse live provider drift verification

### DIFF
--- a/.github/workflows/provider-drift.yml
+++ b/.github/workflows/provider-drift.yml
@@ -1,0 +1,81 @@
+name: Provider Drift
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: "Anchor provider to verify"
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - anthropic
+          - google
+          - openai
+      dry_run:
+        description: "Validate selection and guardrails without provider requests"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: "17 9 * * 2"
+
+concurrency:
+  group: provider-drift-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  verify:
+    name: Sparse live verification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Beam
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          otp-version: "29"
+          elixir-version: "1.20"
+
+      - name: Install dependencies
+        env:
+          MIX_ENV: test
+        run: mix deps.get
+
+      - name: Compile provider drift tooling
+        env:
+          MIX_ENV: test
+        run: mix compile --warnings-as-errors
+
+      - name: Run sparse provider drift verification
+        env:
+          MIX_ENV: test
+          DRIFT_PROVIDER: ${{ inputs.provider || 'all' }}
+          DRIFT_DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+          args=(--provider "$DRIFT_PROVIDER" --output-dir .artifacts/provider-drift)
+          if [ "$DRIFT_DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          mix req_llm.provider_drift "${args[@]}"
+
+      - name: Upload sanitized drift report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provider-drift-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/provider-drift
+          if-no-files-found: error
+          retention-days: 14

--- a/guides/fixture-testing.md
+++ b/guides/fixture-testing.md
@@ -88,6 +88,50 @@ Run `mix req_llm.model_support --generate` to regenerate the deterministic
 are descriptive compatibility-tool output only; ReqLLM continues to resolve
 models independently of this evidence.
 
+### Sparse Live Provider Drift Verification
+
+Normal pull-request CI remains fixture replay only and requires no provider
+credentials. The `Provider Drift` workflow adds a separate live lane that runs
+manually or every Tuesday at 09:17 UTC. Its checked-in matrix lives in
+`priv/provider_drift_anchors.json`:
+
+| Provider | Model | Expected surface | Scenario |
+| --- | --- | --- | --- |
+| Anthropic | `claude-sonnet-4-5-20250929` | `anthropic.messages` | `basic` |
+| Google | `gemini-2.0-flash` | `google.generate_content` | `basic` |
+| OpenAI | `gpt-4o-mini` | `openai.responses` | `basic` |
+| OpenAI | `chat-latest` | `openai.chat_completions` | `basic` |
+
+The lane is bounded to four anchors, one concurrent request, 180 seconds and 64
+output tokens per anchor, and an estimated maximum provider cost of $0.03 per
+complete run. Missing credentials skip only their anchors. Failures report the
+provider, model, expected or observed surface, scenario, classified failure
+layer, remediation, and GitHub run correlation. Prompt and response bodies,
+credential values, and staged fixtures are never included in its artifacts.
+
+Validate the matrix without making provider requests:
+
+```bash
+mix req_llm.provider_drift --dry-run
+```
+
+Run the available anchors, or select one provider:
+
+```bash
+mix req_llm.provider_drift
+mix req_llm.provider_drift --provider openai
+```
+
+Live probes capture fixtures only in a temporary directory long enough to
+derive the actual execution surface, then delete them. They do not update
+`priv/model_compat_scenarios.json`, support tiers, or checked-in fixtures. A
+maintainer who deliberately wants new fixtures uses the separate existing
+recording command:
+
+```bash
+mix req_llm.model_compat openai:gpt-4o-mini --scenario basic --record
+```
+
 ### Comprehensive Test Macro
 
 Tests use the `ReqLLM.ProviderTest.Comprehensive` macro (in `test/support/provider_test/comprehensive.ex`), which generates up to 9 focused tests per model based on capabilities:

--- a/guides/mix-tasks.md
+++ b/guides/mix-tasks.md
@@ -4,12 +4,14 @@ ReqLLM provides powerful Mix tasks for text generation and model coverage valida
 
 ## Overview
 
-ReqLLM includes two main Mix tasks:
+ReqLLM includes these main Mix tasks:
 
 | Task | Alias | Purpose |
 |------|-------|---------|
 | `mix req_llm.gen` | `mix llm` | Generate text/objects from the command line |
 | `mix req_llm.model_compat` | `mix mc` | Validate model coverage with fixtures |
+| `mix req_llm.model_support` | — | Inspect and verify evidence-derived support tiers |
+| `mix req_llm.provider_drift` | — | Run bounded, read-only live anchor verification |
 
 ## mix req_llm.gen
 
@@ -388,6 +390,50 @@ for a given catalog and evidence snapshot. Tiers are surface-specific:
 
 Catalog presence alone is never evidence. These tiers do not act as a runtime
 allowlist.
+
+## `mix req_llm.provider_drift`
+
+Validate the sparse live anchor configuration without making provider calls:
+
+```bash
+mix req_llm.provider_drift --dry-run
+```
+
+Run every anchor whose credential is available, or select a provider:
+
+```bash
+mix req_llm.provider_drift
+mix req_llm.provider_drift --provider openai
+mix req_llm.provider_drift --provider anthropic,google
+```
+
+Write the sanitized JSON and Markdown reports to a chosen directory:
+
+```bash
+mix req_llm.provider_drift --output-dir .artifacts/provider-drift
+```
+
+| Option | Purpose |
+| --- | --- |
+| `--dry-run` | Validate anchors, evidence references, and guardrails without provider requests |
+| `--provider NAME[,NAME]` | Limit the run to selected configured providers |
+| `--config PATH` | Validate and run a different anchor configuration |
+| `--output-dir PATH` | Choose the report directory; defaults to `_build/provider_drift` |
+
+The default matrix is `priv/provider_drift_anchors.json`. It explicitly caps
+anchor count, concurrency, per-anchor timeout, output tokens, and estimated
+cost. Missing credentials produce skipped results rather than failures. An
+executed failure uses the same resolution, planning, encoding, transport,
+decoding, materialization, assertion, and provider-drift layers as compatibility
+evidence.
+
+The task records provider responses only into a temporary directory, derives
+the actual execution surface, and deletes the temporary files. Reports contain
+no prompts, response bodies, or credential values. They embed completed results
+in the versioned compatibility evidence schema with mode `live_probe`, but do
+not modify the checked-in evidence or influence runtime support. Use the
+separate `mix req_llm.model_compat MODEL --scenario SCENARIO --record` action
+when fixture recording is intentional.
 
 ### Example Output
 

--- a/lib/mix/tasks/provider_drift.ex
+++ b/lib/mix/tasks/provider_drift.ex
@@ -1,0 +1,254 @@
+defmodule Mix.Tasks.ReqLlm.ProviderDrift do
+  @shortdoc "Run bounded live provider drift verification"
+  @moduledoc """
+  Run a small, credential-aware live verification matrix without updating
+  fixtures or checked-in compatibility evidence.
+
+      mix req_llm.provider_drift --dry-run
+      mix req_llm.provider_drift --provider openai
+      mix req_llm.provider_drift --output-dir .artifacts/provider-drift
+
+  Missing provider credentials are reported as skipped anchors. The generated
+  JSON embeds compatibility evidence using the current versioned schema, while
+  the Markdown report contains only model, surface, scenario, status, failure
+  layer, remediation, and correlation metadata.
+
+  Fixture recording remains a separate explicit action through
+  `mix req_llm.model_compat MODEL --scenario SCENARIO --record`.
+  """
+
+  use Mix.Task
+
+  alias Mix.Tasks.ReqLlm.ModelCompat
+  alias ReqLLM.Compatibility.{Evidence, ProviderDrift}
+
+  @preferred_cli_env :test
+
+  @impl Mix.Task
+  def run(args) do
+    Application.ensure_all_started(:req_llm)
+    opts = parse_args!(args)
+    config = ProviderDrift.load_config!(opts[:config] || ProviderDrift.default_config_path())
+    providers = providers(opts[:provider])
+    checked_at = DateTime.utc_now() |> DateTime.truncate(:second)
+    correlation = correlation()
+
+    results =
+      ProviderDrift.run(config, &execute_anchor/2,
+        providers: providers,
+        dry_run: opts[:dry_run] || false,
+        checked_at: checked_at,
+        correlation: correlation
+      )
+
+    if results == [] do
+      Mix.raise("No provider drift anchors match --provider #{opts[:provider]}")
+    end
+
+    report =
+      ProviderDrift.report(config, results,
+        checked_at: checked_at,
+        correlation: correlation,
+        dry_run: opts[:dry_run] || false
+      )
+
+    output_dir = Path.expand(opts[:output_dir] || "_build/provider_drift")
+    json_path = Path.join(output_dir, "provider-drift-report.json")
+    markdown_path = Path.join(output_dir, "provider-drift-report.md")
+    ProviderDrift.write_report!(json_path, markdown_path, report)
+
+    summary = ProviderDrift.markdown(report)
+    Mix.shell().info(summary)
+    Mix.shell().info("Reports: #{json_path}, #{markdown_path}")
+    append_github_summary(summary)
+
+    if ProviderDrift.failures?(results) do
+      failed = Enum.count(results, &(&1["status"] == "fail"))
+      Mix.raise("#{failed} provider drift anchor(s) failed; inspect the sanitized report")
+    end
+  end
+
+  @doc false
+  def execute_anchor(anchor, context) do
+    stage_root = stage_root(anchor)
+    File.rm_rf(stage_root)
+
+    try do
+      provider = String.to_existing_atom(anchor["provider"])
+      operation = String.to_existing_atom(anchor["operation"])
+      scenario = anchor["scenario"]
+      args = ModelCompat.test_args_for(provider, operation, scenario)
+
+      {output, exit_code} =
+        System.cmd("mix", args,
+          env: probe_env(anchor, stage_root, context),
+          stderr_to_stdout: true
+        )
+
+      parsed =
+        ModelCompat.parse_test_result(
+          provider,
+          anchor["model"],
+          output,
+          exit_code,
+          scenario
+        )
+
+      fixtures = fixture_names(stage_root, parsed.fixtures)
+
+      surface =
+        Evidence.fixture_surface(
+          stage_root,
+          anchor["model_spec"],
+          operation,
+          fixtures
+        )
+
+      probe_result(parsed, fixtures, surface)
+    after
+      File.rm_rf(stage_root)
+    end
+  end
+
+  defp parse_args!(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          config: :string,
+          output_dir: :string,
+          provider: :string,
+          dry_run: :boolean
+        ]
+      )
+
+    if positional != [] or invalid != [] do
+      Mix.raise("Invalid provider drift arguments: #{inspect(positional ++ invalid)}")
+    end
+
+    opts
+  end
+
+  defp providers(nil), do: ["all"]
+
+  defp providers(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> case do
+      [] -> ["all"]
+      selected -> selected
+    end
+  end
+
+  defp probe_env(anchor, stage_root, context) do
+    correlation = context.correlation
+
+    [
+      {"REQ_LLM_MODELS", anchor["model_spec"]},
+      {"REQ_LLM_OPERATION", anchor["operation"]},
+      {"REQ_LLM_FIXTURES_MODE", "record"},
+      {"REQ_LLM_DEBUG", "1"},
+      {"REQ_LLM_INCLUDE_RESPONSES", "1"},
+      {"REQ_LLM_FIXTURE_ALLOW_CREDENTIAL_FALLBACK", "0"},
+      {"REQ_LLM_FIXTURE_RECORD_ROOT", stage_root},
+      {"REQ_LLM_DRIFT_MAX_TOKENS", Integer.to_string(anchor["max_output_tokens"])},
+      {"REQ_LLM_DRIFT_CORRELATION_ID", correlation_id(correlation, anchor["id"])}
+    ]
+  end
+
+  defp stage_root(anchor) do
+    suffix =
+      [
+        anchor["provider"],
+        anchor["model"],
+        anchor["scenario"],
+        System.unique_integer([:positive])
+      ]
+      |> Enum.map_join("_", &path_slug/1)
+
+    Path.join(System.tmp_dir!(), "req_llm_provider_drift_#{suffix}")
+  end
+
+  defp path_slug(value) do
+    value
+    |> to_string()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/u, "_")
+    |> String.trim("_")
+  end
+
+  defp fixture_names(stage_root, parsed_fixtures) do
+    staged =
+      stage_root
+      |> Path.join("**/*.json")
+      |> Path.wildcard()
+      |> Enum.map(&Path.basename(&1, ".json"))
+
+    (parsed_fixtures ++ staged)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp probe_result(%{status: :pass}, fixtures, nil) do
+    %{
+      "status" => "fail",
+      "fixtures" => fixtures,
+      "surface" => nil,
+      "failure_layer" => "materialization",
+      "remediation" => "No staged fixture surface was available for the successful probe"
+    }
+  end
+
+  defp probe_result(%{status: :pass}, fixtures, surface) do
+    %{
+      "status" => "pass",
+      "fixtures" => fixtures,
+      "surface" => surface,
+      "failure_layer" => nil
+    }
+  end
+
+  defp probe_result(parsed, fixtures, surface) do
+    %{
+      "status" => "fail",
+      "fixtures" => fixtures,
+      "surface" => surface,
+      "failure_layer" => parsed.failure_layer || "assertion"
+    }
+  end
+
+  defp correlation do
+    %{
+      "workflow" => env_or("GITHUB_WORKFLOW", "local"),
+      "run_id" => env_or("GITHUB_RUN_ID", "local"),
+      "run_attempt" => env_or("GITHUB_RUN_ATTEMPT", "1"),
+      "sha" => env_or("GITHUB_SHA", git_sha())
+    }
+  end
+
+  defp correlation_id(correlation, anchor_id) do
+    "#{correlation["run_id"]}-#{correlation["run_attempt"]}-#{anchor_id}"
+  end
+
+  defp env_or(name, fallback) do
+    case System.get_env(name) do
+      value when is_binary(value) and value != "" -> value
+      _value -> fallback
+    end
+  end
+
+  defp git_sha do
+    case System.cmd("git", ["rev-parse", "HEAD"], stderr_to_stdout: true) do
+      {sha, 0} -> String.trim(sha)
+      _result -> "unknown"
+    end
+  end
+
+  defp append_github_summary(summary) do
+    case System.get_env("GITHUB_STEP_SUMMARY") do
+      path when is_binary(path) and path != "" -> File.write!(path, summary, [:append])
+      _value -> :ok
+    end
+  end
+end

--- a/lib/req_llm/compatibility/provider_drift.ex
+++ b/lib/req_llm/compatibility/provider_drift.ex
@@ -1,0 +1,580 @@
+defmodule ReqLLM.Compatibility.ProviderDrift do
+  @moduledoc """
+  Bounded, read-only live verification for a small compatibility anchor matrix.
+
+  Provider drift reports are tooling artifacts. They do not update checked-in
+  fixtures, compatibility evidence, support tiers, model resolution, or request
+  routing.
+  """
+
+  alias ReqLLM.Compatibility.{Evidence, ScenarioCatalog}
+
+  @config_schema_version 1
+  @report_schema_version 1
+  @operations ~w(text embedding image speech transcription rerank ocr)
+  @credential_name ~r/^[A-Z][A-Z0-9_]*$/
+
+  @doc "Returns the checked-in anchor configuration path."
+  @spec default_config_path() :: Path.t()
+  def default_config_path do
+    :req_llm
+    |> :code.priv_dir()
+    |> Path.join("provider_drift_anchors.json")
+  end
+
+  @doc "Loads and validates the checked-in anchor configuration."
+  @spec load_config!(Path.t(), keyword()) :: map()
+  def load_config!(path \\ default_config_path(), opts \\ []) do
+    evidence = Keyword.get_lazy(opts, :evidence, &Evidence.load!/0)
+
+    with {:ok, content} <- File.read(path),
+         {:ok, config} <- Jason.decode(content) do
+      validate_config!(config, evidence)
+    else
+      {:error, reason} ->
+        raise ArgumentError, "cannot load provider drift config: #{inspect(reason)}"
+    end
+  end
+
+  @doc "Validates anchor selection, evidence references, and resource limits."
+  @spec validate_config!(map(), map()) :: map()
+  def validate_config!(config, evidence) when is_map(config) and is_map(evidence) do
+    require_equal!(config["schema_version"], @config_schema_version, "config schema_version")
+
+    limits = require_map!(config["limits"], "limits")
+    anchors = require_non_empty_list!(config["anchors"], "anchors")
+
+    validate_limits!(limits)
+    validate_anchor_count!(anchors, limits)
+    validate_unique_anchor_ids!(anchors)
+    Enum.each(anchors, &validate_anchor!(&1, limits, evidence))
+    validate_cost_budget!(anchors, limits)
+
+    config
+  end
+
+  @doc "Builds a credential-aware plan without making provider requests."
+  @spec plan(map(), keyword()) :: [map()]
+  def plan(config, opts \\ []) when is_map(config) do
+    env = Keyword.get(opts, :env, System.get_env())
+    providers = provider_filter(Keyword.get(opts, :providers, []))
+    dry_run? = Keyword.get(opts, :dry_run, false)
+
+    config["anchors"]
+    |> Enum.filter(&selected_provider?(&1, providers))
+    |> Enum.map(&plan_anchor(&1, env, dry_run?))
+  end
+
+  @doc "Runs ready anchors through the supplied bounded executor."
+  @spec run(map(), (map(), map() -> map()), keyword()) :: [map()]
+  def run(config, executor, opts \\ []) when is_map(config) and is_function(executor, 2) do
+    checked_at = Keyword.get(opts, :checked_at, DateTime.utc_now()) |> DateTime.truncate(:second)
+    correlation = Keyword.get(opts, :correlation, %{})
+    plans = plan(config, opts)
+    limits = config["limits"]
+
+    ready = Enum.filter(plans, &(&1["status"] == "ready"))
+
+    executed =
+      ready
+      |> Task.async_stream(
+        fn anchor ->
+          started_at = System.monotonic_time(:millisecond)
+
+          result =
+            executor.(anchor, %{
+              checked_at: checked_at,
+              correlation: correlation,
+              limits: limits
+            })
+
+          duration_ms = System.monotonic_time(:millisecond) - started_at
+          normalize_execution_result(anchor, result, checked_at, correlation, duration_ms)
+        end,
+        max_concurrency: limits["max_concurrency"],
+        timeout: limits["timeout_seconds"] * 1_000,
+        on_timeout: :kill_task,
+        ordered: true
+      )
+      |> Enum.zip(ready)
+      |> Map.new(fn
+        {{:ok, result}, _anchor} ->
+          {result["id"], result}
+
+        {{:exit, :timeout}, anchor} ->
+          result = failed_result(anchor, checked_at, correlation, "transport", "Anchor timed out")
+          {anchor["id"], result}
+
+        {{:exit, _reason}, anchor} ->
+          result =
+            failed_result(anchor, checked_at, correlation, "assertion", "Anchor process failed")
+
+          {anchor["id"], result}
+      end)
+
+    Enum.map(plans, fn plan ->
+      Map.get(executed, plan["id"], finalize_plan(plan, checked_at, correlation))
+    end)
+  end
+
+  @doc "Builds a sanitized report with an embedded schema-compatible evidence artifact."
+  @spec report(map(), [map()], keyword()) :: map()
+  def report(config, results, opts \\ []) when is_map(config) and is_list(results) do
+    checked_at = Keyword.get(opts, :checked_at, checked_at_from_results(results))
+    correlation = Keyword.get(opts, :correlation, %{})
+    mode = if Keyword.get(opts, :dry_run, false), do: "dry_run", else: "live_probe"
+
+    %{
+      "schema_version" => @report_schema_version,
+      "kind" => "req_llm_provider_drift",
+      "mode" => mode,
+      "generated_at" => DateTime.to_iso8601(checked_at),
+      "correlation" => correlation,
+      "limits" => config["limits"],
+      "summary" => summarize(results),
+      "results" => results,
+      "evidence" => evidence(results, checked_at)
+    }
+  end
+
+  @doc "Returns a compatibility evidence document containing completed probes only."
+  @spec evidence([map()], DateTime.t()) :: map()
+  def evidence(results, %DateTime{} = checked_at) do
+    results
+    |> Enum.filter(&(&1["status"] in ["pass", "fail"]))
+    |> Enum.reduce(Evidence.migrate(%{}), fn result, acc ->
+      evidence_result = %{
+        model_spec: result["model_spec"],
+        provider: String.to_existing_atom(result["provider"]),
+        model_id: result["model"],
+        status: String.to_existing_atom(result["status"]),
+        scenarios: [
+          %{
+            "scenario" => result["scenario"],
+            "status" => result["status"],
+            "fixtures" => result["fixtures"],
+            "failure_layer" => result["failure_layer"],
+            "error" => sanitized_evidence_error(result)
+          }
+        ]
+      }
+
+      Evidence.record(acc, [evidence_result], checked_at, "live_probe",
+        surface_resolver: fn _model_spec, _operation, _fixtures -> result["surface"] end
+      )
+    end)
+  end
+
+  @doc "Renders a concise GitHub step summary without provider payloads."
+  @spec markdown(map()) :: binary()
+  def markdown(report) when is_map(report) do
+    summary = report["summary"]
+    limits = report["limits"]
+
+    rows =
+      report["results"]
+      |> Enum.map_join("\n", fn result ->
+        "| #{cell(result["provider"])} | #{cell(result["model"])} | " <>
+          "#{cell(result["surface"] || result["expected_surface"])} | " <>
+          "#{cell(result["scenario"])} | #{cell(result["status"])} | " <>
+          "#{cell(result["failure_layer"] || "—")} | #{cell(result["remediation"])} |"
+      end)
+
+    """
+    ## ReqLLM provider drift verification
+
+    - Mode: `#{report["mode"]}`
+    - Correlation: `#{correlation_label(report["correlation"])}`
+    - Results: #{summary["pass"]} passed, #{summary["fail"]} failed, #{summary["skipped"]} skipped, #{summary["planned"]} planned
+    - Selected budget: #{summary["total"]}/#{limits["max_anchors"]} anchors, estimated maximum $#{format_cost(summary["estimated_max_cost_usd"])}
+    - Guardrails: concurrency #{limits["max_concurrency"]}, #{limits["timeout_seconds"]}s per anchor, #{limits["max_output_tokens_per_anchor"]} output tokens per anchor, matrix maximum $#{format_cost(limits["estimated_max_cost_usd"])}
+
+    | Provider | Model | Surface | Scenario | Status | Failure layer | Remediation |
+    | --- | --- | --- | --- | --- | --- | --- |
+    #{rows}
+    """
+  end
+
+  @doc "Writes deterministic JSON and Markdown report files."
+  @spec write_report!(Path.t(), Path.t(), map()) :: :ok
+  def write_report!(json_path, markdown_path, report) do
+    json_path |> Path.dirname() |> File.mkdir_p!()
+    markdown_path |> Path.dirname() |> File.mkdir_p!()
+    File.write!(json_path, Evidence.canonical_json(report))
+    File.write!(markdown_path, markdown(report))
+  end
+
+  @doc "Returns true when any executed anchor failed."
+  @spec failures?([map()]) :: boolean()
+  def failures?(results), do: Enum.any?(results, &(&1["status"] == "fail"))
+
+  defp validate_limits!(limits) do
+    require_positive_integer!(limits["max_anchors"], "limits.max_anchors")
+    require_positive_integer!(limits["max_concurrency"], "limits.max_concurrency")
+    require_positive_integer!(limits["timeout_seconds"], "limits.timeout_seconds")
+
+    require_positive_integer!(
+      limits["max_output_tokens_per_anchor"],
+      "limits.max_output_tokens_per_anchor"
+    )
+
+    require_non_negative_number!(
+      limits["estimated_max_cost_usd"],
+      "limits.estimated_max_cost_usd"
+    )
+
+    if limits["max_concurrency"] > limits["max_anchors"] do
+      raise ArgumentError, "limits.max_concurrency cannot exceed limits.max_anchors"
+    end
+  end
+
+  defp validate_anchor_count!(anchors, limits) do
+    if length(anchors) > limits["max_anchors"] do
+      raise ArgumentError,
+            "anchor count #{length(anchors)} exceeds limits.max_anchors #{limits["max_anchors"]}"
+    end
+  end
+
+  defp validate_unique_anchor_ids!(anchors) do
+    ids = Enum.map(anchors, &require_binary!(&1["id"], "anchor.id"))
+
+    if length(ids) != length(Enum.uniq(ids)) do
+      raise ArgumentError, "anchor ids must be unique"
+    end
+  end
+
+  defp validate_anchor!(anchor, limits, evidence) when is_map(anchor) do
+    id = require_binary!(anchor["id"], "anchor.id")
+    provider = require_binary!(anchor["provider"], "#{id}.provider")
+    model = require_binary!(anchor["model"], "#{id}.model")
+    operation = require_member!(anchor["operation"], @operations, "#{id}.operation")
+    surface = require_binary!(anchor["surface"], "#{id}.surface")
+    scenario_id = require_binary!(anchor["scenario"], "#{id}.scenario")
+    credentials = require_non_empty_list!(anchor["credential_env"], "#{id}.credential_env")
+    max_tokens = require_positive_integer!(anchor["max_output_tokens"], "#{id}.max_output_tokens")
+
+    require_non_negative_number!(
+      anchor["estimated_max_cost_usd"],
+      "#{id}.estimated_max_cost_usd"
+    )
+
+    if max_tokens > limits["max_output_tokens_per_anchor"] do
+      raise ArgumentError,
+            "#{id}.max_output_tokens exceeds limits.max_output_tokens_per_anchor"
+    end
+
+    Enum.each(credentials, &validate_credential_name!(&1, id))
+
+    scenario = ScenarioCatalog.fetch_scenario!(scenario_id)
+
+    if Atom.to_string(scenario.operation) != operation do
+      raise ArgumentError, "#{id}.scenario operation does not match #{operation}"
+    end
+
+    applicable_providers =
+      if scenario.providers == :all, do: :all, else: Enum.map(scenario.providers, &to_string/1)
+
+    if applicable_providers != :all and provider not in applicable_providers do
+      raise ArgumentError, "#{id}.scenario does not apply to provider #{provider}"
+    end
+
+    model_spec = "#{provider}:#{model}"
+
+    unless is_map(get_in(evidence, ["models", model_spec, "surfaces", surface])) do
+      raise ArgumentError, "#{id}.surface is not present in checked-in compatibility evidence"
+    end
+
+    unless is_map(
+             get_in(evidence, [
+               "models",
+               model_spec,
+               "surfaces",
+               surface,
+               "scenarios",
+               scenario_id
+             ])
+           ) do
+      raise ArgumentError, "#{id}.scenario is not recorded on expected surface #{surface}"
+    end
+  end
+
+  defp validate_anchor!(_anchor, _limits, _evidence) do
+    raise ArgumentError, "each anchor must be an object"
+  end
+
+  defp validate_cost_budget!(anchors, limits) do
+    estimated = Enum.reduce(anchors, 0.0, &(&1["estimated_max_cost_usd"] + &2))
+
+    if estimated > limits["estimated_max_cost_usd"] do
+      raise ArgumentError,
+            "anchor estimated cost #{format_cost(estimated)} exceeds configured maximum " <>
+              format_cost(limits["estimated_max_cost_usd"])
+    end
+  end
+
+  defp plan_anchor(anchor, _env, true) do
+    anchor
+    |> anchor_identity()
+    |> Map.merge(%{
+      "status" => "planned",
+      "missing_credentials" => [],
+      "failure_layer" => nil,
+      "remediation" => "Dry run only; no provider request was made"
+    })
+  end
+
+  defp plan_anchor(anchor, env, false) do
+    missing = Enum.reject(anchor["credential_env"], &credential_present?(env[&1]))
+
+    if missing == [] do
+      anchor
+      |> anchor_identity()
+      |> Map.merge(%{
+        "status" => "ready",
+        "missing_credentials" => [],
+        "failure_layer" => nil,
+        "remediation" => "Run the bounded live probe"
+      })
+    else
+      anchor
+      |> anchor_identity()
+      |> Map.merge(%{
+        "status" => "skipped",
+        "missing_credentials" => missing,
+        "failure_layer" => nil,
+        "remediation" => "Configure repository secret(s): #{Enum.join(missing, ", ")}"
+      })
+    end
+  end
+
+  defp anchor_identity(anchor) do
+    %{
+      "id" => anchor["id"],
+      "provider" => anchor["provider"],
+      "model" => anchor["model"],
+      "model_spec" => "#{anchor["provider"]}:#{anchor["model"]}",
+      "operation" => anchor["operation"],
+      "expected_surface" => anchor["surface"],
+      "surface" => anchor["surface"],
+      "scenario" => anchor["scenario"],
+      "fixtures" => ScenarioCatalog.fixtures(anchor["scenario"]),
+      "estimated_max_cost_usd" => anchor["estimated_max_cost_usd"],
+      "max_output_tokens" => anchor["max_output_tokens"]
+    }
+  end
+
+  defp normalize_execution_result(anchor, result, checked_at, correlation, duration_ms)
+       when is_map(result) do
+    status = result["status"] || result[:status]
+    surface = result["surface"] || result[:surface] || anchor["expected_surface"]
+    fixtures = result["fixtures"] || result[:fixtures] || anchor["fixtures"]
+    failure_layer = result["failure_layer"] || result[:failure_layer]
+
+    {status, failure_layer, remediation} =
+      normalize_execution_status(
+        status,
+        failure_layer,
+        surface,
+        anchor["expected_surface"],
+        result["remediation"] || result[:remediation]
+      )
+
+    anchor
+    |> Map.merge(%{
+      "status" => status,
+      "surface" => surface,
+      "fixtures" => fixtures,
+      "failure_layer" => failure_layer,
+      "remediation" => remediation,
+      "checked_at" => DateTime.to_iso8601(checked_at),
+      "duration_ms" => duration_ms,
+      "correlation_id" => correlation_id(correlation, anchor["id"]),
+      "missing_credentials" => []
+    })
+  end
+
+  defp normalize_execution_result(anchor, _result, checked_at, correlation, _duration_ms) do
+    failed_result(anchor, checked_at, correlation, "assertion", "Anchor returned invalid data")
+  end
+
+  defp normalize_execution_status(
+         "pass",
+         _failure_layer,
+         surface,
+         expected_surface,
+         _remediation
+       )
+       when surface != expected_surface do
+    {"fail", "provider_drift",
+     "Observed surface changed from #{expected_surface} to #{surface}; inspect routing before updating evidence"}
+  end
+
+  defp normalize_execution_status("pass", _failure_layer, _surface, _expected, _remediation) do
+    {"pass", nil, "No action required"}
+  end
+
+  defp normalize_execution_status("fail", failure_layer, _surface, _expected, remediation) do
+    layer = if failure_layer in Evidence.failure_layers(), do: failure_layer, else: "assertion"
+    {"fail", layer, remediation || remediation_for(layer)}
+  end
+
+  defp normalize_execution_status(_status, _failure_layer, _surface, _expected, _remediation) do
+    {"fail", "assertion", "Anchor returned an invalid status"}
+  end
+
+  defp failed_result(anchor, checked_at, correlation, layer, remediation) do
+    anchor
+    |> Map.merge(%{
+      "status" => "fail",
+      "failure_layer" => layer,
+      "remediation" => remediation,
+      "checked_at" => DateTime.to_iso8601(checked_at),
+      "duration_ms" => nil,
+      "correlation_id" => correlation_id(correlation, anchor["id"]),
+      "missing_credentials" => []
+    })
+  end
+
+  defp finalize_plan(plan, checked_at, correlation) do
+    plan
+    |> Map.put("checked_at", DateTime.to_iso8601(checked_at))
+    |> Map.put("duration_ms", 0)
+    |> Map.put("correlation_id", correlation_id(correlation, plan["id"]))
+  end
+
+  defp summarize(results) do
+    counts = Enum.frequencies_by(results, & &1["status"])
+
+    %{
+      "total" => length(results),
+      "pass" => Map.get(counts, "pass", 0),
+      "fail" => Map.get(counts, "fail", 0),
+      "skipped" => Map.get(counts, "skipped", 0),
+      "planned" => Map.get(counts, "planned", 0),
+      "estimated_max_cost_usd" => Enum.reduce(results, 0.0, &(&1["estimated_max_cost_usd"] + &2))
+    }
+  end
+
+  defp sanitized_evidence_error(%{"status" => "fail", "failure_layer" => layer}) do
+    "Live provider probe failed at #{layer || "assertion"}; see the sanitized drift report"
+  end
+
+  defp sanitized_evidence_error(_result), do: nil
+
+  defp remediation_for("resolution"), do: "Verify the anchor model ID and current catalog entry"
+  defp remediation_for("planning"), do: "Verify scenario routing and anchor configuration"
+  defp remediation_for("encoding"), do: "Inspect provider request translation for the scenario"
+
+  defp remediation_for("transport"),
+    do: "Retry once, then inspect network and provider availability"
+
+  defp remediation_for("decoding"),
+    do: "Inspect the provider response decoder against current wire data"
+
+  defp remediation_for("materialization"),
+    do: "Inspect response assembly and recorded surface extraction"
+
+  defp remediation_for("provider_drift"),
+    do: "Inspect provider status, API changes, and the expected execution surface"
+
+  defp remediation_for(_layer), do: "Inspect the focused compatibility assertion"
+
+  defp checked_at_from_results([%{"checked_at" => checked_at} | _]) when is_binary(checked_at) do
+    case DateTime.from_iso8601(checked_at) do
+      {:ok, parsed, _offset} -> parsed
+      _error -> DateTime.utc_now() |> DateTime.truncate(:second)
+    end
+  end
+
+  defp checked_at_from_results(_results), do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  defp provider_filter([]), do: MapSet.new()
+  defp provider_filter(["all"]), do: MapSet.new()
+  defp provider_filter(providers), do: MapSet.new(providers)
+
+  defp selected_provider?(anchor, providers) do
+    MapSet.size(providers) == 0 or MapSet.member?(providers, anchor["provider"])
+  end
+
+  defp credential_present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp credential_present?(_value), do: false
+
+  defp validate_credential_name!(name, id) when is_binary(name) do
+    unless Regex.match?(@credential_name, name) do
+      raise ArgumentError, "#{id}.credential_env contains invalid name #{inspect(name)}"
+    end
+  end
+
+  defp validate_credential_name!(_name, id) do
+    raise ArgumentError, "#{id}.credential_env entries must be strings"
+  end
+
+  defp correlation_id(correlation, anchor_id) do
+    run_id = correlation["run_id"] || correlation[:run_id] || "local"
+    attempt = correlation["run_attempt"] || correlation[:run_attempt] || "1"
+    "#{run_id}-#{attempt}-#{anchor_id}"
+  end
+
+  defp correlation_label(correlation) do
+    run_id = correlation["run_id"] || correlation[:run_id] || "local"
+    attempt = correlation["run_attempt"] || correlation[:run_attempt] || "1"
+    "#{run_id}/#{attempt}"
+  end
+
+  defp cell(nil), do: "—"
+
+  defp cell(value) do
+    value
+    |> to_string()
+    |> String.replace("|", "\\|")
+    |> String.replace(~r/[\r\n]+/, " ")
+  end
+
+  defp format_cost(value) when is_integer(value),
+    do: :erlang.float_to_binary(value * 1.0, decimals: 3)
+
+  defp format_cost(value) when is_float(value), do: :erlang.float_to_binary(value, decimals: 3)
+
+  defp require_equal!(actual, expected, field) do
+    unless actual == expected do
+      raise ArgumentError, "#{field} must be #{inspect(expected)}, got: #{inspect(actual)}"
+    end
+  end
+
+  defp require_map!(value, _field) when is_map(value), do: value
+
+  defp require_map!(value, field),
+    do: raise(ArgumentError, "#{field} must be an object, got: #{inspect(value)}")
+
+  defp require_non_empty_list!(value, _field) when is_list(value) and value != [], do: value
+
+  defp require_non_empty_list!(value, field) do
+    raise ArgumentError, "#{field} must be a non-empty list, got: #{inspect(value)}"
+  end
+
+  defp require_binary!(value, _field) when is_binary(value) and value != "", do: value
+
+  defp require_binary!(value, field),
+    do: raise(ArgumentError, "#{field} must be a non-empty string, got: #{inspect(value)}")
+
+  defp require_member!(value, members, field) do
+    if value in members do
+      value
+    else
+      raise ArgumentError,
+            "#{field} must be one of #{Enum.join(members, ", ")}, got: #{inspect(value)}"
+    end
+  end
+
+  defp require_positive_integer!(value, _field) when is_integer(value) and value > 0, do: value
+
+  defp require_positive_integer!(value, field) do
+    raise ArgumentError, "#{field} must be a positive integer, got: #{inspect(value)}"
+  end
+
+  defp require_non_negative_number!(value, _field) when is_number(value) and value >= 0, do: value
+
+  defp require_non_negative_number!(value, field) do
+    raise ArgumentError, "#{field} must be a non-negative number, got: #{inspect(value)}"
+  end
+end

--- a/priv/provider_drift_anchors.json
+++ b/priv/provider_drift_anchors.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "limits": {
+    "max_anchors": 4,
+    "max_concurrency": 1,
+    "timeout_seconds": 180,
+    "max_output_tokens_per_anchor": 64,
+    "estimated_max_cost_usd": 0.03
+  },
+  "anchors": [
+    {
+      "id": "anthropic-messages-basic",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5-20250929",
+      "operation": "text",
+      "surface": "anthropic.messages",
+      "scenario": "basic",
+      "credential_env": ["ANTHROPIC_API_KEY"],
+      "max_output_tokens": 64,
+      "estimated_max_cost_usd": 0.01
+    },
+    {
+      "id": "google-generate-content-basic",
+      "provider": "google",
+      "model": "gemini-2.0-flash",
+      "operation": "text",
+      "surface": "google.generate_content",
+      "scenario": "basic",
+      "credential_env": ["GOOGLE_API_KEY"],
+      "max_output_tokens": 64,
+      "estimated_max_cost_usd": 0.005
+    },
+    {
+      "id": "openai-responses-basic",
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "operation": "text",
+      "surface": "openai.responses",
+      "scenario": "basic",
+      "credential_env": ["OPENAI_API_KEY"],
+      "max_output_tokens": 64,
+      "estimated_max_cost_usd": 0.005
+    },
+    {
+      "id": "openai-chat-completions-basic",
+      "provider": "openai",
+      "model": "chat-latest",
+      "operation": "text",
+      "surface": "openai.chat_completions",
+      "scenario": "basic",
+      "credential_env": ["OPENAI_API_KEY"],
+      "max_output_tokens": 64,
+      "estimated_max_cost_usd": 0.005
+    }
+  ]
+}

--- a/test/mix/tasks/provider_drift_test.exs
+++ b/test/mix/tasks/provider_drift_test.exs
@@ -1,0 +1,86 @@
+defmodule Mix.Tasks.ReqLlm.ProviderDriftTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.ReqLlm.ProviderDrift
+  alias ReqLLM.Test.Helpers
+
+  setup do
+    previous_limit = System.get_env("REQ_LLM_DRIFT_MAX_TOKENS")
+
+    on_exit(fn ->
+      restore_env("REQ_LLM_DRIFT_MAX_TOKENS", previous_limit)
+      Mix.Task.reenable("req_llm.provider_drift")
+    end)
+
+    :ok
+  end
+
+  test "dry run writes deterministic sanitized reports" do
+    output_dir =
+      Path.join(System.tmp_dir!(), "provider_drift_task_#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm_rf(output_dir) end)
+
+    output =
+      capture_io(fn ->
+        ProviderDrift.run(["--dry-run", "--output-dir", output_dir])
+      end)
+
+    report =
+      output_dir
+      |> Path.join("provider-drift-report.json")
+      |> File.read!()
+      |> Jason.decode!()
+
+    assert output =~ "4 planned"
+    assert report["mode"] == "dry_run"
+    assert report["summary"]["planned"] == 4
+    assert File.exists?(Path.join(output_dir, "provider-drift-report.md"))
+    refute Jason.encode!(report) =~ "response_body"
+  end
+
+  test "provider selection is explicit and rejects unknown values" do
+    output_dir =
+      Path.join(System.tmp_dir!(), "provider_drift_empty_#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm_rf(output_dir) end)
+
+    assert_raise Mix.Error, ~r/No provider drift anchors match/, fn ->
+      capture_io(fn ->
+        ProviderDrift.run([
+          "--dry-run",
+          "--provider",
+          "unknown",
+          "--output-dir",
+          output_dir
+        ])
+      end)
+    end
+  end
+
+  test "drift token cap is opt-in and never increases a scenario budget" do
+    System.put_env("REQ_LLM_DRIFT_MAX_TOKENS", "32")
+
+    assert Helpers.fixture_opts("basic", max_tokens: 50)[:max_tokens] == 32
+    assert Helpers.fixture_opts("basic", max_tokens: 16)[:max_tokens] == 16
+
+    System.delete_env("REQ_LLM_DRIFT_MAX_TOKENS")
+    assert Helpers.fixture_opts("basic", max_tokens: 50)[:max_tokens] == 50
+  end
+
+  test "workflow is scheduled and manual without pull-request secrets or write permissions" do
+    workflow = File.read!(".github/workflows/provider-drift.yml")
+
+    assert workflow =~ "workflow_dispatch:"
+    assert workflow =~ "schedule:"
+    assert workflow =~ "contents: read"
+    assert workflow =~ "timeout-minutes: 15"
+    refute workflow =~ "pull_request:"
+    refute workflow =~ "contents: write"
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+end

--- a/test/req_llm/compatibility/provider_drift_test.exs
+++ b/test/req_llm/compatibility/provider_drift_test.exs
@@ -1,0 +1,166 @@
+defmodule ReqLLM.Compatibility.ProviderDriftTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Compatibility.{Evidence, ProviderDrift}
+
+  setup do
+    config = ProviderDrift.load_config!()
+    %{config: config}
+  end
+
+  test "loads a bounded anchor matrix backed by checked-in evidence", %{config: config} do
+    assert config["schema_version"] == 1
+    assert length(config["anchors"]) == 4
+    assert config["limits"]["max_concurrency"] == 1
+    assert config["limits"]["max_output_tokens_per_anchor"] == 64
+
+    estimated = Enum.sum(Enum.map(config["anchors"], & &1["estimated_max_cost_usd"]))
+    assert estimated <= config["limits"]["estimated_max_cost_usd"]
+  end
+
+  test "rejects anchors whose expected surface is not in compatibility evidence", %{
+    config: config
+  } do
+    anchors =
+      List.update_at(config["anchors"], 0, &Map.put(&1, "surface", "anthropic.unknown"))
+
+    invalid = Map.put(config, "anchors", anchors)
+
+    assert_raise ArgumentError, ~r/surface is not present/, fn ->
+      ProviderDrift.validate_config!(invalid, Evidence.load!())
+    end
+  end
+
+  test "rejects anchor cost estimates above the configured maximum", %{config: config} do
+    limits = Map.put(config["limits"], "estimated_max_cost_usd", 0.001)
+    invalid = Map.put(config, "limits", limits)
+
+    assert_raise ArgumentError, ~r/estimated cost/, fn ->
+      ProviderDrift.validate_config!(invalid, Evidence.load!())
+    end
+  end
+
+  test "skips unavailable credentials without executing anchors", %{config: config} do
+    executor = fn _anchor, _context -> flunk("executor should not run") end
+
+    results =
+      ProviderDrift.run(config, executor,
+        env: %{},
+        checked_at: ~U[2026-07-16 12:00:00Z]
+      )
+
+    assert Enum.all?(results, &(&1["status"] == "skipped"))
+    assert Enum.all?(results, &is_nil(&1["failure_layer"]))
+    assert Enum.all?(results, &(&1["missing_credentials"] != []))
+  end
+
+  test "dry runs validate every anchor without credentials or requests", %{config: config} do
+    results =
+      ProviderDrift.run(config, fn _anchor, _context -> flunk("executor should not run") end,
+        env: %{},
+        dry_run: true,
+        checked_at: ~U[2026-07-16 12:00:00Z]
+      )
+
+    assert Enum.all?(results, &(&1["status"] == "planned"))
+  end
+
+  test "completed probes produce schema-compatible live evidence", %{config: config} do
+    env = credential_env(config)
+
+    executor = fn anchor, _context ->
+      %{
+        "status" => "pass",
+        "surface" => anchor["expected_surface"],
+        "fixtures" => [anchor["scenario"]],
+        "failure_layer" => nil
+      }
+    end
+
+    results =
+      ProviderDrift.run(config, executor,
+        env: env,
+        checked_at: ~U[2026-07-16 12:00:00Z],
+        correlation: %{"run_id" => "42", "run_attempt" => "2"}
+      )
+
+    report =
+      ProviderDrift.report(config, results,
+        checked_at: ~U[2026-07-16 12:00:00Z],
+        correlation: %{"run_id" => "42", "run_attempt" => "2"}
+      )
+
+    assert report["summary"] == %{
+             "total" => 4,
+             "pass" => 4,
+             "fail" => 0,
+             "skipped" => 0,
+             "planned" => 0,
+             "estimated_max_cost_usd" => 0.025
+           }
+
+    assert report["evidence"]["schema_version"] == Evidence.schema_version()
+
+    assert get_in(report, [
+             "evidence",
+             "models",
+             "openai:gpt-4o-mini",
+             "surfaces",
+             "openai.responses",
+             "scenarios",
+             "basic",
+             "observations",
+             Access.at(0),
+             "mode"
+           ]) == "live_probe"
+
+    assert Enum.all?(results, &String.starts_with?(&1["correlation_id"], "42-2-"))
+  end
+
+  test "a changed execution surface is a provider drift failure", %{config: config} do
+    [openai_anchor] = Enum.filter(config["anchors"], &(&1["id"] == "openai-responses-basic"))
+
+    scoped = Map.put(config, "anchors", [openai_anchor])
+    scoped = put_in(scoped["limits"]["max_anchors"], 1)
+
+    results =
+      ProviderDrift.run(
+        scoped,
+        fn _anchor, _context ->
+          %{
+            "status" => "pass",
+            "surface" => "openai.chat_completions",
+            "fixtures" => ["basic"]
+          }
+        end,
+        env: %{"OPENAI_API_KEY" => "available"},
+        checked_at: ~U[2026-07-16 12:00:00Z]
+      )
+
+    assert [%{"status" => "fail", "failure_layer" => "provider_drift"} = result] = results
+    assert result["remediation"] =~ "Observed surface changed"
+  end
+
+  test "reports contain sanitized metadata rather than provider payloads", %{config: config} do
+    results =
+      ProviderDrift.run(config, fn _anchor, _context -> flunk("executor should not run") end,
+        env: %{},
+        checked_at: ~U[2026-07-16 12:00:00Z]
+      )
+
+    report = ProviderDrift.report(config, results, checked_at: ~U[2026-07-16 12:00:00Z])
+    encoded = Jason.encode!(report)
+
+    refute encoded =~ "prompt"
+    refute encoded =~ "response_body"
+    refute encoded =~ "api_key"
+    assert ProviderDrift.markdown(report) =~ "Configure repository secret(s)"
+  end
+
+  defp credential_env(config) do
+    config["anchors"]
+    |> Enum.flat_map(& &1["credential_env"])
+    |> Enum.uniq()
+    |> Map.new(&{&1, "available"})
+  end
+end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -359,11 +359,26 @@ defmodule ReqLLM.Test.Helpers do
       [temperature: 0.0, fixture: "basic"]
   """
   def fixture_opts(name, extra_opts \\ []) do
-    Keyword.put(extra_opts, :fixture, name)
+    extra_opts
+    |> cap_provider_drift_tokens()
+    |> Keyword.put(:fixture, name)
   end
 
   def fixture_opts(_provider, name, extra_opts) do
     fixture_opts(name, extra_opts)
+  end
+
+  defp cap_provider_drift_tokens(opts) do
+    case Integer.parse(System.get_env("REQ_LLM_DRIFT_MAX_TOKENS") || "") do
+      {limit, ""} when limit > 0 ->
+        Keyword.update(opts, :max_tokens, limit, fn
+          current when is_integer(current) and current > 0 -> min(current, limit)
+          _current -> limit
+        end)
+
+      _value ->
+        opts
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- add a manual/weekly, credential-aware live verification lane for four evidence-backed provider anchors
- keep pull-request CI replay-only and stage live fixtures only in a temporary directory
- emit sanitized JSON/Markdown reports with explicit concurrency, timeout, output-token, and estimated-cost guardrails
- document dry-run, provider selection, report handling, and the separate explicit fixture-recording workflow

## Backward compatibility

This is additive CI/tooling. It does not change ReqLLM's runtime API, request routing, provider implementations, model resolution, checked-in fixtures, compatibility evidence, or support tiers. The test-helper token cap is opt-in through the drift task's private environment variable and leaves all existing callers unchanged.

## Validation

- `mix test` — 3,655 passed, 11 skipped, 145 excluded
- `mix quality` — format, compile with warnings as errors, Credo, and Dialyzer passed
- focused provider-drift tests — 12 passed
- `mix docs` — passed (one pre-existing hidden-module reference warning)
- `mix hex.build --unpack` — new task, module, config, and guides included
- `mix req_llm.model_support --check` — current
- dry run and explicit missing-credential paths passed
- bounded live OpenAI smoke passed both anchors and observed the expected Responses and Chat Completions surfaces

Closes #837