### PR TITLE
refactor: share OpenAI Chat Completions result materialization

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1140,14 +1140,7 @@ defmodule ReqLLM.Provider.Defaults do
         _ -> {[], %{}}
       end
 
-    message =
-      content_chunks
-      |> build_openai_message_from_chunks()
-      |> put_openai_reasoning_details(raw_message, model.provider)
-
-    context = %ReqLLM.Context{
-      messages: [message]
-    }
+    chunks = content_chunks ++ openai_reasoning_details_chunks(raw_message, model.provider)
 
     logprobs = get_in(first_choice, ["logprobs", "content"])
 
@@ -1155,22 +1148,23 @@ defmodule ReqLLM.Provider.Defaults do
       data
       |> Map.drop(["id", "model", "choices", "usage"])
       |> then(fn meta ->
-        if logprobs, do: Map.put(meta, :logprobs, logprobs), else: meta
+        if is_nil(logprobs), do: meta, else: Map.put(meta, :logprobs, logprobs)
       end)
 
-    response = %ReqLLM.Response{
-      id: id,
-      model: model_name,
-      context: context,
-      message: message,
-      stream?: false,
-      stream: nil,
+    metadata = %{
+      response_id: id,
+      response_model: model_name,
       usage: usage,
       finish_reason: finish_reason,
       provider_meta: provider_meta
     }
 
-    {:ok, response}
+    ReqLLM.Provider.Defaults.ResponseBuilder.build_buffered_response(
+      chunks,
+      metadata,
+      context: %ReqLLM.Context{messages: []},
+      model: model
+    )
   end
 
   @doc """
@@ -1312,18 +1306,15 @@ defmodule ReqLLM.Provider.Defaults do
 
   defp decode_openai_tool_calls(_), do: []
 
-  defp put_openai_reasoning_details(message, %{"reasoning_details" => details}, provider)
+  defp openai_reasoning_details_chunks(%{"reasoning_details" => details}, provider)
        when is_list(details) and details != [] do
-    normalized_details = decode_openai_reasoning_details(details, provider)
-
-    if normalized_details == [] do
-      message
-    else
-      %{message | reasoning_details: normalized_details}
+    case decode_openai_reasoning_details(details, provider) do
+      [] -> []
+      normalized_details -> [ReqLLM.StreamChunk.meta(%{reasoning_details: normalized_details})]
     end
   end
 
-  defp put_openai_reasoning_details(message, _raw_message, _provider), do: message
+  defp openai_reasoning_details_chunks(_raw_message, _provider), do: []
 
   defp decode_openai_reasoning_details(details, provider) when is_list(details) do
     details
@@ -1527,67 +1518,6 @@ defmodule ReqLLM.Provider.Defaults do
        decoded_arguments: arguments
      }}
   end
-
-  defp build_openai_message_from_chunks(chunks) when is_list(chunks) do
-    content_parts =
-      chunks
-      |> Enum.filter(&(&1.type in [:content, :thinking]))
-      |> Enum.map(&openai_chunk_to_content_part/1)
-      |> Enum.reject(&is_nil/1)
-
-    tool_calls =
-      chunks
-      |> Enum.filter(&(&1.type == :tool_call))
-      |> Enum.map(&openai_chunk_to_tool_call/1)
-      |> Enum.reject(&is_nil/1)
-
-    %ReqLLM.Message{
-      role: :assistant,
-      content: content_parts,
-      tool_calls: if(tool_calls != [], do: tool_calls),
-      metadata: %{}
-    }
-  end
-
-  defp openai_chunk_to_content_part(%ReqLLM.StreamChunk{type: :content, text: text}) do
-    %ReqLLM.Message.ContentPart{type: :text, text: text}
-  end
-
-  defp openai_chunk_to_content_part(%ReqLLM.StreamChunk{type: :thinking, text: text}) do
-    %ReqLLM.Message.ContentPart{type: :thinking, text: text}
-  end
-
-  defp openai_chunk_to_content_part(_), do: nil
-
-  defp openai_chunk_to_tool_call(%ReqLLM.StreamChunk{
-         type: :tool_call,
-         name: name,
-         arguments: args,
-         metadata: meta
-       }) do
-    args_json =
-      cond do
-        Map.get(meta, :unparseable_arguments) && is_binary(Map.get(meta, :raw_arguments)) ->
-          Map.get(meta, :raw_arguments)
-
-        Map.get(meta, :invalid_arguments) ->
-          Jason.encode!(args)
-
-        is_binary(Map.get(meta, :raw_arguments)) ->
-          Map.get(meta, :raw_arguments)
-
-        is_binary(args) ->
-          args
-
-        true ->
-          Jason.encode!(args)
-      end
-
-    id = Map.get(meta, :id)
-    ReqLLM.ToolCall.new(id, name, args_json)
-  end
-
-  defp openai_chunk_to_tool_call(_), do: nil
 
   defp parse_openai_usage(usage, choices \\ [])
 

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -43,32 +43,51 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
   @spec build_response([StreamChunk.t()], map(), keyword()) ::
           {:ok, Response.t()} | {:error, term()}
   def build_response(chunks, metadata, opts) do
+    do_build_response(chunks, metadata, opts, :stream)
+  end
+
+  @doc false
+  @spec build_buffered_response([StreamChunk.t()], map(), keyword()) ::
+          {:ok, Response.t()} | {:error, term()}
+  def build_buffered_response(chunks, metadata, opts) do
+    do_build_response(chunks, metadata, opts, :buffered)
+  end
+
+  defp do_build_response(chunks, metadata, opts, profile) do
     context = Keyword.fetch!(opts, :context)
     model = Keyword.fetch!(opts, :model)
 
-    acc = ChunkAccumulator.reduce(ChunkAccumulator.new(), chunks)
+    acc =
+      chunks
+      |> accumulator_chunks(profile)
+      |> then(&ChunkAccumulator.reduce(ChunkAccumulator.new(), &1))
+
     reconstructed_tool_calls = ChunkAccumulator.finalize_tool_calls_for_response(acc)
-    normalized_tool_calls = normalize_tool_calls(reconstructed_tool_calls)
+    normalized_tool_calls = normalize_tool_calls(reconstructed_tool_calls, profile)
 
     text_content = ChunkAccumulator.finalize_text(acc)
     thinking_content = ChunkAccumulator.finalize_thinking(acc)
-    content_parts = build_content_parts(text_content, thinking_content, normalized_tool_calls)
 
-    reasoning_details =
-      case ChunkAccumulator.finalize_reasoning_details(acc) do
-        [] -> extract_reasoning_from_thinking_chunks(chunks, model.provider)
-        details -> details
-      end
+    content_parts =
+      materialize_content_parts(
+        profile,
+        chunks,
+        text_content,
+        thinking_content,
+        normalized_tool_calls
+      )
+
+    reasoning_details = materialize_reasoning_details(profile, chunks, acc, model.provider)
 
     message = %Message{
       role: :assistant,
       content: content_parts,
       tool_calls: if(normalized_tool_calls != [], do: normalized_tool_calls),
-      metadata: build_message_metadata(metadata),
+      metadata: materialize_message_metadata(profile, metadata),
       reasoning_details: reasoning_details
     }
 
-    object = extract_object_from_message(message)
+    object = materialize_object(profile, message)
     usage = normalize_usage_fields(metadata[:usage])
     finish_reason = normalize_finish_reason(metadata[:finish_reason])
     base_provider_meta = metadata[:provider_meta] || %{}
@@ -81,7 +100,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
 
     base_response = %Response{
       id: metadata[:response_id] || generate_response_id(),
-      model: model.id,
+      model: materialize_model(profile, metadata, model),
       context: context,
       message: message,
       object: object,
@@ -116,38 +135,46 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
   """
   @spec normalize_tool_calls([map() | ToolCall.t()]) :: [ToolCall.t()]
   def normalize_tool_calls(tool_calls) when is_list(tool_calls) do
-    Enum.map(tool_calls, &normalize_tool_call/1)
+    normalize_tool_calls(tool_calls, :stream)
   end
 
   def normalize_tool_calls(_), do: []
 
-  defp normalize_tool_call(%ToolCall{} = call), do: call
+  defp normalize_tool_calls(tool_calls, profile) when is_list(tool_calls) do
+    Enum.map(tool_calls, &normalize_tool_call(&1, profile))
+  end
 
-  defp normalize_tool_call(%{id: id, name: name, arguments: args} = m) do
+  defp normalize_tool_calls(_tool_calls, _profile), do: []
+
+  defp normalize_tool_call(%ToolCall{} = call, _profile), do: call
+
+  defp normalize_tool_call(%{id: id, name: name, arguments: args} = m, profile) do
     constructor =
       if ToolCall.flagged_builtin?(m), do: &ToolCall.new_builtin/3, else: &ToolCall.new/3
 
     constructor.(id, name, encode_tool_args(args))
-    |> put_tool_call_metadata(m)
+    |> put_tool_call_metadata(m, profile)
   end
 
-  defp normalize_tool_call(%{"id" => id, "name" => name, "arguments" => args} = m) do
+  defp normalize_tool_call(%{"id" => id, "name" => name, "arguments" => args} = m, profile) do
     constructor =
       if ToolCall.flagged_builtin?(m), do: &ToolCall.new_builtin/3, else: &ToolCall.new/3
 
     constructor.(id, name, encode_tool_args(args))
-    |> put_tool_call_metadata(m)
+    |> put_tool_call_metadata(m, profile)
   end
 
-  defp normalize_tool_call(other) when is_map(other) do
+  defp normalize_tool_call(other, profile) when is_map(other) do
     constructor =
       if ToolCall.flagged_builtin?(other), do: &ToolCall.new_builtin/3, else: &ToolCall.new/3
 
     constructor.(other[:id], other[:name], encode_tool_args(other[:arguments]))
-    |> put_tool_call_metadata(other)
+    |> put_tool_call_metadata(other, profile)
   end
 
-  defp put_tool_call_metadata(%ToolCall{} = call, source) do
+  defp put_tool_call_metadata(%ToolCall{} = call, _source, :buffered), do: call
+
+  defp put_tool_call_metadata(%ToolCall{} = call, source, _profile) do
     ToolCall.put_metadata(call, ToolCall.metadata(source))
   end
 
@@ -238,6 +265,74 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       _ -> nil
     end)
   end
+
+  defp accumulator_chunks(chunks, :buffered) do
+    Enum.map(chunks, &restore_buffered_tool_arguments/1)
+  end
+
+  defp accumulator_chunks(chunks, _profile), do: chunks
+
+  defp restore_buffered_tool_arguments(
+         %StreamChunk{
+           type: :tool_call,
+           metadata: %{unparseable_arguments: true, raw_arguments: raw_arguments} = metadata
+         } = chunk
+       )
+       when is_binary(raw_arguments) do
+    %{chunk | arguments: raw_arguments, metadata: drop_buffered_argument_metadata(metadata)}
+  end
+
+  defp restore_buffered_tool_arguments(
+         %StreamChunk{type: :tool_call, metadata: %{invalid_arguments: true} = metadata} = chunk
+       ) do
+    %{chunk | metadata: drop_buffered_argument_metadata(metadata)}
+  end
+
+  defp restore_buffered_tool_arguments(chunk), do: chunk
+
+  defp drop_buffered_argument_metadata(metadata) do
+    Map.drop(metadata, [
+      :decoded_arguments,
+      :invalid_arguments,
+      :raw_arguments,
+      :unparseable_arguments
+    ])
+  end
+
+  defp materialize_content_parts(:buffered, chunks, _text, _thinking, _tool_calls) do
+    Enum.flat_map(chunks, fn
+      %StreamChunk{type: :content, text: text} -> [%ContentPart{type: :text, text: text}]
+      %StreamChunk{type: :thinking, text: text} -> [%ContentPart{type: :thinking, text: text}]
+      _chunk -> []
+    end)
+  end
+
+  defp materialize_content_parts(_profile, _chunks, text, thinking, tool_calls) do
+    build_content_parts(text, thinking, tool_calls)
+  end
+
+  defp materialize_reasoning_details(:buffered, _chunks, acc, _provider) do
+    case ChunkAccumulator.finalize_reasoning_details(acc) do
+      [] -> nil
+      details -> details
+    end
+  end
+
+  defp materialize_reasoning_details(_profile, chunks, acc, provider) do
+    case ChunkAccumulator.finalize_reasoning_details(acc) do
+      [] -> extract_reasoning_from_thinking_chunks(chunks, provider)
+      details -> details
+    end
+  end
+
+  defp materialize_message_metadata(:buffered, _metadata), do: %{}
+  defp materialize_message_metadata(_profile, metadata), do: build_message_metadata(metadata)
+
+  defp materialize_object(:buffered, _message), do: nil
+  defp materialize_object(_profile, message), do: extract_object_from_message(message)
+
+  defp materialize_model(:buffered, metadata, model), do: metadata[:response_model] || model.id
+  defp materialize_model(_profile, _metadata, model), do: model.id
 
   # ============================================================================
   # Metadata Helpers

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -434,22 +434,7 @@ defmodule ReqLLM.StreamResponse do
     callbacks = extract_callbacks(opts)
 
     chunks = process_stream_with_callbacks(stream_response.stream, callbacks)
-    metadata = MetadataHandle.await(stream_response.metadata_handle)
-
-    case metadata do
-      %{error: reason} ->
-        {:error, reason}
-
-      _ ->
-        builder = ResponseBuilder.for_model(stream_response.model)
-
-        builder.build_response(
-          chunks,
-          metadata,
-          context: stream_response.context,
-          model: stream_response.model
-        )
-    end
+    materialize_chunks(stream_response, chunks)
   rescue
     error -> {:error, error}
   catch
@@ -664,24 +649,32 @@ defmodule ReqLLM.StreamResponse do
   """
   @spec to_response(t()) :: {:ok, Response.t()} | {:error, term()}
   def to_response(%__MODULE__{} = stream_response) do
-    # Consume stream and collect metadata
     chunks = Enum.to_list(stream_response.stream)
-    metadata = MetadataHandle.await(stream_response.metadata_handle)
-
-    # Use the appropriate ResponseBuilder for this model
-    builder = ResponseBuilder.for_model(stream_response.model)
-
-    builder.build_response(
-      chunks,
-      metadata,
-      context: stream_response.context,
-      model: stream_response.model
-    )
+    materialize_chunks(stream_response, chunks)
   rescue
     error -> {:error, error}
   catch
     :exit, reason -> {:error, reason}
   after
     MetadataHandle.stop(stream_response.metadata_handle)
+  end
+
+  defp materialize_chunks(stream_response, chunks) do
+    metadata = MetadataHandle.await(stream_response.metadata_handle)
+
+    case metadata do
+      %{error: reason} ->
+        {:error, reason}
+
+      _metadata ->
+        builder = ResponseBuilder.for_model(stream_response.model)
+
+        builder.build_response(
+          chunks,
+          metadata,
+          context: stream_response.context,
+          model: stream_response.model
+        )
+    end
   end
 end

--- a/test/req_llm/provider/openai_chat_materialization_test.exs
+++ b/test/req_llm/provider/openai_chat_materialization_test.exs
@@ -152,6 +152,12 @@ defmodule ReqLLM.Provider.OpenAIChatMaterializationTest do
 
     {:ok, scalar_response} = Defaults.decode_response_body_openai_format(scalar, model)
 
+    {:ok, unknown_finish_response} =
+      Defaults.decode_response_body_openai_format(
+        buffered_tool_response("{}", "tool_call"),
+        model
+      )
+
     [malformed_call] = malformed_response.message.tool_calls
     [scalar_call] = scalar_response.message.tool_calls
 
@@ -159,6 +165,7 @@ defmodule ReqLLM.Provider.OpenAIChatMaterializationTest do
     assert ToolCall.args_json(scalar_call) == "{}"
     assert ToolCall.metadata(malformed_call) == %{}
     assert ToolCall.metadata(scalar_call) == %{}
+    assert unknown_finish_response.finish_reason == :error
   end
 
   test "StreamResponse helpers share terminal error materialization", %{model: model} do
@@ -234,7 +241,7 @@ defmodule ReqLLM.Provider.OpenAIChatMaterializationTest do
     }
   end
 
-  defp buffered_tool_response(arguments) do
+  defp buffered_tool_response(arguments, finish_reason \\ "tool_calls") do
     %{
       "id" => "chatcmpl-tool",
       "choices" => [
@@ -248,7 +255,7 @@ defmodule ReqLLM.Provider.OpenAIChatMaterializationTest do
               }
             ]
           },
-          "finish_reason" => "tool_calls"
+          "finish_reason" => finish_reason
         }
       ]
     }

--- a/test/req_llm/provider/openai_chat_materialization_test.exs
+++ b/test/req_llm/provider/openai_chat_materialization_test.exs
@@ -1,0 +1,278 @@
+defmodule ReqLLM.Provider.OpenAIChatMaterializationTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :provider_boundary
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Message.ReasoningDetails
+  alias ReqLLM.Provider.Defaults
+  alias ReqLLM.Provider.Defaults.ResponseBuilder
+  alias ReqLLM.Response
+  alias ReqLLM.Response.Stream, as: ResponseStream
+  alias ReqLLM.StreamChunk
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.StreamResponse.MetadataHandle
+  alias ReqLLM.ToolCall
+
+  setup do
+    %{model: %LLMDB.Model{provider: :openai, id: "gpt-chat-test"}}
+  end
+
+  test "buffered and streamed chat data share semantic materialization", %{model: model} do
+    reasoning_detail = %{
+      "type" => "reasoning.text",
+      "text" => "Think",
+      "signature" => "sig-1",
+      "index" => 0
+    }
+
+    logprobs = [%{"token" => "Hello", "logprob" => -0.1}]
+
+    buffered_data = %{
+      "id" => "chatcmpl-123",
+      "model" => "gpt-chat-wire",
+      "system_fingerprint" => "fp-123",
+      "warnings" => ["provider warning"],
+      "choices" => [
+        %{
+          "message" => %{
+            "content" => "Hello",
+            "reasoning_content" => "Think",
+            "reasoning_details" => [reasoning_detail],
+            "tool_calls" => [
+              %{
+                "id" => "call-1",
+                "type" => "function",
+                "function" => %{
+                  "name" => "lookup",
+                  "arguments" => ~s({"city":"Paris"})
+                }
+              }
+            ]
+          },
+          "finish_reason" => "tool_calls",
+          "logprobs" => %{"content" => logprobs}
+        }
+      ],
+      "usage" => %{
+        "prompt_tokens" => 4,
+        "completion_tokens" => 3,
+        "total_tokens" => 7
+      }
+    }
+
+    {:ok, buffered} = Defaults.decode_response_body_openai_format(buffered_data, model)
+
+    normalized_detail =
+      ReasoningDetails.from_openai_compatible(reasoning_detail, :openai, 0)
+
+    streamed_chunks = [
+      StreamChunk.text("Hello"),
+      StreamChunk.thinking("Think"),
+      StreamChunk.tool_call("lookup", %{"city" => "Paris"}, %{id: "call-1", index: 0}),
+      StreamChunk.meta(%{reasoning_details: [normalized_detail]}),
+      StreamChunk.meta(%{logprobs: logprobs}),
+      StreamChunk.meta(%{
+        usage: %{
+          input_tokens: 4,
+          output_tokens: 3,
+          total_tokens: 7,
+          cached_tokens: 0,
+          reasoning_tokens: 3
+        },
+        finish_reason: :tool_calls
+      })
+    ]
+
+    {:ok, streamed} =
+      ResponseBuilder.build_response(
+        streamed_chunks,
+        %{
+          response_id: "chatcmpl-123",
+          usage: %{
+            input_tokens: 4,
+            output_tokens: 3,
+            total_tokens: 7,
+            cached_tokens: 0,
+            reasoning_tokens: 3
+          },
+          finish_reason: :tool_calls,
+          provider_meta: %{
+            "system_fingerprint" => "fp-123",
+            "warnings" => ["provider warning"]
+          }
+        },
+        context: Context.new(),
+        model: model
+      )
+
+    assert semantic_projection(buffered) == semantic_projection(streamed)
+    assert buffered.id == streamed.id
+    assert buffered.message.metadata == %{}
+    assert streamed.message.metadata == %{response_id: "chatcmpl-123"}
+    assert buffered.model == "gpt-chat-wire"
+    assert streamed.model == "gpt-chat-test"
+  end
+
+  test "buffered compatibility profile preserves legacy content and tool argument shapes", %{
+    model: model
+  } do
+    content_data = %{
+      "choices" => [
+        %{
+          "message" => %{
+            "content" => [
+              %{"type" => "text", "text" => "{\"answer\":"},
+              %{"type" => "text", "text" => "42}"}
+            ]
+          },
+          "finish_reason" => "stop"
+        }
+      ]
+    }
+
+    {:ok, content_response} =
+      Defaults.decode_response_body_openai_format(content_data, model)
+
+    assert content_response.message.content == [
+             %ContentPart{type: :text, text: "{\"answer\":", metadata: %{}},
+             %ContentPart{type: :text, text: "42}", metadata: %{}}
+           ]
+
+    assert content_response.object == nil
+    assert content_response.message.metadata == %{}
+    assert content_response.context == Context.new([content_response.message])
+
+    malformed = buffered_tool_response("{not-json")
+    scalar = buffered_tool_response(~s("draft"))
+
+    {:ok, malformed_response} =
+      Defaults.decode_response_body_openai_format(malformed, model)
+
+    {:ok, scalar_response} = Defaults.decode_response_body_openai_format(scalar, model)
+
+    [malformed_call] = malformed_response.message.tool_calls
+    [scalar_call] = scalar_response.message.tool_calls
+
+    assert ToolCall.args_json(malformed_call) == "{not-json"
+    assert ToolCall.args_json(scalar_call) == "{}"
+    assert ToolCall.metadata(malformed_call) == %{}
+    assert ToolCall.metadata(scalar_call) == %{}
+  end
+
+  test "StreamResponse helpers share terminal error materialization", %{model: model} do
+    error = ReqLLM.Error.API.Stream.exception(reason: "provider failed", cause: :closed)
+
+    to_response = stream_response(model, [StreamChunk.text("partial")], %{error: error})
+    process_stream = stream_response(model, [StreamChunk.text("partial")], %{error: error})
+
+    assert {:error, ^error} = StreamResponse.to_response(to_response)
+    assert {:error, ^error} = StreamResponse.process_stream(process_stream)
+    refute Process.alive?(to_response.metadata_handle)
+    refute Process.alive?(process_stream.metadata_handle)
+  end
+
+  test "StreamResponse helpers retain cancellation materialization", %{model: model} do
+    to_response = stream_response(model, [], %{finish_reason: :cancelled})
+    process_stream = stream_response(model, [], %{finish_reason: :cancelled})
+
+    assert {:ok, %Response{finish_reason: :cancelled}} =
+             StreamResponse.to_response(to_response)
+
+    assert {:ok, %Response{finish_reason: :cancelled}} =
+             StreamResponse.process_stream(process_stream)
+
+    refute Process.alive?(to_response.metadata_handle)
+    refute Process.alive?(process_stream.metadata_handle)
+  end
+
+  test "legacy stream summaries and final responses retain equal projections", %{model: model} do
+    usage = %{
+      input_tokens: 2,
+      output_tokens: 1,
+      total_tokens: 3,
+      cached_tokens: 0,
+      reasoning_tokens: 0
+    }
+
+    chunks = [
+      StreamChunk.text("Answer"),
+      StreamChunk.thinking("Think"),
+      StreamChunk.tool_call("lookup", %{}, %{id: "call-1", index: 0}),
+      StreamChunk.meta(%{tool_call_args: %{index: 0, fragment: ~s({"q":"docs"})}}),
+      StreamChunk.meta(%{usage: usage, finish_reason: :tool_calls})
+    ]
+
+    summary = ResponseStream.summarize(chunks)
+
+    response =
+      stream_response(model, chunks, %{
+        usage: ReqLLM.Usage.normalize(usage),
+        finish_reason: :tool_calls
+      })
+
+    assert {:ok, materialized} = StreamResponse.to_response(response)
+    assert summary.text == Response.text(materialized)
+    assert summary.thinking == Response.thinking(materialized)
+    assert summary.tool_calls == Enum.map(Response.tool_calls(materialized), &ToolCall.to_map/1)
+
+    assert canonical_usage(summary.usage) == canonical_usage(materialized.usage)
+    assert summary.finish_reason == materialized.finish_reason
+  end
+
+  defp semantic_projection(response) do
+    %{
+      text: Response.text(response),
+      thinking: Response.thinking(response),
+      tool_calls: Enum.map(Response.tool_calls(response), &ToolCall.to_map/1),
+      reasoning_details: response.message.reasoning_details,
+      object: response.object,
+      usage: response.usage,
+      finish_reason: response.finish_reason,
+      provider_meta: response.provider_meta
+    }
+  end
+
+  defp buffered_tool_response(arguments) do
+    %{
+      "id" => "chatcmpl-tool",
+      "choices" => [
+        %{
+          "message" => %{
+            "tool_calls" => [
+              %{
+                "id" => "call-1",
+                "type" => "function",
+                "function" => %{"name" => "lookup", "arguments" => arguments}
+              }
+            ]
+          },
+          "finish_reason" => "tool_calls"
+        }
+      ]
+    }
+  end
+
+  defp canonical_usage(usage) do
+    Map.take(usage, [
+      :input_tokens,
+      :output_tokens,
+      :total_tokens,
+      :cached_tokens,
+      :reasoning_tokens
+    ])
+  end
+
+  defp stream_response(model, chunks, metadata) do
+    {:ok, handle} = MetadataHandle.start_link(fn -> metadata end)
+
+    %StreamResponse{
+      stream: chunks,
+      metadata_handle: handle,
+      cancel: fn -> :ok end,
+      model: model,
+      context: Context.new()
+    }
+  end
+end


### PR DESCRIPTION
Closes #847

## Summary

- route buffered OpenAI Chat Completions decoding through the existing chunk accumulator and response builder
- share StreamResponse terminal-error and cancellation materialization across helper paths
- preserve buffered response shapes with a narrow compatibility profile for content boundaries, tool arguments, message metadata, wire model IDs, and structured-object behavior
- add contract coverage for buffered/streamed parity, replay projections, errors, cancellation, usage, finish reasons, reasoning, tool calls, logprobs, warnings, and response IDs

## Backward compatibility

- no request encoding or transport changes
- no public struct or callback changes
- no Responses API or provider-specific migrations
- existing buffered serialization and tool-argument edge cases remain locked by regression tests
- `StreamResponse.to_response/1` now returns the same terminal metadata error as `process_stream/2`, matching its documented return contract

## Validation

- `mix test test/req_llm/provider/openai_chat_materialization_test.exs test/req_llm/provider/defaults_test.exs test/req_llm/provider/chunk_accumulator_test.exs test/req_llm/response/stream_test.exs test/req_llm/stream_response_test.exs` (215 passed)
- expanded OpenAI Chat/OpenAI-compatible provider suite (228 passed, 8 excluded)
- `mix test` (3,758 passed, 11 skipped, 145 excluded)
- `mix quality`
- `mix docs` (passes with one pre-existing hidden-module reference warning)