### PR TITLE
feat: add structured output contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ schema = [name: [type: :string, required: true], age: [type: :pos_integer]]
 person = ReqLLM.generate_object!(model, "Generate a person", schema)
 #=> %{name: "John Doe", age: 30}
 
+output = ReqLLM.Output.array([name: [type: :string, required: true]])
+{:ok, response} = ReqLLM.generate_text(model, "Generate three people", output: output)
+ReqLLM.Response.output(response, output)
+#=> [%{"name" => "Ada"}, %{"name" => "Grace"}, %{"name" => "Linus"}]
+
 {:ok, image_response} = ReqLLM.generate_image("openai:gpt-image-1.5", "A simple red square")
 image_bytes = ReqLLM.Response.image_data(image_response)
 File.write!("red_square.png", image_bytes)
@@ -171,8 +176,9 @@ usage = ReqLLM.StreamResponse.usage(response)
   - Req-backed request/response calls and Finch-backed streaming behind the same provider abstraction
   - Advanced Req request customization available for non-streaming use cases
 
-- **Structured object generation**
-  - `generate_object/4` renders JSON-compatible Elixir maps validated by a NimbleOptions-compiled schema
+- **Structured output generation**
+  - `ReqLLM.Output` descriptors add text, object, array, choice, and arbitrary JSON contracts to `generate_text/3` and `stream_text/3`
+  - `generate_object/4` and `stream_object/4` remain compatible object-generation conveniences
   - Zero-copy mapping to provider JSON-schema / function-calling endpoints
   - OpenAI native structured outputs with three modes (`:auto` (default), `:json_schema`, `:tool_strict`)
 

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -918,6 +918,8 @@ defmodule ReqLLM do
     * `:frequency_penalty` - Penalize new tokens based on frequency
     * `:tools` - List of tool definitions
     * `:tool_choice` - Tool choice strategy
+    * `:output` - A `ReqLLM.Output` descriptor for text, object, array, choice,
+      or arbitrary JSON output
     * `:system_prompt` - System prompt to prepend
     * `:receive_timeout` - Provider-transport inactivity timeout in milliseconds
     * `:total_timeout` - Optional whole-call deadline in milliseconds, including retries
@@ -934,6 +936,11 @@ defmodule ReqLLM do
       ReqLLM.Response.usage(response)
       #=> %{input_tokens: 10, output_tokens: 8}
 
+      output = ReqLLM.Output.array([name: [type: :string, required: true]])
+      {:ok, response} = ReqLLM.generate_text(model, "Generate people", output: output)
+      ReqLLM.Response.output(response, output)
+      #=> [%{"name" => "Ada"}]
+
   """
   defdelegate generate_text(model_spec, messages, opts \\ []), to: Generation
 
@@ -942,7 +949,8 @@ defmodule ReqLLM do
 
   This is a convenience function that extracts just the text from the response.
   For access to usage metadata and other response data, use `generate_text/3`.
-  Raises on error.
+  Raises on error. This function remains a text-only convenience; use
+  `generate_text/3` and `ReqLLM.Response.output/2` for structured descriptors.
 
   ## Parameters
 
@@ -962,6 +970,11 @@ defmodule ReqLLM do
   Returns a `ReqLLM.StreamResponse` that provides both real-time token streaming
   and asynchronous metadata collection (usage, finish_reason). This enables
   zero-latency content delivery while collecting billing/usage data concurrently.
+
+  Structured `:output` descriptors reuse the existing object-stream path.
+  Partial chunks are not final-schema validation results. Convert the response
+  once with `ReqLLM.StreamResponse.to_response/1`, then project the complete
+  value with `ReqLLM.Response.output/2`.
 
   The streaming implementation uses Finch directly for production-grade performance
   with automatic connection pooling and configurable checkout timeouts.

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -50,6 +50,9 @@ defmodule ReqLLM.Generation do
     * `:frequency_penalty` - Penalize new tokens based on frequency
     * `:tools` - List of tool definitions
     * `:tool_choice` - Tool choice strategy
+    * `:output` - A `ReqLLM.Output` descriptor; omitted and `ReqLLM.Output.text/0`
+      preserve plain-text behavior, while structured descriptors reuse the existing
+      provider-native or tool-fallback object path
     * `:system_prompt` - System prompt to prepend
     * `:receive_timeout` - Provider-transport inactivity timeout in milliseconds
     * `:total_timeout` - Optional whole-call deadline in milliseconds, including retries
@@ -66,6 +69,11 @@ defmodule ReqLLM.Generation do
       ReqLLM.Response.usage(response)
       #=> %{input_tokens: 10, output_tokens: 8}
 
+      output = ReqLLM.Output.object([name: [type: :string, required: true]])
+      {:ok, response} = ReqLLM.Generation.generate_text(model, "Generate a person", output: output)
+      ReqLLM.Response.output(response, output)
+      #=> %{"name" => "Ada"}
+
   """
 
   @spec generate_text(
@@ -75,7 +83,18 @@ defmodule ReqLLM.Generation do
         ) :: {:ok, Response.t()} | {:error, term()}
   def generate_text(model_spec, messages, opts \\ []) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :chat, opts)
+    {output, opts} = Keyword.pop(opts, :output)
 
+    with {:ok, descriptor} <- ReqLLM.Output.normalize(output),
+         {:ok, contract} <- ReqLLM.Output.compile(descriptor) do
+      case contract.operation do
+        :chat -> generate_text_response(model_spec, messages, opts)
+        :object -> generate_output_response(model_spec, messages, contract, opts)
+      end
+    end
+  end
+
+  defp generate_text_response(model_spec, messages, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
@@ -103,12 +122,22 @@ defmodule ReqLLM.Generation do
     end
   end
 
+  defp generate_output_response(model_spec, messages, contract, opts) do
+    generate_object_response(
+      model_spec,
+      messages,
+      {:compiled, contract.compiled_schema},
+      opts
+    )
+  end
+
   @doc """
   Generates text using an AI model, returning only the text content.
 
   This is a convenience function that extracts just the text from the response.
   For access to usage metadata and other response data, use `generate_text/3`.
-  Raises on error.
+  Raises on error. This function remains a text-only convenience; use
+  `generate_text/3` and `ReqLLM.Response.output/2` for structured descriptors.
 
   ## Parameters
 
@@ -138,6 +167,12 @@ defmodule ReqLLM.Generation do
   Returns a canonical ReqLLM.Response containing usage data and stream.
   For simple streaming without metadata, use `stream_text!/3`.
 
+  When `:output` is structured, the stream retains the existing object-stream
+  representation. Partial content and tool-call argument chunks are transport
+  fragments, not final-schema validation results. Materialize the stream once
+  with `ReqLLM.StreamResponse.to_response/1`, then call
+  `ReqLLM.Response.output/2` with the same descriptor.
+
   ## Parameters
 
   Same as `generate_text/3`.
@@ -159,7 +194,18 @@ defmodule ReqLLM.Generation do
         ) :: {:ok, ReqLLM.StreamResponse.t()} | {:error, term()}
   def stream_text(model_spec, messages, opts \\ []) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :chat, opts)
+    {output, opts} = Keyword.pop(opts, :output)
 
+    with {:ok, descriptor} <- ReqLLM.Output.normalize(output),
+         {:ok, contract} <- ReqLLM.Output.compile(descriptor) do
+      case contract.operation do
+        :chat -> stream_text_response(model_spec, messages, opts)
+        :object -> stream_output_response(model_spec, messages, contract, opts)
+      end
+    end
+  end
+
+  defp stream_text_response(model_spec, messages, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
@@ -183,6 +229,15 @@ defmodule ReqLLM.Generation do
           )
       end
     end
+  end
+
+  defp stream_output_response(model_spec, messages, contract, opts) do
+    stream_object_response(
+      model_spec,
+      messages,
+      {:compiled, contract.compiled_schema},
+      opts
+    )
   end
 
   @doc """
@@ -268,8 +323,15 @@ defmodule ReqLLM.Generation do
           keyword()
         ) :: {:ok, Response.t()} | {:error, term()}
   def generate_object(model_spec, messages, object_schema, opts \\ []) do
-    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :object, opts)
+    opts =
+      model_spec
+      |> ReqLLM.ModelInput.merge_tuple_defaults(:object, opts)
+      |> Keyword.delete(:output)
 
+    generate_object_response(model_spec, messages, {:schema, object_schema}, opts)
+  end
+
+  defp generate_object_response(model_spec, messages, schema_source, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
@@ -280,7 +342,7 @@ defmodule ReqLLM.Generation do
              opts
            ),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
-         {:ok, compiled_schema} <- ReqLLM.Schema.compile(object_schema) do
+         {:ok, compiled_schema} <- compile_schema_source(schema_source) do
       compiled_opts = Keyword.put(opts, :compiled_schema, compiled_schema)
 
       case ReqLLM.Cache.fetch(model, :object, context, opts, compiled_schema.schema) do
@@ -300,6 +362,9 @@ defmodule ReqLLM.Generation do
       end
     end
   end
+
+  defp compile_schema_source({:schema, schema}), do: ReqLLM.Schema.compile(schema)
+  defp compile_schema_source({:compiled, compiled_schema}), do: {:ok, compiled_schema}
 
   @doc """
   Generates structured data using an AI model, returning only the object content.
@@ -541,8 +606,15 @@ defmodule ReqLLM.Generation do
           keyword()
         ) :: {:ok, ReqLLM.StreamResponse.t()} | {:error, term()}
   def stream_object(model_spec, messages, object_schema, opts \\ []) do
-    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :object, opts)
+    opts =
+      model_spec
+      |> ReqLLM.ModelInput.merge_tuple_defaults(:object, opts)
+      |> Keyword.delete(:output)
 
+    stream_object_response(model_spec, messages, {:schema, object_schema}, opts)
+  end
+
+  defp stream_object_response(model_spec, messages, schema_source, opts) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
@@ -552,7 +624,7 @@ defmodule ReqLLM.Generation do
              model,
              opts
            ),
-         {:ok, compiled_schema} <- ReqLLM.Schema.compile(object_schema),
+         {:ok, compiled_schema} <- compile_schema_source(schema_source),
          {:ok, prepared_req} <-
            provider_module.prepare_request(
              :object,

--- a/lib/req_llm/output.ex
+++ b/lib/req_llm/output.ex
@@ -1,0 +1,325 @@
+defmodule ReqLLM.Output do
+  @moduledoc """
+  Describes the value expected from text generation.
+
+  Output descriptors are additive request values for `ReqLLM.generate_text/3`
+  and `ReqLLM.stream_text/3`. Omitting `:output`, or passing `text/0`, keeps the
+  existing text-generation path. Structured descriptors reuse ReqLLM's existing
+  object-generation path and preserve the returned `ReqLLM.Response` or
+  `ReqLLM.StreamResponse` shape.
+
+  Use `ReqLLM.Response.output/2` to project a buffered response. For streaming,
+  materialize once with `ReqLLM.StreamResponse.to_response/1`, then project that
+  response so the parsed output remains beside usage and provider metadata. Raw
+  generated text and structured tool-call arguments remain available through
+  their existing response accessors.
+
+  Streaming responses continue to expose the existing one-consumer stream of
+  `ReqLLM.StreamChunk` values. Content and structured tool-call chunks are
+  partial transport values and are not claimed to satisfy the final schema.
+
+  ## Examples
+
+      output = ReqLLM.Output.object(
+        [name: [type: :string, required: true]],
+        name: "person",
+        description: "A generated person"
+      )
+
+      {:ok, response} = ReqLLM.generate_text(model, "Generate a person", output: output)
+      ReqLLM.Response.output(response, output)
+      #=> %{"name" => "Ada"}
+
+      output = ReqLLM.Output.array(
+        Zoi.object(%{name: Zoi.string()}),
+        name: "people"
+      )
+
+      output = ReqLLM.Output.choice(["sunny", "rainy", "snowy"])
+      output = ReqLLM.Output.json(description: "Any valid JSON value")
+
+  Complete structured values retain the current V1 validation and repair
+  behavior. Partial stream values are never final-schema validation evidence.
+
+  ## Result and error semantics
+
+  `ReqLLM.Response.output/2` returns text for `text/0`, a map for `object/2`, a
+  list for `array/2`, a string for `choice/2`, and any JSON-compatible value for
+  `json/1`. It returns `nil` when the existing provider path did not materialize
+  a structured value.
+
+  Constructors raise `ArgumentError` for invalid descriptor metadata options.
+  Schema and choice contracts are checked before an HTTP request; generation
+  returns `{:error, %ReqLLM.Error.Invalid.Parameter{}}` when a contract cannot be
+  compiled. Descriptors do not introduce a new final-value validation policy:
+  current V1 provider validation, coercion, and JSON-repair behavior is retained.
+  """
+
+  @type output_type :: :text | :object | :array | :choice | :json
+
+  @type t :: %__MODULE__{
+          type: output_type(),
+          schema: term() | nil,
+          element: term() | nil,
+          choices: [String.t()] | nil,
+          name: String.t() | nil,
+          description: String.t() | nil
+        }
+
+  @type contract :: %{
+          descriptor: t(),
+          operation: :chat | :object,
+          compiled_schema: map() | nil,
+          wrapped?: boolean()
+        }
+
+  @enforce_keys [:type]
+  defstruct [:type, :schema, :element, :choices, :name, :description]
+
+  @doc "Returns the default plain-text output descriptor."
+  @spec text() :: t()
+  def text, do: %__MODULE__{type: :text}
+
+  @doc """
+  Returns an object output descriptor.
+
+  The schema may be a NimbleOptions-style keyword schema, JSON Schema map, or
+  Zoi schema. Optional `:name` and `:description` values provide provider
+  guidance where the selected structured-output surface supports it.
+  """
+  @spec object(term(), keyword()) :: t()
+  def object(schema, opts \\ []) do
+    build(:object, [schema: schema], opts)
+  end
+
+  @doc """
+  Returns an array output descriptor.
+
+  `element` is the schema for one array element and accepts the same schema
+  forms as `object/2`.
+  """
+  @spec array(term(), keyword()) :: t()
+  def array(element, opts \\ []) do
+    build(:array, [element: element], opts)
+  end
+
+  @doc "Returns a descriptor requesting one of the provided unique strings."
+  @spec choice([String.t()], keyword()) :: t()
+  def choice(choices, opts \\ []) do
+    build(:choice, [choices: choices], opts)
+  end
+
+  @doc "Returns a descriptor for any JSON value without a shape constraint."
+  @spec json(keyword()) :: t()
+  def json(opts \\ []) do
+    build(:json, [], opts)
+  end
+
+  @doc false
+  @spec normalize(nil | t()) :: {:ok, t()} | {:error, ReqLLM.Error.t()}
+  def normalize(nil), do: {:ok, text()}
+  def normalize(%__MODULE__{} = output), do: validate_descriptor(output)
+
+  def normalize(output) do
+    invalid_output(":output must be a ReqLLM.Output descriptor, got: #{inspect(output)}")
+  end
+
+  @doc false
+  @spec compile(t()) :: {:ok, contract()} | {:error, ReqLLM.Error.t()}
+  def compile(%__MODULE__{type: :text} = descriptor) do
+    {:ok,
+     %{
+       descriptor: descriptor,
+       operation: :chat,
+       compiled_schema: nil,
+       wrapped?: false
+     }}
+  end
+
+  def compile(%__MODULE__{type: :object, schema: schema} = descriptor) do
+    with :ok <- validate_schema(schema),
+         {:ok, json_schema} <- schema_to_json(schema),
+         :ok <- ensure_object_schema(json_schema) do
+      {:ok, structured_contract(descriptor, decorate_schema(json_schema, descriptor), false)}
+    end
+  end
+
+  def compile(%__MODULE__{type: :array, element: element} = descriptor) do
+    with :ok <- validate_schema(element),
+         {:ok, element_schema} <- schema_to_json(element) do
+      value_schema = %{"type" => "array", "items" => element_schema}
+      {:ok, structured_contract(descriptor, wrap_value_schema(value_schema, descriptor), true)}
+    end
+  end
+
+  def compile(%__MODULE__{type: :choice, choices: choices} = descriptor) do
+    with :ok <- validate_choices(choices) do
+      value_schema = %{"type" => "string", "enum" => choices}
+      {:ok, structured_contract(descriptor, wrap_value_schema(value_schema, descriptor), true)}
+    end
+  end
+
+  def compile(%__MODULE__{type: :json} = descriptor) do
+    {:ok, structured_contract(descriptor, wrap_value_schema(%{}, descriptor), true)}
+  end
+
+  def compile(%__MODULE__{type: type}) do
+    invalid_output("unsupported ReqLLM.Output type: #{inspect(type)}")
+  end
+
+  @doc false
+  @spec value(t(), term()) :: term()
+  def value(%__MODULE__{type: :text}, response) do
+    ReqLLM.Response.text(response)
+  end
+
+  def value(%__MODULE__{type: :object}, response) do
+    Map.get(response, :object)
+  end
+
+  def value(%__MODULE__{type: type}, response) when type in [:array, :choice, :json] do
+    response
+    |> Map.get(:object)
+    |> unwrap_value()
+  end
+
+  defp build(type, fields, opts) do
+    metadata = validate_metadata!(opts)
+
+    struct!(
+      __MODULE__,
+      [type: type] ++ fields ++ [name: metadata.name, description: metadata.description]
+    )
+  end
+
+  defp validate_metadata!(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "output descriptor options must be a keyword list"
+    end
+
+    unknown = Keyword.keys(opts) -- [:name, :description]
+
+    if unknown != [] do
+      raise ArgumentError, "unknown output descriptor options: #{inspect(unknown)}"
+    end
+
+    name = Keyword.get(opts, :name)
+    description = Keyword.get(opts, :description)
+
+    unless is_nil(name) or is_binary(name) do
+      raise ArgumentError, "output descriptor :name must be a string"
+    end
+
+    unless is_nil(description) or is_binary(description) do
+      raise ArgumentError, "output descriptor :description must be a string"
+    end
+
+    %{name: name, description: description}
+  end
+
+  defp validate_descriptor(%__MODULE__{type: type} = output)
+       when type in [:text, :object, :array, :choice, :json] do
+    with :ok <- validate_descriptor_metadata(:name, output.name),
+         :ok <- validate_descriptor_metadata(:description, output.description) do
+      {:ok, output}
+    end
+  end
+
+  defp validate_descriptor(%__MODULE__{type: type}) do
+    invalid_output("unsupported ReqLLM.Output type: #{inspect(type)}")
+  end
+
+  defp validate_descriptor_metadata(_key, nil), do: :ok
+  defp validate_descriptor_metadata(_key, value) when is_binary(value), do: :ok
+
+  defp validate_descriptor_metadata(key, value) do
+    invalid_output("output descriptor #{inspect(key)} must be a string, got: #{inspect(value)}")
+  end
+
+  defp structured_contract(descriptor, schema, wrapped?) do
+    compiled_schema =
+      %{schema: schema, compiled: nil}
+      |> maybe_put(:name, descriptor.name)
+      |> maybe_put(:description, descriptor.description)
+
+    %{
+      descriptor: descriptor,
+      operation: :object,
+      compiled_schema: compiled_schema,
+      wrapped?: wrapped?
+    }
+  end
+
+  defp schema_to_json(schema) do
+    {:ok, ReqLLM.Schema.to_json(schema)}
+  rescue
+    error ->
+      invalid_output("invalid output schema: #{Exception.message(error)}")
+  end
+
+  defp validate_schema(schema) do
+    case ReqLLM.Schema.compile(schema) do
+      {:ok, _compiled} -> :ok
+      {:error, error} -> invalid_output("invalid output schema: #{Exception.message(error)}")
+    end
+  end
+
+  defp ensure_object_schema(%{"type" => type}) when type not in ["object", nil] do
+    invalid_output("object output requires a top-level object schema, got: #{inspect(type)}")
+  end
+
+  defp ensure_object_schema(%{type: type}) when type not in [:object, nil] do
+    invalid_output("object output requires a top-level object schema, got: #{inspect(type)}")
+  end
+
+  defp ensure_object_schema(_schema), do: :ok
+
+  defp validate_choices(choices) when is_list(choices) and choices != [] do
+    cond do
+      not Enum.all?(choices, &is_binary/1) ->
+        invalid_output("choice output options must all be strings")
+
+      Enum.uniq(choices) != choices ->
+        invalid_output("choice output options must be unique")
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_choices(_choices) do
+    invalid_output("choice output requires a non-empty list of strings")
+  end
+
+  defp wrap_value_schema(value_schema, descriptor) do
+    %{
+      "type" => "object",
+      "properties" => %{"value" => value_schema},
+      "required" => ["value"],
+      "additionalProperties" => false
+    }
+    |> decorate_schema(descriptor)
+  end
+
+  defp decorate_schema(schema, %__MODULE__{description: nil}), do: schema
+
+  defp decorate_schema(schema, %__MODULE__{description: description}) do
+    Map.put(schema, "description", description)
+  end
+
+  defp unwrap_value(%{} = object) do
+    case Map.fetch(object, "value") do
+      {:ok, value} -> value
+      :error -> Map.get(object, :value)
+    end
+  end
+
+  defp unwrap_value(_object), do: nil
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp invalid_output(message) do
+    {:error, ReqLLM.Error.Invalid.Parameter.exception(parameter: message)}
+  end
+end

--- a/lib/req_llm/output.ex
+++ b/lib/req_llm/output.ex
@@ -137,30 +137,52 @@ defmodule ReqLLM.Output do
   end
 
   def compile(%__MODULE__{type: :object, schema: schema} = descriptor) do
-    with :ok <- validate_schema(schema),
+    with {:ok, compiled_schema} <- compile_schema(schema),
          {:ok, json_schema} <- schema_to_json(schema),
          :ok <- ensure_object_schema(json_schema) do
-      {:ok, structured_contract(descriptor, decorate_schema(json_schema, descriptor), false)}
+      {:ok,
+       structured_contract(
+         descriptor,
+         decorate_schema(json_schema, descriptor),
+         compiled_schema.compiled,
+         false
+       )}
     end
   end
 
   def compile(%__MODULE__{type: :array, element: element} = descriptor) do
-    with :ok <- validate_schema(element),
-         {:ok, element_schema} <- schema_to_json(element) do
+    with {:ok, _compiled_element} <- compile_schema(element),
+         {:ok, element_schema} <- schema_to_json(element),
+         {:ok, compiled_wrapper} <- compile_array_wrapper(element) do
       value_schema = %{"type" => "array", "items" => element_schema}
-      {:ok, structured_contract(descriptor, wrap_value_schema(value_schema, descriptor), true)}
+
+      {:ok,
+       structured_contract(
+         descriptor,
+         wrap_value_schema(value_schema, descriptor),
+         compiled_wrapper.compiled,
+         true
+       )}
     end
   end
 
   def compile(%__MODULE__{type: :choice, choices: choices} = descriptor) do
-    with :ok <- validate_choices(choices) do
+    with :ok <- validate_choices(choices),
+         {:ok, compiled_wrapper} <- compile_choice_wrapper(choices) do
       value_schema = %{"type" => "string", "enum" => choices}
-      {:ok, structured_contract(descriptor, wrap_value_schema(value_schema, descriptor), true)}
+
+      {:ok,
+       structured_contract(
+         descriptor,
+         wrap_value_schema(value_schema, descriptor),
+         compiled_wrapper.compiled,
+         true
+       )}
     end
   end
 
   def compile(%__MODULE__{type: :json} = descriptor) do
-    {:ok, structured_contract(descriptor, wrap_value_schema(%{}, descriptor), true)}
+    {:ok, structured_contract(descriptor, wrap_value_schema(%{}, descriptor), nil, true)}
   end
 
   def compile(%__MODULE__{type: type}) do
@@ -236,9 +258,9 @@ defmodule ReqLLM.Output do
     invalid_output("output descriptor #{inspect(key)} must be a string, got: #{inspect(value)}")
   end
 
-  defp structured_contract(descriptor, schema, wrapped?) do
+  defp structured_contract(descriptor, schema, compiled, wrapped?) do
     compiled_schema =
-      %{schema: schema, compiled: nil}
+      %{schema: schema, compiled: compiled}
       |> maybe_put(:name, descriptor.name)
       |> maybe_put(:description, descriptor.description)
 
@@ -257,11 +279,21 @@ defmodule ReqLLM.Output do
       invalid_output("invalid output schema: #{Exception.message(error)}")
   end
 
-  defp validate_schema(schema) do
+  defp compile_schema(schema) do
     case ReqLLM.Schema.compile(schema) do
-      {:ok, _compiled} -> :ok
+      {:ok, compiled_schema} -> {:ok, compiled_schema}
       {:error, error} -> invalid_output("invalid output schema: #{Exception.message(error)}")
     end
+  end
+
+  defp compile_array_wrapper(element) when is_list(element) do
+    compile_schema(value: [type: {:list, {:map, element}}, required: true])
+  end
+
+  defp compile_array_wrapper(_element), do: {:ok, %{compiled: nil}}
+
+  defp compile_choice_wrapper(choices) do
+    compile_schema(value: [type: {:in, choices}, required: true])
   end
 
   defp ensure_object_schema(%{"type" => type}) when type not in ["object", nil] do

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -165,6 +165,11 @@ defmodule ReqLLM.Provider.Options do
                                ],
 
                                # Output control
+                               output: [
+                                 type: :any,
+                                 doc:
+                                   "ReqLLM.Output descriptor for text, object, array, choice, or JSON generation"
+                               ],
                                n: [
                                  type: :pos_integer,
                                  default: 1,
@@ -1028,7 +1033,7 @@ defmodule ReqLLM.Provider.Options do
     unknown_keys = extract_unknown_keys_from_opts(opts)
     provider_suggestions = get_provider_option_suggestions(provider_mod, unknown_keys)
 
-    output_related_keys = [:output, :mode, :schema_name, :schema_description, :enum]
+    output_related_keys = [:mode, :schema_name, :schema_description, :enum]
     has_output_options = Enum.any?(unknown_keys, &(&1 in output_related_keys))
 
     base_message = message
@@ -1036,10 +1041,9 @@ defmodule ReqLLM.Provider.Options do
     base_message =
       if has_output_options do
         output_tip =
-          "Tip: The :output option and related options (:mode, :schema_name, :schema_description, :enum) are not yet supported. " <>
-            "For array/enum outputs, use Zoi to define your schema and convert it with ReqLLM.Schema.to_json/1, then pass it to generate_object/4. " <>
-            "This requires a provider that supports JSON Schema (e.g., OpenAI). " <>
-            "Example: array_schema = Zoi.array(Zoi.object(%{name: Zoi.string()})) |> ReqLLM.Schema.to_json()"
+          "Tip: Use the :output option with a ReqLLM.Output descriptor. " <>
+            "The legacy :mode, :schema_name, :schema_description, and :enum options are not supported. " <>
+            "Example: output: ReqLLM.Output.array(Zoi.object(%{name: Zoi.string()}), name: \"people\")"
 
         base_message <> "\n\n" <> output_tip
       else

--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -103,6 +103,23 @@ defmodule ReqLLM.Response do
   end
 
   @doc """
+  Projects the value described by a `ReqLLM.Output` descriptor.
+
+  This is a computed view over the unchanged response. Plain text delegates to
+  `text/1`; object output uses the existing `object` value; array, choice, and
+  JSON outputs unwrap the private compatibility envelope used by providers that
+  require a top-level object schema.
+
+  Raw text, structured tool-call arguments, usage, and provider metadata remain
+  available through their existing accessors. This projection follows the
+  current V1 structured-output validation and repair behavior.
+  """
+  @spec output(t(), ReqLLM.Output.t()) :: term()
+  def output(%__MODULE__{} = response, %ReqLLM.Output{} = descriptor) do
+    ReqLLM.Output.value(descriptor, response)
+  end
+
+  @doc """
   Extract image content parts from the response message.
 
   Returns a list of `ReqLLM.Message.ContentPart` where `type` is `:image` or `:image_url`.

--- a/test/req_llm/output_generation_test.exs
+++ b/test/req_llm/output_generation_test.exs
@@ -153,47 +153,49 @@ defmodule ReqLLM.OutputGenerationTest do
 
   describe "stream_text/3 output contracts" do
     test "exposes unvalidated partial chunks and materializes the final projected value" do
-      output = Output.array(name: [type: :string, required: true])
-      stub = stub_tool_stream(%{"value" => [%{"name" => "Ada"}]})
+      output =
+        Output.object(
+          [
+            name: [type: :string, required: true],
+            age: [type: :pos_integer, required: true],
+            occupation: [type: :string, required: true]
+          ],
+          name: "person"
+        )
+
+      opts = [output: output, max_tokens: 500, fixture: "object_streaming"]
 
       assert {:ok, partial_response} =
                ReqLLM.stream_text(
-                 @model,
-                 "Generate people",
-                 output: output,
-                 openai_structured_output_mode: :tool_strict,
-                 req_http_options: [plug: {Req.Test, stub}]
+                 "openai:gpt-4o-mini",
+                 "Generate a software engineer profile",
+                 opts
                )
 
       chunks = Enum.to_list(partial_response.stream)
 
-      assert %ReqLLM.StreamChunk{type: :tool_call, name: "structured_output"} =
-               chunk = Enum.find(chunks, &(&1.type == :tool_call))
+      content_chunks = Enum.filter(chunks, &(&1.type == :content and is_binary(&1.text)))
 
-      assert chunk.arguments == %{}
-      assert chunk.metadata.invalid_arguments == true
-
-      assert Enum.any?(chunks, fn chunk ->
-               chunk.type == :meta and
-                 is_binary(get_in(chunk.metadata, [:tool_call_args, :fragment]))
-             end)
+      assert length(content_chunks) > 1
+      assert Enum.any?(content_chunks, &match?({:error, _reason}, Jason.decode(&1.text)))
+      streamed_json = content_chunks |> Enum.map_join(& &1.text) |> Jason.decode!()
 
       assert {:ok, final_stream} =
                ReqLLM.stream_text(
-                 @model,
-                 "Generate people",
-                 output: output,
-                 openai_structured_output_mode: :tool_strict,
-                 req_http_options: [plug: {Req.Test, stub}]
+                 "openai:gpt-4o-mini",
+                 "Generate a software engineer profile",
+                 opts
                )
 
       assert {:ok, response} = StreamResponse.to_response(final_stream)
       value = Response.output(response, output)
-      assert is_list(value)
-      assert value != []
-      assert Enum.all?(value, &is_binary(&1["name"]))
-      assert response.object == %{"value" => value}
-      assert [%ToolCall{}] = Response.tool_calls(response)
+      assert is_binary(value["name"])
+      assert is_integer(value["age"])
+      assert is_binary(value["occupation"])
+      assert response.object == value
+      assert streamed_json == value
+      assert response.provider_meta["status"] == "completed"
+      assert Response.tool_calls(response) == []
     end
   end
 
@@ -254,52 +256,6 @@ defmodule ReqLLM.OutputGenerationTest do
         "output_text" => Jason.encode!(object),
         "usage" => %{"input_tokens" => 10, "output_tokens" => 4}
       })
-    end)
-
-    stub
-  end
-
-  defp stub_tool_stream(arguments) do
-    stub = {__MODULE__, make_ref()}
-    argument_json = Jason.encode!(arguments)
-
-    delta = %{
-      "id" => "chatcmpl-stream-123",
-      "choices" => [
-        %{
-          "delta" => %{
-            "role" => "assistant",
-            "tool_calls" => [
-              %{
-                "index" => 0,
-                "id" => "call_123",
-                "type" => "function",
-                "function" => %{
-                  "name" => "structured_output",
-                  "arguments" => argument_json
-                }
-              }
-            ]
-          },
-          "finish_reason" => nil
-        }
-      ]
-    }
-
-    finish = %{
-      "id" => "chatcmpl-stream-123",
-      "choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls"}]
-    }
-
-    Req.Test.stub(stub, fn conn ->
-      body =
-        "data: #{Jason.encode!(delta)}\n\n" <>
-          "data: #{Jason.encode!(finish)}\n\n" <>
-          "data: [DONE]\n\n"
-
-      conn
-      |> Plug.Conn.put_resp_header("content-type", "text/event-stream")
-      |> Plug.Conn.send_resp(200, body)
     end)
 
     stub

--- a/test/req_llm/output_generation_test.exs
+++ b/test/req_llm/output_generation_test.exs
@@ -37,9 +37,7 @@ defmodule ReqLLM.OutputGenerationTest do
       assert Response.text(legacy_response) == "Hello"
       assert Response.text(explicit_response) == "Hello"
       assert Response.output(explicit_response, Output.text()) == "Hello"
-
-      assert Map.from_struct(legacy_response) |> Map.keys() |> Enum.sort() ==
-               Map.from_struct(explicit_response) |> Map.keys() |> Enum.sort()
+      assert legacy_response == explicit_response
     end
 
     test "object output reuses the existing object operation and response shape" do

--- a/test/req_llm/output_generation_test.exs
+++ b/test/req_llm/output_generation_test.exs
@@ -1,0 +1,335 @@
+defmodule ReqLLM.OutputGenerationTest do
+  use ExUnit.Case, async: true
+
+  @moduletag contract: :public_api
+
+  alias ReqLLM.Generation
+  alias ReqLLM.Output
+  alias ReqLLM.Response
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.ToolCall
+
+  @model %{
+    provider: :openai,
+    id: "gpt-4-turbo",
+    extra: %{wire: %{protocol: "openai_chat"}}
+  }
+
+  describe "generate_text/3 output contracts" do
+    test "omitted output and Output.text use the unchanged chat path" do
+      stub = stub_text_response("Hello")
+
+      assert {:ok, legacy_response} =
+               Generation.generate_text(
+                 @model,
+                 "Hello",
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert {:ok, explicit_response} =
+               Generation.generate_text(
+                 @model,
+                 "Hello",
+                 output: Output.text(),
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert Response.text(legacy_response) == "Hello"
+      assert Response.text(explicit_response) == "Hello"
+      assert Response.output(explicit_response, Output.text()) == "Hello"
+
+      assert Map.from_struct(legacy_response) |> Map.keys() |> Enum.sort() ==
+               Map.from_struct(explicit_response) |> Map.keys() |> Enum.sort()
+    end
+
+    test "object output reuses the existing object operation and response shape" do
+      output =
+        Output.object(
+          [name: [type: :string, required: true]],
+          name: "person",
+          description: "A generated person"
+        )
+
+      stub = stub_tool_response(%{"name" => "Ada"}, self())
+
+      assert {:ok, response} =
+               Generation.generate_text(
+                 @model,
+                 "Generate a person",
+                 output: output,
+                 openai_structured_output_mode: :tool_strict,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert %Response{} = response
+      assert response.object == %{"name" => "Ada"}
+      assert Response.output(response, output) == %{"name" => "Ada"}
+      assert response.usage.total_tokens == 14
+
+      assert [%ToolCall{} = tool_call] = Response.tool_calls(response)
+      assert ToolCall.args_map(tool_call) == %{"name" => "Ada"}
+
+      assert_receive {:request_body, body}
+      refute Map.has_key?(body, "output")
+      structured_tool = Enum.find(body["tools"], &(&1["function"]["name"] == "structured_output"))
+      assert structured_tool["function"]["parameters"]["description"] == "A generated person"
+
+      assert structured_tool["function"]["parameters"]["properties"]["name"]["type"] ==
+               "string"
+    end
+
+    test "prefers the provider-native structured output surface when available" do
+      output = Output.object([name: [type: :string, required: true]], name: "person")
+      stub = stub_native_object_response(%{"name" => "Ada"}, self())
+
+      assert {:ok, response} =
+               ReqLLM.generate_text(
+                 "openai:gpt-4o-2024-08-06",
+                 "Generate a person",
+                 output: output,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert Response.output(response, output) == %{"name" => "Ada"}
+      assert Response.text(response) == ~s({"name":"Ada"})
+      assert Response.tool_calls(response) == []
+      assert response.provider_meta["api_type"] == "responses"
+
+      assert_receive {:request_body, body}
+      assert body["text"]["format"]["type"] == "json_schema"
+      assert body["text"]["format"]["name"] == "person"
+      refute Map.has_key?(body, "output")
+      refute Map.has_key?(body, "tools")
+    end
+
+    test "array output projects the wrapped array while retaining raw arguments" do
+      output = Output.array([name: [type: :string, required: true]], name: "people")
+      value = [%{"name" => "Ada"}, %{"name" => "Grace"}]
+      stub = stub_tool_response(%{"value" => value})
+
+      assert {:ok, response} = generate_structured(output, stub)
+      assert Response.output(response, output) == value
+      assert response.object == %{"value" => value}
+
+      assert [%ToolCall{} = tool_call] = Response.tool_calls(response)
+      assert ToolCall.args_map(tool_call) == %{"value" => value}
+    end
+
+    test "choice output projects one string choice" do
+      output = Output.choice(["sunny", "rainy", "snowy"])
+      stub = stub_tool_response(%{"value" => "sunny"})
+
+      assert {:ok, response} = generate_structured(output, stub)
+      assert Response.output(response, output) == "sunny"
+      assert response.object == %{"value" => "sunny"}
+    end
+
+    test "JSON output projects any JSON value" do
+      output = Output.json(description: "Any JSON value")
+      value = [1, %{"nested" => true}, nil]
+      stub = stub_tool_response(%{"value" => value})
+
+      assert {:ok, response} = generate_structured(output, stub)
+      assert Response.output(response, output) == value
+      assert response.object == %{"value" => value}
+    end
+
+    test "returns descriptor errors before making a request" do
+      stub = {__MODULE__, make_ref()}
+
+      Req.Test.stub(stub, fn _conn ->
+        raise "HTTP request should not execute for an invalid output descriptor"
+      end)
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{parameter: message}} =
+               Generation.generate_text(
+                 @model,
+                 "Hello",
+                 output: %{type: :object},
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert message =~ "ReqLLM.Output descriptor"
+    end
+  end
+
+  describe "stream_text/3 output contracts" do
+    test "exposes unvalidated partial chunks and materializes the final projected value" do
+      output = Output.array(name: [type: :string, required: true])
+      stub = stub_tool_stream(%{"value" => [%{"name" => "Ada"}]})
+
+      assert {:ok, partial_response} =
+               ReqLLM.stream_text(
+                 @model,
+                 "Generate people",
+                 output: output,
+                 openai_structured_output_mode: :tool_strict,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      chunks = Enum.to_list(partial_response.stream)
+
+      assert %ReqLLM.StreamChunk{type: :tool_call, name: "structured_output"} =
+               chunk = Enum.find(chunks, &(&1.type == :tool_call))
+
+      assert chunk.arguments == %{}
+      assert chunk.metadata.invalid_arguments == true
+
+      assert Enum.any?(chunks, fn chunk ->
+               chunk.type == :meta and
+                 is_binary(get_in(chunk.metadata, [:tool_call_args, :fragment]))
+             end)
+
+      assert {:ok, final_stream} =
+               ReqLLM.stream_text(
+                 @model,
+                 "Generate people",
+                 output: output,
+                 openai_structured_output_mode: :tool_strict,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert {:ok, response} = StreamResponse.to_response(final_stream)
+      value = Response.output(response, output)
+      assert is_list(value)
+      assert value != []
+      assert Enum.all?(value, &is_binary(&1["name"]))
+      assert response.object == %{"value" => value}
+      assert [%ToolCall{}] = Response.tool_calls(response)
+    end
+  end
+
+  defp generate_structured(output, stub) do
+    Generation.generate_text(
+      @model,
+      "Generate structured data",
+      output: output,
+      openai_structured_output_mode: :tool_strict,
+      req_http_options: [plug: {Req.Test, stub}]
+    )
+  end
+
+  defp stub_text_response(text) do
+    stub = {__MODULE__, make_ref()}
+
+    Req.Test.stub(stub, fn conn ->
+      Req.Test.json(conn, %{
+        "id" => "cmpl_text_123",
+        "model" => "gpt-4-turbo",
+        "choices" => [
+          %{"message" => %{"role" => "assistant", "content" => text}, "finish_reason" => "stop"}
+        ],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 1, "total_tokens" => 11}
+      })
+    end)
+
+    stub
+  end
+
+  defp stub_tool_response(arguments, test_pid \\ nil) do
+    stub = {__MODULE__, make_ref()}
+
+    Req.Test.stub(stub, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      if test_pid do
+        send(test_pid, {:request_body, Jason.decode!(body)})
+      end
+
+      Req.Test.json(conn, tool_response(arguments))
+    end)
+
+    stub
+  end
+
+  defp stub_native_object_response(object, test_pid) do
+    stub = {__MODULE__, make_ref()}
+
+    Req.Test.stub(stub, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:request_body, Jason.decode!(body)})
+
+      Req.Test.json(conn, %{
+        "id" => "resp_object_123",
+        "model" => "gpt-4o-2024-08-06",
+        "status" => "completed",
+        "output_text" => Jason.encode!(object),
+        "usage" => %{"input_tokens" => 10, "output_tokens" => 4}
+      })
+    end)
+
+    stub
+  end
+
+  defp stub_tool_stream(arguments) do
+    stub = {__MODULE__, make_ref()}
+    argument_json = Jason.encode!(arguments)
+
+    delta = %{
+      "id" => "chatcmpl-stream-123",
+      "choices" => [
+        %{
+          "delta" => %{
+            "role" => "assistant",
+            "tool_calls" => [
+              %{
+                "index" => 0,
+                "id" => "call_123",
+                "type" => "function",
+                "function" => %{
+                  "name" => "structured_output",
+                  "arguments" => argument_json
+                }
+              }
+            ]
+          },
+          "finish_reason" => nil
+        }
+      ]
+    }
+
+    finish = %{
+      "id" => "chatcmpl-stream-123",
+      "choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls"}]
+    }
+
+    Req.Test.stub(stub, fn conn ->
+      body =
+        "data: #{Jason.encode!(delta)}\n\n" <>
+          "data: #{Jason.encode!(finish)}\n\n" <>
+          "data: [DONE]\n\n"
+
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "text/event-stream")
+      |> Plug.Conn.send_resp(200, body)
+    end)
+
+    stub
+  end
+
+  defp tool_response(arguments) do
+    %{
+      "id" => "cmpl_object_123",
+      "model" => "gpt-4-turbo",
+      "choices" => [
+        %{
+          "message" => %{
+            "role" => "assistant",
+            "tool_calls" => [
+              %{
+                "id" => "call_123",
+                "type" => "function",
+                "function" => %{
+                  "name" => "structured_output",
+                  "arguments" => Jason.encode!(arguments)
+                }
+              }
+            ]
+          },
+          "finish_reason" => "tool_calls"
+        }
+      ],
+      "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 4, "total_tokens" => 14}
+    }
+  end
+end

--- a/test/req_llm/output_generation_test.exs
+++ b/test/req_llm/output_generation_test.exs
@@ -100,6 +100,48 @@ defmodule ReqLLM.OutputGenerationTest do
       refute Map.has_key?(body, "tools")
     end
 
+    test "preserves existing native response validation for compiled schemas" do
+      output =
+        Output.object(
+          [
+            name: [type: :string, required: true],
+            age: [type: :pos_integer, required: true]
+          ],
+          name: "person"
+        )
+
+      stub = stub_native_object_response(%{"name" => "Ada"}, self())
+
+      assert {:ok, response} =
+               ReqLLM.generate_text(
+                 "openai:gpt-4o-2024-08-06",
+                 "Generate a person",
+                 output: output,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert Response.output(response, output) == nil
+      assert response.provider_meta[:object_parse_error] == :validation_failed
+      assert_receive {:request_body, _body}
+    end
+
+    test "validates compiled array wrappers before projection" do
+      output = Output.array([name: [type: :string, required: true]], name: "people")
+      stub = stub_native_object_response(%{"value" => [%{"name" => 123}]}, self())
+
+      assert {:ok, response} =
+               ReqLLM.generate_text(
+                 "openai:gpt-4o-2024-08-06",
+                 "Generate people",
+                 output: output,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert Response.output(response, output) == nil
+      assert response.provider_meta[:object_parse_error] == :validation_failed
+      assert_receive {:request_body, _body}
+    end
+
     test "array output projects the wrapped array while retaining raw arguments" do
       output = Output.array([name: [type: :string, required: true]], name: "people")
       value = [%{"name" => "Ada"}, %{"name" => "Grace"}]

--- a/test/req_llm/output_test.exs
+++ b/test/req_llm/output_test.exs
@@ -65,6 +65,7 @@ defmodule ReqLLM.OutputTest do
       refute contract.wrapped?
       assert contract.compiled_schema.name == "person"
       assert contract.compiled_schema.description == "A generated person"
+      refute is_nil(contract.compiled_schema.compiled)
 
       assert contract.compiled_schema.schema == %{
                "type" => "object",
@@ -106,6 +107,7 @@ defmodule ReqLLM.OutputTest do
       assert {:ok, contract} = Output.compile(output)
       assert contract.wrapped?
       assert contract.compiled_schema.name == "people"
+      refute is_nil(contract.compiled_schema.compiled)
 
       assert get_in(contract.compiled_schema.schema, ["properties", "value", "type"]) ==
                "array"
@@ -144,6 +146,7 @@ defmodule ReqLLM.OutputTest do
 
     test "wraps choice and arbitrary JSON values" do
       assert {:ok, choice_contract} = Output.compile(Output.choice(["sunny", "rainy"]))
+      refute is_nil(choice_contract.compiled_schema.compiled)
 
       assert get_in(choice_contract.compiled_schema.schema, [
                "properties",

--- a/test/req_llm/output_test.exs
+++ b/test/req_llm/output_test.exs
@@ -1,0 +1,182 @@
+defmodule ReqLLM.OutputTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Output
+
+  @moduletag contract: :public_api
+
+  describe "constructors" do
+    test "builds text, object, array, choice, and JSON descriptors" do
+      schema = [name: [type: :string, required: true]]
+
+      assert %Output{type: :text} = Output.text()
+
+      assert %Output{
+               type: :object,
+               schema: ^schema,
+               name: "person",
+               description: "A person"
+             } = Output.object(schema, name: "person", description: "A person")
+
+      assert %Output{type: :array, element: ^schema, name: "people"} =
+               Output.array(schema, name: "people")
+
+      assert %Output{type: :choice, choices: ["yes", "no"]} =
+               Output.choice(["yes", "no"])
+
+      assert %Output{type: :json, description: "Any JSON"} =
+               Output.json(description: "Any JSON")
+    end
+
+    test "rejects invalid metadata options immediately" do
+      assert_raise ArgumentError, ~r/unknown output descriptor options/, fn ->
+        Output.json(mode: :strict)
+      end
+
+      assert_raise ArgumentError, ~r/:name must be a string/, fn -> Output.json(name: :value) end
+
+      assert_raise ArgumentError, ~r/:description must be a string/, fn ->
+        Output.json(description: :value)
+      end
+    end
+  end
+
+  describe "compile/1" do
+    test "keeps text on the chat operation without a schema" do
+      assert {:ok,
+              %{
+                operation: :chat,
+                compiled_schema: nil,
+                wrapped?: false,
+                descriptor: %Output{type: :text}
+              }} = Output.compile(Output.text())
+    end
+
+    test "normalizes NimbleOptions object schemas to JSON Schema" do
+      output =
+        Output.object(
+          [name: [type: :string, required: true]],
+          name: "person",
+          description: "A generated person"
+        )
+
+      assert {:ok, contract} = Output.compile(output)
+      assert contract.operation == :object
+      refute contract.wrapped?
+      assert contract.compiled_schema.name == "person"
+      assert contract.compiled_schema.description == "A generated person"
+
+      assert contract.compiled_schema.schema == %{
+               "type" => "object",
+               "properties" => %{
+                 "name" => %{"type" => "string"}
+               },
+               "required" => ["name"],
+               "propertyOrdering" => ["name"],
+               "additionalProperties" => false,
+               "description" => "A generated person"
+             }
+    end
+
+    test "normalizes raw JSON Schema and Zoi object schemas" do
+      json_schema = %{
+        "type" => "object",
+        "properties" => %{"name" => %{"type" => "string"}}
+      }
+
+      assert {:ok, json_contract} = Output.compile(Output.object(json_schema))
+      assert json_contract.compiled_schema.schema == json_schema
+
+      assert {:ok, zoi_contract} =
+               Output.object(Zoi.object(%{name: Zoi.string()}))
+               |> Output.compile()
+
+      assert zoi_contract.compiled_schema.schema["type"] == "object"
+      assert zoi_contract.compiled_schema.schema["properties"]["name"]["type"] == "string"
+    end
+
+    test "wraps array element schemas in a provider-compatible object" do
+      output =
+        Output.array(
+          [name: [type: :string, required: true]],
+          name: "people",
+          description: "Generated people"
+        )
+
+      assert {:ok, contract} = Output.compile(output)
+      assert contract.wrapped?
+      assert contract.compiled_schema.name == "people"
+
+      assert get_in(contract.compiled_schema.schema, ["properties", "value", "type"]) ==
+               "array"
+
+      assert get_in(contract.compiled_schema.schema, [
+               "properties",
+               "value",
+               "items",
+               "type"
+             ]) == "object"
+
+      assert contract.compiled_schema.schema["required"] == ["value"]
+      assert contract.compiled_schema.schema["additionalProperties"] == false
+      assert contract.compiled_schema.schema["description"] == "Generated people"
+    end
+
+    test "supports primitive array elements through Zoi or JSON Schema" do
+      assert {:ok, zoi_contract} = Output.compile(Output.array(Zoi.string()))
+
+      assert get_in(zoi_contract.compiled_schema.schema, [
+               "properties",
+               "value",
+               "items",
+               "type"
+             ]) == "string"
+
+      assert {:ok, json_contract} =
+               Output.compile(Output.array(%{"type" => "integer"}))
+
+      assert get_in(json_contract.compiled_schema.schema, [
+               "properties",
+               "value",
+               "items"
+             ]) == %{"type" => "integer"}
+    end
+
+    test "wraps choice and arbitrary JSON values" do
+      assert {:ok, choice_contract} = Output.compile(Output.choice(["sunny", "rainy"]))
+
+      assert get_in(choice_contract.compiled_schema.schema, [
+               "properties",
+               "value"
+             ]) == %{"type" => "string", "enum" => ["sunny", "rainy"]}
+
+      assert {:ok, json_contract} = Output.compile(Output.json())
+      assert get_in(json_contract.compiled_schema.schema, ["properties", "value"]) == %{}
+    end
+
+    test "rejects invalid descriptor contracts" do
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{parameter: message}} =
+               Output.compile(Output.object(%{"type" => "array", "items" => %{}}))
+
+      assert message =~ "top-level object schema"
+
+      for choices <- [[], ["yes", :no], ["yes", "yes"]] do
+        assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+                 Output.compile(Output.choice(choices))
+      end
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Output.normalize(%{type: :text})
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{parameter: schema_message}} =
+               Output.compile(Output.object(name: [required: "yes"]))
+
+      assert schema_message =~ "invalid output schema"
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{parameter: metadata_message}} =
+               Output.normalize(%Output{type: :text, name: :invalid})
+
+      assert metadata_message =~ ":name must be a string"
+    end
+  end
+end


### PR DESCRIPTION
Closes #851

## Summary

- add `ReqLLM.Output` descriptors for text, object, array, choice, and arbitrary JSON output
- accept `output:` on `generate_text/3` and `stream_text/3` while preserving the omitted/`Output.text/0` chat path
- reuse existing object planning, provider-native JSON Schema selection, strict-tool fallback, streaming materialization, validation, coercion, and JSON repair
- add `ReqLLM.Response.output/2` as a computed projection without changing response structs or serialization
- retain `generate_object/4` and `stream_object/4` call shapes and behavior through shared internal helpers

## Compatibility

- additive V1 API; structured output is opt-in
- no `Response` or `StreamResponse` fields changed
- no agent loop, model-assisted repair, new coercion, or final-validation policy
- raw native JSON text, tool fallback arguments, usage, and provider metadata remain on the existing response
- partial stream chunks remain transport fragments and are not presented as final-valid values

## Validation

- `mix test`
- `mix test --only contract:public_api`
- focused descriptor, generation, object, response, provider-option, and OpenAI Responses suites
- OpenAI `object_basic` and `object_streaming` fixture replays
- Anthropic native and auto structured streaming fixture replays
- `mix quality`

The existing Anthropic `object_streaming_tool_strict` replay has a stale assertion against `ToolCall.name`; the struct exposes `function.name`. The exercised library path materializes the tool call correctly, and this PR does not change `ToolCall`.
