### PR TITLE
feat(openai_codex): support Responses Lite models

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -93,10 +93,14 @@ ReqLLM.generate_text(
 
 If you need to customize the refresh HTTP client, pass `oauth_http_options` under `provider_options`.
 
-For `openai_codex`, you can also override the backend headers with:
+For `openai_codex`, you can also override backend request headers with:
 
 - `provider_options: [chatgpt_account_id: "..."]`
 - `provider_options: [codex_originator: "pi"]`
+
+ReqLLM applies the complete Responses Lite wire profile when the Codex model catalog marks a model with `use_responses_lite: true`. The bundled catalog currently enables that profile for GPT-5.6 Sol, Terra, and Luna. Explicit model specs can provide updated provider metadata under `extra.openai_codex.use_responses_lite`.
+
+Responses Lite is an internal Codex backend contract, not a mode of the public OpenAI Responses API. It sends instructions and client-executed tools as input items, uses persistent reasoning context, disables parallel tool calls, and marks the request with the Codex Responses Lite header. The canonical behavior is defined by the [Codex model metadata](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/openai_models.rs) and [Responses Lite contract tests](https://github.com/openai/codex/blob/main/codex-rs/core/tests/suite/responses_lite.rs).
 
 ## Attachments
 

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -70,7 +70,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   require Logger
   require ReqLLM.Debug, as: Debug
 
-  @builtin_tool_types ~w(web_search web_search_preview file_search mcp x_search code_interpreter)
+  @builtin_tool_types ~w(web_search web_search_preview file_search mcp x_search code_interpreter image_generation)
   @tool_usage_type_atoms %{
     "web_search" => :web_search,
     "web_search_preview" => :web_search_preview,

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -12,6 +12,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
   alias ReqLLM.Providers.OpenAI
   alias ReqLLM.Providers.OpenAI.ResponsesAPI
+  alias ReqLLM.Providers.OpenAICodex.ResponsesLite
 
   @provider_schema [
     access_token: [
@@ -112,6 +113,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
   ]
 
   @codex_response_statuses ~w(completed incomplete failed cancelled queued in_progress)
+  @codex_model_option :openai_codex_model
 
   @impl ReqLLM.Provider
   def oauth_provider_id, do: "openai-codex"
@@ -212,12 +214,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Req.Request.put_header("authorization", "Bearer #{credential.token}")
     |> Req.Request.put_header("chatgpt-account-id", account_id)
     |> Req.Request.put_header("originator", originator)
-    |> Req.Request.register_options(extra_option_keys)
+    |> ResponsesLite.put_req_header(model)
+    |> Req.Request.register_options([@codex_model_option | extra_option_keys])
     |> Req.Request.merge_options(
       ReqLLM.Provider.Defaults.finch_option(request) ++
         [
-          model: model.provider_model_id || model.id,
-          auth: {:bearer, credential.token}
+          {@codex_model_option, model},
+          {:model, model.provider_model_id || model.id},
+          {:auth, {:bearer, credential.token}}
         ] ++ user_opts
     )
     |> attach_retry(user_opts)
@@ -231,8 +235,8 @@ defmodule ReqLLM.Providers.OpenAICodex do
   @impl ReqLLM.Provider
   def encode_body(request) do
     context = request.options[:context] || %ReqLLM.Context{messages: []}
-    model_name = request.options[:model] || request.options[:id]
-    body = build_codex_body(context, model_name, request.options, request)
+    model = request.options[@codex_model_option]
+    body = build_codex_body(context, model, request.options, request)
     encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
     Map.put(request, :body, encoded)
   end
@@ -306,17 +310,19 @@ defmodule ReqLLM.Providers.OpenAICodex do
       |> Keyword.put(:context, context)
       |> Keyword.put(:base_url, base_url)
 
-    body = build_codex_body(context, model.id, cleaned_opts, nil)
+    body = build_codex_body(context, model, cleaned_opts, nil)
     url = codex_url(base_url)
 
-    headers = [
-      {"authorization", "Bearer " <> credential.token},
-      {"chatgpt-account-id", account_id},
-      {"originator", codex_originator(opts)},
-      {"content-type", "application/json"},
-      {"accept", "text/event-stream"},
-      {"openai-beta", "responses=experimental"}
-    ]
+    headers =
+      [
+        {"authorization", "Bearer " <> credential.token},
+        {"chatgpt-account-id", account_id},
+        {"originator", codex_originator(opts)},
+        {"content-type", "application/json"},
+        {"accept", "text/event-stream"},
+        {"openai-beta", "responses=experimental"}
+      ]
+      |> ResponsesLite.put_header(model)
 
     encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
     {:ok, Finch.build(:post, url, headers, encoded)}
@@ -350,7 +356,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     credential = ReqLLM.Auth.resolve!(model, opts)
     account_id = resolve_account_id!(credential, opts)
     base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, opts)
-    headers = websocket_headers(credential.token, account_id, opts)
+    headers = websocket_headers(model, credential.token, account_id, opts)
     url = codex_websocket_url(base_url)
 
     cleaned_opts =
@@ -364,7 +370,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
       |> Keyword.put(:context, context)
       |> Keyword.put(:base_url, base_url)
 
-    body = build_codex_body(context, model.id, cleaned_opts, nil)
+    body = build_codex_body(context, model, cleaned_opts, nil)
     create_event = Map.put(body, "type", "response.create")
 
     {:ok,
@@ -392,13 +398,13 @@ defmodule ReqLLM.Providers.OpenAICodex do
     base_url = ReqLLM.Provider.Options.effective_base_url(__MODULE__, model, opts)
 
     ReqLLM.Streaming.WebSocketSession.start_link(codex_websocket_url(base_url),
-      headers: websocket_headers(credential.token, account_id, opts)
+      headers: websocket_headers(model, credential.token, account_id, opts)
     )
   end
 
-  defp build_codex_body(context, model_name, opts, request) do
+  defp build_codex_body(context, %LLMDB.Model{} = model, opts, request) do
     opts = opts |> ensure_provider_options() |> force_store_false()
-    body = ResponsesAPI.build_request_body(context, model_name, opts, request)
+    body = ResponsesAPI.build_request_body(context, effective_model_id(model), opts, request)
     provider_opts = provider_options(opts)
     instructions = extract_instructions(context) || ""
 
@@ -419,6 +425,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Map.put_new("text", %{"verbosity" => normalize_codex_verbosity(provider_opts[:verbosity])})
     |> Map.put("instructions", instructions)
     |> maybe_put_parallel_tool_calls(provider_opts[:openai_parallel_tool_calls])
+    |> ResponsesLite.apply_body(model)
   end
 
   defp ensure_provider_options(opts) when is_list(opts),
@@ -607,7 +614,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> ReqLLM.Providers.OpenAI.WebSocket.websocket_url("")
   end
 
-  defp websocket_headers(token, account_id, opts) do
+  defp websocket_headers(model, token, account_id, opts) do
     request_id = codex_request_id(opts)
 
     [
@@ -617,8 +624,13 @@ defmodule ReqLLM.Providers.OpenAICodex do
       {"openai-beta", "responses_websockets=2026-02-06"},
       {"x-client-request-id", request_id},
       {"session_id", request_id}
-    ] ++ ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options])
+    ]
+    |> ResponsesLite.put_header(model)
+    |> Kernel.++(ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options]))
   end
+
+  defp effective_model_id(%LLMDB.Model{provider_model_id: id}) when is_binary(id), do: id
+  defp effective_model_id(%LLMDB.Model{id: id}), do: id
 
   defp codex_request_id(opts) do
     opts

--- a/lib/req_llm/providers/openai_codex/responses_lite.ex
+++ b/lib/req_llm/providers/openai_codex/responses_lite.ex
@@ -2,6 +2,8 @@ defmodule ReqLLM.Providers.OpenAICodex.ResponsesLite do
   @moduledoc false
 
   @header "x-openai-internal-codex-responses-lite"
+  @hosted_tool_types ~w(web_search web_search_preview file_search mcp x_search code_interpreter)
+  @remote_image_omission "image content omitted because remote image URLs are not supported"
 
   @bundled_model_metadata %{
     "gpt-5.6-sol" => %{use_responses_lite: true},
@@ -38,13 +40,13 @@ defmodule ReqLLM.Providers.OpenAICodex.ResponsesLite do
   end
 
   defp apply_lite_contract(body) do
-    tools = body |> Map.get("tools") |> List.wrap()
+    tools = body |> Map.get("tools") |> List.wrap() |> client_executed_tools()
     instructions = Map.get(body, "instructions", "")
 
     input =
       [%{"type" => "additional_tools", "role" => "developer", "tools" => tools}]
       |> maybe_add_instructions(instructions)
-      |> Kernel.++(body |> Map.get("input") |> List.wrap() |> strip_image_details())
+      |> Kernel.++(body |> Map.get("input") |> List.wrap() |> prepare_images())
 
     body
     |> Map.put("input", input)
@@ -74,19 +76,38 @@ defmodule ReqLLM.Providers.OpenAICodex.ResponsesLite do
 
   defp put_reasoning_context(_reasoning), do: %{"context" => "all_turns"}
 
-  defp strip_image_details(items) when is_list(items), do: Enum.map(items, &strip_image_details/1)
+  defp client_executed_tools(tools) do
+    Enum.reject(tools, fn tool -> tool_type(tool) in @hosted_tool_types end)
+  end
 
-  defp strip_image_details(%{"type" => "input_image"} = item) do
+  defp tool_type(%{"type" => type}) when is_atom(type), do: Atom.to_string(type)
+  defp tool_type(%{"type" => type}), do: type
+  defp tool_type(%{type: type}) when is_atom(type), do: Atom.to_string(type)
+  defp tool_type(%{type: type}), do: type
+  defp tool_type(_tool), do: nil
+
+  defp prepare_images(items) when is_list(items), do: Enum.map(items, &prepare_images/1)
+
+  defp prepare_images(%{"type" => "input_image", "image_url" => "data:" <> _rest} = item) do
     item
     |> Map.delete("detail")
-    |> Map.new(fn {key, value} -> {key, strip_image_details(value)} end)
+    |> Map.new(fn {key, value} -> {key, prepare_images(value)} end)
   end
 
-  defp strip_image_details(%{} = item) do
-    Map.new(item, fn {key, value} -> {key, strip_image_details(value)} end)
+  defp prepare_images(%{"type" => "input_image", "image_url" => image_url})
+       when is_binary(image_url) do
+    %{"type" => "input_text", "text" => @remote_image_omission}
   end
 
-  defp strip_image_details(value), do: value
+  defp prepare_images(%{"type" => "input_image"} = item) do
+    Map.delete(item, "detail")
+  end
+
+  defp prepare_images(%{} = item) do
+    Map.new(item, fn {key, value} -> {key, prepare_images(value)} end)
+  end
+
+  defp prepare_images(value), do: value
 
   defp model_metadata_value(%LLMDB.Model{extra: extra}, key) when is_map(extra) do
     metadata = Map.get(extra, :openai_codex) || Map.get(extra, "openai_codex") || %{}

--- a/lib/req_llm/providers/openai_codex/responses_lite.ex
+++ b/lib/req_llm/providers/openai_codex/responses_lite.ex
@@ -1,0 +1,110 @@
+defmodule ReqLLM.Providers.OpenAICodex.ResponsesLite do
+  @moduledoc false
+
+  @header "x-openai-internal-codex-responses-lite"
+
+  @bundled_model_metadata %{
+    "gpt-5.6-sol" => %{use_responses_lite: true},
+    "gpt-5.6-terra" => %{use_responses_lite: true},
+    "gpt-5.6-luna" => %{use_responses_lite: true}
+  }
+
+  @spec enabled?(LLMDB.Model.t()) :: boolean()
+  def enabled?(%LLMDB.Model{} = model) do
+    case model_metadata_value(model, :use_responses_lite) do
+      enabled when is_boolean(enabled) -> enabled
+      _other -> bundled_model_value(model, :use_responses_lite) == true
+    end
+  end
+
+  @spec apply_body(map(), LLMDB.Model.t()) :: map()
+  def apply_body(body, %LLMDB.Model{} = model) when is_map(body) do
+    if enabled?(model), do: apply_lite_contract(body), else: body
+  end
+
+  @spec put_req_header(Req.Request.t(), LLMDB.Model.t()) :: Req.Request.t()
+  def put_req_header(request, %LLMDB.Model{} = model) do
+    if enabled?(model) do
+      Req.Request.put_header(request, @header, "true")
+    else
+      request
+    end
+  end
+
+  @spec put_header([{String.t(), String.t()}], LLMDB.Model.t()) ::
+          [{String.t(), String.t()}]
+  def put_header(headers, %LLMDB.Model{} = model) when is_list(headers) do
+    if enabled?(model), do: [{@header, "true"} | headers], else: headers
+  end
+
+  defp apply_lite_contract(body) do
+    tools = body |> Map.get("tools") |> List.wrap()
+    instructions = Map.get(body, "instructions", "")
+
+    input =
+      [%{"type" => "additional_tools", "role" => "developer", "tools" => tools}]
+      |> maybe_add_instructions(instructions)
+      |> Kernel.++(body |> Map.get("input") |> List.wrap() |> strip_image_details())
+
+    body
+    |> Map.put("input", input)
+    |> Map.delete("instructions")
+    |> Map.delete("tools")
+    |> Map.delete("previous_response_id")
+    |> Map.put("parallel_tool_calls", false)
+    |> Map.update("reasoning", %{"context" => "all_turns"}, &put_reasoning_context/1)
+  end
+
+  defp maybe_add_instructions(prefix, instructions)
+       when is_binary(instructions) and instructions != "" do
+    prefix ++
+      [
+        %{
+          "type" => "message",
+          "role" => "developer",
+          "content" => [%{"type" => "input_text", "text" => instructions}]
+        }
+      ]
+  end
+
+  defp maybe_add_instructions(prefix, _instructions), do: prefix
+
+  defp put_reasoning_context(reasoning) when is_map(reasoning),
+    do: Map.put(reasoning, "context", "all_turns")
+
+  defp put_reasoning_context(_reasoning), do: %{"context" => "all_turns"}
+
+  defp strip_image_details(items) when is_list(items), do: Enum.map(items, &strip_image_details/1)
+
+  defp strip_image_details(%{"type" => "input_image"} = item) do
+    item
+    |> Map.delete("detail")
+    |> Map.new(fn {key, value} -> {key, strip_image_details(value)} end)
+  end
+
+  defp strip_image_details(%{} = item) do
+    Map.new(item, fn {key, value} -> {key, strip_image_details(value)} end)
+  end
+
+  defp strip_image_details(value), do: value
+
+  defp model_metadata_value(%LLMDB.Model{extra: extra}, key) when is_map(extra) do
+    metadata = Map.get(extra, :openai_codex) || Map.get(extra, "openai_codex") || %{}
+
+    case Map.fetch(metadata, key) do
+      {:ok, value} -> value
+      :error -> Map.get(metadata, Atom.to_string(key))
+    end
+  end
+
+  defp model_metadata_value(_model, _key), do: nil
+
+  defp bundled_model_value(model, key) do
+    model
+    |> effective_model_id()
+    |> then(&get_in(@bundled_model_metadata, [&1, key]))
+  end
+
+  defp effective_model_id(%LLMDB.Model{provider_model_id: id}) when is_binary(id), do: id
+  defp effective_model_id(%LLMDB.Model{id: id}), do: id
+end

--- a/lib/req_llm/providers/openai_codex/responses_lite.ex
+++ b/lib/req_llm/providers/openai_codex/responses_lite.ex
@@ -2,7 +2,7 @@ defmodule ReqLLM.Providers.OpenAICodex.ResponsesLite do
   @moduledoc false
 
   @header "x-openai-internal-codex-responses-lite"
-  @hosted_tool_types ~w(web_search web_search_preview file_search mcp x_search code_interpreter)
+  @hosted_tool_types ~w(web_search web_search_preview file_search mcp x_search code_interpreter image_generation)
   @remote_image_omission "image content omitted because remote image URLs are not supported"
 
   @bundled_model_metadata %{

--- a/test/providers/openai_codex/responses_lite_test.exs
+++ b/test/providers/openai_codex/responses_lite_test.exs
@@ -88,6 +88,60 @@ defmodule ReqLLM.Providers.OpenAICodex.ResponsesLiteTest do
 
       assert ResponsesLite.apply_body(body, model("gpt-5.5")) == body
     end
+
+    test "keeps client-executed tools and omits provider-hosted tools" do
+      body = %{
+        "tools" => [
+          %{"type" => "web_search"},
+          %{"type" => :file_search},
+          %{type: :code_interpreter},
+          %{"type" => "function", "name" => "lookup"}
+        ]
+      }
+
+      transformed = ResponsesLite.apply_body(body, model("gpt-5.6-sol"))
+
+      assert [%{"type" => "additional_tools", "tools" => tools}] = transformed["input"]
+      assert tools == [%{"type" => "function", "name" => "lookup"}]
+    end
+
+    test "replaces remote images and preserves data images without detail" do
+      body = %{
+        "input" => [
+          %{
+            "type" => "message",
+            "role" => "user",
+            "content" => [
+              %{
+                "type" => "input_image",
+                "image_url" => "https://example.com/image.png",
+                "detail" => "high"
+              },
+              %{
+                "type" => "input_image",
+                "image_url" => "data:image/png;base64,abc",
+                "detail" => "original"
+              }
+            ]
+          }
+        ]
+      }
+
+      transformed = ResponsesLite.apply_body(body, model("gpt-5.6-sol"))
+      [_additional_tools, user_message] = transformed["input"]
+
+      assert [omission, data_image] = user_message["content"]
+
+      assert omission == %{
+               "type" => "input_text",
+               "text" => "image content omitted because remote image URLs are not supported"
+             }
+
+      assert data_image == %{
+               "type" => "input_image",
+               "image_url" => "data:image/png;base64,abc"
+             }
+    end
   end
 
   defp model(id, extra \\ %{}) do

--- a/test/providers/openai_codex/responses_lite_test.exs
+++ b/test/providers/openai_codex/responses_lite_test.exs
@@ -1,0 +1,96 @@
+defmodule ReqLLM.Providers.OpenAICodex.ResponsesLiteTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.OpenAICodex.ResponsesLite
+
+  describe "enabled?/1" do
+    test "uses the bundled Codex model catalog for known Responses Lite models" do
+      for id <- ~w(gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna) do
+        assert id |> model() |> ResponsesLite.enabled?()
+      end
+
+      refute "gpt-5.6" |> model() |> ResponsesLite.enabled?()
+      refute "gpt-5.5" |> model() |> ResponsesLite.enabled?()
+    end
+
+    test "provider-specific model metadata overrides the bundled catalog" do
+      refute "gpt-5.6-sol"
+             |> model(%{openai_codex: %{use_responses_lite: false}})
+             |> ResponsesLite.enabled?()
+
+      assert "custom-codex-model"
+             |> model(%{"openai_codex" => %{"use_responses_lite" => true}})
+             |> ResponsesLite.enabled?()
+    end
+  end
+
+  describe "apply_body/2" do
+    test "applies the complete Responses Lite request contract" do
+      body = %{
+        "model" => "gpt-5.6-sol",
+        "instructions" => "Be concise.",
+        "input" => [
+          %{
+            "type" => "message",
+            "role" => "user",
+            "content" => [
+              %{
+                "type" => "input_image",
+                "image_url" => "data:image/png;base64,abc",
+                "detail" => "high"
+              },
+              %{"type" => "input_text", "text" => "Describe this image"}
+            ]
+          }
+        ],
+        "tools" => [
+          %{
+            "type" => "function",
+            "name" => "lookup",
+            "parameters" => %{"type" => "object"}
+          }
+        ],
+        "parallel_tool_calls" => true,
+        "previous_response_id" => "resp_previous",
+        "reasoning" => %{"effort" => "high"}
+      }
+
+      transformed = ResponsesLite.apply_body(body, model("gpt-5.6-sol"))
+
+      refute Map.has_key?(transformed, "instructions")
+      refute Map.has_key?(transformed, "tools")
+      refute Map.has_key?(transformed, "previous_response_id")
+      assert transformed["parallel_tool_calls"] == false
+      assert transformed["reasoning"] == %{"effort" => "high", "context" => "all_turns"}
+
+      assert [additional_tools, developer_instructions, user_message] = transformed["input"]
+
+      assert additional_tools == %{
+               "type" => "additional_tools",
+               "role" => "developer",
+               "tools" => body["tools"]
+             }
+
+      assert developer_instructions == %{
+               "type" => "message",
+               "role" => "developer",
+               "content" => [%{"type" => "input_text", "text" => "Be concise."}]
+             }
+
+      assert [%{"type" => "input_image"} = image, %{"type" => "input_text"}] =
+               user_message["content"]
+
+      refute Map.has_key?(image, "detail")
+    end
+
+    test "leaves non-Lite requests unchanged" do
+      body = %{"instructions" => "Be concise.", "input" => [], "parallel_tool_calls" => true}
+
+      assert ResponsesLite.apply_body(body, model("gpt-5.5")) == body
+    end
+  end
+
+  defp model(id, extra \\ %{}) do
+    ReqLLM.model!(%{provider: :openai_codex, id: id, extra: extra})
+  end
+end

--- a/test/providers/openai_codex/responses_lite_test.exs
+++ b/test/providers/openai_codex/responses_lite_test.exs
@@ -93,6 +93,7 @@ defmodule ReqLLM.Providers.OpenAICodex.ResponsesLiteTest do
       body = %{
         "tools" => [
           %{"type" => "web_search"},
+          %{"type" => "image_generation"},
           %{"type" => :file_search},
           %{type: :code_interpreter},
           %{"type" => "function", "name" => "lookup"}

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -183,7 +183,11 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
           model,
           context,
           [
-            tools: [%{"type" => "web_search"}, local_tool],
+            tools: [
+              %{"type" => "web_search"},
+              %{"type" => "image_generation"},
+              local_tool
+            ],
             provider_options: [
               auth_mode: :oauth,
               access_token: jwt_with_account_id("acct_lite_contract")

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -159,6 +159,56 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert [%{"type" => "additional_tools", "role" => "developer"} | _input] = body["input"]
     end
 
+    test "normalizes Responses Lite tools and images after shared Responses encoding" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.6-sol")
+
+      local_tool =
+        ReqLLM.Tool.new!(
+          name: "lookup",
+          description: "Look up a value",
+          parameter_schema: [value: [type: :string, required: true]],
+          callback: fn args -> {:ok, args} end
+        )
+
+      context =
+        ReqLLM.context([
+          ReqLLM.Context.user([
+            ReqLLM.Message.ContentPart.image_url("https://example.com/image.png"),
+            ReqLLM.Message.ContentPart.image("png", "image/png")
+          ])
+        ])
+
+      {:ok, request} =
+        OpenAICodex.attach_stream(
+          model,
+          context,
+          [
+            tools: [%{"type" => "web_search"}, local_tool],
+            provider_options: [
+              auth_mode: :oauth,
+              access_token: jwt_with_account_id("acct_lite_contract")
+            ]
+          ],
+          nil
+        )
+
+      body = ReqLLM.Test.Helpers.json_body(request)
+      [additional_tools, user_message] = body["input"]
+
+      assert [%{"type" => "function", "name" => "lookup"}] = additional_tools["tools"]
+
+      assert [omission, data_image] = user_message["content"]
+
+      assert omission == %{
+               "type" => "input_text",
+               "text" => "image content omitted because remote image URLs are not supported"
+             }
+
+      assert data_image["type"] == "input_image"
+      assert String.starts_with?(data_image["image_url"], "data:image/png;base64,")
+      refute Map.has_key?(data_image, "detail")
+    end
+
     test "builds websocket request with codex websocket beta" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
 

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -32,6 +32,21 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert request.headers["authorization"] == ["Bearer #{jwt_with_account_id("acct_123")}"]
       assert request.headers["chatgpt-account-id"] == ["acct_123"]
       assert request.headers["originator"] == ["pi"]
+      refute Map.has_key?(request.headers, "x-openai-internal-codex-responses-lite")
+    end
+
+    test "prepare_request automatically enables Responses Lite from model metadata" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.6-sol")
+
+      {:ok, request} =
+        OpenAICodex.prepare_request(:chat, model, "Summarize BHP",
+          provider_options: [
+            auth_mode: :oauth,
+            access_token: jwt_with_account_id("acct_lite")
+          ]
+        )
+
+      assert request.headers["x-openai-internal-codex-responses-lite"] == ["true"]
     end
 
     test "prepare_request loads oauth_file without explicit auth_mode" do
@@ -102,6 +117,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert request.path == "/backend-api/codex/responses"
       assert {"accept", "text/event-stream"} in request.headers
       assert {"openai-beta", "responses=experimental"} in request.headers
+      refute {"x-openai-internal-codex-responses-lite", "true"} in request.headers
 
       body = ReqLLM.Test.Helpers.json_body(request)
 
@@ -113,6 +129,34 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       refute Map.has_key?(body, "max_output_tokens")
       refute Map.has_key?(body, "max_completion_tokens")
       assert Enum.all?(body["input"], &(&1["role"] != "system"))
+    end
+
+    test "adds Responses Lite to SSE requests for matching models" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.6-sol")
+      context = ReqLLM.context([ReqLLM.Context.user("Say hi")])
+
+      {:ok, request} =
+        OpenAICodex.attach_stream(
+          model,
+          context,
+          [
+            provider_options: [
+              auth_mode: :oauth,
+              access_token: jwt_with_account_id("acct_lite_stream")
+            ]
+          ],
+          nil
+        )
+
+      assert {"x-openai-internal-codex-responses-lite", "true"} in request.headers
+
+      body = ReqLLM.Test.Helpers.json_body(request)
+
+      refute Map.has_key?(body, "instructions")
+      refute Map.has_key?(body, "tools")
+      assert body["parallel_tool_calls"] == false
+      assert body["reasoning"]["context"] == "all_turns"
+      assert [%{"type" => "additional_tools", "role" => "developer"} | _input] = body["input"]
     end
 
     test "builds websocket request with codex websocket beta" do
@@ -136,6 +180,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert {"openai-beta", "responses_websockets=2026-02-06"} in config.headers
       assert {"session_id", "req_ws"} in config.headers
       assert {"x-client-request-id", "req_ws"} in config.headers
+      refute {"x-openai-internal-codex-responses-lite", "true"} in config.headers
       refute Enum.any?(config.headers, &(elem(&1, 0) == "content-type"))
 
       payload = config.initial_messages |> hd() |> Jason.decode!()
@@ -147,6 +192,31 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       assert payload["previous_response_id"] == "resp_ws_789"
       refute Map.has_key?(payload, "max_completion_tokens")
       refute Map.has_key?(payload, "response")
+    end
+
+    test "adds Responses Lite to websocket requests for matching models" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.6-sol")
+
+      {:ok, config} =
+        OpenAICodex.attach_websocket_stream(
+          model,
+          ReqLLM.context([ReqLLM.Context.user("Say hi")]),
+          provider_options: [
+            auth_mode: :oauth,
+            access_token: jwt_with_account_id("acct_lite_ws")
+          ]
+        )
+
+      assert {"x-openai-internal-codex-responses-lite", "true"} in config.headers
+
+      payload = config.initial_messages |> hd() |> Jason.decode!()
+
+      refute Map.has_key?(payload, "previous_response_id")
+      refute Map.has_key?(payload, "instructions")
+      refute Map.has_key?(payload, "tools")
+      assert payload["parallel_tool_calls"] == false
+      assert payload["reasoning"]["context"] == "all_turns"
+      assert [%{"type" => "additional_tools", "role" => "developer"} | _input] = payload["input"]
     end
 
     test "loads oauth_file without explicit auth_mode for streaming" do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -1818,7 +1818,7 @@ defmodule ReqLLM.Providers.OpenAITest do
   end
 
   describe "ResponsesAPI tool encoding" do
-    test "passes through built-in web_search tool definitions" do
+    test "passes through built-in hosted tool definitions" do
       {:ok, model} = ReqLLM.model("openai:gpt-5-nano")
 
       context = %ReqLLM.Context{
@@ -1833,7 +1833,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       opts = [
         context: context,
         model: model.model,
-        tools: [%{"type" => "web_search"}]
+        tools: [%{"type" => "web_search"}, %{"type" => "image_generation"}]
       ]
 
       request = %Req.Request{
@@ -1845,7 +1845,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       encoded_request = ReqLLM.Providers.OpenAI.ResponsesAPI.encode_body(request)
       body = ReqLLM.Test.Helpers.json_body(encoded_request)
 
-      assert Enum.any?(body["tools"], fn tool -> tool["type"] == "web_search" end)
+      assert Enum.map(body["tools"], & &1["type"]) == ["web_search", "image_generation"]
     end
   end
 end


### PR DESCRIPTION
## Description

Implement the complete OpenAI Codex Responses Lite wire profile for models whose Codex metadata enables it.

- uses exact bundled Codex model metadata for GPT-5.6 Sol, Terra, and Luna instead of model-family or ID-prefix inference
- allows explicit model specs to override provider metadata through `extra.openai_codex.use_responses_lite`
- moves instructions and client-executed tools into the required input items
- sets persistent reasoning context, disables parallel tool calls, removes `previous_response_id`, and strips unsupported image detail fields
- applies the Responses Lite header consistently to Req, SSE, and WebSocket transports
- keeps non-Lite Codex requests and `originator: pi` unchanged

The profile is isolated in `ReqLLM.Providers.OpenAICodex.ResponsesLite`. Request construction remains deterministic and does not fetch remote metadata during each call.

Responses Lite is an internal Codex backend contract, not a public OpenAI Responses API mode. The implementation follows the official Codex `ModelInfo.use_responses_lite` field and contract tests.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None.

## Testing

- [x] Focused provider tests pass — 20 tests
- [x] Full suite passes — 3,794 tests, 11 skipped
- [x] `mix quality` passes — Credo clean and Dialyzer 0 errors
- [x] Authenticated GPT-5.6 Sol request returns `OK`
- [x] Authenticated GPT-5.6 Terra request returns `OK`
- [x] Authenticated GPT-5.6 Luna request returns `OK`
- [x] Authenticated GPT-5.6 Sol WebSocket stream returns `OK`
- [x] Authenticated GPT-5.6 Sol strict function-tool request returns a tool call

The authenticated Codex catalog marks Sol, Terra, and Luna with `use_responses_lite: true`; plain `gpt-5.6` is absent. All three catalogued GPT-5.6 models completed authenticated smoke requests successfully.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove the feature works
- [x] All new and existing tests pass
- [x] My commit follows conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md`

## Related Issues

None.
