### PR TITLE
fix: harden canonical reasoning options

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -35,6 +35,36 @@ config :req_llm,
   debug: false                       # Enable verbose logging
 ```
 
+## Canonical Reasoning Options
+
+ReqLLM accepts provider-neutral reasoning controls on text requests:
+
+```elixir
+ReqLLM.generate_text(
+  "anthropic:claude-sonnet-4-5",
+  "Solve this carefully",
+  reasoning_effort: :high,
+  reasoning_token_budget: 8_192
+)
+```
+
+`reasoning_effort` accepts `:none`, `:minimal`, `:low`, `:medium`, `:high`,
+`:xhigh`, and `:default`. `reasoning_token_budget` refines the request on
+provider surfaces with an explicit thinking budget. Older `reasoning: true` and
+string-valued `reasoning` aliases remain supported, but new code should use the
+canonical options.
+
+Provider-native controls such as Anthropic `thinking` and Google
+`google_thinking_budget` remain available under `provider_options`. Avoid mixing
+canonical and provider-native controls unless you rely on the provider's
+existing precedence rules.
+
+Lossy or ignored reasoning translations are non-fatal by default and emit a
+deterministic warning. `ReqLLM.plan/3` reports the same sanitized warnings
+without making a request. These reasoning advisories do not introduce new
+failures for `on_unsupported: :error`; existing enforceable provider warnings
+retain their current behavior.
+
 ## Timeout Configuration
 
 ReqLLM uses multiple timeout settings to handle different scenarios:

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -324,6 +324,8 @@ defmodule ReqLLM.Provider.Options do
     # Auto-hoist provider-specific top-level options into :provider_options
     user_opts = auto_hoist_provider_options(provider_mod, user_opts)
 
+    reasoning_advisory_options = flatten_options_for_advisories(user_opts)
+
     telemetry_original_opts =
       user_opts
       |> Keyword.merge(Keyword.take(internal_opts, [:telemetry, :context, :text, :operation]))
@@ -345,7 +347,7 @@ defmodule ReqLLM.Provider.Options do
       ReqLLM.Provider.Reasoning.advisories(
         provider_mod,
         model,
-        flattened_for_translation,
+        reasoning_advisory_options,
         translated_opts
       )
 
@@ -774,6 +776,18 @@ defmodule ReqLLM.Provider.Options do
       NimbleOptions.new!(updated_keys)
     else
       base_schema
+    end
+  end
+
+  defp flatten_options_for_advisories(opts) do
+    case Keyword.pop(opts, :provider_options, []) do
+      {provider_options, standard_options} when is_list(provider_options) ->
+        if Keyword.keyword?(provider_options),
+          do: Keyword.merge(standard_options, provider_options),
+          else: standard_options
+
+      {_provider_options, standard_options} ->
+        standard_options
     end
   end
 

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -329,14 +329,25 @@ defmodule ReqLLM.Provider.Options do
       |> Keyword.merge(Keyword.take(internal_opts, [:telemetry, :context, :text, :operation]))
 
     # Apply pre-validation normalization (allows providers to filter/map unsupported options)
-    user_opts = apply_pre_validation(provider_mod, operation, model, user_opts)
+    {user_opts, prevalidation_warnings} =
+      apply_pre_validation(provider_mod, operation, model, user_opts)
 
     schema = compose_schema_internal(base_schema_for_operation(operation), provider_mod)
     validated_opts = NimbleOptions.validate!(user_opts, schema)
 
     {provider_options, standard_opts} = Keyword.pop(validated_opts, :provider_options, [])
     flattened_for_translation = Keyword.merge(standard_opts, provider_options)
-    translated_opts = apply_translation(provider_mod, operation, model, flattened_for_translation)
+
+    {translated_opts, translation_warnings, translation_replaced_warnings?} =
+      apply_translation(provider_mod, operation, model, flattened_for_translation)
+
+    reasoning_advisories =
+      ReqLLM.Provider.Reasoning.advisories(
+        provider_mod,
+        model,
+        flattened_for_translation,
+        translated_opts
+      )
 
     final_opts =
       if provider_options == [] do
@@ -352,7 +363,21 @@ defmodule ReqLLM.Provider.Options do
         end
       end
 
-    final_opts = handle_warnings(final_opts, opts)
+    callback_warnings = prevalidation_warnings ++ translation_warnings
+
+    enforceable_warnings =
+      if translation_replaced_warnings?,
+        do: translation_warnings,
+        else: callback_warnings
+
+    final_opts =
+      handle_warnings(
+        final_opts,
+        opts,
+        callback_warnings,
+        enforceable_warnings,
+        reasoning_advisories
+      )
 
     final_opts =
       final_opts
@@ -615,7 +640,7 @@ defmodule ReqLLM.Provider.Options do
   defp normalize_legacy_options(opts) do
     opts
     |> normalize_stop_sequences()
-    |> normalize_legacy_reasoning()
+    |> ReqLLM.Provider.Reasoning.normalize_options()
     |> normalize_req_http_options()
     |> normalize_tools()
   end
@@ -684,69 +709,6 @@ defmodule ReqLLM.Provider.Options do
     case Keyword.pop(opts, :stop_sequences) do
       {nil, rest} -> rest
       {sequences, rest} -> Keyword.put(rest, :stop, sequences)
-    end
-  end
-
-  defp normalize_legacy_reasoning(opts) do
-    opts
-    |> normalize_thinking_flag()
-    |> normalize_reasoning_flag()
-  end
-
-  defp normalize_thinking_flag(opts) do
-    case Keyword.pop(opts, :thinking) do
-      {nil, rest} ->
-        rest
-
-      {false, rest} ->
-        rest
-
-      {true, rest} ->
-        rest
-
-      {thinking, rest} when is_map(thinking) ->
-        Keyword.put(rest, :thinking, thinking)
-    end
-  end
-
-  defp normalize_reasoning_flag(opts) do
-    case Keyword.pop(opts, :reasoning) do
-      {nil, rest} ->
-        rest
-
-      {false, rest} ->
-        rest
-
-      {true, rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :medium)
-
-      {"auto", rest} ->
-        rest
-
-      {"none", rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :none)
-
-      {"minimal", rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :minimal)
-
-      {"low", rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :low)
-
-      {"medium", rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :medium)
-
-      {"high", rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :high)
-
-      {"xhigh", rest} ->
-        rest
-        |> Keyword.put_new(:reasoning_effort, :xhigh)
     end
   end
 
@@ -819,15 +781,13 @@ defmodule ReqLLM.Provider.Options do
     if function_exported?(provider_mod, :pre_validate_options, 3) do
       case provider_mod.pre_validate_options(operation, model, opts) do
         {normalized_opts, warnings} when is_list(warnings) ->
-          existing_warnings = Process.get(:req_llm_warnings, [])
-          Process.put(:req_llm_warnings, existing_warnings ++ warnings)
-          normalized_opts
+          {normalized_opts, warnings}
 
         normalized_opts ->
-          normalized_opts
+          {normalized_opts, []}
       end
     else
-      opts
+      {opts, []}
     end
   end
 
@@ -835,42 +795,56 @@ defmodule ReqLLM.Provider.Options do
     if function_exported?(provider_mod, :translate_options, 3) do
       case provider_mod.translate_options(operation, model, opts) do
         {translated_opts, warnings} when is_list(warnings) ->
-          Process.put(:req_llm_warnings, warnings)
-          translated_opts
+          {translated_opts, warnings, true}
 
         translated_opts ->
-          translated_opts
+          {translated_opts, [], false}
       end
     else
-      opts
+      {opts, [], false}
     end
   end
 
-  defp handle_warnings(opts, original_opts) do
-    warnings = Process.get(:req_llm_warnings, [])
-    Process.delete(:req_llm_warnings)
+  defp handle_warnings(
+         opts,
+         original_opts,
+         callback_warnings,
+         enforceable_warnings,
+         reasoning_advisories
+       ) do
+    advisory_messages = ReqLLM.Provider.Reasoning.messages(reasoning_advisories)
+    all_warnings = callback_warnings ++ advisory_messages
 
-    if warnings == [] do
+    if all_warnings == [] do
       opts
     else
       case Keyword.get(original_opts, :on_unsupported, :warn) do
         :warn ->
-          Enum.each(warnings, fn warning ->
-            require Logger
-
-            Logger.warning(warning)
-          end)
+          log_warnings(all_warnings)
 
           opts
 
         :error ->
-          reason = Enum.join(warnings, "; ")
-          raise ReqLLM.Error.Validation.Error.exception(reason: reason)
+          if enforceable_warnings == [] do
+            log_warnings(all_warnings)
+            opts
+          else
+            reason = Enum.join(enforceable_warnings, "; ")
+            raise ReqLLM.Error.Validation.Error.exception(reason: reason)
+          end
 
         :ignore ->
           opts
       end
     end
+  end
+
+  defp log_warnings(warnings) do
+    Enum.each(warnings, fn warning ->
+      require Logger
+
+      Logger.warning(warning)
+    end)
   end
 
   defp validate_context(opts, original_opts) do

--- a/lib/req_llm/provider/reasoning.ex
+++ b/lib/req_llm/provider/reasoning.ex
@@ -94,9 +94,12 @@ defmodule ReqLLM.Provider.Reasoning do
   end
 
   defp ignored_budget_advisory(provider, canonical_opts, translated_opts) do
-    if Keyword.has_key?(canonical_opts, :reasoning_token_budget) and
-         !budget_consumed?(provider, translated_opts) do
-      ignored_budget(provider)
+    case Keyword.fetch(canonical_opts, :reasoning_token_budget) do
+      {:ok, budget} ->
+        if !budget_consumed?(provider, budget, translated_opts), do: ignored_budget(provider)
+
+      :error ->
+        nil
     end
   end
 
@@ -122,19 +125,19 @@ defmodule ReqLLM.Provider.Reasoning do
 
   defp ignored_budget(_provider), do: nil
 
-  defp budget_consumed?(provider, _translated_opts)
+  defp budget_consumed?(provider, _budget, _translated_opts)
        when provider in [:openai, :openrouter, :groq, :xai],
        do: false
 
-  defp budget_consumed?(:anthropic, translated_opts) do
+  defp budget_consumed?(:anthropic, budget, translated_opts) do
     case Keyword.get(translated_opts, :thinking) do
-      %{budget_tokens: budget} when is_integer(budget) -> true
-      %{"budget_tokens" => budget} when is_integer(budget) -> true
+      %{budget_tokens: ^budget} -> true
+      %{"budget_tokens" => ^budget} -> true
       _ -> false
     end
   end
 
-  defp budget_consumed?(_provider, _translated_opts), do: true
+  defp budget_consumed?(_provider, _budget, _translated_opts), do: true
 
   defp google_effort_advisory(provider, canonical_opts, translated_opts)
        when provider in [:google, :google_vertex] do

--- a/lib/req_llm/provider/reasoning.ex
+++ b/lib/req_llm/provider/reasoning.ex
@@ -1,0 +1,166 @@
+defmodule ReqLLM.Provider.Reasoning do
+  @moduledoc false
+
+  @type advisory :: %{
+          required(:kind) => :ignored | :clamped | :unsupported | :lossy,
+          required(:option) => atom(),
+          required(:message) => String.t()
+        }
+
+  @effort_strings %{
+    "none" => :none,
+    "minimal" => :minimal,
+    "low" => :low,
+    "medium" => :medium,
+    "high" => :high,
+    "xhigh" => :xhigh,
+    "default" => :default
+  }
+
+  @budget_ignored_providers %{
+    openai: "OpenAI",
+    openrouter: "OpenRouter",
+    groq: "Groq",
+    xai: "xAI"
+  }
+
+  @spec normalize_options(keyword()) :: keyword()
+  def normalize_options(opts) do
+    opts
+    |> normalize_thinking_flag()
+    |> normalize_reasoning_alias()
+  end
+
+  @spec normalize_effort_option(keyword()) :: keyword()
+  def normalize_effort_option(opts) do
+    case Keyword.fetch(opts, :reasoning_effort) do
+      {:ok, value} -> Keyword.put(opts, :reasoning_effort, normalize_effort(value))
+      :error -> opts
+    end
+  end
+
+  @spec normalize_effort(term()) :: term()
+  def normalize_effort(value) when is_binary(value), do: Map.get(@effort_strings, value, value)
+  def normalize_effort(value), do: value
+
+  @spec advisories(module(), LLMDB.Model.t(), keyword(), keyword()) :: [advisory()]
+  def advisories(provider_module, model, canonical_opts, translated_opts) do
+    provider = provider_id(provider_module, model)
+
+    [
+      ignored_budget_advisory(provider, canonical_opts, translated_opts),
+      google_effort_advisory(provider, canonical_opts, translated_opts)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @spec messages([advisory()]) :: [String.t()]
+  def messages(advisories), do: Enum.map(advisories, & &1.message)
+
+  defp normalize_thinking_flag(opts) do
+    case Keyword.pop(opts, :thinking) do
+      {nil, rest} -> rest
+      {false, rest} -> rest
+      {true, rest} -> rest
+      {thinking, rest} when is_map(thinking) -> Keyword.put(rest, :thinking, thinking)
+    end
+  end
+
+  defp normalize_reasoning_alias(opts) do
+    case Keyword.pop(opts, :reasoning) do
+      {nil, rest} ->
+        rest
+
+      {false, rest} ->
+        rest
+
+      {true, rest} ->
+        Keyword.put_new(rest, :reasoning_effort, :medium)
+
+      {"auto", rest} ->
+        rest
+
+      {value, rest} when is_map_key(@effort_strings, value) ->
+        Keyword.put_new(rest, :reasoning_effort, Map.fetch!(@effort_strings, value))
+    end
+  end
+
+  defp provider_id(provider_module, model) do
+    if function_exported?(provider_module, :provider_id, 0) do
+      provider_module.provider_id()
+    else
+      model.provider
+    end
+  end
+
+  defp ignored_budget_advisory(provider, canonical_opts, translated_opts) do
+    if Keyword.has_key?(canonical_opts, :reasoning_token_budget) and
+         !budget_consumed?(provider, translated_opts) do
+      ignored_budget(provider)
+    end
+  end
+
+  defp ignored_budget(provider) when is_map_key(@budget_ignored_providers, provider) do
+    provider_name = Map.fetch!(@budget_ignored_providers, provider)
+
+    %{
+      kind: :ignored,
+      option: :reasoning_token_budget,
+      message:
+        ":reasoning_token_budget is not supported by #{provider_name} effort controls and was ignored"
+    }
+  end
+
+  defp ignored_budget(:anthropic) do
+    %{
+      kind: :ignored,
+      option: :reasoning_token_budget,
+      message:
+        ":reasoning_token_budget was ignored because the Anthropic request did not enable budget-based thinking"
+    }
+  end
+
+  defp ignored_budget(_provider), do: nil
+
+  defp budget_consumed?(provider, _translated_opts)
+       when provider in [:openai, :openrouter, :groq, :xai],
+       do: false
+
+  defp budget_consumed?(:anthropic, translated_opts) do
+    case Keyword.get(translated_opts, :thinking) do
+      %{budget_tokens: budget} when is_integer(budget) -> true
+      %{"budget_tokens" => budget} when is_integer(budget) -> true
+      _ -> false
+    end
+  end
+
+  defp budget_consumed?(_provider, _translated_opts), do: true
+
+  defp google_effort_advisory(provider, canonical_opts, translated_opts)
+       when provider in [:google, :google_vertex] do
+    effort = canonical_opts |> Keyword.get(:reasoning_effort) |> normalize_effort()
+    level = Keyword.get(translated_opts, :google_thinking_level)
+
+    case {effort, level} do
+      {:xhigh, level} when level in [:high, "high"] ->
+        %{
+          kind: :clamped,
+          option: :reasoning_effort,
+          message: ":reasoning_effort :xhigh was clamped to Gemini thinking level :high"
+        }
+
+      {:none, level} when level in [:minimal, "minimal"] ->
+        %{
+          kind: :lossy,
+          option: :reasoning_effort,
+          message:
+            ":reasoning_effort :none has no exact Gemini thinking-level mapping and was translated to :minimal"
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  defp google_effort_advisory(_provider, _canonical_opts, _translated_opts), do: nil
+end

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -1374,19 +1374,17 @@ defmodule ReqLLM.Providers.Anthropic do
       iex> ReqLLM.Providers.Anthropic.map_reasoning_effort_to_budget("medium")
       2048
   """
-  def map_reasoning_effort_to_budget(:none), do: nil
-  def map_reasoning_effort_to_budget(:minimal), do: @reasoning_budget_minimal
-  def map_reasoning_effort_to_budget(:low), do: @reasoning_budget_low
-  def map_reasoning_effort_to_budget(:medium), do: @reasoning_budget_medium
-  def map_reasoning_effort_to_budget(:high), do: @reasoning_budget_high
-  def map_reasoning_effort_to_budget(:xhigh), do: @reasoning_budget_xhigh
-  def map_reasoning_effort_to_budget("none"), do: map_reasoning_effort_to_budget(:none)
-  def map_reasoning_effort_to_budget("minimal"), do: map_reasoning_effort_to_budget(:minimal)
-  def map_reasoning_effort_to_budget("low"), do: map_reasoning_effort_to_budget(:low)
-  def map_reasoning_effort_to_budget("medium"), do: map_reasoning_effort_to_budget(:medium)
-  def map_reasoning_effort_to_budget("high"), do: map_reasoning_effort_to_budget(:high)
-  def map_reasoning_effort_to_budget("xhigh"), do: map_reasoning_effort_to_budget(:xhigh)
-  def map_reasoning_effort_to_budget(_), do: @reasoning_budget_medium
+  def map_reasoning_effort_to_budget(effort) do
+    case ReqLLM.Provider.Reasoning.normalize_effort(effort) do
+      :none -> nil
+      :minimal -> @reasoning_budget_minimal
+      :low -> @reasoning_budget_low
+      :medium -> @reasoning_budget_medium
+      :high -> @reasoning_budget_high
+      :xhigh -> @reasoning_budget_xhigh
+      _ -> @reasoning_budget_medium
+    end
+  end
 
   defp translate_reasoning_effort(opts, model) do
     {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -811,48 +811,30 @@ defmodule ReqLLM.Providers.Google do
 
   defp normalize_response_modality(modality), do: modality
 
-  defp translate_reasoning_effort_to_budget(:none, _model), do: 0
-  defp translate_reasoning_effort_to_budget(:minimal, _model), do: 2_048
-  defp translate_reasoning_effort_to_budget(:low, _model), do: 4_096
-  defp translate_reasoning_effort_to_budget(:medium, _model), do: 8_192
-  defp translate_reasoning_effort_to_budget(:high, _model), do: 16_384
-  defp translate_reasoning_effort_to_budget(:xhigh, _model), do: 32_768
+  defp translate_reasoning_effort_to_budget(effort, _model) do
+    case ReqLLM.Provider.Reasoning.normalize_effort(effort) do
+      :none -> 0
+      :minimal -> 2_048
+      :low -> 4_096
+      :medium -> 8_192
+      :high -> 16_384
+      :xhigh -> 32_768
+      budget when is_integer(budget) -> budget
+      _ -> 8_192
+    end
+  end
 
-  defp translate_reasoning_effort_to_budget("none", model),
-    do: translate_reasoning_effort_to_budget(:none, model)
-
-  defp translate_reasoning_effort_to_budget("minimal", model),
-    do: translate_reasoning_effort_to_budget(:minimal, model)
-
-  defp translate_reasoning_effort_to_budget("low", model),
-    do: translate_reasoning_effort_to_budget(:low, model)
-
-  defp translate_reasoning_effort_to_budget("medium", model),
-    do: translate_reasoning_effort_to_budget(:medium, model)
-
-  defp translate_reasoning_effort_to_budget("high", model),
-    do: translate_reasoning_effort_to_budget(:high, model)
-
-  defp translate_reasoning_effort_to_budget("xhigh", model),
-    do: translate_reasoning_effort_to_budget(:xhigh, model)
-
-  defp translate_reasoning_effort_to_budget(budget, _model) when is_integer(budget), do: budget
-  defp translate_reasoning_effort_to_budget(_unknown, _model), do: 8_192
-
-  defp translate_reasoning_effort_to_level(:none), do: :minimal
-  defp translate_reasoning_effort_to_level(:minimal), do: :minimal
-  defp translate_reasoning_effort_to_level(:low), do: :low
-  defp translate_reasoning_effort_to_level(:medium), do: :medium
-  defp translate_reasoning_effort_to_level(:high), do: :high
-  defp translate_reasoning_effort_to_level(:xhigh), do: :high
-
-  defp translate_reasoning_effort_to_level("none"), do: :minimal
-  defp translate_reasoning_effort_to_level("minimal"), do: :minimal
-  defp translate_reasoning_effort_to_level("low"), do: :low
-  defp translate_reasoning_effort_to_level("medium"), do: :medium
-  defp translate_reasoning_effort_to_level("high"), do: :high
-  defp translate_reasoning_effort_to_level("xhigh"), do: :high
-  defp translate_reasoning_effort_to_level(_unknown), do: :medium
+  defp translate_reasoning_effort_to_level(effort) do
+    case ReqLLM.Provider.Reasoning.normalize_effort(effort) do
+      :none -> :minimal
+      :minimal -> :minimal
+      :low -> :low
+      :medium -> :medium
+      :high -> :high
+      :xhigh -> :high
+      _ -> :medium
+    end
+  end
 
   @impl ReqLLM.Provider
   def translate_options(:image, _model, opts) do

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -311,20 +311,8 @@ defmodule ReqLLM.Providers.OpenAI do
 
   @doc false
   def pre_validate_options(_operation, _model, opts) do
-    case Keyword.fetch(opts, :reasoning_effort) do
-      {:ok, value} -> Keyword.put(opts, :reasoning_effort, normalize_reasoning_effort(value))
-      :error -> opts
-    end
+    ReqLLM.Provider.Reasoning.normalize_effort_option(opts)
   end
-
-  defp normalize_reasoning_effort("none"), do: :none
-  defp normalize_reasoning_effort("minimal"), do: :minimal
-  defp normalize_reasoning_effort("low"), do: :low
-  defp normalize_reasoning_effort("medium"), do: :medium
-  defp normalize_reasoning_effort("high"), do: :high
-  defp normalize_reasoning_effort("xhigh"), do: :xhigh
-  defp normalize_reasoning_effort("default"), do: :default
-  defp normalize_reasoning_effort(value), do: value
 
   @impl ReqLLM.Provider
   @doc """

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -762,10 +762,7 @@ defmodule ReqLLM.Providers.XAI do
   end
 
   def pre_validate_options(_operation, _model, opts) do
-    case Keyword.fetch(opts, :reasoning_effort) do
-      {:ok, effort} -> Keyword.put(opts, :reasoning_effort, normalize_reasoning_effort(effort))
-      :error -> opts
-    end
+    ReqLLM.Provider.Reasoning.normalize_effort_option(opts)
   end
 
   @impl ReqLLM.Provider
@@ -862,15 +859,6 @@ defmodule ReqLLM.Providers.XAI do
   defp reasoning_effort_supported?(%{id: "grok-4-1-fast" <> _}), do: true
   defp reasoning_effort_supported?(%{id: "grok-4" <> _}), do: true
   defp reasoning_effort_supported?(_), do: false
-
-  defp normalize_reasoning_effort("none"), do: :none
-  defp normalize_reasoning_effort("minimal"), do: :minimal
-  defp normalize_reasoning_effort("low"), do: :low
-  defp normalize_reasoning_effort("medium"), do: :medium
-  defp normalize_reasoning_effort("high"), do: :high
-  defp normalize_reasoning_effort("xhigh"), do: :xhigh
-  defp normalize_reasoning_effort("default"), do: :default
-  defp normalize_reasoning_effort(value), do: value
 
   defp drop_image_unsupported(opts, explicit_keys) do
     unsupported_params = [:size, :output_format, :quality, :style, :negative_prompt, :seed, :user]

--- a/lib/req_llm/request_plan/diagnostic.ex
+++ b/lib/req_llm/request_plan/diagnostic.ex
@@ -29,12 +29,13 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
   def build(model_input, operation, opts) when is_list(opts) do
     with :ok <- validate_options(opts),
          {:ok, plan} <- RequestPlan.build(model_input, operation, opts),
-         {:ok, canonical_options} <- flatten_provider_options(plan.options),
-         {:ok, translated_options, translation_warnings} <-
+         {:ok, normalized_options} <- normalize_options(plan.options),
+         {:ok, canonical_options} <- flatten_provider_options(normalized_options),
+         {:ok, translated_options, enforceable_warnings, diagnostic_warnings} <-
            translate_options(plan, canonical_options),
          redacted_warnings <-
-           redact_warning_values(plan.warnings ++ translation_warnings, canonical_options),
-         :ok <- enforce_warning_policy(plan.options, translation_warnings, canonical_options) do
+           redact_warning_values(plan.warnings ++ diagnostic_warnings, canonical_options),
+         :ok <- enforce_warning_policy(plan.options, enforceable_warnings, canonical_options) do
       {:ok, diagnostic(plan, canonical_options, translated_options, redacted_warnings)}
     else
       {:error, error} -> {:error, sanitize_error(error)}
@@ -74,12 +75,31 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
     end
   end
 
+  defp normalize_options(opts) do
+    {:ok, ReqLLM.Provider.Reasoning.normalize_options(opts)}
+  rescue
+    _error -> translation_error()
+  end
+
   defp translate_options(plan, opts) do
-    with {:ok, prevalidated, prevalidation_warnings} <-
+    with {:ok, prevalidated, prevalidation_warnings, _prevalidation_replaced_warnings?} <-
            apply_option_callback(plan.provider_module, :pre_validate_options, plan, opts),
-         {:ok, translated, translation_warnings} <-
+         {:ok, translated, translation_warnings, translation_replaced_warnings?} <-
            apply_option_callback(plan.provider_module, :translate_options, plan, prevalidated) do
-      {:ok, translated, prevalidation_warnings ++ translation_warnings}
+      callback_warnings = prevalidation_warnings ++ translation_warnings
+
+      enforceable_warnings =
+        if translation_replaced_warnings?,
+          do: translation_warnings,
+          else: callback_warnings
+
+      diagnostic_warnings =
+        callback_warnings ++
+          (plan.provider_module
+           |> ReqLLM.Provider.Reasoning.advisories(plan.model, opts, translated)
+           |> ReqLLM.Provider.Reasoning.messages())
+
+      {:ok, translated, enforceable_warnings, diagnostic_warnings}
     end
   end
 
@@ -89,7 +109,7 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
       |> apply(callback, [option_operation(plan), plan.model, opts])
       |> normalize_option_callback_result()
     else
-      {:ok, opts, []}
+      {:ok, opts, [], false}
     end
   rescue
     _error -> translation_error()
@@ -101,14 +121,14 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
   defp normalize_option_callback_result({opts, warnings})
        when is_list(opts) and is_list(warnings) do
     if Keyword.keyword?(opts) and Enum.all?(warnings, &is_binary/1) do
-      {:ok, opts, warnings}
+      {:ok, opts, warnings, true}
     else
       translation_error()
     end
   end
 
   defp normalize_option_callback_result(opts) when is_list(opts) do
-    if Keyword.keyword?(opts), do: {:ok, opts, []}, else: translation_error()
+    if Keyword.keyword?(opts), do: {:ok, opts, [], false}, else: translation_error()
   end
 
   defp normalize_option_callback_result(_result), do: translation_error()

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -66,6 +66,27 @@ defmodule ReqLLM.Provider.OptionsTest do
       default_base_url: "https://example.com"
   end
 
+  defmodule WarningPipelineProvider do
+    @behaviour ReqLLM.Provider
+
+    def provider_id, do: :warning_pipeline
+    def default_base_url, do: "https://api.warning-pipeline.test"
+    def supported_provider_options, do: []
+
+    def pre_validate_options(_operation, _model, opts) do
+      {opts, ["pre-validation warning"]}
+    end
+
+    def translate_options(_operation, _model, opts) do
+      {opts, ["translation warning"]}
+    end
+
+    def attach(_request, _model, _opts), do: nil
+    def prepare_request(_operation, _model, _input, _opts), do: {:error, :not_implemented}
+    def encode_body(_request), do: nil
+    def decode_response(_response), do: nil
+  end
+
   describe "Options.process/4 - core functionality" do
     test "validates and passes through standard generation options" do
       model = %LLMDB.Model{provider: :mock, id: "test-model"}
@@ -619,6 +640,46 @@ defmodule ReqLLM.Provider.OptionsTest do
       refute Keyword.has_key?(processed, :max_tokens)
       assert %ReqLLM.Context{} = processed[:context]
     end
+
+    test "keeps warning stages ordered and local to one call" do
+      model = %LLMDB.Model{provider: :warning_pipeline, id: "test-model"}
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _processed} =
+                   Options.process(WarningPipelineProvider, :chat, model, [])
+        end)
+
+      assert warning_lines(log) == ["pre-validation warning", "translation warning"]
+      refute Process.get(:req_llm_warnings)
+    end
+
+    test "does not retain pre-validation warnings after validation fails" do
+      model = %LLMDB.Model{provider: :warning_pipeline, id: "test-model"}
+
+      assert {:error, %ReqLLM.Error.Unknown.Unknown{}} =
+               Options.process(WarningPipelineProvider, :chat, model, temperature: "invalid")
+
+      refute Process.get(:req_llm_warnings)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _processed} =
+                   Options.process(WarningPipelineProvider, :chat, model, [])
+        end)
+
+      assert warning_lines(log) == ["pre-validation warning", "translation warning"]
+    end
+
+    test "does not make newly visible pre-validation warnings strict" do
+      model = %LLMDB.Model{provider: :warning_pipeline, id: "test-model"}
+
+      assert {:error, %ReqLLM.Error.Validation.Error{} = error} =
+               Options.process(WarningPipelineProvider, :chat, model, on_unsupported: :error)
+
+      assert Exception.message(error) =~ "translation warning"
+      refute Exception.message(error) =~ "pre-validation warning"
+    end
   end
 
   describe "Options.process/4 - internal keys handling" do
@@ -870,5 +931,12 @@ defmodule ReqLLM.Provider.OptionsTest do
       assert processed[:temperature] == 0.7
       assert processed[:max_tokens] == 1000
     end
+  end
+
+  defp warning_lines(log) do
+    log
+    |> String.split("\n", trim: true)
+    |> Enum.filter(&String.ends_with?(&1, "warning"))
+    |> Enum.map(&String.replace(&1, ~r/^.*\[warning\] /, ""))
   end
 end

--- a/test/req_llm/provider/reasoning_test.exs
+++ b/test/req_llm/provider/reasoning_test.exs
@@ -198,6 +198,39 @@ defmodule ReqLLM.Provider.ReasoningTest do
                  )
     end
 
+    test "does not mistake an unrelated native budget for the canonical budget" do
+      model = ReqLLM.model!("anthropic:claude-sonnet-4-5")
+
+      assert [
+               %{
+                 kind: :ignored,
+                 option: :reasoning_token_budget
+               }
+             ] =
+               Reasoning.advisories(
+                 Anthropic,
+                 model,
+                 [reasoning_token_budget: 4_096, thinking: %{budget_tokens: 7_777}],
+                 thinking: %{budget_tokens: 7_777}
+               )
+    end
+
+    test "reports lossy nested legacy effort translations before pre-validation removes them" do
+      model = ReqLLM.model!("google:gemini-3-flash-preview")
+
+      log =
+        capture_log(fn ->
+          assert {:ok, processed} =
+                   Options.process(Google, :chat, model,
+                     provider_options: [reasoning_effort: "xhigh"]
+                   )
+
+          assert processed[:google_thinking_level] == :high
+        end)
+
+      assert log =~ ":reasoning_effort :xhigh was clamped"
+    end
+
     test "exposes advisories through sanitized request planning" do
       assert {:ok, openai_plan} =
                ReqLLM.plan("openai:gpt-5", :chat, reasoning_token_budget: 4_096)

--- a/test/req_llm/provider/reasoning_test.exs
+++ b/test/req_llm/provider/reasoning_test.exs
@@ -1,0 +1,208 @@
+defmodule ReqLLM.Provider.ReasoningTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias ReqLLM.Provider.Options
+  alias ReqLLM.Provider.Reasoning
+  alias ReqLLM.Providers.{Anthropic, Google, OpenAI, XAI}
+
+  describe "normalization" do
+    test "preserves the documented legacy aliases" do
+      assert Reasoning.normalize_options(reasoning: true) == [reasoning_effort: :medium]
+      assert Reasoning.normalize_options(reasoning: "high") == [reasoning_effort: :high]
+      assert Reasoning.normalize_options(reasoning: "none") == [reasoning_effort: :none]
+      assert Reasoning.normalize_options(reasoning: "auto") == []
+      assert Reasoning.normalize_options(reasoning: false) == []
+
+      assert Reasoning.normalize_options(reasoning: "low", reasoning_effort: :high) ==
+               [reasoning_effort: :high]
+    end
+
+    test "uses one effort normalizer for accepted string values" do
+      for effort <- [:none, :minimal, :low, :medium, :high, :xhigh, :default] do
+        assert Reasoning.normalize_effort(Atom.to_string(effort)) == effort
+        assert Reasoning.normalize_effort(effort) == effort
+      end
+
+      assert Reasoning.normalize_effort("provider-native") == "provider-native"
+    end
+  end
+
+  describe "request compatibility" do
+    test "canonical and legacy aliases produce identical processed options" do
+      cases = [
+        {OpenAI, "openai:gpt-5"},
+        {Anthropic, "anthropic:claude-sonnet-4-5"},
+        {Google, "google:gemini-2.5-pro"},
+        {XAI, "xai:grok-4"}
+      ]
+
+      capture_log(fn ->
+        for {provider, model_spec} <- cases do
+          model = ReqLLM.model!(model_spec)
+
+          assert {:ok, canonical} =
+                   Options.process(provider, :chat, model, reasoning_effort: :high)
+
+          assert {:ok, legacy} = Options.process(provider, :chat, model, reasoning: "high")
+          assert canonical == legacy
+        end
+      end)
+    end
+
+    test "preserves accepted OpenAI and xAI string efforts" do
+      cases = [{OpenAI, "openai:gpt-5"}, {XAI, "xai:grok-4"}]
+
+      capture_log(fn ->
+        for {provider, model_spec} <- cases do
+          model = ReqLLM.model!(model_spec)
+
+          assert {:ok, atom_options} =
+                   Options.process(provider, :chat, model, reasoning_effort: :high)
+
+          assert {:ok, string_options} =
+                   Options.process(provider, :chat, model, reasoning_effort: "high")
+
+          assert Keyword.delete(atom_options, :telemetry_original_opts) ==
+                   Keyword.delete(string_options, :telemetry_original_opts)
+
+          assert atom_options[:telemetry_original_opts][:reasoning_effort] == :high
+          assert string_options[:telemetry_original_opts][:reasoning_effort] == "high"
+        end
+      end)
+    end
+
+    test "omitted reasoning controls do not add provider reasoning fields" do
+      cases = [
+        {OpenAI, "openai:gpt-4o-mini", [:reasoning_effort, :reasoning_token_budget]},
+        {Anthropic, "anthropic:claude-sonnet-4-5", [:thinking]},
+        {Google, "google:gemini-2.5-pro", [:google_thinking_budget, :google_thinking_level]},
+        {XAI, "xai:grok-4", [:reasoning_effort, :reasoning_token_budget]}
+      ]
+
+      capture_log(fn ->
+        for {provider, model_spec, absent_keys} <- cases do
+          assert {:ok, processed} =
+                   Options.process(provider, :chat, ReqLLM.model!(model_spec), [])
+
+          for key <- absent_keys do
+            refute Keyword.has_key?(processed, key)
+          end
+        end
+      end)
+    end
+
+    test "preserves existing canonical precedence over native reasoning controls" do
+      anthropic = ReqLLM.model!("anthropic:claude-sonnet-4-5")
+
+      assert {:ok, anthropic_opts} =
+               Options.process(Anthropic, :chat, anthropic,
+                 reasoning_effort: :low,
+                 provider_options: [thinking: %{type: "enabled", budget_tokens: 7_777}]
+               )
+
+      assert anthropic_opts[:thinking] == %{type: "enabled", budget_tokens: 1_024}
+
+      google = ReqLLM.model!("google:gemini-2.5-pro")
+
+      assert {:ok, google_opts} =
+               Options.process(Google, :chat, google,
+                 reasoning_effort: :low,
+                 provider_options: [google_thinking_budget: 7_777]
+               )
+
+      assert google_opts[:google_thinking_budget] == 4_096
+    end
+
+    test "preserves invalid reasoning error shapes" do
+      cases = [
+        {OpenAI, "openai:gpt-5"},
+        {Anthropic, "anthropic:claude-sonnet-4-5"},
+        {Google, "google:gemini-2.5-pro"},
+        {XAI, "xai:grok-4"}
+      ]
+
+      for {provider, model_spec} <- cases do
+        model = ReqLLM.model!(model_spec)
+
+        assert {:error,
+                %ReqLLM.Error.Unknown.Unknown{
+                  error: %NimbleOptions.ValidationError{}
+                }} = Options.process(provider, :chat, model, reasoning_effort: :invalid)
+
+        assert {:error,
+                %ReqLLM.Error.Unknown.Unknown{
+                  error: %NimbleOptions.ValidationError{}
+                }} = Options.process(provider, :chat, model, reasoning_token_budget: 0)
+      end
+    end
+  end
+
+  describe "structured advisories" do
+    test "reports ignored token budgets without making them enforceable" do
+      model = ReqLLM.model!("openai:gpt-4.1")
+
+      assert [
+               %{
+                 kind: :ignored,
+                 option: :reasoning_token_budget,
+                 message: message
+               }
+             ] =
+               Reasoning.advisories(
+                 OpenAI,
+                 model,
+                 [reasoning_token_budget: 4_096],
+                 []
+               )
+
+      assert message =~ "OpenAI"
+      assert message =~ "ignored"
+
+      assert capture_log(fn ->
+               assert {:ok, _processed} =
+                        Options.process(OpenAI, :chat, model,
+                          reasoning_token_budget: 4_096,
+                          on_unsupported: :error
+                        )
+             end) =~ ":reasoning_token_budget"
+
+      assert capture_log(fn ->
+               assert {:ok, _processed} =
+                        Options.process(OpenAI, :chat, model,
+                          reasoning_token_budget: 4_096,
+                          on_unsupported: :ignore
+                        )
+             end) == ""
+    end
+
+    test "reports deterministic Gemini clamping and lossy mappings" do
+      model = ReqLLM.model!("google:gemini-3-flash-preview")
+
+      assert [
+               %{kind: :clamped, option: :reasoning_effort},
+               %{kind: :lossy, option: :reasoning_effort}
+             ] =
+               Reasoning.advisories(
+                 Google,
+                 model,
+                 [reasoning_effort: :xhigh],
+                 google_thinking_level: :high
+               ) ++
+                 Reasoning.advisories(
+                   Google,
+                   model,
+                   [reasoning_effort: :none],
+                   google_thinking_level: :minimal
+                 )
+    end
+
+    test "exposes advisories through sanitized request planning" do
+      assert {:ok, openai_plan} =
+               ReqLLM.plan("openai:gpt-5", :chat, reasoning_token_budget: 4_096)
+
+      assert Enum.any?(openai_plan.warnings, &String.contains?(&1, "ignored"))
+    end
+  end
+end


### PR DESCRIPTION
Closes #843

## Summary

- centralize canonical and legacy reasoning-option normalization without changing accepted V1 inputs
- replace process-dictionary warning state with deterministic call-local warning propagation
- report ignored and lossy reasoning translations as structured, non-enforceable advisories
- preserve existing provider-native precedence, wire mappings, strict-warning boundaries, and invalid-input error shapes
- document canonical reasoning controls and add cross-provider compatibility coverage

## Compatibility

- omitted reasoning options do not add provider reasoning fields
- canonical and legacy aliases produce identical processed request options
- accepted OpenAI/xAI string efforts retain their original telemetry value and identical wire options
- new reasoning advisories never create a new `on_unsupported: :error` failure
- existing enforceable provider warnings retain their prior error payload
- cached request fixtures and public result shapes are unchanged

## Validation

- `mix test` — 3,711 passed, 11 skipped, 145 excluded
- targeted OpenAI, Anthropic, Google, Google Vertex, Azure, xAI, Groq, and OpenRouter suites — 631 passed
- focused option/planner contracts — 317 passed after review hardening
- `mix quality`
- `mix docs` (one pre-existing hidden-module warning)