### PR TITLE
refactor: plan OpenAI text requests

### DIFF
--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -259,37 +259,23 @@ defmodule ReqLLM.Providers.OpenAI do
 
   @compile {:no_warn_undefined, [{nil, :path, 0}, {nil, :attach_stream, 4}]}
 
-  defp get_api_type(%LLMDB.Model{} = model) do
-    protocol =
-      get_in(model, [Access.key(:extra, %{}), :wire, :protocol]) ||
-        get_in(model, [Access.key(:extra, %{}), "wire", "protocol"])
-
-    case protocol do
-      "openai_responses" ->
-        "responses"
-
-      "openai_chat" ->
-        "chat"
-
-      _ ->
-        # Fallback for newer OpenAI models whose wire metadata may lag behind.
-        # GPT-4o and reasoning/Codex families should use Responses API.
-        model_id = model.provider_model_id || model.id
-
-        if ReqLLM.Providers.OpenAI.AdapterHelpers.responses_model?(model_id) do
-          "responses"
-        else
-          nil
-        end
+  defp responses_api?(model) do
+    case ReqLLM.RequestPlan.openai_surface(model) do
+      {:ok, surface, _api_module, _warnings} -> surface == :openai_responses
+      {:error, error} -> raise error
     end
   end
 
-  defp select_api_mod(%LLMDB.Model{} = model) do
-    case get_api_type(model) do
-      "chat" -> ReqLLM.Providers.OpenAI.ChatAPI
-      "responses" -> ReqLLM.Providers.OpenAI.ResponsesAPI
-      _ -> ReqLLM.Providers.OpenAI.ChatAPI
-    end
+  defp request_plan_metadata(plan) do
+    Map.take(plan, [
+      :operation,
+      :provider,
+      :surface,
+      :transport,
+      :provider_module,
+      :api_module,
+      :warnings
+    ])
   end
 
   defp get_timeout_for_operation(:image, opts) do
@@ -427,13 +413,15 @@ defmodule ReqLLM.Providers.OpenAI do
   def prepare_request(:chat, model_spec, prompt, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, context} <- ReqLLM.Context.normalize(prompt, opts),
-         :ok <- validate_attachments(context, model),
+         operation = Keyword.get(opts, :operation, :chat),
+         {:ok, plan} <- ReqLLM.RequestPlan.build(model, operation, opts),
+         :ok <- validate_attachments(context, plan),
          opts_with_context = Keyword.put(opts, :context, context),
          http_opts = Keyword.get(opts, :req_http_options, []),
          {:ok, processed_opts} <-
            ReqLLM.Provider.Options.process(__MODULE__, :chat, model, opts_with_context) do
-      api_mod = select_api_mod(model)
-      path = api_mod.path()
+      api_mod = plan.api_module
+      path = Function.capture(api_mod, :path, 0).()
 
       req_keys =
         supported_provider_options() ++
@@ -473,6 +461,7 @@ defmodule ReqLLM.Providers.OpenAI do
             ]
         )
         |> attach(model, processed_opts)
+        |> Req.Request.put_private(:req_llm_request_plan, request_plan_metadata(plan))
 
       {:ok, request}
     end
@@ -698,7 +687,7 @@ defmodule ReqLLM.Providers.OpenAI do
     steps = ReqLLM.Providers.OpenAI.ParamProfiles.steps_for(op, model)
     {opts1, warns} = ReqLLM.ParamTransform.apply(opts, steps)
 
-    if get_api_type(model) == "responses" do
+    if responses_api?(model) do
       mct = Keyword.get(opts1, :max_completion_tokens)
 
       if is_integer(mct) and mct < 16 do
@@ -759,32 +748,76 @@ defmodule ReqLLM.Providers.OpenAI do
   """
   @impl ReqLLM.Provider
   def attach_stream(model, context, opts, finch_name) do
-    api_mod = select_api_mod(model)
     operation = opts[:operation] || :chat
 
-    processed_opts =
-      ReqLLM.Provider.Options.process_stream!(
-        __MODULE__,
-        operation,
-        model,
-        context,
-        opts
-      )
+    with {:ok, plan} <-
+           ReqLLM.RequestPlan.build(model, operation, Keyword.put(opts, :stream, true)) do
+      processed_opts =
+        ReqLLM.Provider.Options.process_stream!(
+          __MODULE__,
+          operation,
+          model,
+          context,
+          opts
+        )
 
-    api_mod.attach_stream(model, context, processed_opts, finch_name)
+      case plan.api_module.attach_stream(model, context, processed_opts, finch_name) do
+        {:ok, %Finch.Request{} = request} ->
+          {:ok,
+           Finch.Request.put_private(
+             request,
+             :req_llm_request_plan,
+             request_plan_metadata(plan)
+           )}
+
+        result ->
+          result
+      end
+    end
   end
 
   def attach_websocket_stream(model, context, opts) do
-    api_mod = select_api_mod(model)
+    operation = opts[:operation] || :chat
+    plan_opts = opts |> Keyword.put(:stream, true) |> Keyword.put(:stream_transport, :websocket)
 
-    if function_exported?(api_mod, :attach_websocket_stream, 3) do
-      Function.capture(api_mod, :attach_websocket_stream, 3).(model, context, opts)
-    else
-      {:error,
-       ReqLLM.Error.API.Request.exception(
-         reason:
-           "OpenAI WebSocket mode is only supported for Responses models. #{LLMDB.Model.spec(model)} routes to #{inspect(api_mod)}."
-       )}
+    case ReqLLM.RequestPlan.build(model, operation, plan_opts) do
+      {:ok, plan} ->
+        if function_exported?(plan.api_module, :attach_websocket_stream, 3) do
+          case Function.capture(plan.api_module, :attach_websocket_stream, 3).(
+                 model,
+                 context,
+                 opts
+               ) do
+            {:ok, config} -> {:ok, Map.put(config, :request_plan, request_plan_metadata(plan))}
+            result -> result
+          end
+        else
+          websocket_surface_error(model, plan.api_module)
+        end
+
+      {:error, %ReqLLM.Error.Invalid.Parameter{} = error} ->
+        websocket_planning_error(model, error)
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp websocket_surface_error(model, api_module) do
+    {:error,
+     ReqLLM.Error.API.Request.exception(
+       reason:
+         "OpenAI WebSocket mode is only supported for Responses models. #{LLMDB.Model.spec(model)} routes to #{inspect(api_module)}."
+     )}
+  end
+
+  defp websocket_planning_error(model, error) do
+    case ReqLLM.RequestPlan.openai_surface(model) do
+      {:ok, :openai_chat_completions, api_module, _warnings} ->
+        websocket_surface_error(model, api_module)
+
+      _result ->
+        {:error, ReqLLM.Error.API.Request.exception(reason: error.parameter)}
     end
   end
 
@@ -903,7 +936,7 @@ defmodule ReqLLM.Providers.OpenAI do
 
   @impl ReqLLM.Provider
   def decode_stream_event(event, model, state) do
-    if get_api_type(model) == "responses" do
+    if responses_api?(model) do
       ReqLLM.Providers.OpenAI.ResponsesAPI.decode_stream_event(event, model, state)
     else
       chunks = ReqLLM.Providers.OpenAI.ChatAPI.decode_stream_event(event, model)
@@ -948,8 +981,8 @@ defmodule ReqLLM.Providers.OpenAI do
     ReqLLM.Providers.OpenAI.AdapterHelpers.enforce_strict_recursive(schema)
   end
 
-  defp validate_attachments(context, model) do
-    case select_api_mod(model) do
+  defp validate_attachments(context, plan) do
+    case plan.api_module do
       ReqLLM.Providers.OpenAI.ResponsesAPI ->
         validate_responses_api_attachments(context)
 

--- a/lib/req_llm/request_plan.ex
+++ b/lib/req_llm/request_plan.ex
@@ -68,6 +68,18 @@ defmodule ReqLLM.RequestPlan do
     invalid_parameter("options must be a keyword list, got: #{inspect(opts)}")
   end
 
+  @doc false
+  @spec openai_surface(LLMDB.Model.t()) ::
+          {:ok, :openai_responses | :openai_chat_completions, module(), [binary()]}
+          | {:error, term()}
+  def openai_surface(%LLMDB.Model{provider: :openai} = model) do
+    resolve_openai_surface(model)
+  end
+
+  def openai_surface(%LLMDB.Model{provider: provider}) do
+    invalid_parameter("OpenAI surface resolution does not support provider #{inspect(provider)}")
+  end
+
   defp validate_options(opts) do
     if Keyword.keyword?(opts) do
       :ok
@@ -92,7 +104,7 @@ defmodule ReqLLM.RequestPlan do
 
   defp resolve_surface(%LLMDB.Model{provider: :openai} = model, provider_module) do
     if provider_module == ReqLLM.Providers.OpenAI do
-      resolve_openai_surface(model)
+      openai_surface(model)
     else
       invalid_parameter(
         "provider :openai resolves to unsupported request-plan module #{inspect(provider_module)}"

--- a/test/providers/openai_request_plan_test.exs
+++ b/test/providers/openai_request_plan_test.exs
@@ -1,0 +1,169 @@
+defmodule ReqLLM.Providers.OpenAIRequestPlanTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.OpenAI
+
+  @api_key "request-plan-test-key"
+
+  describe "planned request routing" do
+    test "records the selected surface for non-streaming Chat and Responses requests" do
+      context = context_fixture()
+
+      cases = [
+        {chat_model(), :openai_chat_completions, OpenAI.ChatAPI, "/chat/completions"},
+        {ReqLLM.model!("openai:gpt-4o-mini"), :openai_responses, OpenAI.ResponsesAPI,
+         "/responses"}
+      ]
+
+      for {model, surface, api_module, path} <- cases do
+        assert {:ok, request} =
+                 OpenAI.prepare_request(:chat, model, context, api_key: @api_key)
+
+        assert request.url.path == path
+        assert request.options[:api_mod] == api_module
+
+        assert %{
+                 operation: :chat,
+                 provider: :openai,
+                 surface: ^surface,
+                 transport: :req,
+                 provider_module: OpenAI,
+                 api_module: ^api_module,
+                 warnings: []
+               } = request.private[:req_llm_request_plan]
+
+        refute inspect(request.private[:req_llm_request_plan]) =~ @api_key
+      end
+    end
+
+    test "records object planning without changing the existing Responses request" do
+      model = ReqLLM.model!("openai:gpt-4o-mini")
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+
+      assert {:ok, request} =
+               OpenAI.prepare_request(:object, model, "Return a name",
+                 api_key: @api_key,
+                 compiled_schema: schema
+               )
+
+      assert request.url.path == "/responses"
+      assert request.options[:api_mod] == OpenAI.ResponsesAPI
+
+      assert %{
+               operation: :object,
+               surface: :openai_responses,
+               transport: :req,
+               api_module: OpenAI.ResponsesAPI
+             } = request.private[:req_llm_request_plan]
+    end
+
+    test "records the selected surface for Finch Chat and Responses streams" do
+      context = context_fixture()
+
+      cases = [
+        {chat_model(), :openai_chat_completions, OpenAI.ChatAPI, "/v1/chat/completions"},
+        {ReqLLM.model!("openai:gpt-4o-mini"), :openai_responses, OpenAI.ResponsesAPI,
+         "/v1/responses"}
+      ]
+
+      for {model, surface, api_module, path} <- cases do
+        assert {:ok, request} =
+                 OpenAI.attach_stream(model, context, [api_key: @api_key], ReqLLM.Finch)
+
+        assert request.path == path
+
+        assert %{
+                 operation: :chat,
+                 provider: :openai,
+                 surface: ^surface,
+                 transport: :finch,
+                 provider_module: OpenAI,
+                 api_module: ^api_module,
+                 warnings: []
+               } = request.private[:req_llm_request_plan]
+
+        refute inspect(request.private[:req_llm_request_plan]) =~ @api_key
+      end
+    end
+
+    test "records the planned Responses WebSocket surface" do
+      model = ReqLLM.model!("openai:gpt-4o-mini")
+
+      assert {:ok, config} =
+               OpenAI.attach_websocket_stream(model, context_fixture(),
+                 api_key: @api_key,
+                 base_url: "http://localhost:4010/v1",
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert config.url == "ws://localhost:4010/v1/responses"
+
+      assert %{
+               operation: :chat,
+               provider: :openai,
+               surface: :openai_responses,
+               transport: :websocket,
+               provider_module: OpenAI,
+               api_module: OpenAI.ResponsesAPI,
+               warnings: []
+             } = config.request_plan
+
+      refute inspect(config.request_plan) =~ @api_key
+    end
+
+    test "retains planning warnings for inferred Chat routing" do
+      assert {:ok, request} =
+               OpenAI.prepare_request(:chat, ReqLLM.model!("openai:chat-latest"), "Hello",
+                 api_key: @api_key
+               )
+
+      assert request.url.path == "/chat/completions"
+
+      assert request.private[:req_llm_request_plan].warnings == [
+               "Defaulted to OpenAI Chat Completions because model wire metadata is absent"
+             ]
+    end
+  end
+
+  describe "planning failures" do
+    test "rejects invalid OpenAI wire metadata before request construction" do
+      model =
+        ReqLLM.model!(%{
+          provider: :openai,
+          id: "invalid-wire-model",
+          extra: %{wire: %{protocol: "unsupported_wire"}}
+        })
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               OpenAI.prepare_request(:chat, model, "Hello", api_key: @api_key)
+
+      assert Exception.message(error) =~ "wire protocol \"unsupported_wire\" is invalid"
+    end
+
+    test "keeps the existing WebSocket request error for Chat models" do
+      assert {:error, %ReqLLM.Error.API.Request{} = error} =
+               OpenAI.attach_websocket_stream(chat_model(), context_fixture(),
+                 api_key: @api_key,
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert Exception.message(error) =~
+               "OpenAI WebSocket mode is only supported for Responses models"
+
+      assert Exception.message(error) =~ "routes to ReqLLM.Providers.OpenAI.ChatAPI"
+    end
+  end
+
+  defp chat_model do
+    ReqLLM.model!(%{
+      provider: :openai,
+      id: "request-plan-chat-model",
+      limits: %{output: 1024},
+      extra: %{wire: %{protocol: "openai_chat"}}
+    })
+  end
+
+  defp context_fixture do
+    ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+  end
+end


### PR DESCRIPTION
Closes #839

## Summary

- make `ReqLLM.RequestPlan` the single source of truth for OpenAI Chat Completions versus Responses routing
- route non-streaming, Finch streaming, WebSocket streaming, option translation, stream decoding, and attachment validation through the planned surface
- retain safe internal route metadata without storing caller options or credentials
- preserve existing Chat WebSocket error behavior while rejecting invalid surface/transport combinations before I/O

## Compatibility

- no public API or default surface changes
- existing ChatAPI and ResponsesAPI encoders, decoders, response builders, and transports remain unchanged
- request bodies and cached fixtures remain unchanged

## Validation

- `mix test` — 3,675 passed, 11 skipped, 145 excluded
- `mix quality` — format, warnings-as-errors compile, Credo, and Dialyzer green
- focused OpenAI planner/provider/WebSocket/streaming suites — 407 passing tests
- cached `openai:chat-latest` basic replay — green
- cached `openai:gpt-4o-mini` core, usage, context, tools, and object replays — green
- cached `openai:gpt-5` core, usage, tools, object, and reasoning replays — green