### PR TITLE
refactor: add internal request planning

### DIFF
--- a/lib/req_llm/model_input.ex
+++ b/lib/req_llm/model_input.ex
@@ -8,19 +8,32 @@ defmodule ReqLLM.ModelInput do
   }
 
   @spec merge_tuple_defaults(ReqLLM.model_input(), atom(), keyword()) :: keyword()
-  def merge_tuple_defaults({provider, model_id, tuple_opts}, operation, call_opts)
+  def merge_tuple_defaults(model_input, operation, call_opts) do
+    {merged, warnings} = merge_tuple_defaults_with_warnings(model_input, operation, call_opts)
+    Enum.each(warnings, &IO.warn/1)
+    merged
+  end
+
+  @doc false
+  @spec merge_tuple_defaults_with_warnings(ReqLLM.model_input(), atom(), keyword()) ::
+          {keyword(), [binary()]}
+  def merge_tuple_defaults_with_warnings(
+        {provider, model_id, tuple_opts},
+        operation,
+        call_opts
+      )
       when is_atom(provider) and is_binary(model_id) and is_list(call_opts) do
     if Keyword.keyword?(tuple_opts) do
       {defaults, ignored} = select_defaults(tuple_opts, operation)
-      warn_ignored(operation, ignored, tuple_opts, call_opts)
-      merge_defaults(defaults, call_opts)
+      warnings = ignored_defaults_warnings(operation, ignored, tuple_opts, call_opts)
+      {merge_defaults(defaults, call_opts), warnings}
     else
-      warn_invalid_container(operation, call_opts)
-      call_opts
+      {call_opts, invalid_container_warnings(operation, call_opts)}
     end
   end
 
-  def merge_tuple_defaults(_model_input, _operation, call_opts), do: call_opts
+  def merge_tuple_defaults_with_warnings(_model_input, _operation, call_opts),
+    do: {call_opts, []}
 
   defp select_defaults(tuple_opts, operation) do
     schema = option_schema(operation).schema
@@ -68,24 +81,28 @@ defmodule ReqLLM.ModelInput do
     Keyword.merge(defaults, call_opts)
   end
 
-  defp warn_ignored(_operation, [], _tuple_opts, _call_opts), do: :ok
+  defp ignored_defaults_warnings(_operation, [], _tuple_opts, _call_opts), do: []
 
-  defp warn_ignored(operation, ignored, tuple_opts, call_opts) do
+  defp ignored_defaults_warnings(operation, ignored, tuple_opts, call_opts) do
     if warning_enabled?(tuple_opts, call_opts) do
       details = Enum.map_join(ignored, ", ", &format_ignored/1)
 
-      IO.warn(
+      [
         "Ignoring tuple model defaults for #{operation}: #{details}. " <>
           "Pass only documented #{operation} options; explicit call options take precedence."
-      )
+      ]
+    else
+      []
     end
   end
 
-  defp warn_invalid_container(operation, call_opts) do
+  defp invalid_container_warnings(operation, call_opts) do
     if warning_enabled?([], call_opts) do
-      IO.warn(
+      [
         "Ignoring tuple model defaults for #{operation}: the third tuple element must be a keyword list."
-      )
+      ]
+    else
+      []
     end
   end
 

--- a/lib/req_llm/request_plan.ex
+++ b/lib/req_llm/request_plan.ex
@@ -84,8 +84,11 @@ defmodule ReqLLM.RequestPlan do
     )
   end
 
-  defp resolve_model(%LLMDB.Model{} = model), do: {:ok, model}
-  defp resolve_model(model_input), do: ReqLLM.model(model_input)
+  defp resolve_model(model_input) do
+    with {:ok, %LLMDB.Model{} = model} <- ReqLLM.model(model_input) do
+      ReqLLM.model(model)
+    end
+  end
 
   defp resolve_surface(%LLMDB.Model{provider: :openai} = model, provider_module) do
     if provider_module == ReqLLM.Providers.OpenAI do
@@ -174,18 +177,26 @@ defmodule ReqLLM.RequestPlan do
   end
 
   defp requested_stream_transport(opts) do
-    case explicit_transport(opts) do
-      :none -> {:ok, :http, false}
-      value when value in [:http, :sse, "http", "sse"] -> {:ok, :http, true}
-      value when value in [:websocket, "websocket"] -> {:ok, :websocket, true}
-      value -> invalid_parameter("unsupported stream transport: #{inspect(value)}")
+    with :ok <- validate_internal_stream_transport(opts) do
+      case provider_option(opts, :openai_stream_transport, :none) do
+        :none -> {:ok, :http, false}
+        value when value in [:sse, "sse"] -> {:ok, :http, true}
+        value when value in [:websocket, "websocket"] -> {:ok, :websocket, true}
+        value -> invalid_parameter("unsupported OpenAI stream transport: #{inspect(value)}")
+      end
     end
   end
 
-  defp explicit_transport(opts) do
+  defp validate_internal_stream_transport(opts) do
     case Keyword.fetch(opts, :stream_transport) do
-      {:ok, value} -> value
-      :error -> provider_option(opts, :openai_stream_transport, :none)
+      :error ->
+        :ok
+
+      {:ok, value} when value in [:http, :websocket] ->
+        :ok
+
+      {:ok, value} ->
+        invalid_parameter("unsupported internal stream transport: #{inspect(value)}")
     end
   end
 

--- a/lib/req_llm/request_plan.ex
+++ b/lib/req_llm/request_plan.ex
@@ -1,0 +1,259 @@
+defmodule ReqLLM.RequestPlan do
+  @moduledoc false
+
+  alias ReqLLM.Error.Invalid.Parameter
+
+  @enforce_keys [
+    :model,
+    :operation,
+    :provider,
+    :surface,
+    :transport,
+    :options,
+    :provider_module,
+    :api_module
+  ]
+  defstruct @enforce_keys ++ [warnings: []]
+
+  @type surface ::
+          :openai_responses
+          | :openai_chat_completions
+          | :anthropic_messages
+  @type transport :: :req | :finch | :websocket
+
+  @type t :: %__MODULE__{
+          model: LLMDB.Model.t(),
+          operation: :chat | :object,
+          provider: atom(),
+          surface: surface(),
+          transport: transport(),
+          options: keyword(),
+          provider_module: module(),
+          api_module: module(),
+          warnings: [binary()]
+        }
+
+  @doc false
+  @spec build(ReqLLM.model_input(), atom(), keyword()) :: {:ok, t()} | {:error, term()}
+  def build(model_input, operation, opts \\ [])
+
+  def build(model_input, operation, opts) when is_list(opts) do
+    with :ok <- validate_options(opts),
+         :ok <- validate_operation(operation),
+         {merged_opts, input_warnings} <-
+           ReqLLM.ModelInput.merge_tuple_defaults_with_warnings(model_input, operation, opts),
+         normalized_opts <- normalize_options(merged_opts),
+         {:ok, model} <- resolve_model(model_input),
+         {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, surface, api_module, surface_warnings} <-
+           resolve_surface(model, provider_module),
+         {:ok, transport, transport_warnings} <-
+           resolve_transport(surface, normalized_opts) do
+      {:ok,
+       %__MODULE__{
+         model: model,
+         operation: operation,
+         provider: model.provider,
+         surface: surface,
+         transport: transport,
+         options: canonicalize(normalized_opts),
+         provider_module: provider_module,
+         api_module: api_module,
+         warnings: input_warnings ++ surface_warnings ++ transport_warnings
+       }}
+    end
+  end
+
+  def build(_model_input, _operation, opts) do
+    invalid_parameter("options must be a keyword list, got: #{inspect(opts)}")
+  end
+
+  defp validate_options(opts) do
+    if Keyword.keyword?(opts) do
+      :ok
+    else
+      invalid_parameter("options must be a keyword list, got: #{inspect(opts)}")
+    end
+  end
+
+  defp validate_operation(operation) when operation in [:chat, :object], do: :ok
+
+  defp validate_operation(operation) do
+    invalid_parameter(
+      "request planning supports only :chat and :object operations, got: #{inspect(operation)}"
+    )
+  end
+
+  defp resolve_model(%LLMDB.Model{} = model), do: {:ok, model}
+  defp resolve_model(model_input), do: ReqLLM.model(model_input)
+
+  defp resolve_surface(%LLMDB.Model{provider: :openai} = model, provider_module) do
+    if provider_module == ReqLLM.Providers.OpenAI do
+      resolve_openai_surface(model)
+    else
+      invalid_parameter(
+        "provider :openai resolves to unsupported request-plan module #{inspect(provider_module)}"
+      )
+    end
+  end
+
+  defp resolve_surface(%LLMDB.Model{provider: :anthropic} = model, provider_module) do
+    if provider_module == ReqLLM.Providers.Anthropic do
+      case wire_protocol(model) do
+        nil ->
+          {:ok, :anthropic_messages, ReqLLM.Providers.Anthropic, []}
+
+        "anthropic_messages" ->
+          {:ok, :anthropic_messages, ReqLLM.Providers.Anthropic, []}
+
+        protocol ->
+          invalid_surface(model, protocol)
+      end
+    else
+      invalid_parameter(
+        "provider :anthropic resolves to unsupported request-plan module #{inspect(provider_module)}"
+      )
+    end
+  end
+
+  defp resolve_surface(%LLMDB.Model{provider: provider}, _provider_module) do
+    invalid_parameter(
+      "request planning does not define an execution surface for provider #{inspect(provider)}"
+    )
+  end
+
+  defp resolve_openai_surface(model) do
+    case wire_protocol(model) do
+      "openai_responses" ->
+        {:ok, :openai_responses, ReqLLM.Providers.OpenAI.ResponsesAPI, []}
+
+      "openai_chat" ->
+        {:ok, :openai_chat_completions, ReqLLM.Providers.OpenAI.ChatAPI, []}
+
+      nil ->
+        infer_openai_surface(model)
+
+      protocol ->
+        invalid_surface(model, protocol)
+    end
+  end
+
+  defp infer_openai_surface(model) do
+    model_id = model.provider_model_id || model.id
+
+    if ReqLLM.Providers.OpenAI.AdapterHelpers.responses_model?(model_id) do
+      {:ok, :openai_responses, ReqLLM.Providers.OpenAI.ResponsesAPI,
+       ["Inferred OpenAI Responses because model wire metadata is absent"]}
+    else
+      {:ok, :openai_chat_completions, ReqLLM.Providers.OpenAI.ChatAPI,
+       ["Defaulted to OpenAI Chat Completions because model wire metadata is absent"]}
+    end
+  end
+
+  defp invalid_surface(model, protocol) do
+    invalid_parameter(
+      "wire protocol #{inspect(protocol)} is invalid for provider #{inspect(model.provider)}"
+    )
+  end
+
+  defp resolve_transport(surface, opts) do
+    with {:ok, stream?} <- stream?(opts),
+         {:ok, requested, explicit?} <- requested_stream_transport(opts),
+         :ok <- validate_transport_surface(surface, stream?, requested) do
+      transport = selected_transport(stream?, requested)
+      warnings = transport_warnings(stream?, explicit?)
+      {:ok, transport, warnings}
+    end
+  end
+
+  defp stream?(opts) do
+    case Keyword.get(opts, :stream, false) do
+      value when is_boolean(value) -> {:ok, value}
+      value -> invalid_parameter(":stream must be a boolean, got: #{inspect(value)}")
+    end
+  end
+
+  defp requested_stream_transport(opts) do
+    case explicit_transport(opts) do
+      :none -> {:ok, :http, false}
+      value when value in [:http, :sse, "http", "sse"] -> {:ok, :http, true}
+      value when value in [:websocket, "websocket"] -> {:ok, :websocket, true}
+      value -> invalid_parameter("unsupported stream transport: #{inspect(value)}")
+    end
+  end
+
+  defp explicit_transport(opts) do
+    case Keyword.fetch(opts, :stream_transport) do
+      {:ok, value} -> value
+      :error -> provider_option(opts, :openai_stream_transport, :none)
+    end
+  end
+
+  defp provider_option(opts, key, default) do
+    case Keyword.get(opts, :provider_options, []) do
+      provider_opts when is_list(provider_opts) -> Keyword.get(provider_opts, key, default)
+      provider_opts when is_map(provider_opts) -> Map.get(provider_opts, key, default)
+      _provider_opts -> default
+    end
+  end
+
+  defp validate_transport_surface(:openai_responses, true, :websocket), do: :ok
+
+  defp validate_transport_surface(surface, true, :websocket) do
+    invalid_parameter("WebSocket transport is not supported by #{surface_name(surface)}")
+  end
+
+  defp validate_transport_surface(_surface, _stream?, _transport), do: :ok
+
+  defp selected_transport(false, _requested), do: :req
+  defp selected_transport(true, :http), do: :finch
+  defp selected_transport(true, :websocket), do: :websocket
+
+  defp transport_warnings(false, true),
+    do: ["Ignored streaming transport selection for a non-streaming request plan"]
+
+  defp transport_warnings(_stream?, _explicit?), do: []
+
+  defp surface_name(:openai_chat_completions), do: "OpenAI Chat Completions"
+  defp surface_name(:anthropic_messages), do: "Anthropic Messages"
+
+  defp normalize_options(opts) do
+    case Keyword.pop(opts, :stream?) do
+      {nil, rest} -> rest
+      {value, rest} -> Keyword.put(rest, :stream, value)
+    end
+  end
+
+  defp canonicalize(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      value
+      |> Enum.map(fn {key, item} -> {key, canonicalize(item)} end)
+      |> Enum.sort_by(fn {key, _value} -> to_string(key) end)
+    else
+      Enum.map(value, &canonicalize/1)
+    end
+  end
+
+  defp canonicalize(%_{} = struct), do: struct
+
+  defp canonicalize(value) when is_map(value) do
+    Map.new(value, fn {key, item} -> {key, canonicalize(item)} end)
+  end
+
+  defp canonicalize(value), do: value
+
+  defp wire_protocol(%LLMDB.Model{extra: extra}) when is_map(extra) do
+    wire = Map.get(extra, :wire) || Map.get(extra, "wire")
+
+    case wire do
+      wire when is_map(wire) -> Map.get(wire, :protocol) || Map.get(wire, "protocol")
+      _wire -> nil
+    end
+  end
+
+  defp wire_protocol(%LLMDB.Model{}), do: nil
+
+  defp invalid_parameter(message) do
+    {:error, Parameter.exception(parameter: message)}
+  end
+end

--- a/test/req_llm/request_plan_test.exs
+++ b/test/req_llm/request_plan_test.exs
@@ -1,0 +1,171 @@
+defmodule ReqLLM.RequestPlanTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias ReqLLM.RequestPlan
+
+  describe "build/3" do
+    test "plans OpenAI Responses without changing caller options" do
+      assert {:ok, plan} =
+               RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 max_tokens: 100,
+                 temperature: 0.2
+               )
+
+      assert %LLMDB.Model{provider: :openai, id: "gpt-4o-mini"} = plan.model
+      assert plan.operation == :chat
+      assert plan.provider == :openai
+      assert plan.surface == :openai_responses
+      assert plan.transport == :req
+      assert plan.provider_module == ReqLLM.Providers.OpenAI
+      assert plan.api_module == ReqLLM.Providers.OpenAI.ResponsesAPI
+      assert plan.options == [max_tokens: 100, temperature: 0.2]
+      assert plan.warnings == []
+    end
+
+    test "plans inferred OpenAI Chat Completions and Finch streaming" do
+      assert {:ok, plan} =
+               RequestPlan.build("openai:chat-latest", :chat,
+                 temperature: 0.3,
+                 stream: true
+               )
+
+      assert plan.surface == :openai_chat_completions
+      assert plan.transport == :finch
+      assert plan.api_module == ReqLLM.Providers.OpenAI.ChatAPI
+
+      assert plan.warnings == [
+               "Defaulted to OpenAI Chat Completions because model wire metadata is absent"
+             ]
+    end
+
+    test "plans Anthropic Messages over Finch" do
+      assert {:ok, plan} =
+               RequestPlan.build("anthropic:claude-sonnet-4-5-20250929", :object, stream: true)
+
+      assert plan.operation == :object
+      assert plan.provider == :anthropic
+      assert plan.surface == :anthropic_messages
+      assert plan.transport == :finch
+      assert plan.provider_module == ReqLLM.Providers.Anthropic
+      assert plan.api_module == ReqLLM.Providers.Anthropic
+      assert plan.warnings == []
+    end
+
+    test "equivalent model inputs and option order produce equal plans" do
+      model = ReqLLM.model!("openai:gpt-4o-mini")
+
+      assert {:ok, from_string} =
+               RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 temperature: 0.2,
+                 max_tokens: 64
+               )
+
+      assert {:ok, from_tuple} =
+               RequestPlan.build(
+                 {:openai, "gpt-4o-mini", [max_tokens: 64, temperature: 0.2]},
+                 :chat
+               )
+
+      assert {:ok, from_model} =
+               RequestPlan.build(model, :chat, max_tokens: 64, temperature: 0.2)
+
+      assert from_string == from_tuple
+      assert from_tuple == from_model
+    end
+
+    test "inline specs and their resolved models produce equal plans" do
+      model_spec = %{
+        provider: :openai,
+        id: "custom-chat",
+        base_url: "https://llm.example.test/v1",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      model = ReqLLM.model!(model_spec)
+
+      assert RequestPlan.build(model_spec, :chat, temperature: 0.4) ==
+               RequestPlan.build(model, :chat, temperature: 0.4)
+    end
+
+    test "keeps planning warnings in deterministic source order" do
+      model_input =
+        {:openai, "chat-latest", [stream_transport: :http, unsupported_default: true]}
+
+      assert capture_io(:stderr, fn ->
+               send(
+                 self(),
+                 RequestPlan.build(model_input, :chat,
+                   provider_options: [openai_stream_transport: :websocket]
+                 )
+               )
+             end) == ""
+
+      assert_received {:ok, plan}
+
+      assert plan.warnings == [
+               "Ignoring tuple model defaults for chat: :stream_transport is controlled by the operation boundary, not the model, :unsupported_default is not accepted by this operation. Pass only documented chat options; explicit call options take precedence.",
+               "Defaulted to OpenAI Chat Completions because model wire metadata is absent",
+               "Ignored streaming transport selection for a non-streaming request plan"
+             ]
+    end
+
+    test "selects WebSocket only for streaming OpenAI Responses" do
+      assert {:ok, plan} =
+               RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 stream: true,
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert plan.surface == :openai_responses
+      assert plan.transport == :websocket
+    end
+
+    test "rejects an unsupported operation before execution" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               RequestPlan.build("openai:gpt-4o-mini", :image)
+
+      assert Exception.message(error) =~ "supports only :chat and :object"
+    end
+
+    test "rejects a provider and wire protocol mismatch" do
+      model = %{
+        provider: :anthropic,
+        id: "custom-claude",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               RequestPlan.build(model, :chat)
+
+      assert Exception.message(error) =~ "wire protocol \"openai_chat\" is invalid"
+    end
+
+    test "rejects WebSocket for OpenAI Chat Completions" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               RequestPlan.build("openai:chat-latest", :chat,
+                 stream: true,
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert Exception.message(error) =~
+               "WebSocket transport is not supported by OpenAI Chat Completions"
+    end
+
+    test "rejects invalid stream settings with typed errors" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = stream_error} =
+               RequestPlan.build("openai:gpt-4o-mini", :chat, stream: :yes)
+
+      assert Exception.message(stream_error) =~ ":stream must be a boolean"
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = transport_error} =
+               RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 stream: true,
+                 stream_transport: :udp
+               )
+
+      assert Exception.message(transport_error) =~ "unsupported stream transport"
+    end
+  end
+end

--- a/test/req_llm/request_plan_test.exs
+++ b/test/req_llm/request_plan_test.exs
@@ -89,6 +89,18 @@ defmodule ReqLLM.RequestPlanTest do
                RequestPlan.build(model, :chat, temperature: 0.4)
     end
 
+    test "normalizes raw model structs like current execution" do
+      raw_model = %LLMDB.Model{provider: :openai, id: "gpt-4o-mini"}
+
+      assert {:ok, plan} = RequestPlan.build(raw_model, :chat)
+
+      assert plan.model.id == "gpt-4o-mini"
+      assert plan.model.model == "gpt-4o-mini"
+      assert plan.model.family == "gpt-4o"
+      assert plan.model.extra.wire.protocol == "openai_responses"
+      assert plan.surface == :openai_responses
+    end
+
     test "keeps planning warnings in deterministic source order" do
       model_input =
         {:openai, "chat-latest", [stream_transport: :http, unsupported_default: true]}
@@ -120,6 +132,16 @@ defmodule ReqLLM.RequestPlanTest do
 
       assert plan.surface == :openai_responses
       assert plan.transport == :websocket
+    end
+
+    test "does not treat the internal transport flag as the provider selector" do
+      assert {:ok, plan} =
+               RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 stream: true,
+                 stream_transport: :websocket
+               )
+
+      assert plan.transport == :finch
     end
 
     test "rejects an unsupported operation before execution" do
@@ -165,7 +187,7 @@ defmodule ReqLLM.RequestPlanTest do
                  stream_transport: :udp
                )
 
-      assert Exception.message(transport_error) =~ "unsupported stream transport"
+      assert Exception.message(transport_error) =~ "unsupported internal stream transport"
     end
   end
 end


### PR DESCRIPTION
## Summary

- add one hidden deterministic request-plan value for the current OpenAI Responses, OpenAI Chat Completions, and Anthropic Messages surfaces
- capture normalized options, transport, provider/API modules, and ordered warnings without routing production calls through the plan
- split tuple-default warning collection from emission while preserving the existing execution behavior
- cover equivalent inputs, surface and transport selection, warning order, purity, and typed invalid combinations

## Compatibility

This is internal and additive. No public API, accepted production input, provider callback, request body, fixture, response, or stream behavior changes. `mix xref callers ReqLLM.RequestPlan` reports no production consumers.

## Validation

- `mix test test/req_llm/request_plan_test.exs test/req_llm/tuple_model_options_test.exs` (27 passed)
- representative cached OpenAI and Anthropic basic scenarios (passed; no fixture changes)
- `mix test` (3,665 passed, 11 skipped)
- `mix quality`
- `mix docs`
- `mix hex.build`

Closes #838