### PR TITLE
feat: add visible structured output validation policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ output = ReqLLM.Output.array([name: [type: :string, required: true]])
 ReqLLM.Response.output(response, output)
 #=> [%{"name" => "Ada"}, %{"name" => "Grace"}, %{"name" => "Linus"}]
 
+result = ReqLLM.Response.output_result(response, output)
+result.valid?       #=> true
+result.raw          # retained text or tool-call arguments
+result.repairs      # visible legacy or callback repair attempts
+
+{:ok, strict_response} = ReqLLM.generate_text(
+  model,
+  "Generate three people",
+  output: output,
+  output_validation: :strict
+)
+
 {:ok, image_response} = ReqLLM.generate_image("openai:gpt-image-1.5", "A simple red square")
 image_bytes = ReqLLM.Response.image_data(image_response)
 File.write!("red_square.png", image_bytes)

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -920,6 +920,10 @@ defmodule ReqLLM do
     * `:tool_choice` - Tool choice strategy
     * `:output` - A `ReqLLM.Output` descriptor for text, object, array, choice,
       or arbitrary JSON output
+    * `:output_validation` - Final validation policy: `:compatible`, `:warn`,
+      or `:strict`; omission preserves current V1 behavior
+    * `:output_repair` - Optional one-shot local repair callback for an invalid
+      complete structured output
     * `:system_prompt` - System prompt to prepend
     * `:receive_timeout` - Provider-transport inactivity timeout in milliseconds
     * `:total_timeout` - Optional whole-call deadline in milliseconds, including retries

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -53,6 +53,10 @@ defmodule ReqLLM.Generation do
     * `:output` - A `ReqLLM.Output` descriptor; omitted and `ReqLLM.Output.text/0`
       preserve plain-text behavior, while structured descriptors reuse the existing
       provider-native or tool-fallback object path
+    * `:output_validation` - Final validation policy: `:compatible`, `:warn`, or
+      `:strict`; omitted calls preserve current V1 behavior
+    * `:output_repair` - Optional one-argument local repair callback invoked at
+      most once after an invalid complete structured output
     * `:system_prompt` - System prompt to prepend
     * `:receive_timeout` - Provider-transport inactivity timeout in milliseconds
     * `:total_timeout` - Optional whole-call deadline in milliseconds, including retries
@@ -85,11 +89,18 @@ defmodule ReqLLM.Generation do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :chat, opts)
     {output, opts} = Keyword.pop(opts, :output)
 
-    with {:ok, descriptor} <- ReqLLM.Output.normalize(output),
-         {:ok, contract} <- ReqLLM.Output.compile(descriptor) do
+    with {:ok, runtime_config, opts} <- ReqLLM.Output.Validation.take_runtime_options(opts),
+         {:ok, descriptor} <- ReqLLM.Output.normalize(output),
+         {:ok, contract} <- ReqLLM.Output.compile(descriptor),
+         :ok <- ReqLLM.Output.Validation.validate_runtime_config(contract, runtime_config) do
       case contract.operation do
-        :chat -> generate_text_response(model_spec, messages, opts)
-        :object -> generate_output_response(model_spec, messages, contract, opts)
+        :chat ->
+          model_spec
+          |> generate_text_response(messages, opts)
+          |> ReqLLM.Output.Validation.finalize_result(contract, runtime_config)
+
+        :object ->
+          generate_output_response(model_spec, messages, contract, opts, runtime_config)
       end
     end
   end
@@ -122,12 +133,14 @@ defmodule ReqLLM.Generation do
     end
   end
 
-  defp generate_output_response(model_spec, messages, contract, opts) do
+  defp generate_output_response(model_spec, messages, contract, opts, runtime_config) do
     generate_object_response(
       model_spec,
       messages,
       {:compiled, contract.compiled_schema},
-      opts
+      opts,
+      contract.descriptor,
+      runtime_config
     )
   end
 
@@ -171,7 +184,9 @@ defmodule ReqLLM.Generation do
   representation. Partial content and tool-call argument chunks are transport
   fragments, not final-schema validation results. Materialize the stream once
   with `ReqLLM.StreamResponse.to_response/1`, then call
-  `ReqLLM.Response.output/2` with the same descriptor.
+  `ReqLLM.Response.output/2` with the same descriptor. An explicit
+  `:output_validation` policy is enforced by `to_response/1` or
+  `ReqLLM.StreamResponse.process_stream/2` after the complete value exists.
 
   ## Parameters
 
@@ -196,11 +211,18 @@ defmodule ReqLLM.Generation do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :chat, opts)
     {output, opts} = Keyword.pop(opts, :output)
 
-    with {:ok, descriptor} <- ReqLLM.Output.normalize(output),
-         {:ok, contract} <- ReqLLM.Output.compile(descriptor) do
+    with {:ok, runtime_config, opts} <- ReqLLM.Output.Validation.take_runtime_options(opts),
+         {:ok, descriptor} <- ReqLLM.Output.normalize(output),
+         {:ok, contract} <- ReqLLM.Output.compile(descriptor),
+         :ok <- ReqLLM.Output.Validation.validate_runtime_config(contract, runtime_config) do
       case contract.operation do
-        :chat -> stream_text_response(model_spec, messages, opts)
-        :object -> stream_output_response(model_spec, messages, contract, opts)
+        :chat ->
+          model_spec
+          |> stream_text_response(messages, opts)
+          |> ReqLLM.Output.Validation.attach_stream_result(contract, runtime_config)
+
+        :object ->
+          stream_output_response(model_spec, messages, contract, opts, runtime_config)
       end
     end
   end
@@ -231,12 +253,14 @@ defmodule ReqLLM.Generation do
     end
   end
 
-  defp stream_output_response(model_spec, messages, contract, opts) do
+  defp stream_output_response(model_spec, messages, contract, opts, runtime_config) do
     stream_object_response(
       model_spec,
       messages,
       {:compiled, contract.compiled_schema},
-      opts
+      opts,
+      contract.descriptor,
+      runtime_config
     )
   end
 
@@ -304,6 +328,10 @@ defmodule ReqLLM.Generation do
     * `:total_timeout` - Optional whole-call deadline in milliseconds, including retries
     * `:stream_idle_timeout` - Optional semantic-progress timeout for streaming calls
     * `:provider_options` - Provider-specific options
+    * `:output_validation` - Final validation policy: `:compatible`, `:warn`, or
+      `:strict`; omitted calls preserve current V1 behavior
+    * `:output_repair` - Optional one-argument local repair callback invoked at
+      most once after an invalid complete object
 
   ## Examples
 
@@ -328,10 +356,27 @@ defmodule ReqLLM.Generation do
       |> ReqLLM.ModelInput.merge_tuple_defaults(:object, opts)
       |> Keyword.delete(:output)
 
-    generate_object_response(model_spec, messages, {:schema, object_schema}, opts)
+    with {:ok, runtime_config, opts} <-
+           ReqLLM.Output.Validation.take_runtime_options(opts) do
+      generate_object_response(
+        model_spec,
+        messages,
+        {:schema, object_schema},
+        opts,
+        ReqLLM.Output.object(object_schema),
+        runtime_config
+      )
+    end
   end
 
-  defp generate_object_response(model_spec, messages, schema_source, opts) do
+  defp generate_object_response(
+         model_spec,
+         messages,
+         schema_source,
+         opts,
+         descriptor,
+         runtime_config
+       ) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
@@ -344,22 +389,26 @@ defmodule ReqLLM.Generation do
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
          {:ok, compiled_schema} <- compile_schema_source(schema_source) do
       compiled_opts = Keyword.put(opts, :compiled_schema, compiled_schema)
+      contract = ReqLLM.Output.Validation.validation_contract(descriptor, compiled_schema)
 
-      case ReqLLM.Cache.fetch(model, :object, context, opts, compiled_schema.schema) do
-        {:hit, response, _cache_ref} ->
-          {:ok, response}
+      result =
+        case ReqLLM.Cache.fetch(model, :object, context, opts, compiled_schema.schema) do
+          {:hit, response, _cache_ref} ->
+            {:ok, response}
 
-        {:miss, cache_ref} ->
-          execute_generate_object(
-            provider_module,
-            model,
-            context,
-            compiled_schema,
-            ReqLLM.Cache.request_opts(compiled_opts),
-            compiled_opts,
-            cache_ref
-          )
-      end
+          {:miss, cache_ref} ->
+            execute_generate_object(
+              provider_module,
+              model,
+              context,
+              compiled_schema,
+              ReqLLM.Cache.request_opts(compiled_opts),
+              compiled_opts,
+              cache_ref
+            )
+        end
+
+      ReqLLM.Output.Validation.finalize_result(result, contract, runtime_config)
     end
   end
 
@@ -611,10 +660,27 @@ defmodule ReqLLM.Generation do
       |> ReqLLM.ModelInput.merge_tuple_defaults(:object, opts)
       |> Keyword.delete(:output)
 
-    stream_object_response(model_spec, messages, {:schema, object_schema}, opts)
+    with {:ok, runtime_config, opts} <-
+           ReqLLM.Output.Validation.take_runtime_options(opts) do
+      stream_object_response(
+        model_spec,
+        messages,
+        {:schema, object_schema},
+        opts,
+        ReqLLM.Output.object(object_schema),
+        runtime_config
+      )
+    end
   end
 
-  defp stream_object_response(model_spec, messages, schema_source, opts) do
+  defp stream_object_response(
+         model_spec,
+         messages,
+         schema_source,
+         opts,
+         descriptor,
+         runtime_config
+       ) do
     with {:ok, model} <- ReqLLM.model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
@@ -641,7 +707,11 @@ defmodule ReqLLM.Generation do
         |> Keyword.put_new(:operation, :object)
         |> Keyword.put(:compiled_schema, compiled_schema)
 
-      ReqLLM.Streaming.start_stream(provider_module, model, prepared_context, stream_opts)
+      contract = ReqLLM.Output.Validation.validation_contract(descriptor, compiled_schema)
+
+      provider_module
+      |> ReqLLM.Streaming.start_stream(model, prepared_context, stream_opts)
+      |> ReqLLM.Output.Validation.attach_stream_result(contract, runtime_config)
     end
   end
 

--- a/lib/req_llm/output.ex
+++ b/lib/req_llm/output.ex
@@ -38,8 +38,11 @@ defmodule ReqLLM.Output do
       output = ReqLLM.Output.choice(["sunny", "rainy", "snowy"])
       output = ReqLLM.Output.json(description: "Any valid JSON value")
 
-  Complete structured values retain the current V1 validation and repair
-  behavior. Partial stream values are never final-schema validation evidence.
+  Omitting `:output_validation` retains the current V1 validation and repair
+  behavior. `:compatible`, `:warn`, and `:strict` make local final validation
+  explicit without changing provider requests. Partial stream values are never
+  final-schema validation evidence; streaming policies apply when the stream is
+  materialized.
 
   ## Result and error semantics
 
@@ -48,14 +51,34 @@ defmodule ReqLLM.Output do
   `json/1`. It returns `nil` when the existing provider path did not materialize
   a structured value.
 
+  `ReqLLM.Response.output_result/3` exposes the retained raw output, projected
+  value, final validity, validation errors, warnings, extraction source, repair
+  attempts, and provider metadata separately. It is local and never triggers a
+  follow-up model call.
+
   Constructors raise `ArgumentError` for invalid descriptor metadata options.
   Schema and choice contracts are checked before an HTTP request; generation
   returns `{:error, %ReqLLM.Error.Invalid.Parameter{}}` when a contract cannot be
-  compiled. Descriptors do not introduce a new final-value validation policy:
-  current V1 provider validation, coercion, and JSON-repair behavior is retained.
+  compiled. `output_validation: :strict` turns an invalid complete value into a
+  validation error. `:warn` returns the response with structured warnings, and
+  `:compatible` reports validity while retaining V1 success behavior.
+
+  `:output_repair` accepts a callback returning `{:ok, candidate}` or
+  `{:error, reason}`. It runs locally at most once after invalid final output,
+  and a candidate replaces the value only after it passes the same final
+  validation. Existing light `json_repair` remains enabled by default and is
+  reported when detected.
   """
 
   @type output_type :: :text | :object | :array | :choice | :json
+  @type validation_policy :: :compatible | :warn | :strict
+  @type repair_callback :: (ReqLLM.Output.Result.t() -> {:ok, term()} | {:error, term()})
+
+  @type runtime_config :: %{
+          enabled?: boolean(),
+          policy: validation_policy(),
+          repair: repair_callback() | nil
+        }
 
   @type t :: %__MODULE__{
           type: output_type(),
@@ -203,6 +226,19 @@ defmodule ReqLLM.Output do
     response
     |> Map.get(:object)
     |> unwrap_value()
+  end
+
+  @doc """
+  Computes a complete structured-output result without changing the response.
+
+  The default `:compatible` policy reports final validity without converting an
+  invalid V1 response into an error. Pass `policy: :warn` or `policy: :strict`
+  to describe the policy used for the projection. Runtime enforcement is
+  configured on generation calls with `:output_validation`.
+  """
+  @spec result(ReqLLM.Response.t(), t(), keyword()) :: ReqLLM.Output.Result.t()
+  def result(response, descriptor, opts \\ []) do
+    ReqLLM.Output.Validation.result(response, descriptor, opts)
   end
 
   defp build(type, fields, opts) do

--- a/lib/req_llm/output/result.ex
+++ b/lib/req_llm/output/result.ex
@@ -1,0 +1,48 @@
+defmodule ReqLLM.Output.Result do
+  @moduledoc """
+  Describes how a complete `ReqLLM.Output` value was materialized and validated.
+
+  Results keep the retained raw provider value, projected value, validation
+  errors, warnings, repair attempts, extraction source, and provider metadata
+  separate. They are computed with `ReqLLM.Response.output_result/3` and do not
+  change the response or trigger another model call.
+  """
+
+  @type source :: :text | :tool_call | :response_object | :missing
+
+  @type repair :: %{
+          required(:type) => :json_repair | :legacy_type_coercion | :callback,
+          required(:status) => :applied | :failed,
+          optional(:reason) => String.t()
+        }
+
+  @type validation_error :: %{
+          required(:type) => :missing_value | :invalid_type | :schema_validation,
+          required(:message) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          value: term(),
+          raw: term(),
+          valid?: boolean(),
+          errors: [validation_error()],
+          warnings: [String.t()],
+          repairs: [repair()],
+          source: source(),
+          policy: ReqLLM.Output.validation_policy(),
+          provider_metadata: map()
+        }
+
+  @enforce_keys [
+    :value,
+    :raw,
+    :valid?,
+    :errors,
+    :warnings,
+    :repairs,
+    :source,
+    :policy,
+    :provider_metadata
+  ]
+  defstruct @enforce_keys
+end

--- a/lib/req_llm/output/validation.ex
+++ b/lib/req_llm/output/validation.ex
@@ -303,13 +303,19 @@ defmodule ReqLLM.Output.Validation do
   end
 
   defp validation_errors(response, %{compiled_schema: %{schema: schema}}, _value) do
-    case ReqLLM.Schema.validate(response.object, schema) do
-      {:ok, _validated} -> []
-      {:error, error} -> [%{type: :schema_validation, message: Exception.message(error)}]
-    end
+    validate_schema(response.object, schema)
   end
 
   defp validation_errors(_response, _contract, _value), do: []
+
+  defp validate_schema(value, schema) do
+    case ReqLLM.Schema.validate(value, schema) do
+      {:ok, _validated} -> []
+      {:error, error} -> [%{type: :schema_validation, message: Exception.message(error)}]
+    end
+  rescue
+    error -> [%{type: :schema_validation, message: Exception.message(error)}]
+  end
 
   defp evaluation_warnings(descriptor, source, repairs, errors, policy) do
     extraction_warnings(descriptor, source) ++

--- a/lib/req_llm/output/validation.ex
+++ b/lib/req_llm/output/validation.ex
@@ -1,0 +1,467 @@
+defmodule ReqLLM.Output.Validation do
+  @moduledoc false
+
+  alias ReqLLM.Output
+  alias ReqLLM.Output.Result
+  alias ReqLLM.Response
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.StreamResponse.MetadataHandle
+
+  @stream_config_key :req_llm_output_config
+  @diagnostic_key :req_llm_output
+
+  @spec result(Response.t(), Output.t(), keyword()) :: Result.t()
+  def result(response, descriptor, opts \\ []) do
+    policy = Keyword.get(opts, :policy, diagnostic_policy(response, descriptor))
+
+    with {:ok, normalized} <- Output.normalize(descriptor),
+         {:ok, contract} <- Output.compile(normalized),
+         :ok <- validate_policy(policy) do
+      response
+      |> evaluate(contract, policy)
+      |> merge_attached_diagnostic(response, contract)
+    else
+      {:error, error} -> raise error
+    end
+  end
+
+  @spec take_runtime_options(keyword()) ::
+          {:ok, Output.runtime_config(), keyword()} | {:error, ReqLLM.Error.t()}
+  def take_runtime_options(opts) do
+    policy_supplied? = Keyword.has_key?(opts, :output_validation)
+    repair_supplied? = Keyword.has_key?(opts, :output_repair)
+    {policy, opts} = Keyword.pop(opts, :output_validation, :compatible)
+    {repair, opts} = Keyword.pop(opts, :output_repair)
+
+    with :ok <- validate_policy(policy),
+         :ok <- validate_repair(repair) do
+      {:ok,
+       %{
+         enabled?: policy_supplied? or repair_supplied?,
+         policy: policy,
+         repair: repair
+       }, opts}
+    end
+  end
+
+  @spec validation_contract(Output.t(), map()) :: Output.contract()
+  def validation_contract(%Output{} = descriptor, compiled_schema) do
+    schema =
+      case compiled_schema do
+        %{schema: schema} -> ReqLLM.Schema.to_json(schema)
+        _other -> nil
+      end
+
+    %{
+      descriptor: descriptor,
+      operation: if(descriptor.type == :text, do: :chat, else: :object),
+      compiled_schema:
+        if(is_nil(schema), do: nil, else: Map.put(compiled_schema, :schema, schema)),
+      wrapped?: descriptor.type in [:array, :choice, :json]
+    }
+  end
+
+  @spec finalize_result(
+          {:ok, Response.t()} | {:error, term()},
+          Output.contract(),
+          Output.runtime_config()
+        ) :: {:ok, Response.t()} | {:error, term()}
+  def finalize_result(result, _contract, %{enabled?: false}), do: result
+
+  def finalize_result({:ok, response}, contract, config) do
+    finalize_response(response, contract, config)
+  end
+
+  def finalize_result({:error, _error} = error, _contract, _config), do: error
+
+  @spec validate_runtime_config(Output.contract(), Output.runtime_config()) ::
+          :ok | {:error, ReqLLM.Error.t()}
+  def validate_runtime_config(%{descriptor: %{type: :text}}, %{repair: repair})
+      when not is_nil(repair) do
+    invalid_output(":output_repair is available only for structured output descriptors")
+  end
+
+  def validate_runtime_config(_contract, _config), do: :ok
+
+  @spec attach_stream_result(
+          {:ok, StreamResponse.t()} | {:error, term()},
+          Output.contract(),
+          Output.runtime_config()
+        ) :: {:ok, StreamResponse.t()} | {:error, term()}
+  def attach_stream_result(result, _contract, %{enabled?: false}), do: result
+
+  def attach_stream_result({:ok, stream_response}, contract, config) do
+    original_handle = stream_response.metadata_handle
+
+    fetch_metadata = fn ->
+      metadata = await_original_metadata(original_handle)
+      Map.put(metadata, @stream_config_key, {contract, config})
+    end
+
+    case MetadataHandle.start_link(fetch_metadata) do
+      {:ok, metadata_handle} ->
+        cancel = fn ->
+          try do
+            stream_response.cancel.()
+          after
+            MetadataHandle.stop(metadata_handle)
+          end
+        end
+
+        {:ok,
+         %{
+           stream_response
+           | metadata_handle: metadata_handle,
+             cancel: cancel
+         }}
+
+      {:error, reason} ->
+        StreamResponse.close(stream_response)
+        {:error, reason}
+    end
+  end
+
+  def attach_stream_result({:error, _error} = error, _contract, _config), do: error
+
+  @spec pop_stream_config(map()) ::
+          {nil | {Output.contract(), Output.runtime_config()}, map()}
+  def pop_stream_config(metadata) when is_map(metadata) do
+    Map.pop(metadata, @stream_config_key)
+  end
+
+  @spec finalize_stream_response(
+          {:ok, Response.t()} | {:error, term()},
+          nil | {Output.contract(), Output.runtime_config()}
+        ) :: {:ok, Response.t()} | {:error, term()}
+  def finalize_stream_response(result, nil), do: result
+
+  def finalize_stream_response(result, {contract, config}) do
+    finalize_result(result, contract, config)
+  end
+
+  defp finalize_response(response, contract, config) do
+    initial_result = evaluate(response, contract, config.policy)
+    {response, result} = maybe_repair(response, contract, config, initial_result)
+    response = attach_diagnostic(response, contract, result, config.policy)
+
+    if config.policy == :strict and not result.valid? do
+      {:error, strict_validation_error(result)}
+    else
+      {:ok, response}
+    end
+  end
+
+  defp maybe_repair(response, _contract, %{repair: nil}, result), do: {response, result}
+
+  defp maybe_repair(response, _contract, _config, %{valid?: true} = result),
+    do: {response, result}
+
+  defp maybe_repair(response, contract, %{repair: repair, policy: policy}, result) do
+    case invoke_repair(repair, result) do
+      {:ok, candidate} ->
+        candidate_response = put_candidate(response, contract, candidate)
+        candidate_result = evaluate(candidate_response, contract, policy)
+
+        if candidate_result.valid? do
+          repair_entry = %{type: :callback, status: :applied}
+          warnings = Enum.uniq(result.warnings ++ ["Local output repair callback applied once."])
+
+          {candidate_response,
+           %{
+             candidate_result
+             | raw: result.raw,
+               source: result.source,
+               repairs: result.repairs ++ [repair_entry],
+               warnings: warnings
+           }}
+        else
+          failed_callback_result(response, result, validation_summary(candidate_result.errors))
+        end
+
+      {:error, reason} ->
+        failed_callback_result(response, result, format_reason(reason))
+
+      other ->
+        failed_callback_result(response, result, invalid_callback_return(other))
+    end
+  end
+
+  defp invoke_repair(repair, result) do
+    repair.(result)
+  rescue
+    error -> {:error, error}
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  defp failed_callback_result(response, result, reason) do
+    repair_entry = %{type: :callback, status: :failed, reason: reason}
+    warning = "Local output repair callback failed: #{reason}"
+
+    {response,
+     %{
+       result
+       | repairs: result.repairs ++ [repair_entry],
+         warnings: Enum.uniq(result.warnings ++ [warning])
+     }}
+  end
+
+  defp put_candidate(response, %{descriptor: %{type: :object}}, candidate) do
+    %{response | object: candidate}
+  end
+
+  defp put_candidate(response, %{wrapped?: true}, candidate) do
+    %{response | object: %{"value" => candidate}}
+  end
+
+  defp evaluate(response, contract, policy) do
+    descriptor = contract.descriptor
+    value = Output.value(descriptor, response)
+    %{raw: raw, source: source} = raw_value(response, descriptor)
+    repairs = detect_legacy_repairs(raw, response.object)
+    errors = validation_errors(response, contract, value)
+    warnings = evaluation_warnings(descriptor, source, repairs, errors, policy)
+
+    %Result{
+      value: value,
+      raw: raw,
+      valid?: errors == [],
+      errors: errors,
+      warnings: warnings,
+      repairs: repairs,
+      source: source,
+      policy: policy,
+      provider_metadata: Map.delete(response.provider_meta, @diagnostic_key)
+    }
+  end
+
+  defp raw_value(response, %Output{type: :text}) do
+    case Response.text(response) do
+      nil -> %{raw: nil, source: :missing}
+      text -> %{raw: text, source: :text}
+    end
+  end
+
+  defp raw_value(response, _descriptor) do
+    case structured_tool_call(response) do
+      %ReqLLM.ToolCall{} = tool_call ->
+        %{raw: ReqLLM.ToolCall.args_json(tool_call), source: :tool_call}
+
+      nil ->
+        raw_structured_value(response)
+    end
+  end
+
+  defp raw_structured_value(response) do
+    case Response.text(response) do
+      text when is_binary(text) and text != "" -> %{raw: text, source: :text}
+      _other when not is_nil(response.object) -> %{raw: response.object, source: :response_object}
+      _other -> %{raw: nil, source: :missing}
+    end
+  end
+
+  defp structured_tool_call(response) do
+    Enum.find(
+      Response.tool_calls(response),
+      &ReqLLM.ToolCall.matches_name?(&1, "structured_output")
+    )
+  end
+
+  defp detect_legacy_repairs(raw, object) when is_binary(raw) do
+    case {ReqLLM.JSON.decode(raw, json_repair: false), ReqLLM.JSON.decode(raw)} do
+      {{:error, _error}, {:ok, repaired}} when not is_nil(object) and repaired == object ->
+        [%{type: :json_repair, status: :applied}]
+
+      {{:error, _error}, {:ok, repaired}} when not is_nil(object) ->
+        [
+          %{type: :json_repair, status: :applied},
+          %{type: :legacy_type_coercion, status: :applied, reason: coercion_reason(repaired)}
+        ]
+
+      {{:ok, parsed}, _repaired} when parsed != object and not is_nil(object) ->
+        [%{type: :legacy_type_coercion, status: :applied}]
+
+      _other ->
+        []
+    end
+  end
+
+  defp detect_legacy_repairs(_raw, _object), do: []
+
+  defp coercion_reason(_value), do: "parsed value changed during legacy materialization"
+
+  defp validation_errors(_response, %{descriptor: %{type: :text}}, value)
+       when is_binary(value),
+       do: []
+
+  defp validation_errors(_response, %{descriptor: %{type: :text}}, _value) do
+    [%{type: :invalid_type, message: "Final text output is not a string."}]
+  end
+
+  defp validation_errors(%{object: nil}, _contract, _value) do
+    [%{type: :missing_value, message: "No complete structured output value was materialized."}]
+  end
+
+  defp validation_errors(response, %{compiled_schema: %{schema: schema}}, _value) do
+    case ReqLLM.Schema.validate(response.object, schema) do
+      {:ok, _validated} -> []
+      {:error, error} -> [%{type: :schema_validation, message: Exception.message(error)}]
+    end
+  end
+
+  defp validation_errors(_response, _contract, _value), do: []
+
+  defp evaluation_warnings(descriptor, source, repairs, errors, policy) do
+    extraction_warnings(descriptor, source) ++
+      repair_warnings(repairs) ++ policy_warnings(errors, policy)
+  end
+
+  defp extraction_warnings(%{type: :text}, _source), do: []
+
+  defp extraction_warnings(_descriptor, :text),
+    do: ["Structured output was extracted from retained response text."]
+
+  defp extraction_warnings(_descriptor, :tool_call),
+    do: ["Structured output was extracted from retained tool-call arguments."]
+
+  defp extraction_warnings(_descriptor, _source), do: []
+
+  defp repair_warnings(repairs) do
+    Enum.map(repairs, fn
+      %{type: :json_repair} ->
+        "Legacy light JSON repair was applied."
+
+      %{type: :legacy_type_coercion} ->
+        "Legacy structured-output type coercion was applied."
+
+      %{type: :callback, status: :applied} ->
+        "Local output repair callback applied once."
+
+      %{type: :callback, status: :failed, reason: reason} ->
+        "Local output repair callback failed: #{reason}"
+    end)
+  end
+
+  defp policy_warnings([], _policy), do: []
+
+  defp policy_warnings(errors, :warn) do
+    ["Structured output failed final validation: #{validation_summary(errors)}"]
+  end
+
+  defp policy_warnings(_errors, _policy), do: []
+
+  defp attach_diagnostic(response, contract, result, policy) do
+    diagnostic = %{
+      contract: contract_fingerprint(contract),
+      policy: policy,
+      valid?: result.valid?,
+      errors: result.errors,
+      warnings: result.warnings,
+      repairs: result.repairs,
+      source: result.source
+    }
+
+    provider_meta = Map.put(response.provider_meta, @diagnostic_key, diagnostic)
+    provider_meta = maybe_attach_warnings(provider_meta, result, policy)
+
+    %{response | provider_meta: provider_meta}
+  end
+
+  defp merge_attached_diagnostic(result, response, contract) do
+    fingerprint = contract_fingerprint(contract)
+
+    case Map.get(response.provider_meta, @diagnostic_key) do
+      %{contract: ^fingerprint} = diagnostic ->
+        %{
+          result
+          | valid?: diagnostic.valid?,
+            errors: diagnostic.errors,
+            warnings: diagnostic.warnings,
+            repairs: diagnostic.repairs,
+            source: diagnostic.source,
+            policy: diagnostic.policy
+        }
+
+      _other ->
+        result
+    end
+  end
+
+  defp diagnostic_policy(response, descriptor) do
+    with {:ok, contract} <- Output.compile(descriptor),
+         %{contract: fingerprint, policy: policy} <-
+           Map.get(response.provider_meta, @diagnostic_key),
+         true <- fingerprint == contract_fingerprint(contract) do
+      policy
+    else
+      _other -> :compatible
+    end
+  end
+
+  defp contract_fingerprint(contract) do
+    schema = get_in(contract, [:compiled_schema, :schema])
+    :erlang.phash2({contract.descriptor.type, schema, contract.wrapped?})
+  end
+
+  defp maybe_attach_warnings(provider_meta, %{warnings: warnings}, :warn)
+       when warnings != [] do
+    existing =
+      case Map.get(provider_meta, :warnings) do
+        values when is_list(values) -> values
+        value when is_binary(value) -> [value]
+        _other -> []
+      end
+
+    Map.put(provider_meta, :warnings, Enum.uniq(existing ++ warnings))
+  end
+
+  defp maybe_attach_warnings(provider_meta, _result, _policy), do: provider_meta
+
+  defp strict_validation_error(result) do
+    ReqLLM.Error.Validation.Error.exception(
+      tag: :structured_output_validation_failed,
+      reason: "Structured output failed final validation: #{validation_summary(result.errors)}",
+      context: [output_result: result]
+    )
+  end
+
+  defp validation_summary(errors) do
+    Enum.map_join(errors, "; ", & &1.message)
+  end
+
+  defp format_reason(reason) when is_exception(reason), do: Exception.message(reason)
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason) when is_atom(reason) or is_number(reason), do: inspect(reason)
+  defp format_reason(_reason), do: "callback returned an error"
+
+  defp invalid_callback_return(_value) do
+    "expected {:ok, value} or {:error, reason}"
+  end
+
+  defp validate_policy(policy) when policy in [:compatible, :warn, :strict], do: :ok
+
+  defp validate_policy(policy) do
+    invalid_output(
+      ":output_validation must be :compatible, :warn, or :strict, got: #{inspect(policy)}"
+    )
+  end
+
+  defp validate_repair(nil), do: :ok
+  defp validate_repair(repair) when is_function(repair, 1), do: :ok
+
+  defp validate_repair(repair) do
+    invalid_output(":output_repair must be a one-argument function, got: #{inspect(repair)}")
+  end
+
+  defp await_original_metadata(original_handle) do
+    MetadataHandle.await(original_handle)
+  catch
+    :exit, _reason -> %{}
+  after
+    MetadataHandle.stop(original_handle)
+  end
+
+  defp invalid_output(message) do
+    {:error, ReqLLM.Error.Invalid.Parameter.exception(parameter: message)}
+  end
+end

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -170,6 +170,16 @@ defmodule ReqLLM.Provider.Options do
                                  doc:
                                    "ReqLLM.Output descriptor for text, object, array, choice, or JSON generation"
                                ],
+                               output_validation: [
+                                 type: {:in, [:compatible, :warn, :strict]},
+                                 doc:
+                                   "Final output validation policy; omission preserves compatible V1 behavior"
+                               ],
+                               output_repair: [
+                                 type: {:fun, 1},
+                                 doc:
+                                   "One-shot local callback for repairing an invalid complete structured output"
+                               ],
                                n: [
                                  type: :pos_integer,
                                  default: 1,

--- a/lib/req_llm/response.ex
+++ b/lib/req_llm/response.ex
@@ -120,6 +120,21 @@ defmodule ReqLLM.Response do
   end
 
   @doc """
+  Returns a visible final-value report for an output descriptor.
+
+  The report separates retained raw output, the projected value, final validity,
+  validation errors, warnings, extraction source, repair attempts, and provider
+  metadata. It is computed locally and never triggers another model call.
+
+  `:policy` defaults to the policy recorded by generation, or `:compatible` when
+  no policy was explicitly selected.
+  """
+  @spec output_result(t(), ReqLLM.Output.t(), keyword()) :: ReqLLM.Output.Result.t()
+  def output_result(%__MODULE__{} = response, %ReqLLM.Output{} = descriptor, opts \\ []) do
+    ReqLLM.Output.result(response, descriptor, opts)
+  end
+
+  @doc """
   Extract image content parts from the response message.
 
   Returns a list of `ReqLLM.Message.ContentPart` where `type` is `:image` or `:image_url`.

--- a/lib/req_llm/stream_response.ex
+++ b/lib/req_llm/stream_response.ex
@@ -661,6 +661,7 @@ defmodule ReqLLM.StreamResponse do
 
   defp materialize_chunks(stream_response, chunks) do
     metadata = MetadataHandle.await(stream_response.metadata_handle)
+    {output_config, metadata} = ReqLLM.Output.Validation.pop_stream_config(metadata)
 
     case metadata do
       %{error: reason} ->
@@ -669,12 +670,15 @@ defmodule ReqLLM.StreamResponse do
       _metadata ->
         builder = ResponseBuilder.for_model(stream_response.model)
 
-        builder.build_response(
-          chunks,
-          metadata,
-          context: stream_response.context,
-          model: stream_response.model
-        )
+        result =
+          builder.build_response(
+            chunks,
+            metadata,
+            context: stream_response.context,
+            model: stream_response.model
+          )
+
+        ReqLLM.Output.Validation.finalize_stream_response(result, output_config)
     end
   end
 end

--- a/test/req_llm/output_validation_test.exs
+++ b/test/req_llm/output_validation_test.exs
@@ -1,0 +1,473 @@
+defmodule ReqLLM.OutputValidationTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Context
+  alias ReqLLM.Generation
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Output
+  alias ReqLLM.Output.Result
+  alias ReqLLM.Output.Validation
+  alias ReqLLM.Response
+  alias ReqLLM.StreamResponse
+  alias ReqLLM.ToolCall
+
+  @moduletag contract: :public_api
+
+  @model %{
+    provider: :openai,
+    id: "gpt-4-turbo",
+    extra: %{wire: %{protocol: "openai_chat"}}
+  }
+
+  describe "Response.output_result/3" do
+    test "validates every descriptor type locally" do
+      object = Output.object(name: [type: :string, required: true])
+      array = Output.array(name: [type: :string, required: true])
+      choice = Output.choice(["sunny", "rainy"])
+
+      assert %Result{valid?: true, value: "hello", errors: []} =
+               Response.output_result(response(text: "hello"), Output.text())
+
+      assert %Result{valid?: false, value: %{}, errors: [%{type: :schema_validation}]} =
+               Response.output_result(response(object: %{}), object)
+
+      assert %Result{valid?: true, value: [%{"name" => "Ada"}], errors: []} =
+               Response.output_result(
+                 response(object: %{"value" => [%{"name" => "Ada"}]}),
+                 array
+               )
+
+      assert %Result{valid?: false, value: "snowy", errors: [%{type: :schema_validation}]} =
+               Response.output_result(response(object: %{"value" => "snowy"}), choice)
+
+      assert %Result{valid?: true, value: [1, true, nil], errors: []} =
+               Response.output_result(
+                 response(object: %{"value" => [1, true, nil]}),
+                 Output.json()
+               )
+    end
+
+    test "keeps retained raw output, parsed value, warnings, and provider metadata separate" do
+      output = Output.object(name: [type: :string, required: true])
+      raw = ~s({"name":"Ada"})
+
+      result =
+        response(
+          object: %{"name" => "Ada"},
+          tool_arguments: raw,
+          provider_meta: %{request_id: "req_123"}
+        )
+        |> Response.output_result(output)
+
+      assert result.raw == raw
+      assert result.value == %{"name" => "Ada"}
+      assert result.source == :tool_call
+      assert result.valid?
+      assert result.errors == []
+      assert result.provider_metadata == %{request_id: "req_123"}
+
+      assert "Structured output was extracted from retained tool-call arguments." in result.warnings
+    end
+
+    test "makes preserved legacy JSON repair visible" do
+      output = Output.object(name: [type: :string, required: true])
+
+      result =
+        response(object: %{"name" => "Ada"}, tool_arguments: ~s({"name":"Ada",}))
+        |> Response.output_result(output)
+
+      assert result.valid?
+      assert result.repairs == [%{type: :json_repair, status: :applied}]
+      assert "Legacy light JSON repair was applied." in result.warnings
+    end
+
+    test "does not claim repair when malformed raw JSON was not materialized" do
+      output = Output.object(name: [type: :string, required: true])
+
+      result =
+        response(object: nil, tool_arguments: ~s({"name":"Ada",}))
+        |> Response.output_result(output)
+
+      refute result.valid?
+      assert result.repairs == []
+    end
+
+    test "reports legacy JSON repair and type coercion when both changed the value" do
+      output = Output.object(age: [type: :pos_integer, required: true])
+
+      result =
+        response(object: %{"age" => 37}, tool_arguments: ~s({"age":"37",}))
+        |> Response.output_result(output)
+
+      assert result.valid?
+
+      assert [
+               %{type: :json_repair, status: :applied},
+               %{type: :legacy_type_coercion, status: :applied}
+             ] = result.repairs
+    end
+
+    test "does not describe plain text extraction as structured repair" do
+      result = Response.output_result(response(text: "hello"), Output.text())
+
+      assert result.source == :text
+      assert result.warnings == []
+      assert result.repairs == []
+    end
+  end
+
+  describe "runtime validation policies" do
+    test "keeps the default compatible while strict rejects the same invalid final value" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada"})
+
+      assert {:ok, compatible_response} = generate(output, stub)
+      assert Response.output(compatible_response, output) == %{"name" => "Ada"}
+
+      assert {:error,
+              %ReqLLM.Error.Validation.Error{
+                tag: :structured_output_validation_failed,
+                context: context
+              }} = generate(output, stub, output_validation: :strict)
+
+      assert %Result{valid?: false, raw: raw, errors: errors} = context[:output_result]
+      assert Jason.decode!(raw) == %{"name" => "Ada"}
+      assert [%{type: :schema_validation}] = errors
+    end
+
+    test "warn returns the response with structured diagnostics and call warnings" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada"})
+
+      assert {:ok, response} = generate(output, stub, output_validation: :warn)
+      assert response.provider_meta.req_llm_output.policy == :warn
+      refute response.provider_meta.req_llm_output.valid?
+      assert [_warning | _rest] = response.provider_meta.warnings
+      assert [_warning | _rest] = Response.call_metadata(response).warnings
+
+      assert %Result{policy: :warn, valid?: false, errors: [_error | _rest]} =
+               Response.output_result(response, output)
+    end
+
+    test "compatible can record diagnostics without changing success semantics" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada"}, self())
+
+      assert {:ok, response} = generate(output, stub, output_validation: :compatible)
+      assert Response.output(response, output) == %{"name" => "Ada"}
+      refute response.provider_meta.req_llm_output.valid?
+      refute Map.has_key?(response.provider_meta, :warnings)
+
+      assert_receive {:request_body, body}
+      refute Map.has_key?(body, "output_validation")
+      refute Map.has_key?(body, "output_repair")
+    end
+
+    test "applies strict validation to the existing generate_object entrypoint" do
+      schema = [name: [type: :string, required: true], age: [type: :pos_integer, required: true]]
+      stub = stub_tool_response(%{"name" => "Ada"})
+
+      assert {:error, %ReqLLM.Error.Validation.Error{tag: :structured_output_validation_failed}} =
+               Generation.generate_object(
+                 @model,
+                 "Generate a person",
+                 schema,
+                 output_validation: :strict,
+                 openai_structured_output_mode: :tool_strict,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+    end
+
+    test "rejects invalid policy and repair options before an HTTP request" do
+      stub = request_forbidden_stub()
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               generate(person_output(), stub, output_validation: :permissive)
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               generate(person_output(), stub, output_repair: :not_a_callback)
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{parameter: message}} =
+               Generation.generate_text(
+                 @model,
+                 "Hello",
+                 output: Output.text(),
+                 output_repair: fn _result -> {:ok, "repaired"} end,
+                 req_http_options: [plug: {Req.Test, stub}]
+               )
+
+      assert message =~ "structured output descriptors"
+      refute_received :http_request_executed
+    end
+  end
+
+  describe "bounded local repair" do
+    test "does not invoke the callback for an already valid value" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada", "age" => 37})
+      test_pid = self()
+
+      repair = fn result ->
+        send(test_pid, {:repair_attempt, result})
+        {:ok, result.value}
+      end
+
+      assert {:ok, response} =
+               generate(
+                 output,
+                 stub,
+                 output_validation: :strict,
+                 output_repair: repair
+               )
+
+      refute_receive {:repair_attempt, _result}
+      assert %Result{valid?: true, repairs: []} = Response.output_result(response, output)
+    end
+
+    test "invokes one callback once and accepts only a locally valid candidate" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada"})
+      test_pid = self()
+
+      repair = fn result ->
+        send(test_pid, {:repair_attempt, result})
+        {:ok, %{"name" => "Ada", "age" => 37}}
+      end
+
+      assert {:ok, response} =
+               generate(
+                 output,
+                 stub,
+                 output_validation: :strict,
+                 output_repair: repair
+               )
+
+      assert Response.output(response, output) == %{"name" => "Ada", "age" => 37}
+      assert_receive {:repair_attempt, %Result{valid?: false}}
+      refute_receive {:repair_attempt, _result}
+
+      assert %Result{
+               valid?: true,
+               raw: raw,
+               repairs: [%{type: :callback, status: :applied}]
+             } = Response.output_result(response, output)
+
+      assert Jason.decode!(raw) == %{"name" => "Ada"}
+    end
+
+    test "records a failed callback once and strict still returns an error" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada"})
+      test_pid = self()
+
+      repair = fn result ->
+        send(test_pid, {:repair_attempt, result})
+        {:ok, %{"name" => "Still missing age"}}
+      end
+
+      assert {:error, %ReqLLM.Error.Validation.Error{context: context}} =
+               generate(
+                 output,
+                 stub,
+                 output_validation: :strict,
+                 output_repair: repair
+               )
+
+      assert_receive {:repair_attempt, %Result{}}
+      refute_receive {:repair_attempt, _result}
+
+      assert %Result{repairs: [%{type: :callback, status: :failed}]} =
+               context[:output_result]
+    end
+
+    test "records an invalid callback return without raising a case error" do
+      output = person_output()
+      stub = stub_tool_response(%{"name" => "Ada"})
+
+      assert {:ok, response} =
+               generate(
+                 output,
+                 stub,
+                 output_validation: :compatible,
+                 output_repair: fn _result -> %{"age" => 37} end
+               )
+
+      assert %Result{
+               valid?: false,
+               repairs: [%{type: :callback, status: :failed, reason: reason}]
+             } = Response.output_result(response, output)
+
+      assert reason =~ "expected {:ok, value}"
+    end
+  end
+
+  describe "stream final-value parity" do
+    test "enforces strict validation after a stream is materialized" do
+      output = person_output()
+      response = response(object: %{"name" => "Ada"}, tool_arguments: ~s({"name":"Ada"}))
+      model = %LLMDB.Model{provider: :openai, id: "gpt-4-turbo"}
+      stream_response = ReqLLM.Cache.stream_response(response, model, response.context)
+
+      assert {:ok, contract} = Output.compile(output)
+      assert {:ok, config, []} = Validation.take_runtime_options(output_validation: :strict)
+
+      assert {:error, %ReqLLM.Error.Validation.Error{tag: buffered_tag}} =
+               Validation.finalize_result({:ok, response}, contract, config)
+
+      assert {:ok, strict_stream} =
+               Validation.attach_stream_result({:ok, stream_response}, contract, config)
+
+      assert {:error, %ReqLLM.Error.Validation.Error{tag: streamed_tag}} =
+               StreamResponse.to_response(strict_stream)
+
+      assert buffered_tag == streamed_tag
+    end
+
+    test "valid structured fixture remains valid under strict stream materialization" do
+      output =
+        Output.object(
+          [
+            name: [type: :string, required: true],
+            age: [type: :pos_integer, required: true],
+            occupation: [type: :string, required: true]
+          ],
+          name: "person"
+        )
+
+      assert {:ok, stream_response} =
+               ReqLLM.stream_text(
+                 "openai:gpt-4o-mini",
+                 "Generate a software engineer profile",
+                 output: output,
+                 output_validation: :strict,
+                 max_tokens: 500,
+                 fixture: "object_streaming"
+               )
+
+      assert {:ok, response} = StreamResponse.to_response(stream_response)
+
+      assert %Result{valid?: true, errors: [], policy: :strict} =
+               Response.output_result(response, output)
+    end
+  end
+
+  defp person_output do
+    Output.object(
+      [
+        name: [type: :string, required: true],
+        age: [type: :pos_integer, required: true]
+      ],
+      name: "person"
+    )
+  end
+
+  defp generate(output, stub, opts \\ []) do
+    Generation.generate_text(
+      @model,
+      "Generate a person",
+      [
+        output: output,
+        openai_structured_output_mode: :tool_strict,
+        req_http_options: [plug: {Req.Test, stub}]
+      ] ++ opts
+    )
+  end
+
+  defp stub_tool_response(arguments, test_pid \\ nil) do
+    stub = {__MODULE__, make_ref()}
+    encoded_arguments = Jason.encode!(arguments)
+
+    Req.Test.stub(stub, fn conn ->
+      conn = maybe_capture_request(conn, test_pid)
+
+      Req.Test.json(conn, %{
+        "id" => "cmpl_output_validation",
+        "model" => "gpt-4-turbo",
+        "choices" => [
+          %{
+            "message" => %{
+              "role" => "assistant",
+              "tool_calls" => [
+                %{
+                  "id" => "call_output_validation",
+                  "type" => "function",
+                  "function" => %{
+                    "name" => "structured_output",
+                    "arguments" => encoded_arguments
+                  }
+                }
+              ]
+            },
+            "finish_reason" => "tool_calls"
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 4, "total_tokens" => 14}
+      })
+    end)
+
+    stub
+  end
+
+  defp maybe_capture_request(conn, nil), do: conn
+
+  defp maybe_capture_request(conn, test_pid) do
+    {:ok, body, conn} = Plug.Conn.read_body(conn)
+    send(test_pid, {:request_body, Jason.decode!(body)})
+    conn
+  end
+
+  defp request_forbidden_stub do
+    stub = {__MODULE__, make_ref()}
+    test_pid = self()
+
+    Req.Test.stub(stub, fn _conn ->
+      send(test_pid, :http_request_executed)
+      raise "HTTP request should not execute"
+    end)
+
+    stub
+  end
+
+  defp response(opts) do
+    object = Keyword.get(opts, :object)
+    provider_meta = Keyword.get(opts, :provider_meta, %{})
+    message = response_message(opts)
+
+    %Response{
+      id: "response_output_validation",
+      model: "gpt-4-turbo",
+      context: %Context{messages: []},
+      message: message,
+      object: object,
+      stream?: false,
+      stream: nil,
+      usage: nil,
+      finish_reason: :stop,
+      provider_meta: provider_meta,
+      error: nil
+    }
+  end
+
+  defp response_message(opts) do
+    cond do
+      arguments = Keyword.get(opts, :tool_arguments) ->
+        %Message{
+          role: :assistant,
+          content: [],
+          tool_calls: [ToolCall.new("call_output_validation", "structured_output", arguments)],
+          metadata: %{}
+        }
+
+      text = Keyword.get(opts, :text) ->
+        %Message{
+          role: :assistant,
+          content: [ContentPart.text(text)],
+          metadata: %{}
+        }
+
+      true ->
+        %Message{role: :assistant, content: [], metadata: %{}}
+    end
+  end
+end

--- a/test/req_llm/output_validation_test.exs
+++ b/test/req_llm/output_validation_test.exs
@@ -150,6 +150,27 @@ defmodule ReqLLM.OutputValidationTest do
                Response.output_result(response, output)
     end
 
+    test "turns unknown output keys into diagnostics instead of raising" do
+      output = person_output()
+      unknown_key = "unexpected_#{System.unique_integer([:positive])}"
+      value = %{"name" => "Ada", "age" => 37, unknown_key => true}
+
+      assert {:ok, warned_response} =
+               generate(output, stub_tool_response(value), output_validation: :warn)
+
+      assert %Result{valid?: false, errors: [%{type: :schema_validation}]} =
+               Response.output_result(warned_response, output)
+
+      assert {:error,
+              %ReqLLM.Error.Validation.Error{
+                tag: :structured_output_validation_failed,
+                context: context
+              }} = generate(output, stub_tool_response(value), output_validation: :strict)
+
+      assert %Result{valid?: false, errors: [%{type: :schema_validation}]} =
+               context[:output_result]
+    end
+
     test "compatible can record diagnostics without changing success semantics" do
       output = person_output()
       stub = stub_tool_response(%{"name" => "Ada"}, self())


### PR DESCRIPTION
Closes #852

## Summary

- add `ReqLLM.Response.output_result/3` and `%ReqLLM.Output.Result{}` so callers can inspect the retained raw value, projected value, validity, errors, warnings, repair attempts, extraction source, and provider metadata separately
- add explicit `:compatible`, `:warn`, and `:strict` final-value validation policies for buffered and materialized streaming responses
- add an optional one-shot local repair callback that never performs another model call and accepts a replacement only after the same local schema validation succeeds
- surface existing light JSON repair and legacy coercion when they can be detected from retained response data
- isolate the runtime policy lifecycle in `ReqLLM.Output.Validation` so descriptor construction and compilation remain focused

## V1 compatibility

- omitting the new options takes the exact existing path and does not attach diagnostics or change success/error behavior
- no provider request-body fields, public response fields, stream chunk shapes, or cache entries change
- strict failures and repair callbacks are opt-in only
- streaming policies run only after the complete response is materialized
- no hidden model calls, retries, or agent loops are introduced

## Validation

- `mix test` — 3,823 passed, 11 skipped, 145 excluded
- `mix quality` — formatting, warnings-as-errors compilation, Credo, and Dialyzer pass
- `mix docs` — generated successfully; only the pre-existing hidden HTTP2 duplex module warning remains
- `git diff --check`
