### PR TITLE
feat: add model call projections

### DIFF
--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -22,6 +22,7 @@ defmodule ReqLLM.Response do
   """
 
   alias ReqLLM.Message
+  alias ReqLLM.Response.OutputItem
   alias ReqLLM.ToolCall
 
   @derive {Jason.Encoder, except: [:stream]}
@@ -53,6 +54,26 @@ defmodule ReqLLM.Response do
           })
 
   @type t :: unquote(Zoi.type_spec(@schema))
+
+  @typedoc """
+  Computed metadata for one model interaction.
+
+  Optional keys are present only when their values were retained by the
+  provider path. `attempts` never includes separate model interactions from
+  the response context.
+  """
+  @type call_metadata :: %{
+          required(:response_id) => String.t(),
+          required(:model) => String.t(),
+          optional(:finish_reason) => atom(),
+          optional(:usage) => map(),
+          optional(:request_id) => String.t(),
+          optional(:raw_finish_reason) => String.t() | atom(),
+          optional(:warnings) => [String.t()],
+          optional(:attempts) => non_neg_integer(),
+          optional(:timings) => map(),
+          optional(:provider_metadata) => map()
+        }
 
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)
@@ -171,6 +192,99 @@ defmodule ReqLLM.Response do
   end
 
   def tool_calls(%__MODULE__{message: %Message{tool_calls: nil}}), do: []
+
+  @doc """
+  Return a deterministic canonical projection of values retained by this response.
+
+  Message content keeps its existing order. Tool calls follow content because
+  the V1 `ReqLLM.Message` contract stores tool calls separately and does not
+  retain their original interleaving. Sources, annotations, refusals, and
+  provider-native items retained only in metadata follow the message values.
+
+  This function does not add fields to or mutate `ReqLLM.Response`.
+  """
+  @spec output_items(t()) :: [OutputItem.t()]
+  def output_items(%__MODULE__{} = response) do
+    ReqLLM.Response.Projection.output_items(response)
+  end
+
+  @doc "Returns canonical output items grouped into stable result channels."
+  @spec channels(t()) :: %{OutputItem.channel() => [OutputItem.t()]}
+  def channels(%__MODULE__{} = response) do
+    items = output_items(response)
+
+    Map.new(OutputItem.channels(), fn channel ->
+      {channel, Enum.filter(items, &(OutputItem.channel(&1) == channel))}
+    end)
+  end
+
+  @doc "Returns canonical output items for one stable result channel."
+  @spec channel_items(t(), OutputItem.channel()) :: [OutputItem.t()]
+  def channel_items(%__MODULE__{} = response, channel) do
+    response
+    |> output_items()
+    |> Enum.filter(&(OutputItem.channel(&1) == channel))
+  end
+
+  @doc "Returns generated file content parts retained by this response."
+  @spec files(t()) :: [ReqLLM.Message.ContentPart.t()]
+  def files(%__MODULE__{} = response) do
+    response
+    |> output_items()
+    |> Enum.flat_map(fn
+      %OutputItem{type: :file, data: %ReqLLM.Message.ContentPart{} = part} -> [part]
+      _item -> []
+    end)
+  end
+
+  @doc "Returns source values retained by content or provider metadata."
+  @spec sources(t()) :: [term()]
+  def sources(%__MODULE__{} = response) do
+    response
+    |> channel_items(:sources)
+    |> Enum.map(& &1.data)
+  end
+
+  @doc "Returns annotation values retained by content or provider metadata."
+  @spec annotations(t()) :: [term()]
+  def annotations(%__MODULE__{} = response) do
+    response
+    |> channel_items(:annotations)
+    |> Enum.map(& &1.data)
+  end
+
+  @doc "Returns refusal values retained by content or provider metadata."
+  @spec refusals(t()) :: [term()]
+  def refusals(%__MODULE__{} = response) do
+    response
+    |> channel_items(:refusals)
+    |> Enum.map(& &1.data)
+  end
+
+  @doc "Returns provider-native output values retained by this response."
+  @spec provider_items(t()) :: [term()]
+  def provider_items(%__MODULE__{} = response) do
+    response
+    |> channel_items(:provider)
+    |> Enum.map(& &1.data)
+  end
+
+  @doc """
+  Return a redacted call-metadata projection over existing response values.
+
+  The projection includes response identity, normalized finish reason, usage,
+  and safe provider metadata when available. Request IDs, raw finish reasons,
+  warnings, attempt counts, and timings are omitted unless the provider path
+  already retained them. Credentials, prompts, file payloads, and hidden
+  reasoning metadata are redacted recursively.
+
+  This function does not enable additional provider capture or alter legacy
+  response serialization.
+  """
+  @spec call_metadata(t()) :: call_metadata()
+  def call_metadata(%__MODULE__{} = response) do
+    ReqLLM.Response.Projection.call_metadata(response)
+  end
 
   @typedoc """
   Result of classifying a non-streaming response.

--- a/lib/req_llm/response/output_item.ex
+++ b/lib/req_llm/response/output_item.ex
@@ -1,0 +1,69 @@
+defmodule ReqLLM.Response.OutputItem do
+  @moduledoc """
+  A computed, canonical view of one value produced by a model call.
+
+  Output items are projections over values already retained by
+  `ReqLLM.Response`; they are not stored on the response and do not change its
+  serialization. The `data` field contains the existing value, such as text,
+  a `ReqLLM.Message.ContentPart`, or a `ReqLLM.ToolCall`.
+  """
+
+  @derive Jason.Encoder
+
+  @schema Zoi.struct(__MODULE__, %{
+            type:
+              Zoi.enum([
+                :text,
+                :thinking,
+                :image,
+                :image_url,
+                :video_url,
+                :file,
+                :tool_call,
+                :source,
+                :annotation,
+                :refusal,
+                :provider_item
+              ]),
+            data: Zoi.any() |> Zoi.default(nil),
+            metadata: Zoi.map() |> Zoi.default(%{})
+          })
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @type channel ::
+          :message
+          | :reasoning
+          | :tools
+          | :media
+          | :sources
+          | :annotations
+          | :refusals
+          | :provider
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for output item projections."
+  def schema, do: @schema
+
+  @doc "Returns the stable result channel for an output item."
+  @spec channel(t()) :: channel()
+  def channel(%__MODULE__{type: :thinking}), do: :reasoning
+  def channel(%__MODULE__{type: :tool_call}), do: :tools
+
+  def channel(%__MODULE__{type: type}) when type in [:image, :image_url, :video_url, :file],
+    do: :media
+
+  def channel(%__MODULE__{type: :source}), do: :sources
+  def channel(%__MODULE__{type: :annotation}), do: :annotations
+  def channel(%__MODULE__{type: :refusal}), do: :refusals
+  def channel(%__MODULE__{type: :provider_item}), do: :provider
+  def channel(%__MODULE__{}), do: :message
+
+  @doc "Returns all stable output channels in display order."
+  @spec channels() :: [channel()]
+  def channels do
+    [:message, :reasoning, :tools, :media, :sources, :annotations, :refusals, :provider]
+  end
+end

--- a/lib/req_llm/response/projection.ex
+++ b/lib/req_llm/response/projection.ex
@@ -1,0 +1,375 @@
+defmodule ReqLLM.Response.Projection do
+  @moduledoc false
+
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Response
+  alias ReqLLM.Response.OutputItem
+
+  @redacted "[REDACTED]"
+
+  @sensitive_metadata_keys MapSet.new(~w(
+    access_token api_key api_token audio authorization body bytes code_interpreter content contents cookie
+    credential credentials data encrypted encrypted_content encrypted_reasoning error file file_data file_id files header
+    headers image images input inputs instructions logprobs messages password prompt prompts reasoning
+    output outputs provider_item provider_items raw_request raw_response reasoning_details request request_body
+    response response_body secret signature thinking token video web_search_queries
+  ))
+
+  @source_keys [
+    :source,
+    "source",
+    :sources,
+    "sources",
+    :citation,
+    "citation",
+    :citations,
+    "citations"
+  ]
+  @annotation_keys [:annotation, "annotation", :annotations, "annotations"]
+  @refusal_keys [:refusal, "refusal", :refusals, "refusals"]
+  @provider_item_keys [:provider_item, "provider_item", :provider_items, "provider_items"]
+
+  @spec output_items(Response.t()) :: [OutputItem.t()]
+  def output_items(%Response{} = response) do
+    message_items(response.message) ++ provider_output_items(response.provider_meta)
+  end
+
+  @spec call_metadata(Response.t()) :: map()
+  def call_metadata(%Response{} = response) do
+    metadata_sources = message_metadata(response.message) ++ [response.provider_meta]
+
+    %{response_id: response.id, model: response.model}
+    |> put_available(:finish_reason, response.finish_reason)
+    |> put_available(:usage, response.usage)
+    |> put_available(:request_id, request_id(metadata_sources))
+    |> put_available(:raw_finish_reason, raw_finish_reason(metadata_sources))
+    |> put_available(:warnings, warnings(metadata_sources))
+    |> put_available(:attempts, attempts(metadata_sources))
+    |> put_available(:timings, timings(metadata_sources))
+    |> put_available(:provider_metadata, safe_provider_metadata(response.provider_meta))
+  end
+
+  defp message_items(nil), do: []
+
+  defp message_items(%Message{} = message) do
+    content_items = Enum.flat_map(message.content || [], &content_output_items/1)
+    reasoning_items = reasoning_detail_items(message.reasoning_details, content_items)
+    tool_items = Enum.map(message.tool_calls || [], &output_item(:tool_call, &1))
+    content_items ++ reasoning_items ++ tool_items
+  end
+
+  defp content_output_items(%ContentPart{} = part) do
+    [content_part_item(part)] ++ metadata_output_items(part.metadata)
+  end
+
+  defp content_output_items(_value), do: []
+
+  defp content_part_item(%ContentPart{type: type, text: text, metadata: metadata})
+       when type in [:text, :thinking] do
+    output_item(type, text || "", safe_metadata(metadata))
+  end
+
+  defp content_part_item(%ContentPart{type: type, metadata: metadata} = part)
+       when type in [:image, :image_url, :video_url, :file] do
+    output_item(type, part, safe_metadata(metadata))
+  end
+
+  defp content_part_item(%ContentPart{metadata: metadata} = part) do
+    output_item(:provider_item, part, safe_metadata(metadata))
+  end
+
+  defp reasoning_detail_items(details, content_items) when is_list(details) do
+    existing_texts =
+      content_items
+      |> Enum.flat_map(fn
+        %OutputItem{type: :thinking, data: text} when is_binary(text) -> [text]
+        _item -> []
+      end)
+      |> MapSet.new()
+
+    {items, _seen_texts} =
+      Enum.reduce(details, {[], existing_texts}, fn detail, {items, seen_texts} ->
+        case reasoning_detail_value(detail) do
+          {text, metadata} when is_binary(text) and text != "" ->
+            if MapSet.member?(seen_texts, text) do
+              {items, seen_texts}
+            else
+              {[output_item(:thinking, text, metadata) | items], MapSet.put(seen_texts, text)}
+            end
+
+          _unavailable ->
+            {items, seen_texts}
+        end
+      end)
+
+    Enum.reverse(items)
+  end
+
+  defp reasoning_detail_items(_details, _content_items), do: []
+
+  defp reasoning_detail_value(%Message.ReasoningDetails{} = detail) do
+    metadata = detail |> Map.from_struct() |> Map.delete(:text) |> safe_metadata()
+    {detail.text, metadata}
+  end
+
+  defp reasoning_detail_value(detail) when is_map(detail) do
+    text = Map.get(detail, :text) || Map.get(detail, "text")
+    metadata = detail |> Map.delete(:text) |> Map.delete("text") |> safe_metadata()
+    {text, metadata}
+  end
+
+  defp reasoning_detail_value(_detail), do: nil
+
+  defp metadata_output_items(metadata) when is_map(metadata) do
+    values_for_keys(metadata, @source_keys)
+    |> output_items_for(:source)
+    |> Kernel.++(values_for_keys(metadata, @annotation_keys) |> output_items_for(:annotation))
+    |> Kernel.++(values_for_keys(metadata, @refusal_keys) |> output_items_for(:refusal))
+    |> Kernel.++(
+      values_for_keys(metadata, @provider_item_keys)
+      |> output_items_for(:provider_item)
+    )
+  end
+
+  defp metadata_output_items(_metadata), do: []
+
+  defp provider_output_items(provider_meta) when is_map(provider_meta) do
+    source_items =
+      values_for_keys(provider_meta, @source_keys) ++
+        (provider_meta
+         |> nested_map(:google)
+         |> values_for_keys(@source_keys))
+
+    annotation_items = values_for_keys(provider_meta, @annotation_keys)
+    refusal_items = values_for_keys(provider_meta, @refusal_keys)
+
+    provider_items =
+      values_for_keys(provider_meta, @provider_item_keys) ++
+        (provider_meta
+         |> nested_map(:code_interpreter)
+         |> values_for_keys([:items, "items"]))
+
+    output_items_for(source_items, :source) ++
+      output_items_for(annotation_items, :annotation) ++
+      output_items_for(refusal_items, :refusal) ++
+      output_items_for(provider_items, :provider_item)
+  end
+
+  defp provider_output_items(_provider_meta), do: []
+
+  defp output_items_for(values, type) do
+    Enum.map(values, &output_item(type, sanitize_urls(&1)))
+  end
+
+  defp output_item(type, data, metadata \\ %{}) do
+    %OutputItem{type: type, data: data, metadata: metadata}
+  end
+
+  defp values_for_keys(map, keys) when is_map(map) do
+    keys
+    |> Enum.flat_map(fn key -> normalize_values(Map.get(map, key)) end)
+    |> Enum.uniq()
+  end
+
+  defp normalize_values(nil), do: []
+  defp normalize_values(values) when is_list(values), do: Enum.reject(values, &is_nil/1)
+  defp normalize_values(value), do: [value]
+
+  defp nested_map(map, name) do
+    case Map.get(map, name) || Map.get(map, Atom.to_string(name)) do
+      nested when is_map(nested) -> nested
+      _other -> %{}
+    end
+  end
+
+  defp message_metadata(%Message{metadata: metadata}) when is_map(metadata), do: [metadata]
+  defp message_metadata(_message), do: []
+
+  defp request_id(sources) do
+    case first_available(sources, [:request_id, "request_id"]) || nested_id(sources, :request) do
+      id when is_binary(id) and id != "" -> id
+      _other -> nil
+    end
+  end
+
+  defp raw_finish_reason(sources) do
+    case first_available(sources, [
+           :raw_finish_reason,
+           "raw_finish_reason",
+           :raw_stop_reason,
+           "raw_stop_reason",
+           :stop_reason,
+           "stop_reason"
+         ]) do
+      reason when is_binary(reason) or is_atom(reason) -> reason
+      _other -> nil
+    end
+  end
+
+  defp warnings(sources) do
+    case first_available(sources, [:warnings, "warnings"]) do
+      warning when is_binary(warning) and warning != "" ->
+        redact_warnings([warning], sources)
+
+      warnings when is_list(warnings) ->
+        warnings
+        |> Enum.filter(&is_binary/1)
+        |> redact_warnings(sources)
+
+      _other ->
+        nil
+    end
+  end
+
+  defp attempts(sources) do
+    case first_available(sources, [:attempts, "attempts", :attempt_count, "attempt_count"]) do
+      attempts when is_integer(attempts) and attempts >= 0 -> attempts
+      attempts when is_list(attempts) -> length(attempts)
+      _other -> nil
+    end
+  end
+
+  defp timings(sources) do
+    case first_available(sources, [:timings, "timings", :timing, "timing"]) do
+      timings when is_map(timings) -> numeric_metadata(timings)
+      _other -> nil
+    end
+  end
+
+  defp nested_id(sources, name) do
+    Enum.find_value(sources, fn source ->
+      source
+      |> nested_map(name)
+      |> first_available([:id, "id"])
+    end)
+  end
+
+  defp first_available(sources, keys) when is_list(sources) do
+    Enum.find_value(sources, &first_available(&1, keys))
+  end
+
+  defp first_available(source, keys) when is_map(source) do
+    Enum.find_value(keys, fn key ->
+      case Map.fetch(source, key) do
+        {:ok, value} when value not in [nil, "", [], %{}] -> value
+        _other -> nil
+      end
+    end)
+  end
+
+  defp first_available(_source, _keys), do: nil
+
+  defp safe_provider_metadata(provider_meta) when is_map(provider_meta) do
+    case safe_metadata(provider_meta) do
+      metadata when map_size(metadata) > 0 -> metadata
+      _empty -> nil
+    end
+  end
+
+  defp safe_provider_metadata(_provider_meta), do: nil
+
+  defp safe_metadata(value) when is_map(value) do
+    Map.new(value, fn {key, item} ->
+      if sensitive_metadata_key?(key) do
+        {key, @redacted}
+      else
+        {key, safe_metadata(item)}
+      end
+    end)
+  end
+
+  defp safe_metadata(value) when is_list(value), do: Enum.map(value, &safe_metadata/1)
+
+  defp safe_metadata(value) when is_tuple(value),
+    do: value |> Tuple.to_list() |> Enum.map(&safe_metadata/1) |> List.to_tuple()
+
+  defp safe_metadata(value) when is_binary(value), do: sanitize_url(value)
+  defp safe_metadata(value), do: value
+
+  defp sanitize_urls(value) when is_map(value) do
+    Map.new(value, fn {key, item} -> {key, sanitize_urls(item)} end)
+  end
+
+  defp sanitize_urls(value) when is_list(value), do: Enum.map(value, &sanitize_urls/1)
+  defp sanitize_urls(value) when is_binary(value), do: sanitize_url(value)
+  defp sanitize_urls(value), do: value
+
+  defp sensitive_metadata_key?(key) when is_atom(key) or is_binary(key) do
+    name = key |> to_string() |> Macro.underscore() |> String.downcase()
+
+    MapSet.member?(@sensitive_metadata_keys, name) or
+      String.ends_with?(name, ["_key", "_token", "_secret", "_password", "_header", "_headers"]) or
+      String.ends_with?(name, "_body") or
+      String.contains?(name, "credential") or
+      String.starts_with?(name, "auth_") or
+      String.ends_with?(name, "_auth")
+  end
+
+  defp sensitive_metadata_key?(_key), do: false
+
+  defp numeric_metadata(map) do
+    map
+    |> Enum.flat_map(fn
+      {key, value} when is_number(value) -> [{key, value}]
+      {key, value} when is_map(value) -> nested_numeric_metadata(key, value)
+      _other -> []
+    end)
+    |> Map.new()
+    |> case do
+      empty when map_size(empty) == 0 -> nil
+      values -> values
+    end
+  end
+
+  defp nested_numeric_metadata(key, value) do
+    case numeric_metadata(value) do
+      nil -> []
+      nested -> [{key, nested}]
+    end
+  end
+
+  defp sanitize_url(value) do
+    if String.starts_with?(value, ["https://", "http://"]) do
+      ReqLLM.Provider.Utils.sanitize_url(value)
+    else
+      value
+    end
+  rescue
+    _error -> value
+  end
+
+  defp redact_warnings(warnings, sources) do
+    values = Enum.flat_map(sources, &sensitive_values/1)
+
+    Enum.map(warnings, fn warning ->
+      Enum.reduce(values, warning, fn value, redacted ->
+        String.replace(redacted, value, @redacted)
+      end)
+    end)
+  end
+
+  defp sensitive_values(value) when is_map(value) do
+    Enum.flat_map(value, fn {key, item} ->
+      if sensitive_metadata_key?(key) do
+        binary_values(item)
+      else
+        sensitive_values(item)
+      end
+    end)
+  end
+
+  defp sensitive_values(value) when is_list(value), do: Enum.flat_map(value, &sensitive_values/1)
+  defp sensitive_values(_value), do: []
+
+  defp binary_values(value) when is_binary(value), do: if(value == "", do: [], else: [value])
+
+  defp binary_values(value) when is_map(value),
+    do: Enum.flat_map(value, fn {_key, item} -> binary_values(item) end)
+
+  defp binary_values(value) when is_list(value), do: Enum.flat_map(value, &binary_values/1)
+  defp binary_values(_value), do: []
+
+  defp put_available(map, _key, value) when value in [nil, "", [], %{}], do: map
+  defp put_available(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/req_llm/response/projection.ex
+++ b/lib/req_llm/response/projection.ex
@@ -271,7 +271,7 @@ defmodule ReqLLM.Response.Projection do
 
   defp safe_metadata(value) when is_map(value) do
     Map.new(value, fn {key, item} ->
-      if sensitive_metadata_key?(key) do
+      if redacted_metadata_key?(key) do
         {key, @redacted}
       else
         {key, safe_metadata(item)}
@@ -307,6 +307,13 @@ defmodule ReqLLM.Response.Projection do
   end
 
   defp sensitive_metadata_key?(_key), do: false
+
+  defp redacted_metadata_key?(key) when is_atom(key) or is_binary(key) do
+    sensitive_metadata_key?(key) or
+      (key |> to_string() |> Macro.underscore() |> String.downcase()) in ["warning", "warnings"]
+  end
+
+  defp redacted_metadata_key?(_key), do: false
 
   defp numeric_metadata(map) do
     map

--- a/test/req_llm/response_projection_test.exs
+++ b/test/req_llm/response_projection_test.exs
@@ -1,0 +1,307 @@
+defmodule ReqLLM.ResponseProjectionTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :public_api
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Message.ReasoningDetails
+  alias ReqLLM.Response
+  alias ReqLLM.Response.OutputItem
+  alias ReqLLM.ToolCall
+
+  describe "output_items/1" do
+    test "projects retained output values in deterministic order" do
+      text =
+        ContentPart.text("Hello", %{
+          sources: [%{"uri" => "https://example.com/a?api_key=secret", "title" => "A"}],
+          annotations: [%{kind: :citation, start: 0, stop: 5}],
+          refusal: "I cannot include that detail",
+          signature: "opaque-reasoning-signature"
+        })
+
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+      file = ContentPart.file("report", "report.txt", "text/plain")
+      thinking = ContentPart.thinking("Check the available facts", %{signature: "opaque"})
+      tool_call = ToolCall.new("call_123", "lookup", ~s({"query":"facts"}))
+
+      provider_item = %{
+        "type" => "code_interpreter_call",
+        "outputs" => [%{"type" => "file", "file_id" => "file_123"}]
+      }
+
+      response =
+        response(
+          message: %Message{
+            role: :assistant,
+            content: [text, image, file, thinking],
+            tool_calls: [tool_call]
+          },
+          provider_meta: %{
+            "google" => %{
+              "sources" => [%{"uri" => "https://example.com/b", "title" => "B"}]
+            },
+            "code_interpreter" => %{"items" => [provider_item]}
+          }
+        )
+
+      items = Response.output_items(response)
+
+      assert Enum.map(items, & &1.type) == [
+               :text,
+               :source,
+               :annotation,
+               :refusal,
+               :image,
+               :file,
+               :thinking,
+               :tool_call,
+               :source,
+               :provider_item
+             ]
+
+      assert [%OutputItem{data: "Hello", metadata: text_metadata} | _rest] = items
+      assert text_metadata.signature == "[REDACTED]"
+      assert Enum.at(items, 4).data == image
+      assert Enum.at(items, 5).data == file
+      assert Enum.at(items, 6).data == "Check the available facts"
+      assert Enum.at(items, 6).metadata.signature == "[REDACTED]"
+      assert Enum.at(items, 7).data == tool_call
+      assert List.last(items).data == provider_item
+
+      assert Response.files(response) == [file]
+
+      assert Response.sources(response) == [
+               %{"uri" => "https://example.com/a?api_key=[REDACTED]", "title" => "A"},
+               %{"uri" => "https://example.com/b", "title" => "B"}
+             ]
+
+      assert Response.annotations(response) == [%{kind: :citation, start: 0, stop: 5}]
+      assert Response.refusals(response) == ["I cannot include that detail"]
+      assert Response.provider_items(response) == [provider_item]
+    end
+
+    test "groups projections into stable channels" do
+      response =
+        response(
+          message: %Message{
+            role: :assistant,
+            content: [ContentPart.text("Answer"), ContentPart.thinking("Reason")],
+            tool_calls: [ToolCall.new("call_123", "lookup", "{}")]
+          }
+        )
+
+      channels = Response.channels(response)
+
+      assert Map.keys(channels) |> Enum.sort() == OutputItem.channels() |> Enum.sort()
+      assert Enum.map(channels.message, & &1.type) == [:text]
+      assert Enum.map(channels.reasoning, & &1.type) == [:thinking]
+      assert Enum.map(channels.tools, & &1.type) == [:tool_call]
+      assert Response.channel_items(response, :media) == []
+    end
+
+    test "omits output values that were not retained" do
+      response = response(message: nil, finish_reason: :content_filter)
+
+      assert Response.output_items(response) == []
+      assert Response.refusals(response) == []
+    end
+
+    test "handles malformed source URLs and unusual metadata keys defensively" do
+      response =
+        response(
+          provider_meta: %{
+            "sources" => [%{"uri" => "https://example.com/result?bad=%"}],
+            {:provider, :version} => 1
+          }
+        )
+
+      assert Response.sources(response) == [%{"uri" => "https://example.com/result?bad=%25"}]
+      assert Response.call_metadata(response).provider_metadata[{:provider, :version}] == 1
+    end
+
+    test "does not invent a canonical type for unrecognized message content" do
+      object_part = %{type: :object, object: %{answer: 42}}
+      response = response(message: %Message{role: :assistant, content: [object_part]})
+
+      assert Response.output_items(response) == []
+      assert response.object == nil
+    end
+
+    test "projects retained reasoning details without duplicating thinking content" do
+      detail = %ReasoningDetails{
+        text: "Reason from retained details",
+        signature: "opaque",
+        encrypted?: true,
+        provider: :anthropic,
+        format: "anthropic-thinking-v1",
+        index: 0,
+        provider_data: %{"input" => "hidden"}
+      }
+
+      response =
+        response(
+          message: %Message{
+            role: :assistant,
+            content: [ContentPart.text("Answer")],
+            reasoning_details: [detail, detail]
+          }
+        )
+
+      assert [reasoning] = Response.channel_items(response, :reasoning)
+      assert reasoning.data == "Reason from retained details"
+      assert reasoning.metadata.signature == "[REDACTED]"
+      assert reasoning.metadata.provider_data == %{"input" => "[REDACTED]"}
+    end
+  end
+
+  describe "call_metadata/1" do
+    test "projects available call values and recursively redacts sensitive metadata" do
+      response =
+        response(
+          finish_reason: :stop,
+          usage: %{input_tokens: 4, output_tokens: 2, total_tokens: 6},
+          message: %Message{
+            role: :assistant,
+            content: [ContentPart.text("Done")],
+            metadata: %{
+              request_id: "req_123",
+              raw_finish_reason: "end_turn",
+              warnings: ["temperature was ignored for sk-secret"],
+              attempts: [%{prompt: "first"}, %{prompt: "second"}],
+              timings: %{total_ms: 12, phases: %{network_ms: 7, name: "network"}}
+            }
+          },
+          provider_meta: %{
+            "service_tier" => "priority",
+            "output_tokens" => 2,
+            "api_key" => "sk-secret",
+            "prompt" => "private prompt",
+            "files" => [%{"file_id" => "file_secret"}],
+            "reasoningDetails" => %{"signature" => "opaque"},
+            "request" => %{"id" => "provider_req", "body" => "private"},
+            "url" => "https://example.com/result?token=secret&format=json"
+          }
+        )
+
+      metadata = Response.call_metadata(response)
+
+      assert metadata.response_id == "resp_123"
+      assert metadata.model == "test-model"
+      assert metadata.finish_reason == :stop
+      assert metadata.usage == %{input_tokens: 4, output_tokens: 2, total_tokens: 6}
+      assert metadata.request_id == "req_123"
+      assert metadata.raw_finish_reason == "end_turn"
+      assert metadata.warnings == ["temperature was ignored for [REDACTED]"]
+      assert metadata.attempts == 2
+      assert metadata.timings == %{total_ms: 12, phases: %{network_ms: 7}}
+
+      assert metadata.provider_metadata == %{
+               "service_tier" => "priority",
+               "output_tokens" => 2,
+               "api_key" => "[REDACTED]",
+               "prompt" => "[REDACTED]",
+               "files" => "[REDACTED]",
+               "reasoningDetails" => "[REDACTED]",
+               "request" => "[REDACTED]",
+               "url" => "https://example.com/result?format=json&token=[REDACTED]"
+             }
+
+      encoded = inspect(metadata)
+      refute encoded =~ "sk-secret"
+      refute encoded =~ "private prompt"
+      refute encoded =~ "file_secret"
+      refute encoded =~ "opaque"
+    end
+
+    test "omits call metadata that is unavailable instead of synthesizing it" do
+      response = response(message: nil)
+
+      assert Response.call_metadata(response) == %{
+               response_id: "resp_123",
+               model: "test-model"
+             }
+    end
+
+    test "keeps error and response values unchanged" do
+      error = RuntimeError.exception("provider failed")
+      response = response(message: nil, error: error, finish_reason: :error)
+
+      assert Response.output_items(response) == []
+      assert Response.call_metadata(response).finish_reason == :error
+      assert response.error == error
+      refute Map.has_key?(Response.call_metadata(response), :error)
+    end
+  end
+
+  describe "legacy Response compatibility" do
+    test "projections do not change fields, equality, Inspect, Jason, helpers, or schema" do
+      response =
+        response(
+          message: %Message{role: :assistant, content: [ContentPart.text("Hello")]},
+          finish_reason: :stop,
+          usage: %{total_tokens: 3}
+        )
+
+      original = response
+      original_inspect = inspect(response)
+      original_json = Jason.encode!(response)
+
+      assert Map.keys(Map.from_struct(response)) |> Enum.sort() ==
+               [
+                 :context,
+                 :error,
+                 :finish_reason,
+                 :id,
+                 :message,
+                 :model,
+                 :object,
+                 :provider_meta,
+                 :stream,
+                 :stream?,
+                 :usage
+               ]
+               |> Enum.sort()
+
+      assert {:ok, %OutputItem{type: :text, data: "Hello"}} =
+               Zoi.parse(OutputItem.schema(), %OutputItem{type: :text, data: "Hello"})
+
+      assert Jason.decode!(Jason.encode!(hd(Response.output_items(response)))) == %{
+               "type" => "text",
+               "data" => "Hello",
+               "metadata" => %{}
+             }
+
+      assert Response.text(response) == "Hello"
+      assert Response.thinking(response) == ""
+      assert Response.tool_calls(response) == []
+      assert Response.finish_reason(response) == :stop
+      assert Response.usage(response) == %{total_tokens: 3}
+
+      assert response == original
+      assert inspect(response) == original_inspect
+      assert Jason.encode!(response) == original_json
+      refute Map.has_key?(Jason.decode!(original_json), "output_items")
+      refute Map.has_key?(Jason.decode!(original_json), "call_metadata")
+    end
+  end
+
+  defp response(opts) do
+    defaults = %{
+      id: "resp_123",
+      model: "test-model",
+      context: Context.new([]),
+      message: nil,
+      object: nil,
+      stream?: false,
+      stream: nil,
+      usage: nil,
+      finish_reason: nil,
+      provider_meta: %{},
+      error: nil
+    }
+
+    struct!(Response, Map.merge(defaults, Map.new(opts)))
+  end
+end

--- a/test/req_llm/response_projection_test.exs
+++ b/test/req_llm/response_projection_test.exs
@@ -181,6 +181,7 @@ defmodule ReqLLM.ResponseProjectionTest do
             "files" => [%{"file_id" => "file_secret"}],
             "reasoningDetails" => %{"signature" => "opaque"},
             "request" => %{"id" => "provider_req", "body" => "private"},
+            "warnings" => ["temperature was ignored for sk-secret"],
             "url" => "https://example.com/result?token=secret&format=json"
           }
         )
@@ -205,6 +206,7 @@ defmodule ReqLLM.ResponseProjectionTest do
                "files" => "[REDACTED]",
                "reasoningDetails" => "[REDACTED]",
                "request" => "[REDACTED]",
+               "warnings" => "[REDACTED]",
                "url" => "https://example.com/result?format=json&token=[REDACTED]"
              }
 


### PR DESCRIPTION
Closes #845

## Summary

- add computed canonical output-item and channel projections over values already retained by `ReqLLM.Response`
- add file, source, annotation, refusal, provider-item, and redacted call-metadata accessors
- preserve V1 response fields, defaults, equality, Inspect output, Jason serialization, helpers, provider callbacks, and request paths
- omit unavailable values and redact credentials, prompts, file payloads, and hidden reasoning metadata from call metadata

## Compatibility

This is additive and read-only. It does not add fields to `ReqLLM.Response`, change `Response.schema/0`, add legacy JSON keys, rewrite provider materializers, alter streaming, or enable additional metadata capture. Message content order is preserved; separately stored tool calls follow content; metadata-only items follow message values.

## Validation

- `mix test test/req_llm/response_projection_test.exs test/req_llm/response_test.exs test/req_llm/response_images_test.exs`
- `mix test --max-failures 1` — 3,741 passed, 11 skipped, 145 excluded
- `mix quality`
- `mix docs` (passes with one pre-existing hidden-module reference warning)