### PR TITLE
refactor: plan Anthropic Messages requests

### DIFF
--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -189,6 +189,8 @@ defmodule ReqLLM.Providers.Anthropic do
   def prepare_request(:chat, model_spec, prompt, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, context} <- ReqLLM.Context.normalize(prompt, opts),
+         operation = Keyword.get(opts, :operation, :chat),
+         {:ok, plan} <- ReqLLM.RequestPlan.build(model, operation, opts),
          opts_with_context = Keyword.put(opts, :context, context),
          {:ok, processed_opts} <-
            ReqLLM.Provider.Options.process(__MODULE__, :chat, model, opts_with_context) do
@@ -211,7 +213,7 @@ defmodule ReqLLM.Providers.Anthropic do
         Req.new(
           [
             base_url: base_url,
-            url: "/v1/messages",
+            url: request_path(plan),
             method: :post,
             receive_timeout: timeout,
             pool_timeout: timeout
@@ -222,6 +224,7 @@ defmodule ReqLLM.Providers.Anthropic do
           Keyword.take(processed_opts, req_keys) ++ [model: get_api_model_id(model)]
         )
         |> attach(model, processed_opts)
+        |> Req.Request.put_private(:req_llm_request_plan, request_plan_metadata(plan))
 
       {:ok, request}
     end
@@ -677,9 +680,9 @@ defmodule ReqLLM.Providers.Anthropic do
     |> binary_part(0, length)
   end
 
-  defp build_request_url(opts, credential) do
+  defp build_request_url(opts, credential, path) do
     base_url = get_option(opts, :base_url, base_url())
-    add_subscription_beta_query("#{base_url}/v1/messages", credential)
+    add_subscription_beta_query("#{base_url}#{path}", credential)
   end
 
   defp add_subscription_beta_query(url, {credential, opts}) do
@@ -722,56 +725,71 @@ defmodule ReqLLM.Providers.Anthropic do
   def attach_stream(model, context, opts, _finch_name) do
     operation = opts[:operation] || :chat
 
-    translated_opts =
-      ReqLLM.Provider.Options.process_stream!(
-        __MODULE__,
-        operation,
-        model,
-        context,
-        opts
-      )
+    with {:ok, plan} <-
+           ReqLLM.RequestPlan.build(model, operation, Keyword.put(opts, :stream, true)) do
+      translated_opts =
+        ReqLLM.Provider.Options.process_stream!(
+          __MODULE__,
+          operation,
+          model,
+          context,
+          opts
+        )
 
-    default_timeout =
-      if Keyword.has_key?(translated_opts, :thinking) do
-        Application.get_env(:req_llm, :thinking_timeout, 300_000)
-      else
-        Application.get_env(:req_llm, :receive_timeout, 120_000)
-      end
+      default_timeout =
+        if Keyword.has_key?(translated_opts, :thinking) do
+          Application.get_env(:req_llm, :thinking_timeout, 300_000)
+        else
+          Application.get_env(:req_llm, :receive_timeout, 120_000)
+        end
 
-    translated_opts = Keyword.put_new(translated_opts, :receive_timeout, default_timeout)
+      translated_opts = Keyword.put_new(translated_opts, :receive_timeout, default_timeout)
 
-    base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
-    translated_opts = Keyword.put(translated_opts, :base_url, base_url)
+      base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, translated_opts)
+      translated_opts = Keyword.put(translated_opts, :base_url, base_url)
 
-    credential = ReqLLM.Auth.resolve!(model, translated_opts)
-    headers = build_request_headers(translated_opts, credential)
-    streaming_headers = [{"Accept", "text/event-stream"} | headers]
-    beta_headers = build_beta_headers(Keyword.put(translated_opts, :context, context), credential)
+      credential = ReqLLM.Auth.resolve!(model, translated_opts)
+      headers = build_request_headers(translated_opts, credential)
+      streaming_headers = [{"Accept", "text/event-stream"} | headers]
 
-    custom_headers =
-      ReqLLM.Provider.Utils.extract_custom_headers(translated_opts[:req_http_options])
+      beta_headers =
+        build_beta_headers(Keyword.put(translated_opts, :context, context), credential)
 
-    all_headers = streaming_headers ++ beta_headers ++ custom_headers
+      custom_headers =
+        ReqLLM.Provider.Utils.extract_custom_headers(translated_opts[:req_http_options])
 
-    context =
-      ReqLLM.ToolCallIdCompat.apply_context(
-        __MODULE__,
-        operation,
-        model,
-        context,
-        translated_opts
-      )
+      all_headers = streaming_headers ++ beta_headers ++ custom_headers
 
-    body =
-      context
-      |> build_request_body(get_api_model_id(model), translated_opts ++ [stream: true])
-      |> shape_subscription_body({credential, translated_opts})
+      context =
+        ReqLLM.ToolCallIdCompat.apply_context(
+          __MODULE__,
+          operation,
+          model,
+          context,
+          translated_opts
+        )
 
-    url = build_request_url(translated_opts, {credential, translated_opts})
+      body =
+        context
+        |> build_request_body(get_api_model_id(model), translated_opts ++ [stream: true])
+        |> shape_subscription_body({credential, translated_opts})
 
-    encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
-    finch_request = Finch.build(:post, url, all_headers, encoded)
-    {:ok, finch_request}
+      url =
+        build_request_url(
+          translated_opts,
+          {credential, translated_opts},
+          request_path(plan)
+        )
+
+      encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
+
+      finch_request =
+        :post
+        |> Finch.build(url, all_headers, encoded)
+        |> Finch.Request.put_private(:req_llm_request_plan, request_plan_metadata(plan))
+
+      {:ok, finch_request}
+    end
   rescue
     error ->
       {:error,
@@ -798,6 +816,28 @@ defmodule ReqLLM.Providers.Anthropic do
   @impl ReqLLM.Provider
   def flush_stream_state(model, state) do
     ReqLLM.Providers.Anthropic.Response.flush_stream_state(model, state)
+  end
+
+  defp request_plan_metadata(plan) do
+    Map.take(plan, [
+      :operation,
+      :provider,
+      :surface,
+      :transport,
+      :provider_module,
+      :api_module,
+      :warnings
+    ])
+  end
+
+  defp request_path(%ReqLLM.RequestPlan{
+         surface: :anthropic_messages,
+         api_module: __MODULE__
+       }),
+       do: "/v1/messages"
+
+  defp request_path(%ReqLLM.RequestPlan{model: model}) do
+    raise ReqLLM.Error.Invalid.Provider.exception(provider: model.provider)
   end
 
   @impl ReqLLM.Provider

--- a/test/providers/anthropic_request_plan_test.exs
+++ b/test/providers/anthropic_request_plan_test.exs
@@ -1,0 +1,132 @@
+defmodule ReqLLM.Providers.AnthropicRequestPlanTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.Anthropic
+
+  @api_key "anthropic-request-plan-test-key"
+
+  describe "planned request routing" do
+    test "records Anthropic Messages for non-streaming chat requests" do
+      assert {:ok, request} =
+               Anthropic.prepare_request(:chat, model(), "Hello",
+                 api_key: @api_key,
+                 max_tokens: 64
+               )
+
+      assert request.url.path == "/v1/messages"
+
+      assert %{
+               operation: :chat,
+               provider: :anthropic,
+               surface: :anthropic_messages,
+               transport: :req,
+               provider_module: Anthropic,
+               api_module: Anthropic,
+               warnings: []
+             } = request.private[:req_llm_request_plan]
+
+      refute inspect(request.private[:req_llm_request_plan]) =~ @api_key
+
+      body = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      assert body["model"] == "claude-sonnet-4-5-20250929"
+      assert body["max_tokens"] == 64
+      assert body["messages"] == [%{"content" => "Hello", "role" => "user"}]
+    end
+
+    test "records object planning without changing the Messages request" do
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+
+      assert {:ok, request} =
+               Anthropic.prepare_request(:object, model(), "Return a name",
+                 api_key: @api_key,
+                 compiled_schema: schema
+               )
+
+      assert request.url.path == "/v1/messages"
+
+      assert %{
+               operation: :object,
+               surface: :anthropic_messages,
+               transport: :req,
+               api_module: Anthropic
+             } = request.private[:req_llm_request_plan]
+
+      body = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      assert body["model"] == "claude-sonnet-4-5-20250929"
+      assert body["output_format"]["type"] == "json_schema"
+    end
+
+    test "records Anthropic Messages for Finch streams" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      assert {:ok, request} =
+               Anthropic.attach_stream(model(), context, [api_key: @api_key, max_tokens: 64], nil)
+
+      assert request.path == "/v1/messages"
+
+      assert %{
+               operation: :chat,
+               provider: :anthropic,
+               surface: :anthropic_messages,
+               transport: :finch,
+               provider_module: Anthropic,
+               api_module: Anthropic,
+               warnings: []
+             } = request.private[:req_llm_request_plan]
+
+      refute inspect(request.private[:req_llm_request_plan]) =~ @api_key
+
+      body = Jason.decode!(request.body)
+
+      assert body["model"] == "claude-sonnet-4-5-20250929"
+      assert body["max_tokens"] == 64
+      assert body["stream"]
+    end
+  end
+
+  describe "planning failures" do
+    test "preserves the provider mismatch error for prepared requests" do
+      openai_model = ReqLLM.model!("openai:gpt-4o-mini")
+
+      assert_raise ReqLLM.Error.Invalid.Provider, fn ->
+        Anthropic.prepare_request(:chat, openai_model, "Hello", api_key: @api_key)
+      end
+    end
+
+    test "rejects invalid Anthropic wire metadata before request construction" do
+      invalid_model =
+        ReqLLM.model!(%{
+          provider: :anthropic,
+          id: "invalid-wire-model",
+          extra: %{wire: %{protocol: "openai_chat"}}
+        })
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               Anthropic.prepare_request(:chat, invalid_model, "Hello", api_key: @api_key)
+
+      assert Exception.message(error) =~ "wire protocol \"openai_chat\" is invalid"
+    end
+
+    test "rejects invalid Anthropic wire metadata before stream construction" do
+      invalid_model =
+        ReqLLM.model!(%{
+          provider: :anthropic,
+          id: "invalid-wire-stream-model",
+          extra: %{wire: %{protocol: "openai_responses"}}
+        })
+
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               Anthropic.attach_stream(invalid_model, context, [api_key: @api_key], nil)
+
+      assert Exception.message(error) =~ "wire protocol \"openai_responses\" is invalid"
+    end
+  end
+
+  defp model do
+    ReqLLM.model!("anthropic:claude-sonnet-4-5-20250929")
+  end
+end

--- a/test/req_llm/request_plan_test.exs
+++ b/test/req_llm/request_plan_test.exs
@@ -175,6 +175,17 @@ defmodule ReqLLM.RequestPlanTest do
                "WebSocket transport is not supported by OpenAI Chat Completions"
     end
 
+    test "rejects WebSocket for Anthropic Messages" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               RequestPlan.build("anthropic:claude-sonnet-4-5-20250929", :chat,
+                 stream: true,
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert Exception.message(error) =~
+               "WebSocket transport is not supported by Anthropic Messages"
+    end
+
     test "rejects invalid stream settings with typed errors" do
       assert {:error, %ReqLLM.Error.Invalid.Parameter{} = stream_error} =
                RequestPlan.build("openai:gpt-4o-mini", :chat, stream: :yes)


### PR DESCRIPTION
## Summary

- route Anthropic chat, object, and Finch stream request construction through the internal request planner
- derive the existing `/v1/messages` route from the planned `:anthropic_messages` surface
- attach redacted plan metadata without retaining model inputs, option values, prompts, or credentials
- reject invalid Anthropic wire/transport combinations before I/O while preserving the existing provider-mismatch error

## Compatibility

This is an internal V1 refactor. Anthropic option translation, prompt caching, tool and reasoning encoding, authentication, request bodies, fixture names, streaming events, response assembly, usage, and error/result contracts are unchanged.

## Validation

- `mix test` — 3,681 passed, 11 skipped, 145 excluded
- `mix quality` — format, warnings-as-errors compile, Credo, and Dialyzer passed
- focused planner/provider/parity suites — 164 passed, 9 excluded
- cached Anthropic comprehensive/structured replay — unchanged from main at 12/15; the same three pre-existing baseline failures remain (two stale ToolCall field assertions and the exited streaming metadata handle)

Closes #841