### PR TITLE
feat: add namespaced provider options

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -65,6 +65,60 @@ without making a request. These reasoning advisories do not introduce new
 failures for `on_unsupported: :error`; existing enforceable provider warnings
 retain their current behavior.
 
+## Provider Option Namespaces
+
+ReqLLM 1.x accepts both the existing flat `provider_options` shape and an
+additive provider-keyed shape. Existing calls remain valid and do not warn when
+their flat options are unambiguous:
+
+```elixir
+ReqLLM.generate_text(
+  "openai:gpt-5",
+  "Solve this carefully",
+  provider_options: [reasoning_summary: "auto"]
+)
+```
+
+New code can scope the same options to the selected provider:
+
+```elixir
+ReqLLM.generate_text(
+  "openai:gpt-5",
+  "Solve this carefully",
+  provider_options: [
+    openai: [reasoning_summary: "auto"]
+  ]
+)
+```
+
+Keyword lists and atom-keyed maps are supported:
+
+```elixir
+provider_options: %{
+  openai: %{reasoning_summary: "auto"}
+}
+```
+
+The namespace is always the actual ReqLLM provider identity. Use `azure:` for
+Azure-hosted models, `google_vertex:` for Vertex-hosted models, and
+`openrouter:` for OpenRouter models. Do not use `openai:` or `google:` merely
+because the hosted service uses an OpenAI- or Gemini-compatible wire format.
+Foreign namespaces fail before network I/O.
+
+When forms are combined, precedence is deterministic:
+
+1. Explicit top-level canonical options win over the same namespaced option.
+2. Options under the selected provider namespace win over colliding legacy flat
+   provider options.
+3. Non-colliding flat and namespaced provider options are merged.
+
+Mixed forms emit an actionable warning by default. Set `on_unsupported: :error`
+to reject an ambiguous mix, or `on_unsupported: :ignore` to apply the same
+precedence without logging. Invalid namespace containers, unknown namespaced
+options, duplicate namespaced keys, and foreign provider namespaces are rejected
+before I/O. ReqLLM 1.x does not reject an otherwise valid call merely because it
+uses the legacy flat shape.
+
 ## Timeout Configuration
 
 ReqLLM uses multiple timeout settings to handle different scenarios:

--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -205,11 +205,18 @@ defmodule ReqLLM.Embedding do
 
   def embed(model_spec, text, opts) when is_binary(text) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :embedding, opts)
-    {return_usage, provider_opts} = Keyword.pop(opts, :return_usage, false)
+    {return_usage, request_opts} = Keyword.pop(opts, :return_usage, false)
 
     with {:ok, model} <- validate_model(model_spec),
          :ok <- validate_input(text),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, provider_opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :embedding,
+             model,
+             request_opts
+           ),
          {:ok, request} <-
            provider_module.prepare_request(:embedding, model, text, provider_opts),
          {:ok, %Req.Response{status: status} = response} when status in 200..299 <-
@@ -236,11 +243,18 @@ defmodule ReqLLM.Embedding do
 
   def embed(model_spec, texts, opts) when is_list(texts) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :embedding, opts)
-    {return_usage, provider_opts} = Keyword.pop(opts, :return_usage, false)
+    {return_usage, request_opts} = Keyword.pop(opts, :return_usage, false)
 
     with {:ok, model} <- validate_model(model_spec),
          :ok <- validate_input(texts),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, provider_opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :embedding,
+             model,
+             request_opts
+           ),
          {:ok, request} <-
            provider_module.prepare_request(:embedding, model, texts, provider_opts),
          {:ok, %Req.Response{status: status} = response} when status in 200..299 <-

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -75,6 +75,13 @@ defmodule ReqLLM.Generation do
 
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :chat,
+             model,
+             opts
+           ),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
       case ReqLLM.Cache.fetch(model, :chat, context, opts) do
         {:hit, response, _cache_ref} ->
@@ -152,6 +159,13 @@ defmodule ReqLLM.Generation do
 
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :chat,
+             model,
+             opts
+           ),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
       case ReqLLM.Cache.fetch(model, :chat, context, opts) do
         {:hit, response, _cache_ref} ->
@@ -250,15 +264,18 @@ defmodule ReqLLM.Generation do
   def generate_object(model_spec, messages, object_schema, opts \\ []) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :object, opts)
 
-    opts_with_schema = fn compiled_schema ->
-      Keyword.put(opts, :compiled_schema, compiled_schema)
-    end
-
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :object,
+             model,
+             opts
+           ),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
          {:ok, compiled_schema} <- ReqLLM.Schema.compile(object_schema) do
-      compiled_opts = opts_with_schema.(compiled_schema)
+      compiled_opts = Keyword.put(opts, :compiled_schema, compiled_schema)
 
       case ReqLLM.Cache.fetch(model, :object, context, opts, compiled_schema.schema) do
         {:hit, response, _cache_ref} ->
@@ -518,6 +535,13 @@ defmodule ReqLLM.Generation do
 
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :object,
+             model,
+             opts
+           ),
          {:ok, compiled_schema} <- ReqLLM.Schema.compile(object_schema),
          {:ok, prepared_req} <-
            provider_module.prepare_request(

--- a/lib/req_llm/images.ex
+++ b/lib/req_llm/images.ex
@@ -142,6 +142,13 @@ defmodule ReqLLM.Images do
 
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :image,
+             model,
+             opts
+           ),
          {:ok, request} <-
            provider_module.prepare_request(:image, model, prompt_or_messages, opts),
          {:ok, %Req.Response{status: status, body: response}} when status in 200..299 <-

--- a/lib/req_llm/ocr.ex
+++ b/lib/req_llm/ocr.ex
@@ -123,6 +123,13 @@ defmodule ReqLLM.OCR do
 
     with {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :ocr,
+             model,
+             opts
+           ),
          {:ok, request} <-
            provider_module.prepare_request(:ocr, model, document_binary, opts),
          {:ok, %Req.Response{status: status, body: response}} when status in 200..299 <-

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -36,6 +36,19 @@ defmodule ReqLLM.Provider.Options do
   end
   ```
 
+  Request options accept both the legacy flat provider container and an additive
+  provider-keyed form:
+
+  ```elixir
+  provider_options: [reasoning_summary: "auto"]
+  provider_options: [openai: [reasoning_summary: "auto"]]
+  ```
+
+  Namespaces use the selected ReqLLM provider identity. Hosted and compatible
+  providers therefore use names such as `:azure`, `:google_vertex`, and
+  `:openrouter`, rather than an upstream wire protocol such as `:openai` or
+  `:google`.
+
   ## Usage
 
   The main entry point is `process/4` which handles the complete pipeline:
@@ -171,8 +184,9 @@ defmodule ReqLLM.Provider.Options do
 
                                # Provider-specific options container
                                provider_options: [
-                                 type: {:list, :any},
-                                 doc: "Provider-specific options (nested under this key)"
+                                 type: {:or, [:map, {:list, :any}]},
+                                 doc:
+                                   "Provider-specific options as a flat keyword/map or provider-keyed namespace"
                                ],
 
                                # Internal streaming orchestration options
@@ -312,6 +326,11 @@ defmodule ReqLLM.Provider.Options do
   @spec process!(module(), atom(), LLMDB.Model.t(), keyword()) :: keyword()
   def process!(provider_mod, operation, model, opts) do
     {internal_opts, user_opts} = Keyword.split(opts, @internal_keys)
+
+    {user_opts, namespace_warnings} =
+      ReqLLM.Provider.Options.Namespace.normalize!(provider_mod, operation, model, user_opts)
+
+    user_opts = normalize_flat_provider_options!(provider_mod, user_opts)
     user_opts = handle_stream_alias(user_opts)
     user_opts = normalize_legacy_options(user_opts)
 
@@ -365,11 +384,11 @@ defmodule ReqLLM.Provider.Options do
         end
       end
 
-    callback_warnings = prevalidation_warnings ++ translation_warnings
+    callback_warnings = namespace_warnings ++ prevalidation_warnings ++ translation_warnings
 
     enforceable_warnings =
       if translation_replaced_warnings?,
-        do: translation_warnings,
+        do: namespace_warnings ++ translation_warnings,
         else: callback_warnings
 
     final_opts =
@@ -417,6 +436,29 @@ defmodule ReqLLM.Provider.Options do
   """
   def all_generation_keys do
     @generation_options_schema.schema |> Keyword.keys()
+  end
+
+  @doc false
+  @spec normalize_namespaced_provider_options(module(), atom(), LLMDB.Model.t(), keyword()) ::
+          {:ok, keyword()} | {:error, Exception.t()}
+  def normalize_namespaced_provider_options(provider_mod, operation, model, opts) do
+    case ReqLLM.Provider.Options.Namespace.normalize(provider_mod, operation, model, opts) do
+      {:ok, normalized, warnings} ->
+        log_warnings(warnings)
+        {:ok, normalized}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc false
+  @spec normalize_flat_provider_options(module(), keyword()) ::
+          {:ok, keyword()} | {:error, Exception.t()}
+  def normalize_flat_provider_options(provider_mod, opts) do
+    {:ok, normalize_flat_provider_options!(provider_mod, opts)}
+  rescue
+    error -> {:error, error}
   end
 
   defp base_schema_for_operation(:image), do: ReqLLM.Images.schema()
@@ -645,6 +687,63 @@ defmodule ReqLLM.Provider.Options do
     |> ReqLLM.Provider.Reasoning.normalize_options()
     |> normalize_req_http_options()
     |> normalize_tools()
+  end
+
+  defp normalize_flat_provider_options!(provider_mod, opts) do
+    case Keyword.fetch(opts, :provider_options) do
+      {:ok, provider_options} when is_map(provider_options) ->
+        normalized = normalize_provider_option_map!(provider_mod, provider_options)
+        Keyword.put(opts, :provider_options, normalized)
+
+      _other ->
+        opts
+    end
+  end
+
+  defp normalize_provider_option_map!(provider_mod, provider_options) do
+    schema_keys =
+      if function_exported?(provider_mod, :provider_schema, 0) do
+        provider_mod.provider_schema().schema |> Keyword.keys()
+      else
+        []
+      end
+
+    schema_names = Map.new(schema_keys, &{Atom.to_string(&1), &1})
+
+    provider_options
+    |> Enum.map(fn
+      {key, value} when is_atom(key) ->
+        {key, value}
+
+      {key, value} when is_binary(key) ->
+        case Map.fetch(schema_names, key) do
+          {:ok, normalized_key} ->
+            {normalized_key, value}
+
+          :error ->
+            raise ReqLLM.Error.Invalid.Parameter.exception(
+                    parameter: "unknown string provider option #{inspect(key)}"
+                  )
+        end
+
+      {key, _value} ->
+        raise ReqLLM.Error.Invalid.Parameter.exception(
+                parameter: "invalid provider option key #{inspect(key)}"
+              )
+    end)
+    |> reject_normalized_map_collisions!()
+  end
+
+  defp reject_normalized_map_collisions!(provider_options) do
+    keys = Keyword.keys(provider_options)
+
+    if length(keys) == MapSet.size(MapSet.new(keys)) do
+      provider_options
+    else
+      raise ReqLLM.Error.Invalid.Parameter.exception(
+              parameter: "provider_options map contains duplicate atom/string option names"
+            )
+    end
   end
 
   defp extract_model_options(%LLMDB.Model{} = model, opts) do

--- a/lib/req_llm/provider/options/namespace.ex
+++ b/lib/req_llm/provider/options/namespace.ex
@@ -181,6 +181,9 @@ defmodule ReqLLM.Provider.Options.Namespace do
       is_atom(key) and key in schema_keys ->
         {:ok, key}
 
+      is_atom(key) and schema_keys == [] ->
+        {:ok, key}
+
       is_binary(key) and Map.has_key?(schema_names, key) ->
         {:ok, Map.fetch!(schema_names, key)}
 

--- a/lib/req_llm/provider/options/namespace.ex
+++ b/lib/req_llm/provider/options/namespace.ex
@@ -30,12 +30,15 @@ defmodule ReqLLM.Provider.Options.Namespace do
   end
 
   defp normalize_container(provider_mod, operation, provider, opts) do
-    case Keyword.fetch(opts, :provider_options) do
-      :error ->
+    case Keyword.get_values(opts, :provider_options) do
+      [] ->
         {:ok, opts, []}
 
-      {:ok, provider_options} ->
+      [provider_options] ->
         normalize_provider_options(provider_mod, operation, provider, opts, provider_options)
+
+      _provider_options ->
+        invalid_parameter("request options contain provider_options more than once")
     end
   end
 

--- a/lib/req_llm/provider/options/namespace.ex
+++ b/lib/req_llm/provider/options/namespace.ex
@@ -1,0 +1,362 @@
+defmodule ReqLLM.Provider.Options.Namespace do
+  @moduledoc false
+
+  alias ReqLLM.Error.Invalid.Parameter
+  alias ReqLLM.Error.Validation.Error
+
+  @type warning :: String.t()
+
+  @spec normalize(module(), atom(), LLMDB.Model.t(), keyword()) ::
+          {:ok, keyword(), [warning()]} | {:error, Exception.t()}
+  def normalize(provider_mod, operation, %LLMDB.Model{} = model, opts)
+      when is_atom(provider_mod) and is_atom(operation) and is_list(opts) do
+    with :ok <- validate_keyword_options(opts),
+         {:ok, normalized, warnings} <-
+           normalize_container(provider_mod, operation, model.provider, opts) do
+      apply_warning_policy(normalized, warnings, opts)
+    end
+  end
+
+  def normalize(_provider_mod, _operation, _model, _opts) do
+    invalid_parameter("options must be a keyword list")
+  end
+
+  @spec normalize!(module(), atom(), LLMDB.Model.t(), keyword()) :: {keyword(), [warning()]}
+  def normalize!(provider_mod, operation, %LLMDB.Model{} = model, opts) do
+    case normalize(provider_mod, operation, model, opts) do
+      {:ok, normalized, warnings} -> {normalized, warnings}
+      {:error, error} -> raise error
+    end
+  end
+
+  defp normalize_container(provider_mod, operation, provider, opts) do
+    case Keyword.fetch(opts, :provider_options) do
+      :error ->
+        {:ok, opts, []}
+
+      {:ok, provider_options} ->
+        normalize_provider_options(provider_mod, operation, provider, opts, provider_options)
+    end
+  end
+
+  defp normalize_provider_options(provider_mod, operation, provider, opts, provider_options) do
+    with {:ok, entries} <- container_entries(provider_options),
+         schema_keys <- provider_schema_keys(provider_mod),
+         {:ok, flat_entries, namespace_entries} <-
+           classify_entries(entries, provider, schema_keys),
+         {:ok, namespace} <- one_namespace(namespace_entries, provider),
+         {:ok, normalized, warnings} <-
+           normalize_selected_namespace(
+             namespace,
+             flat_entries,
+             provider_mod,
+             operation,
+             provider,
+             opts
+           ) do
+      {:ok, normalized, warnings}
+    else
+      :legacy -> {:ok, opts, []}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp container_entries(options) when is_map(options), do: {:ok, Map.to_list(options)}
+
+  defp container_entries(options) when is_list(options) do
+    if Keyword.keyword?(options), do: {:ok, options}, else: :legacy
+  end
+
+  defp container_entries(_options), do: :legacy
+
+  defp classify_entries(entries, provider, schema_keys) do
+    known_providers = known_provider_ids(provider)
+
+    entries
+    |> Enum.reduce_while({[], []}, fn {key, value}, {flat, namespaces} ->
+      cond do
+        schema_key?(key, schema_keys) ->
+          {:cont, {[{key, value} | flat], namespaces}}
+
+        provider_key?(key, provider) ->
+          {:cont, {flat, [{provider, value} | namespaces]}}
+
+        foreign_provider = provider_key(key, known_providers) ->
+          {:halt, foreign_namespace(foreign_provider, provider)}
+
+        true ->
+          {:cont, {[{key, value} | flat], namespaces}}
+      end
+    end)
+    |> case do
+      {:error, error} -> {:error, error}
+      {flat, namespaces} -> {:ok, Enum.reverse(flat), Enum.reverse(namespaces)}
+    end
+  end
+
+  defp one_namespace([], _provider), do: {:ok, nil}
+  defp one_namespace([{_namespace_provider, value}], _selected_provider), do: {:ok, value}
+
+  defp one_namespace(_namespaces, provider) do
+    invalid_parameter(
+      "provider_options contains the #{inspect(provider)} namespace more than once"
+    )
+  end
+
+  defp normalize_selected_namespace(nil, _flat, _provider_mod, _operation, _provider, opts),
+    do: {:ok, opts, []}
+
+  defp normalize_selected_namespace(
+         namespace,
+         flat,
+         provider_mod,
+         operation,
+         provider,
+         opts
+       ) do
+    schema_keys = provider_schema_keys(provider_mod)
+
+    with {:ok, namespace_entries} <- namespace_entries(namespace, provider),
+         {:ok, normalized_namespace} <-
+           normalize_option_entries(namespace_entries, schema_keys, operation, provider),
+         {:ok, normalized_flat} <-
+           normalize_option_entries(flat, schema_keys, operation, provider),
+         :ok <- reject_duplicate_keys(normalized_namespace, provider),
+         :ok <- reject_duplicate_keys(normalized_flat, provider) do
+      provider_collisions = colliding_keys(normalized_flat, normalized_namespace)
+
+      merged_before_canonical =
+        normalized_flat
+        |> remove_keys(provider_collisions)
+        |> Kernel.++(normalized_namespace)
+
+      {merged, canonical_collisions} =
+        remove_canonical_collisions(merged_before_canonical, operation, opts)
+
+      normalized_opts = Keyword.put(opts, :provider_options, merged)
+
+      warnings =
+        mixed_shape_warnings(provider, normalized_flat, provider_collisions) ++
+          canonical_collision_warnings(provider, canonical_collisions)
+
+      {:ok, normalized_opts, warnings}
+    end
+  end
+
+  defp namespace_entries(namespace, _provider) when is_map(namespace),
+    do: {:ok, Map.to_list(namespace)}
+
+  defp namespace_entries(namespace, provider) when is_list(namespace) do
+    if Keyword.keyword?(namespace) do
+      {:ok, namespace}
+    else
+      invalid_namespace_structure(provider)
+    end
+  end
+
+  defp namespace_entries(_namespace, provider), do: invalid_namespace_structure(provider)
+
+  defp normalize_option_entries(entries, schema_keys, operation, provider) do
+    canonical_keys = canonical_option_keys(operation)
+    schema_names = Map.new(schema_keys, &{Atom.to_string(&1), &1})
+
+    entries
+    |> Enum.reduce_while([], fn {key, value}, normalized ->
+      case normalize_option_key(key, schema_keys, schema_names, canonical_keys, provider) do
+        {:ok, normalized_key} -> {:cont, [{normalized_key, value} | normalized]}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:error, error} -> {:error, error}
+      normalized -> {:ok, Enum.reverse(normalized)}
+    end
+  end
+
+  defp normalize_option_key(key, schema_keys, schema_names, canonical_keys, provider) do
+    cond do
+      is_atom(key) and key in schema_keys ->
+        {:ok, key}
+
+      is_binary(key) and Map.has_key?(schema_names, key) ->
+        {:ok, Map.fetch!(schema_names, key)}
+
+      is_atom(key) and key in canonical_keys ->
+        canonical_option_error(key)
+
+      is_binary(key) ->
+        case Enum.find(canonical_keys, &(Atom.to_string(&1) == key)) do
+          nil -> unknown_provider_option(key, provider)
+          canonical -> canonical_option_error(canonical)
+        end
+
+      true ->
+        unknown_provider_option(key, provider)
+    end
+  end
+
+  defp canonical_option_error(key) do
+    invalid_parameter(
+      "provider option #{inspect(key)} is canonical; pass it as a top-level request option"
+    )
+  end
+
+  defp unknown_provider_option(key, provider) do
+    invalid_parameter(
+      "unknown provider option #{inspect(key)} in the #{inspect(provider)} namespace"
+    )
+  end
+
+  defp reject_duplicate_keys(entries, provider) do
+    duplicates =
+      entries
+      |> Enum.group_by(fn {key, _value} -> key end)
+      |> Enum.filter(fn {_key, values} -> length(values) > 1 end)
+      |> Enum.map(fn {key, _values} -> key end)
+      |> Enum.sort()
+
+    if duplicates == [] do
+      :ok
+    else
+      invalid_parameter(
+        "provider_options contains duplicate #{inspect(provider)} keys: #{format_keys(duplicates)}"
+      )
+    end
+  end
+
+  defp remove_canonical_collisions(namespace, operation, opts) do
+    canonical_keys = MapSet.new(canonical_option_keys(operation))
+    top_level_keys = MapSet.new(Keyword.keys(opts))
+
+    collisions =
+      namespace
+      |> Keyword.keys()
+      |> Enum.filter(&(MapSet.member?(canonical_keys, &1) and MapSet.member?(top_level_keys, &1)))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    {Keyword.drop(namespace, collisions), collisions}
+  end
+
+  defp colliding_keys(left, right) do
+    right_keys = MapSet.new(Keyword.keys(right))
+
+    left
+    |> Keyword.keys()
+    |> Enum.filter(&MapSet.member?(right_keys, &1))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp remove_keys(options, []), do: options
+  defp remove_keys(options, keys), do: Keyword.drop(options, keys)
+
+  defp mixed_shape_warnings(_provider, [], _collisions), do: []
+
+  defp mixed_shape_warnings(provider, _flat, []) do
+    [
+      "Mixed legacy flat provider_options with the #{inspect(provider)} namespace; both forms were merged. " <>
+        "Prefer provider_options: [#{provider}: [...]] without flat provider keys."
+    ]
+  end
+
+  defp mixed_shape_warnings(provider, _flat, collisions) do
+    [
+      "Mixed legacy flat provider_options with the #{inspect(provider)} namespace; namespaced values took precedence for #{format_keys(collisions)}. " <>
+        "Prefer provider_options: [#{provider}: [...]] without flat provider keys."
+    ]
+  end
+
+  defp canonical_collision_warnings(_provider, []), do: []
+
+  defp canonical_collision_warnings(provider, collisions) do
+    [
+      "Ignored namespaced #{inspect(provider)} values for #{format_keys(collisions)} because explicit top-level canonical options take precedence."
+    ]
+  end
+
+  defp apply_warning_policy(normalized, [], _opts), do: {:ok, normalized, []}
+
+  defp apply_warning_policy(normalized, warnings, opts) do
+    case Keyword.get(opts, :on_unsupported, :warn) do
+      :error ->
+        {:error,
+         Error.exception(
+           tag: :unsupported_options,
+           reason: Enum.join(warnings, "; "),
+           context: []
+         )}
+
+      :ignore ->
+        {:ok, normalized, []}
+
+      _policy ->
+        {:ok, normalized, warnings}
+    end
+  end
+
+  defp canonical_option_keys(:chat), do: generation_option_keys()
+  defp canonical_option_keys(:object), do: generation_option_keys()
+  defp canonical_option_keys(:embedding), do: schema_keys(ReqLLM.Embedding.schema())
+  defp canonical_option_keys(:image), do: schema_keys(ReqLLM.Images.schema())
+  defp canonical_option_keys(:transcription), do: schema_keys(ReqLLM.Transcription.schema())
+  defp canonical_option_keys(:speech), do: schema_keys(ReqLLM.Speech.schema())
+  defp canonical_option_keys(:rerank), do: schema_keys(ReqLLM.Rerank.schema())
+  defp canonical_option_keys(:ocr), do: schema_keys(ReqLLM.OCR.schema())
+  defp canonical_option_keys(_operation), do: generation_option_keys()
+
+  defp generation_option_keys do
+    ReqLLM.Provider.Options.generation_schema()
+    |> schema_keys()
+  end
+
+  defp schema_keys(%NimbleOptions{schema: schema}),
+    do: schema |> Keyword.keys() |> Enum.reject(&(&1 == :provider_options))
+
+  defp provider_schema_keys(provider_mod) do
+    if function_exported?(provider_mod, :provider_schema, 0) do
+      provider_mod.provider_schema().schema
+      |> Keyword.keys()
+    else
+      []
+    end
+  end
+
+  defp known_provider_ids(provider) do
+    [provider | ReqLLM.Providers.list()]
+    |> Enum.uniq()
+  end
+
+  defp schema_key?(key, schema_keys) when is_atom(key), do: key in schema_keys
+
+  defp schema_key?(key, schema_keys) when is_binary(key),
+    do: Enum.any?(schema_keys, &(Atom.to_string(&1) == key))
+
+  defp schema_key?(_key, _schema_keys), do: false
+
+  defp provider_key?(key, provider) when is_atom(key), do: key == provider
+  defp provider_key?(key, provider) when is_binary(key), do: key == Atom.to_string(provider)
+  defp provider_key?(_key, _provider), do: false
+
+  defp provider_key(key, providers), do: Enum.find(providers, &provider_key?(key, &1))
+
+  defp foreign_namespace(foreign_provider, selected_provider) do
+    invalid_parameter(
+      "provider_options namespace #{inspect(foreign_provider)} does not match selected provider #{inspect(selected_provider)}; use the #{inspect(selected_provider)} namespace"
+    )
+  end
+
+  defp invalid_namespace_structure(provider) do
+    invalid_parameter(
+      "provider_options namespace #{inspect(provider)} must contain a keyword list or map"
+    )
+  end
+
+  defp validate_keyword_options(opts) do
+    if Keyword.keyword?(opts), do: :ok, else: invalid_parameter("options must be a keyword list")
+  end
+
+  defp format_keys(keys), do: Enum.map_join(keys, ", ", &inspect/1)
+
+  defp invalid_parameter(message), do: {:error, Parameter.exception(parameter: message)}
+end

--- a/lib/req_llm/request_plan.ex
+++ b/lib/req_llm/request_plan.ex
@@ -42,9 +42,21 @@ defmodule ReqLLM.RequestPlan do
          :ok <- validate_operation(operation),
          {merged_opts, input_warnings} <-
            ReqLLM.ModelInput.merge_tuple_defaults_with_warnings(model_input, operation, opts),
-         normalized_opts <- normalize_options(merged_opts),
          {:ok, model} <- resolve_model(model_input),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, namespaced_opts, namespace_warnings} <-
+           ReqLLM.Provider.Options.Namespace.normalize(
+             provider_module,
+             operation,
+             model,
+             merged_opts
+           ),
+         {:ok, flat_opts} <-
+           ReqLLM.Provider.Options.normalize_flat_provider_options(
+             provider_module,
+             namespaced_opts
+           ),
+         normalized_opts <- normalize_options(flat_opts),
          {:ok, surface, api_module, surface_warnings} <-
            resolve_surface(model, provider_module),
          {:ok, transport, transport_warnings} <-
@@ -59,7 +71,7 @@ defmodule ReqLLM.RequestPlan do
          options: canonicalize(normalized_opts),
          provider_module: provider_module,
          api_module: api_module,
-         warnings: input_warnings ++ surface_warnings ++ transport_warnings
+         warnings: input_warnings ++ namespace_warnings ++ surface_warnings ++ transport_warnings
        }}
     end
   end

--- a/lib/req_llm/request_plan/diagnostic.ex
+++ b/lib/req_llm/request_plan/diagnostic.ex
@@ -233,6 +233,12 @@ defmodule ReqLLM.RequestPlan.Diagnostic do
         String.contains?(parameter, "WebSocket transport is not supported") ->
           parameter
 
+        String.contains?(parameter, "provider_options namespace") ->
+          parameter
+
+        String.contains?(parameter, "provider option") ->
+          parameter
+
         true ->
           "request plan is invalid; verify provider, operation, and transport metadata"
       end

--- a/lib/req_llm/rerank.ex
+++ b/lib/req_llm/rerank.ex
@@ -132,6 +132,13 @@ defmodule ReqLLM.Rerank do
          :ok <- validate_batch_size(Keyword.get(opts, :batch_size)),
          {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :rerank,
+             model,
+             opts
+           ),
          {:ok, batch_responses} <-
            rerank_batches(
              provider_module,

--- a/lib/req_llm/speech.ex
+++ b/lib/req_llm/speech.ex
@@ -140,6 +140,13 @@ defmodule ReqLLM.Speech do
 
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :speech,
+             model,
+             opts
+           ),
          {:ok, request} <-
            provider_module.prepare_request(:speech, model, text, opts),
          {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-

--- a/lib/req_llm/transcription.ex
+++ b/lib/req_llm/transcription.ex
@@ -137,6 +137,13 @@ defmodule ReqLLM.Transcription do
     with {:ok, audio_data, media_type} <- resolve_audio(audio),
          {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :transcription,
+             model,
+             opts
+           ),
          {:ok, request} <-
            provider_module.prepare_request(:transcription, model, audio_data, [
              {:media_type, media_type} | opts

--- a/test/req_llm/generation_test.exs
+++ b/test/req_llm/generation_test.exs
@@ -806,6 +806,18 @@ defmodule ReqLLM.GenerationTest do
 
       assert %Response{} = response
     end
+
+    test "handles provider-keyed options through the public API" do
+      {:ok, response} =
+        Generation.generate_text(
+          @chat_model,
+          "Hello",
+          provider_options: [openai: [openai_logprobs: true]],
+          req_http_options: [plug: {Req.Test, ReqLLM.GenerationTest}]
+        )
+
+      assert %Response{} = response
+    end
   end
 
   describe "generate_text/3 with req_http_options" do

--- a/test/req_llm/provider/options/namespace_test.exs
+++ b/test/req_llm/provider/options/namespace_test.exs
@@ -1,0 +1,355 @@
+defmodule ReqLLM.Provider.Options.NamespaceTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias ReqLLM.Provider.Options
+  alias ReqLLM.Provider.Options.Namespace
+
+  defmodule MockProvider do
+    @behaviour ReqLLM.Provider
+
+    def provider_id, do: :mock_namespace
+    def default_base_url, do: "https://mock.namespace.test"
+    def supported_provider_options, do: [:custom_option, :another_option, :payload, :dimensions]
+
+    def provider_schema do
+      NimbleOptions.new!(
+        custom_option: [type: :string],
+        another_option: [type: :integer],
+        payload: [type: :map],
+        dimensions: [type: :pos_integer]
+      )
+    end
+
+    def prepare_request(_operation, _model, _input, _opts), do: {:error, :not_implemented}
+    def attach(request, _model, _opts), do: request
+    def encode_body(request), do: request
+    def decode_response(response), do: response
+  end
+
+  defmodule ProviderNameOptionProvider do
+    @behaviour ReqLLM.Provider
+
+    def provider_id, do: :provider_name_option
+    def default_base_url, do: "https://provider-name-option.test"
+    def supported_provider_options, do: [:openai]
+    def provider_schema, do: NimbleOptions.new!(openai: [type: :any])
+    def prepare_request(_operation, _model, _input, _opts), do: {:error, :not_implemented}
+    def attach(request, _model, _opts), do: request
+    def encode_body(request), do: request
+    def decode_response(response), do: response
+  end
+
+  describe "namespace normalization" do
+    test "preserves unambiguous legacy keyword and map containers" do
+      model = model(:mock_namespace)
+
+      keyword_opts = [provider_options: [custom_option: "legacy"]]
+      map_opts = [provider_options: %{"custom_option" => "legacy"}]
+
+      assert {:ok, ^keyword_opts, []} =
+               Namespace.normalize(MockProvider, :chat, model, keyword_opts)
+
+      assert {:ok, ^map_opts, []} = Namespace.normalize(MockProvider, :chat, model, map_opts)
+    end
+
+    test "normalizes atom and string provider namespaces to the legacy flat shape" do
+      model = model(:mock_namespace)
+
+      assert {:ok, atom_opts, []} =
+               Namespace.normalize(MockProvider, :chat, model,
+                 provider_options: [mock_namespace: [custom_option: "atom"]]
+               )
+
+      assert atom_opts[:provider_options] == [custom_option: "atom"]
+
+      assert {:ok, string_opts, []} =
+               Namespace.normalize(MockProvider, :chat, model,
+                 provider_options: %{
+                   "mock_namespace" => %{"custom_option" => "string"}
+                 }
+               )
+
+      assert string_opts[:provider_options] == [custom_option: "string"]
+    end
+
+    test "uses the same normalization contract across every V1 request operation" do
+      operations = [:chat, :object, :embedding, :image, :transcription, :speech, :rerank, :ocr]
+
+      Enum.each(operations, fn operation ->
+        assert {:ok, normalized} =
+                 Options.normalize_namespaced_provider_options(
+                   MockProvider,
+                   operation,
+                   model(:mock_namespace),
+                   provider_options: [mock_namespace: [custom_option: "value"]]
+                 )
+
+        assert normalized[:provider_options] == [custom_option: "value"]
+      end)
+    end
+
+    test "keeps provider-schema keys ahead of namespace detection" do
+      model = model(:provider_name_option)
+      opts = [provider_options: [openai: [custom: true]]]
+
+      assert {:ok, ^opts, []} =
+               Namespace.normalize(ProviderNameOptionProvider, :chat, model, opts)
+    end
+
+    test "rejects foreign provider namespaces before translation" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [anthropic: [custom_option: "foreign"]]
+               )
+
+      assert Exception.message(error) =~ "namespace :anthropic"
+      assert Exception.message(error) =~ "selected provider :mock_namespace"
+    end
+
+    test "rejects malformed selected namespaces" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [mock_namespace: "invalid"]
+               )
+
+      assert Exception.message(error) =~ "must contain a keyword list or map"
+    end
+
+    test "rejects unknown and misplaced canonical keys inside a namespace" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = unknown_error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [mock_namespace: [unknown: true]]
+               )
+
+      assert Exception.message(unknown_error) =~ "unknown provider option :unknown"
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = canonical_error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [mock_namespace: [temperature: 0.2]]
+               )
+
+      assert Exception.message(canonical_error) =~ "temperature"
+      assert Exception.message(canonical_error) =~ "top-level"
+    end
+
+    test "rejects duplicate selected namespaces and duplicate nested keys" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = namespace_error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [
+                   mock_namespace: [custom_option: "one"],
+                   mock_namespace: [custom_option: "two"]
+                 ]
+               )
+
+      assert Exception.message(namespace_error) =~ "more than once"
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = key_error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [
+                   mock_namespace: [custom_option: "one", custom_option: "two"]
+                 ]
+               )
+
+      assert Exception.message(key_error) =~ "duplicate"
+      assert Exception.message(key_error) =~ ":custom_option"
+    end
+  end
+
+  describe "precedence and warning policy" do
+    test "namespaced provider values win collisions with mixed legacy values" do
+      model = model(:mock_namespace)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, processed} =
+                   Options.process(MockProvider, :chat, model,
+                     provider_options: [
+                       custom_option: "legacy",
+                       mock_namespace: [custom_option: "namespaced", another_option: 2]
+                     ]
+                   )
+
+          assert processed[:provider_options] == [
+                   custom_option: "namespaced",
+                   another_option: 2
+                 ]
+        end)
+
+      assert log =~ "namespaced values took precedence for :custom_option"
+    end
+
+    test "explicit canonical values win collisions with namespaced values" do
+      model = model(:mock_namespace)
+
+      log =
+        capture_log(fn ->
+          assert {:ok, processed} =
+                   Options.process(MockProvider, :embedding, model,
+                     dimensions: 128,
+                     provider_options: [mock_namespace: [dimensions: 256]]
+                   )
+
+          assert processed[:dimensions] == 128
+          assert processed[:provider_options][:dimensions] == 128
+        end)
+
+      assert log =~ "explicit top-level canonical options take precedence"
+      assert log =~ ":dimensions"
+    end
+
+    test "strict policy rejects ambiguous mixed input" do
+      assert {:error, %ReqLLM.Error.Validation.Error{} = error} =
+               Options.process(MockProvider, :chat, model(:mock_namespace),
+                 on_unsupported: :error,
+                 provider_options: [
+                   custom_option: "legacy",
+                   mock_namespace: [custom_option: "namespaced"]
+                 ]
+               )
+
+      assert Exception.message(error) =~ "namespaced values took precedence"
+    end
+
+    test "ignore policy keeps deterministic precedence without logging" do
+      log =
+        capture_log(fn ->
+          assert {:ok, processed} =
+                   Options.process(MockProvider, :chat, model(:mock_namespace),
+                     on_unsupported: :ignore,
+                     provider_options: [
+                       custom_option: "legacy",
+                       mock_namespace: [custom_option: "namespaced"]
+                     ]
+                   )
+
+          assert processed[:provider_options][:custom_option] == "namespaced"
+        end)
+
+      assert log == ""
+    end
+  end
+
+  describe "provider processing and planning" do
+    test "accepts flat provider option maps with known string keys" do
+      assert {:ok, processed} =
+               Options.process(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: %{
+                   "custom_option" => "map",
+                   "another_option" => 7
+                 }
+               )
+
+      assert processed[:provider_options][:custom_option] == "map"
+      assert processed[:provider_options][:another_option] == 7
+    end
+
+    test "produces equivalent options for OpenAI, Anthropic, and OpenRouter" do
+      cases = [
+        {ReqLLM.Providers.OpenAI, model(:openai, "gpt-4.1-mini"), [reasoning_summary: "auto"]},
+        {ReqLLM.Providers.Anthropic, model(:anthropic, "claude-sonnet-4-5-20250929"),
+         [anthropic_top_k: 20]},
+        {ReqLLM.Providers.OpenRouter, model(:openrouter, "openai/gpt-4.1-mini"),
+         [openrouter_route: "fallback"]}
+      ]
+
+      Enum.each(cases, fn {provider_mod, provider_model, provider_options} ->
+        provider = provider_model.provider
+
+        assert {:ok, legacy} =
+                 Options.process(provider_mod, :chat, provider_model,
+                   provider_options: provider_options
+                 )
+
+        assert {:ok, namespaced} =
+                 Options.process(provider_mod, :chat, provider_model,
+                   provider_options: [{provider, provider_options}]
+                 )
+
+        assert comparable_options(namespaced) == comparable_options(legacy)
+      end)
+    end
+
+    test "uses hosted and compatible provider identities instead of upstream protocols" do
+      azure_model = model(:azure, "gpt-4o")
+      vertex_model = model(:google_vertex, "gemini-2.5-flash")
+      openrouter_model = model(:openrouter, "openai/gpt-4.1-mini")
+
+      assert {:ok, azure_opts, []} =
+               Namespace.normalize(ReqLLM.Providers.Azure, :chat, azure_model,
+                 provider_options: [azure: [deployment: "deployment"]]
+               )
+
+      assert azure_opts[:provider_options] == [deployment: "deployment"]
+
+      assert {:ok, vertex_opts, []} =
+               Namespace.normalize(ReqLLM.Providers.GoogleVertex, :chat, vertex_model,
+                 provider_options: [google_vertex: [project_id: "project"]]
+               )
+
+      assert vertex_opts[:provider_options] == [project_id: "project"]
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Namespace.normalize(ReqLLM.Providers.Azure, :chat, azure_model,
+                 provider_options: [openai: [deployment: "deployment"]]
+               )
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Namespace.normalize(ReqLLM.Providers.GoogleVertex, :chat, vertex_model,
+                 provider_options: [google: [project_id: "project"]]
+               )
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Namespace.normalize(ReqLLM.Providers.OpenRouter, :chat, openrouter_model,
+                 provider_options: [openai: [openrouter_route: "fallback"]]
+               )
+    end
+
+    test "makes normalized provider options available to request planning" do
+      assert {:ok, plan} =
+               ReqLLM.RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 stream: true,
+                 provider_options: [openai: [openai_stream_transport: :websocket]]
+               )
+
+      assert plan.transport == :websocket
+      assert plan.options[:provider_options] == [openai_stream_transport: :websocket]
+
+      assert {:ok, diagnostic} =
+               ReqLLM.plan("openai:gpt-4o-mini", :chat,
+                 stream: true,
+                 provider_options: [openai: [openai_stream_transport: :websocket]]
+               )
+
+      assert diagnostic.transport == :websocket
+      assert :openai_stream_transport in diagnostic.options.canonical
+      refute :openai in diagnostic.options.canonical
+
+      assert {:ok, flat_map_plan} =
+               ReqLLM.RequestPlan.build("openai:gpt-4o-mini", :chat,
+                 provider_options: %{"reasoning_summary" => "auto"}
+               )
+
+      assert flat_map_plan.options[:provider_options] == [reasoning_summary: "auto"]
+    end
+
+    test "keeps namespace validation actionable in sanitized planning errors" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
+               ReqLLM.plan("openai:gpt-4o-mini", :chat,
+                 provider_options: [anthropic: [anthropic_top_k: 20]]
+               )
+
+      assert Exception.message(error) =~ "namespace :anthropic"
+      assert Exception.message(error) =~ "selected provider :openai"
+    end
+  end
+
+  defp model(provider, id \\ "model") do
+    %LLMDB.Model{provider: provider, id: id}
+  end
+
+  defp comparable_options(options) do
+    Keyword.drop(options, [:base_url, :telemetry_original_opts])
+  end
+end

--- a/test/req_llm/provider/options/namespace_test.exs
+++ b/test/req_llm/provider/options/namespace_test.exs
@@ -98,6 +98,22 @@ defmodule ReqLLM.Provider.Options.NamespaceTest do
                Namespace.normalize(ProviderNameOptionProvider, :chat, model, opts)
     end
 
+    test "preserves atom-keyed options for schema-less providers" do
+      elevenlabs_model = model(:elevenlabs, "eleven_multilingual_v2")
+
+      assert {:ok, normalized, []} =
+               Namespace.normalize(
+                 ReqLLM.Providers.ElevenLabs,
+                 :speech,
+                 elevenlabs_model,
+                 provider_options: [
+                   elevenlabs: [stability: 0.5, future_voice_setting: true]
+                 ]
+               )
+
+      assert normalized[:provider_options] == [stability: 0.5, future_voice_setting: true]
+    end
+
     test "rejects foreign provider namespaces before translation" do
       assert {:error, %ReqLLM.Error.Invalid.Parameter{} = error} =
                Namespace.normalize(MockProvider, :chat, model(:mock_namespace),

--- a/test/req_llm/provider/options/namespace_test.exs
+++ b/test/req_llm/provider/options/namespace_test.exs
@@ -135,6 +135,14 @@ defmodule ReqLLM.Provider.Options.NamespaceTest do
     end
 
     test "rejects duplicate selected namespaces and duplicate nested keys" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{} = container_error} =
+               Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
+                 provider_options: [mock_namespace: [custom_option: "one"]],
+                 provider_options: [mock_namespace: [custom_option: "two"]]
+               )
+
+      assert Exception.message(container_error) =~ "provider_options more than once"
+
       assert {:error, %ReqLLM.Error.Invalid.Parameter{} = namespace_error} =
                Namespace.normalize(MockProvider, :chat, model(:mock_namespace),
                  provider_options: [

--- a/test/req_llm/tuple_model_options_test.exs
+++ b/test/req_llm/tuple_model_options_test.exs
@@ -78,6 +78,14 @@ defmodule ReqLLM.TupleModelOptionsTest do
              [temperature: 0.2, max_tokens: 64, provider_options: []]
   end
 
+  test "provider-keyed maps remain valid tuple defaults" do
+    tuple =
+      {:openai, "gpt-4-0125-preview", provider_options: %{openai: %{reasoning_summary: "auto"}}}
+
+    assert ReqLLM.ModelInput.merge_tuple_defaults(tuple, :chat, []) ==
+             [provider_options: %{openai: %{reasoning_summary: "auto"}}]
+  end
+
   test "wrong-operation, invalid, duplicate, and ambiguous tuple defaults stay non-fatal" do
     tuple =
       {:cohere, "rerank-v3.5",


### PR DESCRIPTION
## Summary

- accept provider-keyed `provider_options` for every V1 request operation
- normalize selected namespaces before planning, caching, and provider dispatch
- preserve legacy flat keyword/map inputs with deterministic mixed-form precedence
- reject foreign, malformed, duplicate, and misplaced namespaced options before I/O
- document hosted-provider identity and migration behavior

## Backward compatibility

This is additive for V1. Existing unambiguous flat `provider_options` calls preserve their behavior and do not warn. Namespaced inputs flatten to the existing provider option shape before provider callbacks.

## Validation

- `mix test` — 3730 passed, 11 skipped, 145 excluded
- `mix quality`
- `mix docs` — succeeds with one pre-existing hidden-module reference warning

Closes #844