### PR TITLE
refactor: share OpenAI Responses materialization

### DIFF
--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -87,7 +87,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       reasoning_details: reasoning_details
     }
 
-    object = materialize_object(profile, message)
+    object = materialize_object(profile, message, metadata)
     usage = normalize_usage_fields(metadata[:usage])
     finish_reason = normalize_finish_reason(metadata[:finish_reason])
     base_provider_meta = metadata[:provider_meta] || %{}
@@ -275,6 +275,16 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
   defp restore_buffered_tool_arguments(
          %StreamChunk{
            type: :tool_call,
+           metadata: %{buffered_arguments: arguments} = metadata
+         } = chunk
+       )
+       when is_binary(arguments) do
+    %{chunk | arguments: arguments, metadata: Map.delete(metadata, :buffered_arguments)}
+  end
+
+  defp restore_buffered_tool_arguments(
+         %StreamChunk{
+           type: :tool_call,
            metadata: %{unparseable_arguments: true, raw_arguments: raw_arguments} = metadata
          } = chunk
        )
@@ -325,13 +335,22 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     end
   end
 
-  defp materialize_message_metadata(:buffered, _metadata), do: %{}
+  defp materialize_message_metadata(:buffered, metadata) do
+    Map.get(metadata, :message_metadata, %{})
+  end
+
   defp materialize_message_metadata(_profile, metadata), do: build_message_metadata(metadata)
 
-  defp materialize_object(:buffered, _message), do: nil
-  defp materialize_object(_profile, message), do: extract_object_from_message(message)
+  defp materialize_object(:buffered, _message, metadata), do: Map.get(metadata, :object)
+  defp materialize_object(_profile, message, _metadata), do: extract_object_from_message(message)
 
-  defp materialize_model(:buffered, metadata, model), do: metadata[:response_model] || model.id
+  defp materialize_model(:buffered, metadata, model) do
+    case Map.fetch(metadata, :response_model) do
+      {:ok, response_model} -> response_model
+      :error -> model.id
+    end
+  end
+
   defp materialize_model(_profile, _metadata, model), do: model.id
 
   # ============================================================================

--- a/lib/req_llm/providers/azure/responses_api.ex
+++ b/lib/req_llm/providers/azure/responses_api.ex
@@ -86,6 +86,7 @@ defmodule ReqLLM.Providers.Azure.ResponsesAPI do
     fake_request = %{
       options: %{
         model: model.id,
+        req_llm_model: model,
         operation: opts[:operation],
         context: opts[:context],
         compiled_schema: opts[:compiled_schema]

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1732,16 +1732,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     finish_reason =
       determine_finish_reason(body, Enum.reject(tool_calls, &ReqLLM.ToolCall.builtin?/1))
 
-    content_parts = build_content_parts(text, thinking)
     message_metadata = build_message_metadata(body["id"], output_segments)
-
-    msg = %ReqLLM.Message{
-      role: :assistant,
-      content: content_parts,
-      tool_calls: if(tool_calls != [], do: tool_calls),
-      reasoning_details: if(reasoning_details != [], do: reasoning_details),
-      metadata: message_metadata
-    }
 
     {object, object_meta} = maybe_extract_object(req, text, tool_calls) || {nil, %{}}
 
@@ -1760,25 +1751,65 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> Map.merge(object_meta)
       |> put_code_interpreter_meta(code_interpreter_items)
 
-    response = %ReqLLM.Response{
-      id: body["id"] || "unknown",
-      model: body["model"] || req.options[:model],
-      context: %ReqLLM.Context{
-        messages: if(content_parts == [] and is_nil(msg.tool_calls), do: [], else: [msg])
-      },
-      message: msg,
+    ctx = req.options[:context] || %ReqLLM.Context{messages: []}
+    model = response_materialization_model(req, body)
+
+    chunks = buffered_response_chunks(text, thinking, tool_calls, reasoning_details)
+
+    metadata = %{
+      response_id: body["id"] || "unknown",
+      response_model: body["model"] || req.options[:model],
+      message_metadata: message_metadata,
       object: object,
-      stream?: false,
-      stream: nil,
       usage: usage,
       finish_reason: finish_reason,
       provider_meta: provider_meta
     }
 
-    ctx = req.options[:context] || %ReqLLM.Context{messages: []}
-    merged_response = %{response | context: ReqLLM.Context.append(ctx, msg)}
+    case ReqLLM.Providers.OpenAI.ResponsesAPI.ResponseBuilder.build_buffered_response(
+           chunks,
+           metadata,
+           context: ctx,
+           model: model
+         ) do
+      {:ok, response} -> {req, %{resp | body: response}}
+      {:error, error} -> {req, error}
+    end
+  end
 
-    {req, %{resp | body: merged_response}}
+  defp buffered_response_chunks(text, thinking, tool_calls, reasoning_details) do
+    thinking_chunks = if thinking == "", do: [], else: [ReqLLM.StreamChunk.thinking(thinking)]
+    text_chunks = if text == "", do: [], else: [ReqLLM.StreamChunk.text(text)]
+
+    tool_chunks =
+      tool_calls
+      |> Enum.with_index()
+      |> Enum.map(&buffered_tool_call_chunk/1)
+
+    reasoning_chunks =
+      if reasoning_details == [] do
+        []
+      else
+        [ReqLLM.StreamChunk.meta(%{reasoning_details: reasoning_details})]
+      end
+
+    thinking_chunks ++ text_chunks ++ tool_chunks ++ reasoning_chunks
+  end
+
+  defp buffered_tool_call_chunk({%ReqLLM.ToolCall{} = tool_call, index}) do
+    metadata =
+      %{id: tool_call.id, index: index, buffered_arguments: ReqLLM.ToolCall.args_json(tool_call)}
+      |> ReqLLM.ToolCall.put_builtin_flag(ReqLLM.ToolCall.builtin?(tool_call))
+
+    ReqLLM.StreamChunk.tool_call(ReqLLM.ToolCall.name(tool_call), %{}, metadata)
+  end
+
+  defp response_materialization_model(req, body) do
+    request_model(req) ||
+      %LLMDB.Model{
+        provider: :openai,
+        id: body["model"] || req.options[:model] || req.options[:id] || "unknown"
+      }
   end
 
   defp build_message_metadata(response_id, output_segments) do
@@ -2131,26 +2162,6 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   defp normalize_arguments_json(_), do: "{}"
-
-  defp build_content_parts(text, thinking) do
-    parts = []
-
-    parts =
-      if thinking == "" do
-        parts
-      else
-        [%ReqLLM.Message.ContentPart{type: :thinking, text: thinking} | parts]
-      end
-
-    parts =
-      if text == "" do
-        parts
-      else
-        [%ReqLLM.Message.ContentPart{type: :text, text: text} | parts]
-      end
-
-    Enum.reverse(parts)
-  end
 
   defp normalize_responses_usage(usage, response_data) do
     reasoning_tokens =

--- a/lib/req_llm/providers/openai/responses_api/response_builder.ex
+++ b/lib/req_llm/providers/openai/responses_api/response_builder.ex
@@ -20,17 +20,23 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI.ResponseBuilder do
 
   @impl true
   def build_response(chunks, metadata, opts) do
+    DefaultBuilder.build_response(chunks, normalize_metadata(chunks, metadata), opts)
+  end
+
+  @doc false
+  @spec build_buffered_response([StreamChunk.t()], map(), keyword()) ::
+          {:ok, ReqLLM.Response.t()} | {:error, term()}
+  def build_buffered_response(chunks, metadata, opts) do
+    DefaultBuilder.build_buffered_response(chunks, metadata, opts)
+  end
+
+  defp normalize_metadata(chunks, metadata) do
     has_actionable_tool_calls? = Enum.any?(chunks, &actionable_tool_call_chunk?/1)
 
-    metadata =
-      if has_actionable_tool_calls? and finish_reason_is_stop?(metadata[:finish_reason]) do
-        Map.put(metadata, :finish_reason, :tool_calls)
-      else
-        metadata
-      end
-
-    with {:ok, response} <- DefaultBuilder.build_response(chunks, metadata, opts) do
-      {:ok, propagate_response_id(response, metadata)}
+    if has_actionable_tool_calls? and finish_reason_is_stop?(metadata[:finish_reason]) do
+      Map.put(metadata, :finish_reason, :tool_calls)
+    else
+      metadata
     end
   end
 
@@ -43,12 +49,4 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI.ResponseBuilder do
   end
 
   defp actionable_tool_call_chunk?(_), do: false
-
-  defp propagate_response_id(response, %{response_id: id}) when is_binary(id) do
-    update_in(response.message.metadata, fn meta ->
-      Map.put(meta || %{}, :response_id, id)
-    end)
-  end
-
-  defp propagate_response_id(response, _metadata), do: response
 end

--- a/test/req_llm/provider/openai_responses_materialization_test.exs
+++ b/test/req_llm/provider/openai_responses_materialization_test.exs
@@ -1,0 +1,303 @@
+defmodule ReqLLM.Provider.OpenAIResponsesMaterializationTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :provider_boundary
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Message.ReasoningDetails
+  alias ReqLLM.Providers.OpenAI.ResponsesAPI
+  alias ReqLLM.Providers.OpenAI.ResponsesAPI.ResponseBuilder
+  alias ReqLLM.StreamChunk
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.StreamResponse.MetadataHandle
+  alias ReqLLM.ToolCall
+
+  setup do
+    model = %LLMDB.Model{
+      provider: :openai,
+      id: "gpt-responses-local",
+      extra: %{wire: %{protocol: "openai_responses"}}
+    }
+
+    %{model: model}
+  end
+
+  test "buffered and streamed Responses data share semantic materialization", %{model: model} do
+    context = Context.new([Context.user("Question")])
+
+    reasoning_detail = %ReasoningDetails{
+      text: "Plan",
+      signature: "encrypted-plan",
+      encrypted?: true,
+      provider: :openai,
+      format: "openai-responses-v1",
+      index: 0,
+      provider_data: %{"id" => "rs_1", "type" => "reasoning"}
+    }
+
+    usage = %{
+      input_tokens: 5,
+      output_tokens: 7,
+      total_tokens: 12,
+      cached_tokens: 2,
+      reasoning_tokens: 3,
+      tool_usage: %{"function" => %{count: 1, unit: :call}}
+    }
+
+    provider_meta = %{
+      "api_type" => "responses",
+      "service_tier" => "default",
+      "status" => "completed"
+    }
+
+    body = %{
+      "id" => "resp_123",
+      "model" => "gpt-responses-wire",
+      "status" => "completed",
+      "service_tier" => "default",
+      "output" => [
+        %{
+          "id" => "rs_1",
+          "type" => "reasoning",
+          "summary" => [%{"type" => "summary_text", "text" => "Plan"}],
+          "encrypted_content" => "encrypted-plan"
+        },
+        %{
+          "type" => "message",
+          "phase" => "final_answer",
+          "content" => [%{"type" => "output_text", "text" => "Answer"}]
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => "call_1",
+          "name" => "lookup",
+          "arguments" => ~s({"q":"docs"})
+        }
+      ],
+      "usage" => %{
+        "input_tokens" => 5,
+        "output_tokens" => 7,
+        "input_tokens_details" => %{"cached_tokens" => 2},
+        "output_tokens_details" => %{"reasoning_tokens" => 3}
+      }
+    }
+
+    buffered = decode(body, model, context: context)
+
+    chunks = [
+      StreamChunk.thinking("Plan"),
+      StreamChunk.text("Answer"),
+      StreamChunk.tool_call("lookup", %{"q" => "docs"}, %{id: "call_1", index: 0}),
+      StreamChunk.meta(%{reasoning_details: [reasoning_detail]})
+    ]
+
+    {:ok, streamed} =
+      ResponseBuilder.build_response(
+        chunks,
+        %{
+          response_id: "resp_123",
+          usage: usage,
+          finish_reason: :tool_calls,
+          provider_meta: provider_meta,
+          phase: "final_answer"
+        },
+        context: context,
+        model: model
+      )
+
+    assert semantic_projection(buffered) == semantic_projection(streamed)
+    assert buffered.id == streamed.id
+
+    assert buffered.message.metadata == %{
+             response_id: "resp_123",
+             phase: "final_answer"
+           }
+
+    assert streamed.message.metadata == buffered.message.metadata
+    assert buffered.model == "gpt-responses-wire"
+    assert streamed.model == "gpt-responses-local"
+  end
+
+  test "buffered compatibility retains legacy ordering and raw tool arguments", %{model: model} do
+    context = Context.new([Context.user("Keep this")])
+
+    body = %{
+      "status" => "completed",
+      "output" => [
+        %{"type" => "reasoning", "summary" => "Plan"},
+        %{
+          "type" => "message",
+          "content" => [%{"type" => "output_text", "text" => ~s({"answer":42})}]
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => "call_bad",
+          "name" => "malformed",
+          "arguments" => "  {not-json  "
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => "call_scalar",
+          "name" => "scalar",
+          "arguments" => ~s("draft")
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => "call_empty",
+          "name" => "empty",
+          "arguments" => ""
+        },
+        %{
+          "type" => "web_search_call",
+          "id" => "ws_1",
+          "status" => "completed",
+          "action" => %{"query" => "docs", "type" => "search"}
+        }
+      ]
+    }
+
+    response = decode(body, model, context: context)
+
+    assert response.id == "unknown"
+    assert response.model == model.id
+    assert response.finish_reason == :tool_calls
+    assert response.object == nil
+    assert response.message.metadata == %{response_id: nil}
+
+    assert response.message.content == [
+             %ContentPart{type: :thinking, text: "Plan", metadata: %{}},
+             %ContentPart{type: :text, text: ~s({"answer":42}), metadata: %{}}
+           ]
+
+    [malformed, scalar, empty, builtin] = response.message.tool_calls
+
+    assert ToolCall.args_json(malformed) == "{not-json"
+    assert ToolCall.args_json(scalar) == ~s("draft")
+    assert ToolCall.args_json(empty) == "{}"
+    assert ToolCall.args_map(builtin) == %{"action" => %{"query" => "docs", "type" => "search"}}
+    assert Enum.all?(response.message.tool_calls, &(ToolCall.metadata(&1) == %{}))
+    assert ToolCall.builtin?(builtin)
+    assert response.context == Context.new(context.messages ++ [response.message])
+
+    legacy_stop =
+      decode(
+        %{
+          "output" => [
+            %{
+              "type" => "function_call",
+              "call_id" => "call_without_status",
+              "name" => "lookup",
+              "arguments" => "{}"
+            }
+          ]
+        },
+        model
+      )
+
+    assert legacy_stop.finish_reason == :stop
+
+    missing_model = decode(%{"output_text" => "Answer"}, model, request_model: nil)
+    assert missing_model.model == nil
+  end
+
+  test "buffered object results remain explicit without changing content", %{model: model} do
+    body = %{
+      "id" => "resp_object",
+      "model" => "gpt-responses-wire",
+      "status" => "completed",
+      "output_text" => ~s({"answer":42})
+    }
+
+    response = decode(body, model, operation: :object, compiled_schema: nil)
+
+    assert response.object == %{"answer" => 42}
+
+    assert response.message.content == [
+             %ContentPart{type: :text, text: ~s({"answer":42}), metadata: %{}}
+           ]
+
+    refute Map.has_key?(response.provider_meta, :object_parse_error)
+  end
+
+  test "Responses replay helpers use the provider materializer", %{model: model} do
+    usage = %{input_tokens: 2, output_tokens: 1, total_tokens: 3}
+
+    chunks = [
+      StreamChunk.tool_call("lookup", %{"q" => "docs"}, %{id: "call_1", index: 0}),
+      StreamChunk.meta(%{finish_reason: :stop, usage: usage})
+    ]
+
+    to_response =
+      stream_response(model, chunks, %{
+        response_id: "resp_replay",
+        finish_reason: :stop,
+        usage: usage
+      })
+
+    process_stream =
+      stream_response(model, chunks, %{
+        response_id: "resp_replay",
+        finish_reason: :stop,
+        usage: usage
+      })
+
+    assert {:ok, replayed} = StreamResponse.to_response(to_response)
+    assert {:ok, processed} = StreamResponse.process_stream(process_stream)
+    assert semantic_projection(replayed) == semantic_projection(processed)
+    assert replayed.id == "resp_replay"
+    assert replayed.message.metadata == %{response_id: "resp_replay"}
+    assert replayed.finish_reason == :tool_calls
+
+    cancelled = stream_response(model, [], %{finish_reason: :cancelled})
+    assert {:ok, cancelled_response} = StreamResponse.to_response(cancelled)
+    assert cancelled_response.finish_reason == :cancelled
+  end
+
+  defp decode(body, model, opts \\ []) do
+    context = Keyword.get(opts, :context, Context.new())
+
+    request = %Req.Request{
+      method: :post,
+      url: URI.parse("https://api.openai.com/v1/responses"),
+      headers: %{},
+      body: {:json, %{}},
+      options: %{
+        model: Keyword.get(opts, :request_model, model.id),
+        context: context,
+        operation: Keyword.get(opts, :operation, :chat),
+        compiled_schema: Keyword.get(opts, :compiled_schema)
+      },
+      private: %{req_llm_model: model}
+    }
+
+    http_response = %Req.Response{status: 200, headers: %{}, body: body}
+    {_request, decoded} = ResponsesAPI.decode_response({request, http_response})
+    decoded.body
+  end
+
+  defp semantic_projection(response) do
+    %{
+      text: ReqLLM.Response.text(response),
+      thinking: ReqLLM.Response.thinking(response),
+      tool_calls: Enum.map(ReqLLM.Response.tool_calls(response), &ToolCall.to_map/1),
+      reasoning_details: response.message.reasoning_details,
+      object: response.object,
+      usage: response.usage,
+      finish_reason: response.finish_reason,
+      provider_meta: response.provider_meta
+    }
+  end
+
+  defp stream_response(model, chunks, metadata) do
+    {:ok, handle} = MetadataHandle.start_link(fn -> metadata end)
+
+    %StreamResponse{
+      stream: chunks,
+      metadata_handle: handle,
+      cancel: fn -> :ok end,
+      model: model,
+      context: Context.new()
+    }
+  end
+end


### PR DESCRIPTION
Closes #848

## Summary

- route buffered OpenAI Responses output through the existing Responses response builder and shared chunk accumulator
- extend the internal buffered compatibility profile to preserve exact message metadata, object results, wire model values, content order, and raw tool arguments
- remove redundant response ID post-processing from the streaming Responses builder while retaining its finish-reason normalization
- pass Azure's already-resolved model through its internal Responses decoder handoff
- add provider-boundary contracts for buffered/streamed semantic parity, legacy shapes, structured objects, replay, terminal metadata, and cancellation

## Backward compatibility

This is an internal V1 refactor. Public APIs and structs, request encoding and routing, existing stream chunks, response fields, tool-call shapes, context behavior, errors, and provider metadata remain unchanged. Buffered-only edge behavior for missing status/model values and malformed, scalar, or empty tool arguments is explicitly covered.

## Validation

- focused Responses/Chat/default-builder/replay tests: 243 passed
- widened mocked OpenAI/Azure/provider boundary: 517 passed
- full `mix test`: 3,762 passed, 11 skipped, 145 excluded
- `mix quality`: clean (Credo 0 issues, Dialyzer 0 errors)
- `mix docs`: generated successfully (one pre-existing hidden-module reference warning)