### PR TITLE
feat: add execution plan inspection

### DIFF
--- a/guides/model-specs.md
+++ b/guides/model-specs.md
@@ -139,6 +139,39 @@ This path is best when:
 
 This is the key point: you do not need the model to exist in LLMDB before ReqLLM can use it, as long as you provide a complete enough model spec.
 
+## Inspect Request Routing Without Executing
+
+`ReqLLM.plan/3` provides an experimental, redacted view of text-request routing before
+ReqLLM encodes a request or resolves credentials:
+
+```elixir
+{:ok, diagnostic} =
+  ReqLLM.plan("openai:gpt-4o-mini", :chat,
+    max_tokens: 256,
+    stream: true
+  )
+
+diagnostic.surface
+#=> :openai_responses
+
+diagnostic.transport
+#=> :finch
+
+diagnostic.route
+#=> %{method: :post, path: "/responses"}
+```
+
+The result contains the resolved provider/model ID, operation, named surface, transport,
+relative route template, canonical and provider-translated option names, fallbacks, and
+warnings. It does not contain model metadata, internal modules, option values, hosts,
+credentials, prompt/message/tool/file values, or encoded request bodies. ReqLLM 1.x does
+not silently retry another provider surface, so `fallbacks` is currently empty.
+
+Planning currently covers the production surfaces migrated to the shared planner: OpenAI
+Chat Completions, OpenAI Responses, and Anthropic Messages. Unsupported providers and
+surface/transport combinations return normal ReqLLM structured errors without sending a
+request.
+
 ## Recommended Workflow
 
 ### Use a string when the model is in LLMDB

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -108,6 +108,23 @@ defmodule ReqLLM do
           | {atom(), keyword()}
           | LLMDB.Model.t()
 
+  @typedoc """
+  Redacted, JSON-serializable diagnostic returned by `plan/3`.
+
+  The diagnostic contains route and option names only. It never contains provider modules,
+  model metadata, option values, credentials, prompt/message/tool/file values, or encoded bodies.
+  """
+  @type plan_diagnostic :: %{
+          model: %{provider: atom(), id: String.t()},
+          operation: :chat | :object,
+          surface: atom(),
+          transport: :req | :finch | :websocket,
+          route: %{method: :post | :websocket, path: String.t()},
+          options: %{canonical: [atom()], translated: [atom()]},
+          fallbacks: [],
+          warnings: [String.t()]
+        }
+
   @inline_model_example "%{provider: :openai, id: \"gpt-4o\"}"
   @inline_model_fields LLMDB.Model.__struct__(provider: :openai, id: "__inline__")
                        |> Map.from_struct()
@@ -363,6 +380,45 @@ defmodule ReqLLM do
       {:ok, model} -> model
       {:error, error} -> raise error
     end
+  end
+
+  @doc """
+  Returns an experimental redacted diagnostic for a text request before execution.
+
+  `plan/3` uses the same internal planner as OpenAI Chat Completions, OpenAI Responses,
+  and Anthropic Messages execution. It resolves the selected surface and transport, but
+  does not encode a request, resolve credentials, access fixtures, or perform network I/O.
+
+  The returned map includes only the resolved provider/model ID, operation, named surface,
+  transport, relative route template, sorted option names, fallbacks, and warnings. Credential
+  and request-payload control options are omitted even from the option-name lists. ReqLLM 1.x
+  does not silently fall back to another surface, so `:fallbacks` is currently always empty.
+
+  This API is additive and experimental. Its diagnostic fields are not a stable compatibility
+  contract during ReqLLM 1.x, but existing generation and provider behavior are unaffected.
+
+  ## Examples
+
+      {:ok, diagnostic} =
+        ReqLLM.plan("openai:gpt-4o-mini", :chat,
+          max_tokens: 256,
+          stream: true
+        )
+
+      diagnostic.surface
+      #=> :openai_responses
+
+      diagnostic.transport
+      #=> :finch
+
+      diagnostic.route
+      #=> %{method: :post, path: "/responses"}
+
+  """
+  @spec plan(model_input(), :chat | :object, keyword()) ::
+          {:ok, plan_diagnostic()} | {:error, term()}
+  def plan(model_spec, operation, opts \\ []) do
+    ReqLLM.RequestPlan.Diagnostic.build(model_spec, operation, opts)
   end
 
   @doc """

--- a/lib/req_llm/request_plan/diagnostic.ex
+++ b/lib/req_llm/request_plan/diagnostic.ex
@@ -1,0 +1,242 @@
+defmodule ReqLLM.RequestPlan.Diagnostic do
+  @moduledoc false
+
+  alias ReqLLM.Error.Invalid.Parameter
+  alias ReqLLM.RequestPlan
+
+  @omitted_option_keys [
+    :access_token,
+    :api_key,
+    :auth_file,
+    :auth_mode,
+    :chatgpt_account_id,
+    :compiled_schema,
+    :context,
+    :fixture,
+    :oauth_file,
+    :oauth_http_options,
+    :on_finch_request,
+    :req_http_options,
+    :text
+  ]
+
+  @sensitive_option_names ~w(authorization cookie credential header headers password secret token)
+
+  @spec build(ReqLLM.model_input(), atom(), keyword()) ::
+          {:ok, ReqLLM.plan_diagnostic()} | {:error, term()}
+  def build(model_input, operation, opts \\ [])
+
+  def build(model_input, operation, opts) when is_list(opts) do
+    with :ok <- validate_options(opts),
+         {:ok, plan} <- RequestPlan.build(model_input, operation, opts),
+         {:ok, canonical_options} <- flatten_provider_options(plan.options),
+         {:ok, translated_options, translation_warnings} <-
+           translate_options(plan, canonical_options),
+         redacted_warnings <-
+           redact_warning_values(plan.warnings ++ translation_warnings, canonical_options),
+         :ok <- enforce_warning_policy(plan.options, translation_warnings, canonical_options) do
+      {:ok, diagnostic(plan, canonical_options, translated_options, redacted_warnings)}
+    else
+      {:error, error} -> {:error, sanitize_error(error)}
+    end
+  end
+
+  def build(_model_input, _operation, _opts),
+    do: invalid_parameter("options must be a keyword list")
+
+  defp diagnostic(plan, canonical_options, translated_options, warnings) do
+    %{
+      model: %{provider: plan.provider, id: plan.model.id},
+      operation: plan.operation,
+      surface: plan.surface,
+      transport: plan.transport,
+      route: route(plan),
+      options: %{
+        canonical: option_keys(canonical_options),
+        translated: option_keys(translated_options)
+      },
+      fallbacks: [],
+      warnings: warnings
+    }
+  end
+
+  defp validate_options(opts) do
+    if Keyword.keyword?(opts), do: :ok, else: invalid_parameter("options must be a keyword list")
+  end
+
+  defp flatten_provider_options(opts) do
+    {provider_options, canonical_options} = Keyword.pop(opts, :provider_options, [])
+
+    if Keyword.keyword?(provider_options) do
+      {:ok, Keyword.merge(canonical_options, provider_options)}
+    else
+      invalid_parameter(":provider_options must be a keyword list")
+    end
+  end
+
+  defp translate_options(plan, opts) do
+    with {:ok, prevalidated, prevalidation_warnings} <-
+           apply_option_callback(plan.provider_module, :pre_validate_options, plan, opts),
+         {:ok, translated, translation_warnings} <-
+           apply_option_callback(plan.provider_module, :translate_options, plan, prevalidated) do
+      {:ok, translated, prevalidation_warnings ++ translation_warnings}
+    end
+  end
+
+  defp apply_option_callback(provider_module, callback, plan, opts) do
+    if function_exported?(provider_module, callback, 3) do
+      provider_module
+      |> apply(callback, [plan.operation, plan.model, opts])
+      |> normalize_option_callback_result()
+    else
+      {:ok, opts, []}
+    end
+  rescue
+    _error -> translation_error()
+  end
+
+  defp normalize_option_callback_result({opts, warnings})
+       when is_list(opts) and is_list(warnings) do
+    if Keyword.keyword?(opts) and Enum.all?(warnings, &is_binary/1) do
+      {:ok, opts, warnings}
+    else
+      translation_error()
+    end
+  end
+
+  defp normalize_option_callback_result(opts) when is_list(opts) do
+    if Keyword.keyword?(opts), do: {:ok, opts, []}, else: translation_error()
+  end
+
+  defp normalize_option_callback_result(_result), do: translation_error()
+
+  defp enforce_warning_policy(opts, warnings, canonical_options) do
+    if warnings != [] and Keyword.get(opts, :on_unsupported, :warn) == :error do
+      reason = warnings |> redact_warning_values(canonical_options) |> Enum.join("; ")
+
+      {:error,
+       ReqLLM.Error.Validation.Error.exception(
+         tag: :unsupported_options,
+         reason: reason,
+         context: []
+       )}
+    else
+      :ok
+    end
+  end
+
+  defp route(%RequestPlan{surface: surface, api_module: api_module, transport: transport})
+       when surface in [:openai_responses, :openai_chat_completions] do
+    %{method: route_method(transport), path: api_module.path()}
+  end
+
+  defp route(%RequestPlan{surface: :anthropic_messages, transport: transport}) do
+    %{method: route_method(transport), path: "/v1/messages"}
+  end
+
+  defp route_method(:websocket), do: :websocket
+  defp route_method(_transport), do: :post
+
+  defp option_keys(opts) do
+    opts
+    |> Keyword.keys()
+    |> Enum.reject(&omitted_option_key?/1)
+    |> Enum.uniq()
+    |> Enum.sort_by(&to_string/1)
+  end
+
+  defp omitted_option_key?(key) when key in @omitted_option_keys, do: true
+
+  defp omitted_option_key?(key) when is_atom(key) do
+    name = Atom.to_string(key)
+
+    name in @sensitive_option_names or
+      String.ends_with?(name, ["_key", "_token", "_secret", "_password", "_header", "_headers"]) or
+      String.contains?(name, "credential") or
+      String.starts_with?(name, "auth_") or
+      String.ends_with?(name, "_auth")
+  end
+
+  defp omitted_option_key?(_key), do: true
+
+  defp redact_warning_values(warnings, options) do
+    values = collect_binary_values(options)
+
+    Enum.map(warnings, fn warning ->
+      Enum.reduce(values, warning, &String.replace(&2, &1, "[REDACTED]"))
+    end)
+  end
+
+  defp collect_binary_values(value) when is_binary(value),
+    do: if(value == "", do: [], else: [value])
+
+  defp collect_binary_values(value) when is_list(value) do
+    Enum.flat_map(value, fn
+      {_key, item} -> collect_binary_values(item)
+      item -> collect_binary_values(item)
+    end)
+  end
+
+  defp collect_binary_values(%_{} = struct),
+    do: struct |> Map.from_struct() |> collect_binary_values()
+
+  defp collect_binary_values(value) when is_map(value) do
+    Enum.flat_map(value, fn {_key, item} -> collect_binary_values(item) end)
+  end
+
+  defp collect_binary_values(_value), do: []
+
+  defp sanitize_error(%Parameter{parameter: parameter}) when is_binary(parameter) do
+    safe_parameter =
+      cond do
+        String.contains?(parameter, "options must be a keyword list") ->
+          "options must be a keyword list"
+
+        String.contains?(parameter, "supports only :chat and :object") ->
+          "request planning supports only :chat and :object operations"
+
+        String.contains?(parameter, "wire protocol") ->
+          "wire protocol is invalid for the resolved provider"
+
+        String.contains?(parameter, ":stream must be a boolean") ->
+          ":stream must be a boolean"
+
+        String.contains?(parameter, "unsupported OpenAI stream transport") ->
+          "unsupported OpenAI stream transport"
+
+        String.contains?(parameter, "unsupported internal stream transport") ->
+          "unsupported internal stream transport"
+
+        String.contains?(parameter, "WebSocket transport is not supported") ->
+          parameter
+
+        true ->
+          "request plan is invalid; verify provider, operation, and transport metadata"
+      end
+
+    Parameter.exception(parameter: safe_parameter)
+  end
+
+  defp sanitize_error(%ReqLLM.Error.Invalid.Provider{provider: provider}) do
+    ReqLLM.Error.Invalid.Provider.exception(provider: provider)
+  end
+
+  defp sanitize_error(%ReqLLM.Error.Validation.Error{tag: :unsupported_options} = error),
+    do: error
+
+  defp sanitize_error(_error) do
+    ReqLLM.Error.Validation.Error.exception(
+      tag: :invalid_request_plan,
+      reason: "Invalid model specification for request planning",
+      context: []
+    )
+  end
+
+  defp translation_error do
+    invalid_parameter(
+      "provider option translation could not be inspected; verify option names and types"
+    )
+  end
+
+  defp invalid_parameter(message), do: {:error, Parameter.exception(parameter: message)}
+end

--- a/lib/req_llm/request_plan/diagnostic.ex
+++ b/lib/req_llm/request_plan/diagnostic.ex
@@ -86,7 +86,7 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
   defp apply_option_callback(provider_module, callback, plan, opts) do
     if function_exported?(provider_module, callback, 3) do
       provider_module
-      |> apply(callback, [plan.operation, plan.model, opts])
+      |> apply(callback, [option_operation(plan), plan.model, opts])
       |> normalize_option_callback_result()
     else
       {:ok, opts, []}
@@ -94,6 +94,9 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
   rescue
     _error -> translation_error()
   end
+
+  defp option_operation(%RequestPlan{operation: :object}), do: :chat
+  defp option_operation(%RequestPlan{operation: operation}), do: operation
 
   defp normalize_option_callback_result({opts, warnings})
        when is_list(opts) and is_list(warnings) do

--- a/test/req_llm/plan_test.exs
+++ b/test/req_llm/plan_test.exs
@@ -1,0 +1,302 @@
+defmodule ReqLLM.PlanTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :public_api
+
+  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
+
+  alias ReqLLM.Providers.{Anthropic, OpenAI}
+
+  @api_key "plan-api-key-secret"
+  @sensitive_value "plan-sensitive-value-842"
+
+  describe "plan/3" do
+    test "returns a small serializable OpenAI Responses diagnostic" do
+      assert {:ok, diagnostic} =
+               ReqLLM.plan("openai:gpt-4o-mini", :chat,
+                 max_tokens: 256,
+                 stream: true,
+                 temperature: 0.2
+               )
+
+      assert diagnostic == %{
+               model: %{provider: :openai, id: "gpt-4o-mini"},
+               operation: :chat,
+               surface: :openai_responses,
+               transport: :finch,
+               route: %{method: :post, path: "/responses"},
+               options: %{
+                 canonical: [:max_tokens, :stream, :temperature],
+                 translated: [:max_tokens, :stream, :temperature]
+               },
+               fallbacks: [],
+               warnings: []
+             }
+
+      assert {:ok, decoded} = diagnostic |> Jason.encode!() |> Jason.decode()
+      assert decoded["surface"] == "openai_responses"
+      assert decoded["route"] == %{"method" => "post", "path" => "/responses"}
+    end
+
+    test "reports OpenAI Chat option translation warnings without values" do
+      model = %{
+        provider: :openai,
+        id: "chat-latest",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      assert {:ok, diagnostic} =
+               ReqLLM.plan(model, :chat,
+                 api_key: @api_key,
+                 max_tokens: 128,
+                 temperature: 0.2
+               )
+
+      assert diagnostic.surface == :openai_chat_completions
+      assert diagnostic.route == %{method: :post, path: "/chat/completions"}
+      assert diagnostic.options.canonical == [:max_tokens, :temperature]
+      assert diagnostic.options.translated == [:max_completion_tokens]
+      assert Enum.any?(diagnostic.warnings, &String.contains?(&1, ":max_tokens"))
+      assert Enum.any?(diagnostic.warnings, &String.contains?(&1, "temperature"))
+      refute inspect(diagnostic) =~ @api_key
+    end
+
+    test "honors the existing error policy for translated unsupported options" do
+      model = %{
+        provider: :openai,
+        id: "chat-latest",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      assert {:error, %ReqLLM.Error.Validation.Error{} = error} =
+               ReqLLM.plan(model, :chat,
+                 max_tokens: 128,
+                 on_unsupported: :error,
+                 temperature: 0.2
+               )
+
+      assert Exception.message(error) =~ ":max_tokens"
+      assert Exception.message(error) =~ "temperature"
+    end
+
+    test "reports Anthropic option translation without changing values or building a request" do
+      assert {:ok, diagnostic} =
+               ReqLLM.plan("anthropic:claude-sonnet-4-5-20250929", :object,
+                 api_key: @api_key,
+                 max_tokens: 64,
+                 presence_penalty: 0.3,
+                 stop: "END"
+               )
+
+      assert diagnostic.model == %{
+               provider: :anthropic,
+               id: "claude-sonnet-4-5-20250929"
+             }
+
+      assert diagnostic.operation == :object
+      assert diagnostic.surface == :anthropic_messages
+      assert diagnostic.transport == :req
+      assert diagnostic.route == %{method: :post, path: "/v1/messages"}
+
+      assert diagnostic.options.canonical == [
+               :max_tokens,
+               :presence_penalty,
+               :stop
+             ]
+
+      assert diagnostic.options.translated == [:max_tokens, :stop_sequences]
+      assert diagnostic.fallbacks == []
+      refute inspect(diagnostic) =~ @api_key
+      refute inspect(diagnostic) =~ "END"
+    end
+
+    test "uses an explicit WebSocket method for the Responses WebSocket route" do
+      assert {:ok, diagnostic} =
+               ReqLLM.plan("openai:gpt-4o-mini", :chat,
+                 stream: true,
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert diagnostic.transport == :websocket
+      assert diagnostic.route == %{method: :websocket, path: "/responses"}
+      assert diagnostic.options.canonical == [:openai_stream_transport, :stream]
+    end
+
+    test "returns inferred surface decisions as warnings, not runtime fallbacks" do
+      model = %{provider: :openai, id: "unregistered-chat-model"}
+
+      assert {:ok, diagnostic} = ReqLLM.plan(model, :chat)
+
+      assert diagnostic.surface == :openai_chat_completions
+      assert diagnostic.fallbacks == []
+
+      assert diagnostic.warnings == [
+               "Defaulted to OpenAI Chat Completions because model wire metadata is absent"
+             ]
+    end
+  end
+
+  describe "execution parity" do
+    test "selects the same non-streaming surfaces and routes as provider execution" do
+      cases = [
+        {ReqLLM.model!("openai:gpt-4o-mini"), OpenAI},
+        {chat_model(), OpenAI},
+        {ReqLLM.model!("anthropic:claude-sonnet-4-5-20250929"), Anthropic}
+      ]
+
+      for {model, provider} <- cases do
+        opts = [api_key: @api_key, max_tokens: 64]
+
+        assert {:ok, diagnostic} = ReqLLM.plan(model, :chat, opts)
+        assert {:ok, request} = provider.prepare_request(:chat, model, "Hello", opts)
+
+        execution_plan = request.private[:req_llm_request_plan]
+
+        assert diagnostic.surface == execution_plan.surface
+        assert diagnostic.transport == execution_plan.transport
+        assert diagnostic.operation == execution_plan.operation
+        assert diagnostic.route.path == request.url.path
+      end
+    end
+
+    test "selects the same Finch surface and transport as provider execution" do
+      model = ReqLLM.model!("anthropic:claude-sonnet-4-5-20250929")
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+      opts = [api_key: @api_key, max_tokens: 64, stream: true]
+
+      assert {:ok, diagnostic} = ReqLLM.plan(model, :chat, opts)
+      assert {:ok, request} = Anthropic.attach_stream(model, context, opts, nil)
+
+      execution_plan = request.private[:req_llm_request_plan]
+
+      assert diagnostic.surface == execution_plan.surface
+      assert diagnostic.transport == execution_plan.transport
+      assert diagnostic.route.path == request.path
+    end
+  end
+
+  describe "redaction and no-I/O guarantees" do
+    test "does not resolve credentials, access fixtures, or log translation warnings" do
+      model = %{
+        provider: :openai,
+        id: "chat-latest",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      output =
+        capture_io(:stderr, fn ->
+          log =
+            capture_log(fn ->
+              send(
+                self(),
+                ReqLLM.plan(model, :chat,
+                  max_tokens: 64,
+                  temperature: 0.2
+                )
+              )
+            end)
+
+          send(self(), {:captured_log, log})
+        end)
+
+      assert output == ""
+      assert_received {:captured_log, ""}
+      assert_received {:ok, %{surface: :openai_chat_completions}}
+    end
+
+    test "omits credential, payload, header, callback, and option values" do
+      callback = fn request -> request end
+
+      assert {:ok, diagnostic} =
+               ReqLLM.plan(
+                 %{
+                   provider: :anthropic,
+                   id: "redaction-model",
+                   base_url: @sensitive_value
+                 },
+                 :chat,
+                 api_key: @sensitive_value,
+                 access_token: @sensitive_value,
+                 auth_mode: :oauth,
+                 base_url: @sensitive_value,
+                 fixture: @sensitive_value,
+                 files: [@sensitive_value],
+                 max_tokens: 64,
+                 on_finch_request: callback,
+                 req_http_options: [headers: [{"x-secret", @sensitive_value}]],
+                 system_prompt: @sensitive_value,
+                 tools: [%{name: @sensitive_value}],
+                 provider_options: [secret_header: @sensitive_value]
+               )
+
+      serialized = inspect(diagnostic) <> Jason.encode!(diagnostic)
+
+      refute serialized =~ @sensitive_value
+      refute :api_key in diagnostic.options.canonical
+      refute :access_token in diagnostic.options.canonical
+      refute :auth_mode in diagnostic.options.canonical
+      refute :fixture in diagnostic.options.canonical
+      refute :on_finch_request in diagnostic.options.canonical
+      refute :req_http_options in diagnostic.options.canonical
+      refute :secret_header in diagnostic.options.canonical
+      assert :base_url in diagnostic.options.canonical
+      assert :files in diagnostic.options.canonical
+      assert :system_prompt in diagnostic.options.canonical
+      assert :tools in diagnostic.options.canonical
+      refute serialized =~ "ReqLLM.Providers"
+    end
+
+    test "sanitizes invalid option and model errors" do
+      invalid_options = [{"secret", @sensitive_value}, {:api_key, @sensitive_value}]
+
+      assert {:error, option_error} =
+               ReqLLM.plan("openai:gpt-4o-mini", :chat, invalid_options)
+
+      invalid_model = %{provider: @sensitive_value, id: "model"}
+
+      assert {:error, model_error} = ReqLLM.plan(invalid_model, :chat)
+
+      errors = inspect(option_error) <> Exception.message(option_error) <> inspect(model_error)
+
+      refute errors =~ @sensitive_value
+      assert Exception.message(option_error) =~ "options must be a keyword list"
+      assert Exception.message(model_error) =~ "Invalid model specification"
+    end
+
+    test "keeps unsupported combinations actionable without echoing their values" do
+      assert {:error, stream_error} =
+               ReqLLM.plan("openai:gpt-4o-mini", :chat, stream: @sensitive_value)
+
+      assert Exception.message(stream_error) =~ ":stream must be a boolean"
+      refute inspect(stream_error) =~ @sensitive_value
+
+      assert {:error, transport_error} =
+               ReqLLM.plan("anthropic:claude-sonnet-4-5-20250929", :chat,
+                 stream: true,
+                 provider_options: [openai_stream_transport: :websocket]
+               )
+
+      assert Exception.message(transport_error) =~
+               "WebSocket transport is not supported by Anthropic Messages"
+
+      invalid_wire_model = %{
+        provider: :openai,
+        id: "invalid-wire-model",
+        extra: %{wire: %{protocol: @sensitive_value}}
+      }
+
+      assert {:error, wire_error} = ReqLLM.plan(invalid_wire_model, :chat)
+      assert Exception.message(wire_error) =~ "wire protocol is invalid"
+      refute inspect(wire_error) =~ @sensitive_value
+    end
+  end
+
+  defp chat_model do
+    ReqLLM.model!(%{
+      provider: :openai,
+      id: "chat-latest",
+      extra: %{wire: %{protocol: "openai_chat"}}
+    })
+  end
+end

--- a/test/req_llm/plan_test.exs
+++ b/test/req_llm/plan_test.exs
@@ -111,6 +111,22 @@ defmodule ReqLLM.PlanTest do
       refute inspect(diagnostic) =~ "END"
     end
 
+    test "translates object options through the underlying chat request operation" do
+      model = chat_model()
+
+      assert {:ok, diagnostic} =
+               ReqLLM.plan(model, :object,
+                 max_tokens: 128,
+                 temperature: 0.2
+               )
+
+      assert diagnostic.operation == :object
+      assert diagnostic.options.canonical == [:max_tokens, :temperature]
+      assert diagnostic.options.translated == [:max_completion_tokens]
+      assert Enum.any?(diagnostic.warnings, &String.contains?(&1, ":max_tokens"))
+      assert Enum.any?(diagnostic.warnings, &String.contains?(&1, "temperature"))
+    end
+
     test "uses an explicit WebSocket method for the Responses WebSocket route" do
       assert {:ok, diagnostic} =
                ReqLLM.plan("openai:gpt-4o-mini", :chat,
@@ -173,6 +189,27 @@ defmodule ReqLLM.PlanTest do
       assert diagnostic.surface == execution_plan.surface
       assert diagnostic.transport == execution_plan.transport
       assert diagnostic.route.path == request.path
+    end
+
+    test "reports the option translation used by object request execution" do
+      model = chat_model()
+      {:ok, schema} = ReqLLM.Schema.compile(name: [type: :string, required: true])
+      opts = [api_key: @api_key, max_tokens: 128, temperature: 0.2]
+
+      assert {:ok, diagnostic} = ReqLLM.plan(model, :object, opts)
+
+      assert {:ok, request} =
+               OpenAI.prepare_request(
+                 :object,
+                 model,
+                 "Return a name",
+                 Keyword.put(opts, :compiled_schema, schema)
+               )
+
+      assert diagnostic.options.translated == [:max_completion_tokens]
+      assert request.options[:max_completion_tokens] == 128
+      refute Map.has_key?(request.options, :max_tokens)
+      refute Map.has_key?(request.options, :temperature)
     end
   end
 


### PR DESCRIPTION
Closes #842

## Summary

- add an experimental `ReqLLM.plan/3` API backed by the same request planner used for execution
- return a deliberately small, JSON-serializable diagnostic with surface, transport, relative route, redacted option names, fallbacks, and warnings
- keep credential, host, payload, tool/file content, callbacks, provider modules, and encoded bodies out of diagnostics and errors
- document supported OpenAI Chat, OpenAI Responses, and Anthropic Messages surfaces

## Backward compatibility

- additive public API only; no existing function signatures or return values change
- no provider defaults, option policies, routing rules, request encoding, authentication, or execution behavior change
- unsupported models, operations, and transports return existing structured ReqLLM error types with sanitized messages

## Validation

- `mix test test/req_llm/plan_test.exs test/req_llm/request_plan_test.exs test/providers/openai_request_plan_test.exs test/providers/anthropic_request_plan_test.exs` — 41 passed
- `mix test` — 3,696 passed, 11 skipped, 145 excluded
- `mix quality` — format, warnings-as-errors compile, Credo, and Dialyzer passed
- `mix docs` — succeeded (one pre-existing hidden-module reference warning)