### PR TITLE
refactor: share Anthropic Messages materialization

### DIFF
--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -99,7 +99,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       end
 
     base_response = %Response{
-      id: metadata[:response_id] || generate_response_id(),
+      id: materialize_response_id(profile, metadata),
       model: materialize_model(profile, metadata, model),
       context: context,
       message: message,
@@ -352,6 +352,17 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
   end
 
   defp materialize_model(_profile, _metadata, model), do: model.id
+
+  defp materialize_response_id(:buffered, metadata) do
+    case Map.fetch(metadata, :response_id) do
+      {:ok, response_id} -> response_id
+      :error -> generate_response_id()
+    end
+  end
+
+  defp materialize_response_id(_profile, metadata) do
+    metadata[:response_id] || generate_response_id()
+  end
 
   # ============================================================================
   # Metadata Helpers

--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -44,29 +44,24 @@ defmodule ReqLLM.Providers.Anthropic.Response do
     id = Map.get(data, "id", "unknown")
     model_name = Map.get(data, "model", model.id || "unknown")
     usage = parse_usage(Map.get(data, "usage"))
-
     finish_reason = parse_finish_reason(Map.get(data, "stop_reason"))
-
     content_chunks = decode_content(Map.get(data, "content", []))
-    message = build_message_from_chunks(content_chunks)
+    chunks = content_chunks ++ reasoning_detail_chunks(extract_reasoning_details(content_chunks))
 
-    context = %ReqLLM.Context{
-      messages: if(message, do: [message], else: [])
-    }
-
-    response = %ReqLLM.Response{
-      id: id,
-      model: model_name,
-      context: context,
-      message: message,
-      stream?: false,
-      stream: nil,
+    metadata = %{
+      response_id: id,
+      response_model: model_name,
       usage: usage,
       finish_reason: finish_reason,
       provider_meta: Map.drop(data, ["id", "model", "content", "usage", "stop_reason"])
     }
 
-    {:ok, response}
+    ReqLLM.Providers.Anthropic.ResponseBuilder.build_buffered_response(
+      chunks,
+      metadata,
+      context: %ReqLLM.Context{messages: []},
+      model: model
+    )
   end
 
   def decode_response(_data, _model) do
@@ -290,34 +285,6 @@ defmodule ReqLLM.Providers.Anthropic.Response do
     {decode_content_block_start(block, index), state}
   end
 
-  defp build_message_from_chunks([]), do: nil
-
-  defp build_message_from_chunks(chunks) do
-    content_parts =
-      chunks
-      |> Enum.filter(&(&1.type in [:content, :thinking]))
-      |> Enum.map(&chunk_to_content_part/1)
-      |> Enum.reject(&is_nil/1)
-
-    tool_calls =
-      chunks
-      |> Enum.filter(&(&1.type == :tool_call))
-      |> Enum.map(&chunk_to_tool_call/1)
-      |> Enum.reject(&is_nil/1)
-
-    reasoning_details = extract_reasoning_details(chunks)
-
-    if content_parts != [] or tool_calls != [] do
-      %ReqLLM.Message{
-        role: :assistant,
-        content: content_parts,
-        tool_calls: if(tool_calls != [], do: tool_calls),
-        reasoning_details: if(reasoning_details != [], do: reasoning_details),
-        metadata: %{}
-      }
-    end
-  end
-
   defp extract_reasoning_details(chunks) do
     chunks
     |> Enum.filter(&(&1.type == :thinking))
@@ -336,29 +303,6 @@ defmodule ReqLLM.Providers.Anthropic.Response do
       }
     end)
   end
-
-  defp chunk_to_content_part(%ReqLLM.StreamChunk{type: :content, text: text}) do
-    %ReqLLM.Message.ContentPart{type: :text, text: text}
-  end
-
-  defp chunk_to_content_part(%ReqLLM.StreamChunk{type: :thinking, text: text}) do
-    %ReqLLM.Message.ContentPart{type: :thinking, text: text}
-  end
-
-  defp chunk_to_content_part(_), do: nil
-
-  defp chunk_to_tool_call(%ReqLLM.StreamChunk{
-         type: :tool_call,
-         name: name,
-         arguments: args,
-         metadata: meta
-       }) do
-    args_json = if is_binary(args), do: args, else: Jason.encode!(args)
-    id = Map.get(meta, :id)
-    ReqLLM.ToolCall.new(id, name, args_json)
-  end
-
-  defp chunk_to_tool_call(_), do: nil
 
   defp parse_usage(usage) when is_map(usage) and map_size(usage) > 0 do
     input = Map.get(usage, "input_tokens", 0)

--- a/lib/req_llm/providers/anthropic/response_builder.ex
+++ b/lib/req_llm/providers/anthropic/response_builder.ex
@@ -22,6 +22,15 @@ defmodule ReqLLM.Providers.Anthropic.ResponseBuilder do
     end
   end
 
+  @doc false
+  @spec build_buffered_response([ReqLLM.StreamChunk.t()], map(), keyword()) ::
+          {:ok, ReqLLM.Response.t()} | {:error, term()}
+  def build_buffered_response(chunks, metadata, opts) do
+    with {:ok, response} <- DefaultBuilder.build_buffered_response(chunks, metadata, opts) do
+      {:ok, preserve_empty_message(response, chunks, opts)}
+    end
+  end
+
   defp ensure_non_empty_content(%{message: %{tool_calls: tc, content: []}} = response)
        when is_list(tc) and tc != [] do
     content = [ContentPart.text("")]
@@ -29,4 +38,18 @@ defmodule ReqLLM.Providers.Anthropic.ResponseBuilder do
   end
 
   defp ensure_non_empty_content(response), do: response
+
+  defp preserve_empty_message(response, chunks, opts) do
+    if Enum.any?(chunks, &message_chunk?/1) do
+      response
+    else
+      %{response | message: nil, context: Keyword.fetch!(opts, :context)}
+    end
+  end
+
+  defp message_chunk?(%ReqLLM.StreamChunk{type: type})
+       when type in [:content, :thinking, :tool_call],
+       do: true
+
+  defp message_chunk?(_chunk), do: false
 end

--- a/test/req_llm/provider/anthropic_materialization_test.exs
+++ b/test/req_llm/provider/anthropic_materialization_test.exs
@@ -1,0 +1,393 @@
+defmodule ReqLLM.Provider.AnthropicMaterializationTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :provider_boundary
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Providers.Anthropic
+  alias ReqLLM.Providers.Anthropic.Response
+  alias ReqLLM.Providers.Anthropic.ResponseBuilder
+  alias ReqLLM.StreamChunk
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.StreamResponse.MetadataHandle
+  alias ReqLLM.ToolCall
+
+  setup do
+    %{model: %LLMDB.Model{provider: :anthropic, id: "claude-materialization-test"}}
+  end
+
+  test "buffered and streamed Messages data share semantic materialization", %{model: model} do
+    usage = %{
+      "input_tokens" => 8,
+      "output_tokens" => 5,
+      "cache_read_input_tokens" => 3,
+      "cache_creation_input_tokens" => 2,
+      "reasoning_output_tokens" => 4,
+      "server_tool_use" => %{"web_search_requests" => 1}
+    }
+
+    body = %{
+      "id" => "msg_123",
+      "model" => model.id,
+      "type" => "message",
+      "role" => "assistant",
+      "content" => [
+        %{"type" => "thinking", "thinking" => "Plan", "signature" => "sig_plan"},
+        %{"type" => "text", "text" => "Answer "},
+        %{
+          "type" => "tool_use",
+          "id" => "toolu_123",
+          "name" => "lookup",
+          "input" => %{"q" => "docs"}
+        },
+        %{"type" => "thinking", "thinking" => "Verify", "signature" => "sig_verify"},
+        %{"type" => "text", "text" => "ready"}
+      ],
+      "stop_reason" => "tool_use",
+      "stop_sequence" => nil,
+      "usage" => usage
+    }
+
+    {:ok, buffered} = Response.decode_response(body, model)
+    chunks = decode_events(stream_events(usage), model)
+
+    {:ok, streamed} =
+      ResponseBuilder.build_response(
+        chunks,
+        %{
+          response_id: "msg_123",
+          usage: buffered.usage,
+          finish_reason: :tool_calls,
+          provider_meta: %{
+            "type" => "message",
+            "role" => "assistant",
+            "stop_sequence" => nil
+          }
+        },
+        context: Context.new(),
+        model: model
+      )
+
+    assert semantic_projection(buffered) == semantic_projection(streamed)
+    assert buffered.id == streamed.id
+    assert buffered.model == streamed.model
+    assert streamed.context == Context.new([streamed.message])
+
+    assert Enum.any?(chunks, fn
+             %StreamChunk{type: :meta, metadata: %{terminal?: true}} -> true
+             _chunk -> false
+           end)
+
+    assert Enum.any?(chunks, fn
+             %StreamChunk{type: :meta, metadata: %{usage: event_usage}} ->
+               event_usage.cached_tokens == 3 and event_usage.reasoning_tokens == 4
+
+             _chunk ->
+               false
+           end)
+  end
+
+  test "buffered compatibility preserves exact content, metadata, and edge values", %{
+    model: model
+  } do
+    body = %{
+      "id" => "msg_ordered",
+      "model" => "claude-wire",
+      "type" => "message",
+      "role" => "assistant",
+      "content" => [
+        %{"type" => "text", "text" => "First"},
+        %{"type" => "thinking", "thinking" => "Think", "signature" => ""},
+        %{"type" => "text", "text" => "Second"},
+        %{
+          "type" => "tool_use",
+          "id" => "toolu_ordered",
+          "name" => "lookup",
+          "input" => %{"q" => "docs"}
+        }
+      ],
+      "stop_reason" => "future_stop_reason",
+      "stop_sequence" => "END",
+      "custom" => %{"trace" => "trace_123"},
+      "usage" => %{"input_tokens" => 2, "output_tokens" => 3}
+    }
+
+    {:ok, response} = Response.decode_response(body, model)
+
+    assert response.id == "msg_ordered"
+    assert response.model == "claude-wire"
+    assert response.finish_reason == :unknown
+    assert response.message.metadata == %{}
+
+    assert response.message.content == [
+             %ContentPart{type: :text, text: "First", metadata: %{}},
+             %ContentPart{type: :thinking, text: "Think", metadata: %{}},
+             %ContentPart{type: :text, text: "Second", metadata: %{}}
+           ]
+
+    assert [detail] = response.message.reasoning_details
+    assert detail.text == "Think"
+    assert detail.signature == nil
+    assert detail.encrypted? == false
+    assert detail.provider == :anthropic
+    assert detail.format == "anthropic-thinking-v1"
+    assert detail.index == 0
+    assert detail.provider_data == %{"type" => "thinking"}
+
+    assert [tool_call] = response.message.tool_calls
+    assert ToolCall.args_map(tool_call) == %{"q" => "docs"}
+    assert ToolCall.metadata(tool_call) == %{}
+
+    assert response.provider_meta == %{
+             "type" => "message",
+             "role" => "assistant",
+             "stop_sequence" => "END",
+             "custom" => %{"trace" => "trace_123"}
+           }
+
+    assert response.context == Context.new([response.message])
+  end
+
+  test "buffered tool-only and empty responses retain legacy message shapes", %{model: model} do
+    tool_body = %{
+      "id" => "msg_tool",
+      "content" => [
+        %{
+          "type" => "tool_use",
+          "id" => "toolu_empty",
+          "name" => "lookup",
+          "input" => %{}
+        }
+      ],
+      "stop_reason" => "tool_use"
+    }
+
+    {:ok, tool_response} = Response.decode_response(tool_body, model)
+
+    assert tool_response.message.content == []
+    assert [%ToolCall{} = tool_call] = tool_response.message.tool_calls
+    assert ToolCall.args_json(tool_call) == "{}"
+    assert tool_response.context == Context.new([tool_response.message])
+
+    empty_body = %{
+      "id" => nil,
+      "model" => nil,
+      "content" => [%{"type" => "provider_native", "value" => "ignored"}],
+      "custom" => true
+    }
+
+    {:ok, empty_response} = Response.decode_response(empty_body, model)
+
+    assert empty_response.id == nil
+    assert empty_response.model == nil
+    assert empty_response.message == nil
+    assert empty_response.context == Context.new()
+    assert empty_response.finish_reason == nil
+    assert empty_response.object == nil
+
+    assert empty_response.usage == %{
+             input_tokens: 0,
+             output_tokens: 0,
+             total_tokens: 0,
+             cached_tokens: 0,
+             reasoning_tokens: 0
+           }
+
+    assert empty_response.provider_meta == %{"custom" => true}
+    assert {:error, :not_implemented} = Response.decode_response("invalid", model)
+  end
+
+  test "native provider decoding still advances the caller context", %{model: model} do
+    context = Context.new([Context.user("Question")])
+
+    request = %Req.Request{
+      method: :post,
+      url: URI.parse("https://api.anthropic.com/v1/messages"),
+      headers: %{},
+      options: %{context: context, model: model.id, operation: :chat, stream: false},
+      private: %{req_llm_model: model}
+    }
+
+    http_response = %Req.Response{
+      status: 200,
+      headers: %{},
+      body: %{
+        "id" => "msg_context",
+        "model" => model.id,
+        "content" => [%{"type" => "text", "text" => "Answer"}],
+        "stop_reason" => "end_turn"
+      }
+    }
+
+    {_request, decoded} = Anthropic.decode_response({request, http_response})
+    response = decoded.body
+
+    assert response.context == Context.new(context.messages ++ [response.message])
+    assert ReqLLM.Response.text(response) == "Answer"
+  end
+
+  test "StreamResponse replay helpers retain parity and cancellation", %{model: model} do
+    chunks = [
+      StreamChunk.thinking("Plan"),
+      StreamChunk.text("Answer"),
+      StreamChunk.tool_call("lookup", %{}, %{id: "toolu_replay", index: 0}),
+      StreamChunk.meta(%{tool_call_args: %{index: 0, fragment: ~s({"q":"docs"})}})
+    ]
+
+    metadata = %{
+      response_id: "msg_replay",
+      usage: %{
+        input_tokens: 2,
+        output_tokens: 1,
+        total_tokens: 3,
+        cached_tokens: 0,
+        reasoning_tokens: 1
+      },
+      finish_reason: :tool_calls
+    }
+
+    to_response = stream_response(model, chunks, metadata)
+    process_stream = stream_response(model, chunks, metadata)
+
+    assert {:ok, replayed} = StreamResponse.to_response(to_response)
+    assert {:ok, processed} = StreamResponse.process_stream(process_stream)
+    assert semantic_projection(replayed) == semantic_projection(processed)
+    assert replayed.id == "msg_replay"
+    assert replayed.message.content != []
+    assert [%ToolCall{} = replayed_call] = replayed.message.tool_calls
+    assert ToolCall.args_map(replayed_call) == %{"q" => "docs"}
+
+    cancelled = stream_response(model, [], %{finish_reason: :cancelled})
+    assert {:ok, cancelled_response} = StreamResponse.to_response(cancelled)
+    assert cancelled_response.finish_reason == :cancelled
+  end
+
+  defp decode_events(events, model) do
+    {chunks, state} =
+      Enum.reduce(events, {[], Anthropic.init_stream_state(model)}, fn event, {chunks, state} ->
+        {event_chunks, next_state} = Anthropic.decode_stream_event(event, model, state)
+        {chunks ++ event_chunks, next_state}
+      end)
+
+    {flush_chunks, _state} = Anthropic.flush_stream_state(model, state)
+    chunks ++ flush_chunks
+  end
+
+  defp stream_events(usage) do
+    [
+      %{
+        data: %{
+          "type" => "message_start",
+          "message" => %{"usage" => usage}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_start",
+          "index" => 0,
+          "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "thinking_delta", "thinking" => "Plan"}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "signature_delta", "signature" => "sig_plan"}
+        }
+      },
+      %{data: %{"type" => "content_block_stop", "index" => 0}},
+      %{
+        data: %{
+          "type" => "content_block_start",
+          "index" => 1,
+          "content_block" => %{"type" => "text", "text" => "Answer "}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_start",
+          "index" => 2,
+          "content_block" => %{"type" => "tool_use", "id" => "toolu_123", "name" => "lookup"}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_delta",
+          "index" => 2,
+          "delta" => %{"type" => "input_json_delta", "partial_json" => ~s({"q":"docs"})}
+        }
+      },
+      %{data: %{"type" => "content_block_stop", "index" => 2}},
+      %{
+        data: %{
+          "type" => "content_block_start",
+          "index" => 3,
+          "content_block" => %{"type" => "thinking", "thinking" => "", "signature" => ""}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_delta",
+          "index" => 3,
+          "delta" => %{"type" => "thinking_delta", "thinking" => "Verify"}
+        }
+      },
+      %{
+        data: %{
+          "type" => "content_block_delta",
+          "index" => 3,
+          "delta" => %{"type" => "signature_delta", "signature" => "sig_verify"}
+        }
+      },
+      %{data: %{"type" => "content_block_stop", "index" => 3}},
+      %{
+        data: %{
+          "type" => "content_block_start",
+          "index" => 4,
+          "content_block" => %{"type" => "text", "text" => "ready"}
+        }
+      },
+      %{
+        data: %{
+          "type" => "message_delta",
+          "delta" => %{"stop_reason" => "tool_use"},
+          "usage" => %{"output_tokens" => usage["output_tokens"]}
+        }
+      },
+      %{data: %{"type" => "message_stop"}}
+    ]
+  end
+
+  defp semantic_projection(response) do
+    %{
+      text: ReqLLM.Response.text(response),
+      thinking: ReqLLM.Response.thinking(response),
+      tool_calls: Enum.map(ReqLLM.Response.tool_calls(response), &ToolCall.to_map/1),
+      reasoning_details: response.message.reasoning_details,
+      object: response.object,
+      usage: response.usage,
+      finish_reason: response.finish_reason,
+      provider_meta: response.provider_meta
+    }
+  end
+
+  defp stream_response(model, chunks, metadata) do
+    {:ok, handle} = MetadataHandle.start_link(fn -> metadata end)
+
+    %StreamResponse{
+      stream: chunks,
+      metadata_handle: handle,
+      cancel: fn -> :ok end,
+      model: model,
+      context: Context.new()
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- route buffered Anthropic Messages responses through the provider response builder and shared chunk accumulator
- preserve legacy buffered message, content ordering, reasoning, tool, usage, ID, model, and provider metadata projections
- add buffered/streamed semantic parity, adapter-boundary, replay, cancellation, and edge-case coverage

## Compatibility

This is an internal V1 refactor. It does not change request encoding, SSE decoding, cache behavior, object extraction, public structs, provider callbacks, or top-level APIs. Buffered tool-only responses retain empty content, while the existing streaming-only non-empty-content correction remains unchanged. Empty buffered responses retain `message: nil`.

## Validation

- `mix test test/req_llm/provider/anthropic_materialization_test.exs test/providers/anthropic_test.exs` (102 passed)
- native/hosted Anthropic widened suites (261 passed)
- OpenAI buffered materialization regression suites (84 passed with hosted Anthropic subset)
- representative Anthropic fixture replay (21 applicable scenarios passed; three pre-existing coverage-test defects remain outside this PR)
- `mix test` (3,767 passed, 11 skipped, 145 excluded)
- `mix quality`

Closes #849