### PR TITLE
feat: add canonical stream event projections

### DIFF
--- a/lib/req_llm/response/projection.ex
+++ b/lib/req_llm/response/projection.ex
@@ -121,7 +121,9 @@ defmodule ReqLLM.Response.Projection do
 
   defp reasoning_detail_value(_detail), do: nil
 
-  defp metadata_output_items(metadata) when is_map(metadata) do
+  @doc false
+  @spec metadata_output_items(map()) :: [OutputItem.t()]
+  def metadata_output_items(metadata) when is_map(metadata) do
     values_for_keys(metadata, @source_keys)
     |> output_items_for(:source)
     |> Kernel.++(values_for_keys(metadata, @annotation_keys) |> output_items_for(:annotation))
@@ -132,9 +134,11 @@ defmodule ReqLLM.Response.Projection do
     )
   end
 
-  defp metadata_output_items(_metadata), do: []
+  def metadata_output_items(_metadata), do: []
 
-  defp provider_output_items(provider_meta) when is_map(provider_meta) do
+  @doc false
+  @spec provider_output_items(map()) :: [OutputItem.t()]
+  def provider_output_items(provider_meta) when is_map(provider_meta) do
     source_items =
       values_for_keys(provider_meta, @source_keys) ++
         (provider_meta
@@ -156,7 +160,7 @@ defmodule ReqLLM.Response.Projection do
       output_items_for(provider_items, :provider_item)
   end
 
-  defp provider_output_items(_provider_meta), do: []
+  def provider_output_items(_provider_meta), do: []
 
   defp output_items_for(values, type) do
     Enum.map(values, &output_item(type, sanitize_urls(&1)))
@@ -207,7 +211,9 @@ defmodule ReqLLM.Response.Projection do
     end
   end
 
-  defp warnings(sources) do
+  @doc false
+  @spec warnings([term()]) :: [String.t()] | nil
+  def warnings(sources) do
     case first_available(sources, [:warnings, "warnings"]) do
       warning when is_binary(warning) and warning != "" ->
         redact_warnings([warning], sources)
@@ -269,7 +275,15 @@ defmodule ReqLLM.Response.Projection do
 
   defp safe_provider_metadata(_provider_meta), do: nil
 
-  defp safe_metadata(value) when is_map(value) do
+  @doc false
+  @spec safe_metadata(term()) :: term()
+  def safe_metadata(%_{} = value) do
+    value
+    |> Map.from_struct()
+    |> safe_metadata()
+  end
+
+  def safe_metadata(value) when is_map(value) do
     Map.new(value, fn {key, item} ->
       if redacted_metadata_key?(key) do
         {key, @redacted}
@@ -279,13 +293,13 @@ defmodule ReqLLM.Response.Projection do
     end)
   end
 
-  defp safe_metadata(value) when is_list(value), do: Enum.map(value, &safe_metadata/1)
+  def safe_metadata(value) when is_list(value), do: Enum.map(value, &safe_metadata/1)
 
-  defp safe_metadata(value) when is_tuple(value),
+  def safe_metadata(value) when is_tuple(value),
     do: value |> Tuple.to_list() |> Enum.map(&safe_metadata/1) |> List.to_tuple()
 
-  defp safe_metadata(value) when is_binary(value), do: sanitize_url(value)
-  defp safe_metadata(value), do: value
+  def safe_metadata(value) when is_binary(value), do: sanitize_url(value)
+  def safe_metadata(value), do: value
 
   defp sanitize_urls(value) when is_map(value) do
     Map.new(value, fn {key, item} -> {key, sanitize_urls(item)} end)
@@ -346,7 +360,11 @@ defmodule ReqLLM.Response.Projection do
     _error -> value
   end
 
-  defp redact_warnings(warnings, sources) do
+  @doc false
+  @spec redact_warnings([String.t()], [term()]) :: [String.t()]
+  def redact_warnings([], _sources), do: []
+
+  def redact_warnings(warnings, sources) do
     values = Enum.flat_map(sources, &sensitive_values/1)
 
     Enum.map(warnings, fn warning ->
@@ -357,7 +375,9 @@ defmodule ReqLLM.Response.Projection do
   end
 
   defp sensitive_values(value) when is_map(value) do
-    Enum.flat_map(value, fn {key, item} ->
+    value
+    |> Map.to_list()
+    |> Enum.flat_map(fn {key, item} ->
       if sensitive_metadata_key?(key) do
         binary_values(item)
       else
@@ -371,8 +391,11 @@ defmodule ReqLLM.Response.Projection do
 
   defp binary_values(value) when is_binary(value), do: if(value == "", do: [], else: [value])
 
-  defp binary_values(value) when is_map(value),
-    do: Enum.flat_map(value, fn {_key, item} -> binary_values(item) end)
+  defp binary_values(value) when is_map(value) do
+    value
+    |> Map.to_list()
+    |> Enum.flat_map(fn {_key, item} -> binary_values(item) end)
+  end
 
   defp binary_values(value) when is_list(value), do: Enum.flat_map(value, &binary_values/1)
   defp binary_values(_value), do: []

--- a/lib/req_llm/stream_event.ex
+++ b/lib/req_llm/stream_event.ex
@@ -1,0 +1,119 @@
+defmodule ReqLLM.StreamEvent do
+  @moduledoc """
+  A tagged, provider-neutral projection of one streaming event.
+
+  Events are computed from the existing `ReqLLM.StreamChunk` stream. They do
+  not replace chunks in ReqLLM 1.x and are not stored on
+  `ReqLLM.StreamResponse`.
+
+  The event stream begins with `:start` and ends with exactly one of
+  `:finish`, `:cancelled`, or `:error` when it is consumed to completion.
+  Output deltas retain their arrival order. Provider-specific metadata is
+  exposed through `:provider_event` and event metadata without treating raw
+  provider frames as part of the canonical contract.
+
+  ## Event types
+
+  - `:start` carries the resolved provider and model identity.
+  - `:text_delta` and `:reasoning_delta` carry string deltas.
+  - `:tool_call_start` and `:tool_call_delta` carry incremental tool input;
+    `:tool_call` carries the assembled call before the terminal event.
+  - `:tool_result` carries a result already present in provider metadata. It
+    does not execute a tool or continue a model loop.
+  - `:source`, `:file`, and `:output_item` carry
+    `ReqLLM.Response.OutputItem` projections.
+  - `:usage` carries the final usage map and `:warning` carries one warning.
+  - `:finish`, `:cancelled`, and `:error` are mutually exclusive terminal
+    events.
+  - `:provider_event` carries sanitized extension metadata that has no
+    provider-neutral event type.
+  """
+
+  @event_types [
+    :start,
+    :text_delta,
+    :reasoning_delta,
+    :tool_call_start,
+    :tool_call_delta,
+    :tool_call,
+    :tool_result,
+    :source,
+    :file,
+    :output_item,
+    :usage,
+    :warning,
+    :finish,
+    :cancelled,
+    :error,
+    :provider_event
+  ]
+
+  @output_types [
+    :text_delta,
+    :reasoning_delta,
+    :tool_call_start,
+    :tool_call_delta,
+    :tool_call,
+    :tool_result,
+    :source,
+    :file,
+    :output_item
+  ]
+
+  @terminal_types [:finish, :cancelled, :error]
+
+  @schema Zoi.struct(__MODULE__, %{
+            type: Zoi.enum(@event_types),
+            data: Zoi.any() |> Zoi.default(nil),
+            metadata: Zoi.map() |> Zoi.default(%{})
+          })
+
+  @type event_type ::
+          :start
+          | :text_delta
+          | :reasoning_delta
+          | :tool_call_start
+          | :tool_call_delta
+          | :tool_call
+          | :tool_result
+          | :source
+          | :file
+          | :output_item
+          | :usage
+          | :warning
+          | :finish
+          | :cancelled
+          | :error
+          | :provider_event
+
+  @type t :: %__MODULE__{
+          type: event_type(),
+          data: term(),
+          metadata: map()
+        }
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for canonical stream events."
+  def schema, do: @schema
+
+  @doc "Returns all stable stream event types."
+  @spec types() :: [event_type()]
+  def types, do: @event_types
+
+  @doc "Builds a canonical stream event."
+  @spec new(event_type(), term(), map()) :: t()
+  def new(type, data \\ nil, metadata \\ %{})
+      when type in @event_types and is_map(metadata) do
+    %__MODULE__{type: type, data: data, metadata: metadata}
+  end
+
+  @doc "Returns whether an event carries model output or an output delta."
+  @spec output?(t()) :: boolean()
+  def output?(%__MODULE__{type: type}), do: type in @output_types
+
+  @doc "Returns whether an event is the terminal event for a consumed stream."
+  @spec terminal?(t()) :: boolean()
+  def terminal?(%__MODULE__{type: type}), do: type in @terminal_types
+end

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -72,6 +72,7 @@ defmodule ReqLLM.StreamResponse do
   alias ReqLLM.Provider.ResponseBuilder
   alias ReqLLM.Response
   alias ReqLLM.Response.Stream, as: ResponseStream
+  alias ReqLLM.StreamResponse.EventProjector
   alias ReqLLM.StreamResponse.MetadataHandle
   alias ReqLLM.ToolCall
 
@@ -137,6 +138,46 @@ defmodule ReqLLM.StreamResponse do
     stream
     |> Stream.filter(&(&1.type == :content))
     |> Stream.map(& &1.text)
+  end
+
+  @doc """
+  Project the one consumable chunk stream into canonical tagged events.
+
+  This is a lazy view over `stream_response.stream`; it does not create or
+  buffer a second stream. Choose either the legacy chunk stream, `tokens/1`,
+  or `events/1` for a response because consuming one consumes the underlying
+  stream.
+
+  A fully consumed event stream starts with `:start` and ends with exactly one
+  `:finish`, `:cancelled`, or `:error` event. Output deltas and provider
+  extensions retain their arrival order. Final assembled tool calls, usage,
+  and warnings are emitted immediately before the terminal event. Early
+  enumeration halts the underlying stream and therefore cannot deliver a
+  terminal event to a consumer that has already stopped requesting values.
+
+  Provider and transport failures encountered by this projection are yielded
+  as terminal `:error` events. Consuming `stream_response.stream` directly or
+  through `tokens/1` retains the existing exception behavior.
+
+  `StreamResponse.stream` and every `StreamChunk` value remain unchanged in
+  ReqLLM 1.x.
+
+  ## Examples
+
+      {:ok, response} = ReqLLM.stream_text("openai:gpt-4o-mini", "Hello")
+
+      response
+      |> ReqLLM.StreamResponse.events()
+      |> Enum.each(fn
+        %ReqLLM.StreamEvent{type: :text_delta, data: text} -> IO.write(text)
+        %ReqLLM.StreamEvent{type: :error, data: error} -> IO.inspect(error)
+        _event -> :ok
+      end)
+
+  """
+  @spec events(t()) :: Enumerable.t()
+  def events(%__MODULE__{} = stream_response) do
+    EventProjector.events(stream_response)
   end
 
   @doc """

--- a/lib/req_llm/stream_response/event_projector.ex
+++ b/lib/req_llm/stream_response/event_projector.ex
@@ -1,0 +1,510 @@
+defmodule ReqLLM.StreamResponse.EventProjector do
+  @moduledoc false
+
+  alias ReqLLM.Provider.ChunkAccumulator
+  alias ReqLLM.Response.OutputItem
+  alias ReqLLM.Response.Projection
+  alias ReqLLM.StreamChunk
+  alias ReqLLM.StreamEvent
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.StreamResponse.MetadataHandle
+
+  @canonical_meta_keys [
+    :annotation,
+    "annotation",
+    :annotations,
+    "annotations",
+    :citation,
+    "citation",
+    :citations,
+    "citations",
+    :code_interpreter_item,
+    "code_interpreter_item",
+    :error,
+    "error",
+    :file,
+    "file",
+    :files,
+    "files",
+    :finish_reason,
+    "finish_reason",
+    :output_item,
+    "output_item",
+    :output_items,
+    "output_items",
+    :provider_meta,
+    "provider_meta",
+    :provider_item,
+    "provider_item",
+    :provider_items,
+    "provider_items",
+    :reasoning_details,
+    "reasoning_details",
+    :refusal,
+    "refusal",
+    :refusals,
+    "refusals",
+    :source,
+    "source",
+    :sources,
+    "sources",
+    :terminal?,
+    "terminal?",
+    :tool_call_args,
+    "tool_call_args",
+    :tool_result,
+    "tool_result",
+    :tool_results,
+    "tool_results",
+    :usage,
+    "usage",
+    :warning,
+    "warning",
+    :warnings,
+    "warnings"
+  ]
+
+  @terminal_metadata_keys [
+    :model,
+    "model",
+    :provider,
+    "provider",
+    :provider_meta,
+    "provider_meta",
+    :request_id,
+    "request_id",
+    :response_id,
+    "response_id",
+    :status,
+    "status"
+  ]
+
+  @spec events(StreamResponse.t()) :: Enumerable.t()
+  def events(%StreamResponse{} = response) do
+    Stream.resource(
+      fn -> initial_state(response) end,
+      &next_events/1,
+      &halt_iterator/1
+    )
+  end
+
+  defp initial_state(response) do
+    %{
+      accumulator: ChunkAccumulator.new(),
+      emitted_items: MapSet.new(),
+      error: nil,
+      finish_reason: nil,
+      iterator: {:enumerable, response.stream},
+      metadata_handle: response.metadata_handle,
+      model: response.model,
+      started?: false,
+      terminal_metadata: %{},
+      terminal?: false,
+      usage: nil,
+      warning_sources: [],
+      warnings: []
+    }
+  end
+
+  defp next_events(%{terminal?: true} = state), do: {:halt, state}
+
+  defp next_events(state) do
+    case pull(state.iterator) do
+      {:ok, %StreamChunk{} = chunk, iterator} ->
+        {chunk, state} = prepare_chunk(chunk, %{state | iterator: iterator})
+        accumulator = ChunkAccumulator.push(state.accumulator, chunk)
+        state = state |> Map.put(:accumulator, accumulator) |> collect_chunk_metadata(chunk)
+        {events, state} = chunk_events(chunk, state)
+        emit_or_continue(events, state)
+
+      {:ok, value, iterator} ->
+        event = StreamEvent.new(:provider_event, Projection.safe_metadata(value))
+        emit([event], %{state | iterator: iterator})
+
+      :done ->
+        terminal_events(state)
+    end
+  rescue
+    error ->
+      emit_terminal_error(error, state)
+  catch
+    :exit, reason ->
+      emit_terminal_error(reason, state)
+  end
+
+  defp emit_or_continue([], state), do: next_events(state)
+  defp emit_or_continue(events, state), do: emit(events, state)
+
+  defp emit(events, %{started?: false} = state) do
+    {[start_event(state.model) | events], %{state | started?: true}}
+  end
+
+  defp emit(events, state), do: {events, state}
+
+  defp prepare_chunk(%StreamChunk{type: :tool_call} = chunk, state) do
+    metadata = chunk.metadata
+    id = value(metadata, :id) || "call_#{ReqLLM.ID.uuid7()}"
+    index = value(metadata, :index) || 0
+    metadata = metadata |> Map.put_new(:id, id) |> Map.put_new(:index, index)
+    {%{chunk | metadata: metadata}, state}
+  end
+
+  defp prepare_chunk(chunk, state), do: {chunk, state}
+
+  defp chunk_events(%StreamChunk{type: :content, text: text, metadata: metadata}, state)
+       when is_binary(text) do
+    event = StreamEvent.new(:text_delta, text, safe_map(metadata))
+    output_item_events([event], metadata, state)
+  end
+
+  defp chunk_events(%StreamChunk{type: :thinking, text: text, metadata: metadata}, state)
+       when is_binary(text) do
+    event = StreamEvent.new(:reasoning_delta, text, safe_map(metadata))
+    output_item_events([event], metadata, state)
+  end
+
+  defp chunk_events(%StreamChunk{type: :tool_call, name: name} = chunk, state)
+       when is_binary(name) do
+    metadata = chunk.metadata
+
+    data = %{
+      id: value(metadata, :id),
+      index: value(metadata, :index) || 0,
+      name: chunk.name,
+      arguments: chunk.arguments || %{}
+    }
+
+    event = StreamEvent.new(:tool_call_start, data, safe_map(metadata))
+    output_item_events([event], metadata, state)
+  end
+
+  defp chunk_events(%StreamChunk{type: :meta, metadata: metadata}, state)
+       when is_map(metadata) do
+    metadata_events(metadata, state)
+  end
+
+  defp chunk_events(%StreamChunk{} = chunk, state) do
+    data =
+      chunk
+      |> Map.from_struct()
+      |> Projection.safe_metadata()
+
+    {[StreamEvent.new(:provider_event, data)], state}
+  end
+
+  defp metadata_events(metadata, state) do
+    events = tool_delta_events(metadata) ++ tool_result_events(metadata)
+    {events, state} = output_item_events(events, metadata, state)
+
+    provider_data =
+      metadata
+      |> Map.drop(@canonical_meta_keys ++ @terminal_metadata_keys)
+      |> Projection.safe_metadata()
+
+    events =
+      if is_map(provider_data) and map_size(provider_data) > 0 do
+        events ++ [StreamEvent.new(:provider_event, provider_data)]
+      else
+        events
+      end
+
+    {events, state}
+  end
+
+  defp output_item_events(events, metadata, state) do
+    items =
+      Projection.metadata_output_items(metadata) ++
+        Projection.provider_output_items(provider_metadata(metadata)) ++
+        direct_output_items(metadata)
+
+    {item_events, state} = unique_output_item_events(items, state)
+    {events ++ item_events, state}
+  end
+
+  defp unique_output_item_events(items, state) do
+    Enum.reduce(items, {[], state}, fn item, {events, state} ->
+      fingerprint = {item.type, item.data, item.metadata}
+
+      if MapSet.member?(state.emitted_items, fingerprint) do
+        {events, state}
+      else
+        event = output_item_event(item)
+        emitted_items = MapSet.put(state.emitted_items, fingerprint)
+        {events ++ [event], %{state | emitted_items: emitted_items}}
+      end
+    end)
+  end
+
+  defp output_item_event(%OutputItem{type: :source} = item),
+    do: StreamEvent.new(:source, item)
+
+  defp output_item_event(%OutputItem{type: :file} = item),
+    do: StreamEvent.new(:file, item)
+
+  defp output_item_event(%OutputItem{} = item),
+    do: StreamEvent.new(:output_item, item)
+
+  defp direct_output_items(metadata) do
+    values(metadata, [:file, "file", :files, "files"])
+    |> Enum.map(&%OutputItem{type: :file, data: Projection.safe_metadata(&1), metadata: %{}})
+    |> Kernel.++(
+      values(metadata, [:code_interpreter_item, "code_interpreter_item"])
+      |> Enum.map(&%OutputItem{type: :provider_item, data: &1, metadata: %{}})
+    )
+  end
+
+  defp tool_delta_events(metadata) do
+    case value(metadata, :tool_call_args) do
+      data when is_map(data) -> [StreamEvent.new(:tool_call_delta, data)]
+      _other -> []
+    end
+  end
+
+  defp tool_result_events(metadata) do
+    metadata
+    |> values([:tool_result, "tool_result", :tool_results, "tool_results"])
+    |> Enum.map(&StreamEvent.new(:tool_result, &1))
+  end
+
+  defp terminal_events(state) do
+    metadata = await_metadata(state.metadata_handle)
+    {item_events, state} = terminal_output_item_events(metadata, state)
+    tool_events = terminal_tool_events(state.accumulator)
+    usage_events = usage_events(metadata, state)
+
+    warnings =
+      state.warnings
+      |> merge_warnings(warning_values(metadata))
+      |> Projection.redact_warnings(Enum.reverse(state.warning_sources, [metadata]))
+      |> Enum.map(&StreamEvent.new(:warning, &1))
+
+    events =
+      item_events ++ tool_events ++ usage_events ++ warnings ++ [terminal_event(metadata, state)]
+
+    {events, state} = emit(events, %{state | iterator: :done, terminal?: true})
+    {events, state}
+  end
+
+  defp terminal_output_item_events(metadata, state) do
+    items =
+      Projection.metadata_output_items(metadata) ++
+        Projection.provider_output_items(provider_metadata(metadata)) ++
+        direct_output_items(metadata)
+
+    unique_output_item_events(items, state)
+  end
+
+  defp terminal_tool_events(accumulator) do
+    accumulator
+    |> ChunkAccumulator.finalize_tool_calls_for_response()
+    |> Enum.map(&StreamEvent.new(:tool_call, &1))
+  end
+
+  defp usage_events(metadata, state) do
+    usage =
+      value(metadata, :usage) || state.usage ||
+        ChunkAccumulator.finalize_usage(state.accumulator)
+
+    if is_map(usage), do: [StreamEvent.new(:usage, usage)], else: []
+  end
+
+  defp terminal_event(metadata, state) do
+    error = value(metadata, :error) || state.error
+
+    finish_reason =
+      metadata
+      |> value(:finish_reason)
+      |> Kernel.||(state.finish_reason)
+      |> Kernel.||(ChunkAccumulator.finalize_finish_reason(state.accumulator))
+      |> normalize_finish_reason()
+
+    event_metadata = terminal_metadata(Map.merge(state.terminal_metadata, metadata))
+
+    cond do
+      not is_nil(error) ->
+        StreamEvent.new(:error, error, event_metadata)
+
+      finish_reason == :cancelled ->
+        StreamEvent.new(:cancelled, %{finish_reason: :cancelled}, event_metadata)
+
+      finish_reason == :error ->
+        StreamEvent.new(:error, %{finish_reason: :error}, event_metadata)
+
+      true ->
+        StreamEvent.new(:finish, %{finish_reason: finish_reason}, event_metadata)
+    end
+  end
+
+  defp emit_terminal_error(reason, state) do
+    event = StreamEvent.new(:error, reason)
+    {events, state} = emit([event], %{state | iterator: :done, terminal?: true})
+    {events, state}
+  end
+
+  defp start_event(model) do
+    StreamEvent.new(:start, %{
+      model: %{
+        id: model.provider_model_id || model.id || model.model,
+        provider: model.provider
+      }
+    })
+  end
+
+  defp terminal_metadata(metadata) do
+    metadata
+    |> Map.take(@terminal_metadata_keys)
+    |> Projection.safe_metadata()
+  end
+
+  defp await_metadata(handle) do
+    MetadataHandle.await(handle)
+  end
+
+  defp provider_metadata(metadata) do
+    case value(metadata, :provider_meta) do
+      provider_meta when is_map(provider_meta) -> provider_meta
+      _other -> %{}
+    end
+  end
+
+  defp collect_chunk_metadata(state, %StreamChunk{metadata: metadata}) do
+    warnings = merge_warnings(state.warnings, warning_values(metadata))
+    error = value(metadata, :error) || state.error
+    finish_reason = value(metadata, :finish_reason) || state.finish_reason
+    usage = merge_usage(state.usage, value(metadata, :usage))
+    warning_sources = collect_warning_source(state.warning_sources, metadata)
+
+    terminal_metadata =
+      Map.merge(state.terminal_metadata, Map.take(metadata, @terminal_metadata_keys))
+
+    %{
+      state
+      | error: error,
+        finish_reason: finish_reason,
+        terminal_metadata: terminal_metadata,
+        usage: usage,
+        warning_sources: warning_sources,
+        warnings: warnings
+    }
+  end
+
+  defp merge_usage(existing, usage) when is_map(usage) do
+    ReqLLM.Usage.merge(existing || %{}, usage)
+  end
+
+  defp merge_usage(existing, _usage), do: existing
+
+  defp merge_warnings(existing, warnings) when is_list(warnings) do
+    Enum.uniq(existing ++ warnings)
+  end
+
+  defp warning_values(metadata) do
+    case value(metadata, :warnings) || value(metadata, :warning) do
+      warning when is_binary(warning) and warning != "" -> [warning]
+      warnings when is_list(warnings) -> Enum.filter(warnings, &is_binary/1)
+      _other -> []
+    end
+  end
+
+  defp collect_warning_source(sources, metadata) when map_size(metadata) > 0 do
+    if Projection.safe_metadata(metadata) == metadata do
+      sources
+    else
+      [metadata | sources]
+    end
+  end
+
+  defp collect_warning_source(sources, _metadata), do: sources
+
+  defp safe_map(metadata), do: Projection.safe_metadata(metadata)
+
+  defp values(map, keys) when is_map(map) do
+    keys
+    |> Enum.flat_map(fn key -> normalize_values(Map.get(map, key)) end)
+    |> Enum.uniq()
+  end
+
+  defp normalize_values(nil), do: []
+  defp normalize_values(values) when is_list(values), do: Enum.reject(values, &is_nil/1)
+  defp normalize_values(value), do: [value]
+
+  defp value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp pull({:enumerable, enumerable}) do
+    enumerable
+    |> Enumerable.reduce({:cont, nil}, &suspend/2)
+    |> pull_result()
+  end
+
+  defp pull({:continuation, continuation}) do
+    continuation.({:cont, nil})
+    |> pull_result()
+  end
+
+  defp pull_result({:suspended, item, continuation}),
+    do: {:ok, item, {:continuation, continuation}}
+
+  defp pull_result({:done, _accumulator}), do: :done
+  defp pull_result({:halted, _accumulator}), do: :done
+
+  defp suspend(item, _accumulator), do: {:suspend, item}
+
+  defp halt_iterator(%{iterator: {:continuation, continuation}}) do
+    continuation.({:halt, nil})
+    :ok
+  rescue
+    _error -> :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp halt_iterator(_state), do: :ok
+
+  defp normalize_finish_reason(nil), do: :unknown
+
+  defp normalize_finish_reason(reason) when is_atom(reason),
+    do: normalize_finish_reason_atom(reason)
+
+  defp normalize_finish_reason(reason) when is_binary(reason) do
+    case reason do
+      "stop" -> :stop
+      "completed" -> :stop
+      "end_turn" -> :stop
+      "tool_calls" -> :tool_calls
+      "tool_use" -> :tool_calls
+      "length" -> :length
+      "max_tokens" -> :length
+      "max_output_tokens" -> :length
+      "content_filter" -> :content_filter
+      "error" -> :error
+      "cancelled" -> :cancelled
+      "incomplete" -> :incomplete
+      _other -> :unknown
+    end
+  end
+
+  defp normalize_finish_reason(_reason), do: :unknown
+
+  defp normalize_finish_reason_atom(:tool_use), do: :tool_calls
+  defp normalize_finish_reason_atom(:completed), do: :stop
+  defp normalize_finish_reason_atom(:end_turn), do: :stop
+  defp normalize_finish_reason_atom(:max_tokens), do: :length
+  defp normalize_finish_reason_atom(:max_output_tokens), do: :length
+
+  defp normalize_finish_reason_atom(reason)
+       when reason in [
+              :stop,
+              :tool_calls,
+              :length,
+              :content_filter,
+              :error,
+              :cancelled,
+              :incomplete,
+              :unknown
+            ],
+       do: reason
+
+  defp normalize_finish_reason_atom(_reason), do: :unknown
+end

--- a/test/req_llm/stream_event_projection_test.exs
+++ b/test/req_llm/stream_event_projection_test.exs
@@ -1,0 +1,433 @@
+defmodule ReqLLM.StreamEventProjectionTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :public_api
+
+  alias ReqLLM.Context
+  alias ReqLLM.Provider.Defaults
+  alias ReqLLM.Providers.Anthropic
+  alias ReqLLM.Response.OutputItem
+  alias ReqLLM.StreamChunk
+  alias ReqLLM.StreamEvent
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.StreamResponse.MetadataHandle
+
+  describe "StreamEvent" do
+    test "exposes a validated additive event contract" do
+      assert %StreamEvent{type: :text_delta, data: "hello", metadata: %{sequence: 1}} =
+               StreamEvent.new(:text_delta, "hello", %{sequence: 1})
+
+      assert :start in StreamEvent.types()
+      assert :provider_event in StreamEvent.types()
+      assert StreamEvent.output?(StreamEvent.new(:source, %{}))
+      refute StreamEvent.output?(StreamEvent.new(:usage, %{}))
+      assert StreamEvent.terminal?(StreamEvent.new(:finish, %{finish_reason: :stop}))
+      refute StreamEvent.terminal?(StreamEvent.new(:text_delta, "hello"))
+      assert StreamEvent.schema()
+    end
+  end
+
+  describe "events/1" do
+    test "projects ordered text, reasoning, tool, source, usage, and lifecycle events" do
+      source = %{
+        "uri" => "https://example.com/guide?api_key=secret-value",
+        "title" => "Guide"
+      }
+
+      provider_meta = %{"google" => %{"sources" => [source]}}
+      usage = %{input_tokens: 4, output_tokens: 3, total_tokens: 7}
+
+      chunks = [
+        StreamChunk.text("Hello", %{sequence: 1}),
+        StreamChunk.thinking("Consider", %{signature: "reasoning-secret"}),
+        StreamChunk.tool_call("search", %{}, %{
+          id: "call_1",
+          index: 0,
+          expects_arg_fragments: true
+        }),
+        StreamChunk.meta(%{
+          tool_call_args: %{index: 0, fragment: ~s({"query":"elixir"})}
+        }),
+        StreamChunk.meta(%{
+          provider_meta: provider_meta,
+          usage: usage,
+          finish_reason: :stop,
+          terminal?: true
+        })
+      ]
+
+      response =
+        stream_response(chunks, %{
+          provider_meta: provider_meta,
+          usage: usage,
+          finish_reason: :stop,
+          response_id: "resp_123"
+        })
+
+      events = Enum.to_list(StreamResponse.events(response))
+
+      assert Enum.map(events, & &1.type) == [
+               :start,
+               :text_delta,
+               :reasoning_delta,
+               :tool_call_start,
+               :tool_call_delta,
+               :source,
+               :tool_call,
+               :usage,
+               :finish
+             ]
+
+      assert %StreamEvent{data: %{model: %{id: "test-model", provider: :test}}} = hd(events)
+      assert %StreamEvent{type: :text_delta, data: "Hello", metadata: %{sequence: 1}} in events
+
+      assert %StreamEvent{
+               type: :reasoning_delta,
+               data: "Consider",
+               metadata: %{signature: "[REDACTED]"}
+             } in events
+
+      assert %StreamEvent{
+               type: :tool_call,
+               data: %{id: "call_1", name: "search", arguments: %{"query" => "elixir"}}
+             } in events
+
+      assert %StreamEvent{type: :source, data: %OutputItem{type: :source} = source_item} =
+               Enum.find(events, &(&1.type == :source))
+
+      source_json = inspect(source_item.data)
+      refute source_json =~ "secret-value"
+      assert %StreamEvent{type: :usage, data: ^usage} = Enum.find(events, &(&1.type == :usage))
+
+      assert %StreamEvent{
+               type: :finish,
+               data: %{finish_reason: :stop},
+               metadata: %{response_id: "resp_123"}
+             } = List.last(events)
+
+      assert StreamResponse.usage(response) == usage
+      assert StreamResponse.finish_reason(response) == :stop
+    end
+
+    test "normalizes current OpenAI and Anthropic decoder output without consumer branching" do
+      openai_model = %LLMDB.Model{provider: :openai, id: "gpt-test"}
+      anthropic_model = %LLMDB.Model{provider: :anthropic, id: "claude-test"}
+
+      openai_chunks =
+        [
+          %{data: %{"choices" => [%{"delta" => %{"content" => "Hello"}}]}},
+          %{data: %{"choices" => [%{"delta" => %{"reasoning_content" => "Think"}}]}},
+          %{
+            data: %{
+              "choices" => [
+                %{
+                  "delta" => %{
+                    "tool_calls" => [
+                      %{
+                        "id" => "call_1",
+                        "type" => "function",
+                        "index" => 0,
+                        "function" => %{"name" => "lookup"}
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          %{
+            data: %{
+              "choices" => [
+                %{
+                  "delta" => %{
+                    "tool_calls" => [
+                      %{"index" => 0, "function" => %{"arguments" => ~s({"q":"elixir"})}}
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          %{
+            data: %{
+              "choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls"}],
+              "usage" => %{"prompt_tokens" => 4, "completion_tokens" => 3, "total_tokens" => 7}
+            }
+          }
+        ]
+        |> Enum.flat_map(&Defaults.default_decode_stream_event(&1, openai_model))
+
+      anthropic_chunks =
+        [
+          %{
+            data: %{
+              "type" => "content_block_delta",
+              "index" => 0,
+              "delta" => %{"type" => "text_delta", "text" => "Hello"}
+            }
+          },
+          %{
+            data: %{
+              "type" => "content_block_delta",
+              "index" => 1,
+              "delta" => %{"type" => "thinking_delta", "thinking" => "Think"}
+            }
+          },
+          %{
+            data: %{
+              "type" => "content_block_start",
+              "index" => 0,
+              "content_block" => %{"type" => "tool_use", "id" => "call_1", "name" => "lookup"}
+            }
+          },
+          %{
+            data: %{
+              "type" => "content_block_delta",
+              "index" => 0,
+              "delta" => %{"type" => "input_json_delta", "partial_json" => ~s({"q":"elixir"})}
+            }
+          },
+          %{
+            data: %{
+              "type" => "message_delta",
+              "delta" => %{"stop_reason" => "tool_use"},
+              "usage" => %{"input_tokens" => 4, "output_tokens" => 3}
+            }
+          }
+        ]
+        |> Enum.flat_map(&Anthropic.decode_stream_event(&1, anthropic_model))
+
+      openai_events =
+        stream_response(openai_chunks, %{finish_reason: :tool_calls})
+        |> StreamResponse.events()
+        |> Enum.to_list()
+
+      anthropic_events =
+        stream_response(anthropic_chunks, %{finish_reason: :tool_calls})
+        |> StreamResponse.events()
+        |> Enum.to_list()
+
+      expected_types = [
+        :start,
+        :text_delta,
+        :reasoning_delta,
+        :tool_call_start,
+        :tool_call_delta,
+        :tool_call,
+        :usage,
+        :finish
+      ]
+
+      assert Enum.map(openai_events, & &1.type) == expected_types
+      assert Enum.map(anthropic_events, & &1.type) == expected_types
+
+      assert Enum.find(openai_events, &(&1.type == :tool_call)).data.arguments == %{
+               "q" => "elixir"
+             }
+
+      assert Enum.find(anthropic_events, &(&1.type == :tool_call)).data.arguments == %{
+               "q" => "elixir"
+             }
+    end
+
+    test "emits one terminal cancellation event" do
+      response = stream_response([], %{finish_reason: :cancelled})
+
+      assert [
+               %StreamEvent{type: :start},
+               %StreamEvent{type: :cancelled, data: %{finish_reason: :cancelled}}
+             ] = Enum.to_list(StreamResponse.events(response))
+    end
+
+    test "emits one terminal error from collected metadata" do
+      error = ReqLLM.Error.API.Request.exception(reason: "provider unavailable", status: 503)
+      response = stream_response([StreamChunk.text("partial")], %{error: error})
+
+      assert [
+               %StreamEvent{type: :start},
+               %StreamEvent{type: :text_delta, data: "partial"},
+               %StreamEvent{type: :error, data: ^error}
+             ] = Enum.to_list(StreamResponse.events(response))
+    end
+
+    test "uses terminal error and finish signals retained by chunks" do
+      error = ReqLLM.Error.API.Stream.exception(reason: "provider failed", cause: :provider)
+
+      error_response =
+        stream_response(
+          [StreamChunk.meta(%{error: error, finish_reason: :error, terminal?: true})],
+          %{}
+        )
+
+      assert [%StreamEvent{type: :start}, %StreamEvent{type: :error, data: ^error}] =
+               Enum.to_list(StreamResponse.events(error_response))
+
+      finish_response =
+        stream_response([StreamChunk.meta(%{"finish_reason" => "length"})], %{})
+
+      assert [
+               %StreamEvent{type: :start},
+               %StreamEvent{type: :finish, data: %{finish_reason: :length}}
+             ] = Enum.to_list(StreamResponse.events(finish_response))
+    end
+
+    test "turns a fatal stream exception into a terminal error event" do
+      test_pid = self()
+      error = ReqLLM.Error.API.Stream.exception(reason: "transport closed", cause: :closed)
+
+      stream =
+        Stream.resource(
+          fn -> 0 end,
+          fn
+            0 -> {[StreamChunk.text("partial")], 1}
+            1 -> raise error
+          end,
+          fn _state -> send(test_pid, :upstream_closed) end
+        )
+
+      response = stream_response(stream, %{finish_reason: :error})
+      events = Enum.to_list(StreamResponse.events(response))
+
+      assert Enum.map(events, & &1.type) == [:start, :text_delta, :error]
+      assert %StreamEvent{type: :error, data: ^error} = List.last(events)
+      assert_receive :upstream_closed
+    end
+
+    test "halts the one underlying stream when enumeration stops early" do
+      test_pid = self()
+
+      stream =
+        Stream.resource(
+          fn -> 0 end,
+          fn index -> {[StreamChunk.text(Integer.to_string(index))], index + 1} end,
+          fn _state -> send(test_pid, :upstream_halted) end
+        )
+
+      response = stream_response(stream, %{finish_reason: :cancelled})
+
+      assert [
+               %StreamEvent{type: :start},
+               %StreamEvent{type: :text_delta, data: "0"}
+             ] = response |> StreamResponse.events() |> Stream.take(2) |> Enum.to_list()
+
+      assert_receive :upstream_halted
+    end
+
+    test "pulls each underlying chunk once and closes it after full consumption" do
+      test_pid = self()
+      chunks = [StreamChunk.text("a"), StreamChunk.text("b"), StreamChunk.text("c")]
+
+      stream =
+        Stream.resource(
+          fn -> chunks end,
+          fn
+            [chunk | rest] ->
+              send(test_pid, {:pulled, chunk.text})
+              {[chunk], rest}
+
+            [] ->
+              {:halt, []}
+          end,
+          fn _state -> send(test_pid, :upstream_closed) end
+        )
+
+      response = stream_response(stream, %{finish_reason: :stop})
+      events = Enum.to_list(StreamResponse.events(response))
+
+      assert Enum.map(events, & &1.type) == [
+               :start,
+               :text_delta,
+               :text_delta,
+               :text_delta,
+               :finish
+             ]
+
+      assert_receive {:pulled, "a"}
+      assert_receive {:pulled, "b"}
+      assert_receive {:pulled, "c"}
+      refute_receive {:pulled, _text}
+      assert_receive :upstream_closed
+    end
+
+    test "redacts provider metadata and warning secrets" do
+      chunks = [
+        StreamChunk.meta(%{api_key: "sk-secret", provider_sequence: 2}),
+        StreamChunk.meta(%{warning: "Ignored key sk-secret"})
+      ]
+
+      response =
+        stream_response(chunks, %{
+          api_key: "sk-secret",
+          warnings: ["Ignored key sk-secret"],
+          finish_reason: :stop
+        })
+
+      events = Enum.to_list(StreamResponse.events(response))
+
+      assert %StreamEvent{
+               type: :provider_event,
+               data: %{api_key: "[REDACTED]", provider_sequence: 2}
+             } in events
+
+      assert %StreamEvent{type: :warning, data: "Ignored key [REDACTED]"} in events
+      refute inspect(events) =~ "sk-secret"
+    end
+
+    test "projects provider-native items and files without changing chunks" do
+      code_item = %{"type" => "code_interpreter_call", "id" => "ci_1"}
+
+      file = %{
+        url: "https://example.com/result.png?api_key=file-secret",
+        media_type: "image/png"
+      }
+
+      chunks = [
+        StreamChunk.meta(%{code_interpreter_item: code_item}),
+        StreamChunk.meta(%{file: file})
+      ]
+
+      response = stream_response(chunks, %{finish_reason: :stop})
+      events = Enum.to_list(StreamResponse.events(response))
+
+      assert %StreamEvent{
+               type: :output_item,
+               data: %OutputItem{type: :provider_item, data: ^code_item}
+             } = Enum.find(events, &(&1.type == :output_item))
+
+      assert %StreamEvent{type: :file, data: %OutputItem{type: :file} = file_item} =
+               Enum.find(events, &(&1.type == :file))
+
+      assert file_item.data.media_type == "image/png"
+      refute inspect(file_item.data) =~ "file-secret"
+
+      legacy_response = stream_response(chunks, %{finish_reason: :stop})
+      assert Enum.to_list(legacy_response.stream) == chunks
+    end
+
+    test "keeps the StreamResponse struct and legacy projections unchanged" do
+      chunks = [StreamChunk.text("hello"), StreamChunk.meta(%{finish_reason: :stop})]
+      response = stream_response(chunks, %{finish_reason: :stop})
+
+      assert response |> Map.from_struct() |> Map.keys() |> Enum.sort() ==
+               [:cancel, :context, :metadata_handle, :model, :stream]
+
+      token_response = stream_response(chunks, %{finish_reason: :stop})
+      assert Enum.to_list(StreamResponse.tokens(token_response)) == ["hello"]
+
+      legacy_response = stream_response(chunks, %{finish_reason: :stop})
+      assert Enum.to_list(legacy_response.stream) == chunks
+    end
+  end
+
+  defp stream_response(stream, metadata) do
+    {:ok, metadata_handle} = MetadataHandle.start_link(fn -> metadata end)
+
+    %StreamResponse{
+      stream: stream,
+      metadata_handle: metadata_handle,
+      cancel: fn -> :ok end,
+      model: %LLMDB.Model{provider: :test, id: "test-model"},
+      context: Context.new([Context.system("Test")])
+    }
+  end
+end


### PR DESCRIPTION
Closes #846

## Summary

- add `ReqLLM.StreamEvent` and a lazy `StreamResponse.events/1` projection over the existing one-consumable chunk stream
- normalize lifecycle, text, reasoning, tool, source/file, usage, warning, cancellation, completion, error, and provider-extension events
- preserve `StreamResponse.stream`, `StreamChunk`, and `tokens/1` behavior unchanged
- reuse response projection sanitization for event metadata, URLs, and warning secrets
- document early-halt, terminal, and error semantics without adding agent loops, retries, timeouts, or a second stream

## Backward compatibility

This is an additive V1 API. Existing stream consumers and structs are unchanged. Consumers opt into exactly one view of the same underlying stream: raw chunks, text tokens, or canonical events.

## Validation

- `mix test`: 3,753 passed, 11 skipped, 145 excluded
- `mix quality`: passed (format, warnings-as-errors compile, Credo, Dialyzer)
- `mix docs`: passed with one pre-existing hidden Bedrock HTTP/2 module reference warning
- focused stream event/response projection suites: 22 passed
- focused StreamResponse, StreamChunk, response stream, accumulator, and StreamServer compatibility suites: 266 passed