### PR TITLE
test: isolate streaming failure log capture

### DIFF
--- a/test/req_llm/streaming/failure_test.exs
+++ b/test/req_llm/streaming/failure_test.exs
@@ -1,5 +1,5 @@
 defmodule ReqLLM.Streaming.FailureTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 


### PR DESCRIPTION
## Summary

- run the streaming failure log-capture module synchronously
- prevent unrelated logs from concurrent tests from contaminating `capture_log/1` assertions
- leave production behavior and the public API unchanged

## Validation

- `mix test test/req_llm/streaming/failure_test.exs --repeat-until-failure 50`
- `mix test` (3,787 passed, 11 skipped, 145 excluded)
- `mix quality`

## Context

The post-merge `main` workflow after #893 exposed this existing isolation issue on OTP 27 / Elixir 1.18: the cancellation assertion captured an unrelated Azure debug log emitted by another async test. The function under test correctly returned `:cancelled` and emitted no log.