### PR TITLE
feat: harden canonical tool exchange contracts

### DIFF
--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -1344,7 +1344,7 @@ defmodule ReqLLM.Context do
 
   defp normalize_tool_result_struct(%ToolResult{} = result) do
     content = normalize_tool_result_content(result.content, result.output)
-    metadata = ToolResult.put_output_metadata(result.metadata, result.output)
+    metadata = ToolResult.put_message_metadata(result.metadata, result)
     {content, metadata}
   end
 

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -2462,6 +2462,9 @@ defmodule ReqLLM.Providers.Google do
     output = ReqLLM.ToolResult.output_from_message(message)
 
     cond do
+      ReqLLM.ToolResult.explicit_content?(message) ->
+        %{content: extract_content_text(raw_content)}
+
       is_map(output) or is_list(output) ->
         output
 

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -809,9 +809,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       }
     else
       output =
-        case ReqLLM.ToolResult.output_from_message(msg) do
-          nil -> extract_tool_output_text(msg.content)
-          value -> value
+        if ReqLLM.ToolResult.explicit_content?(msg) do
+          extract_tool_output_text(msg.content)
+        else
+          case ReqLLM.ToolResult.output_from_message(msg) do
+            nil -> extract_tool_output_text(msg.content)
+            value -> value
+          end
         end
 
       output_string =

--- a/lib/req_llm/tool.ex
+++ b/lib/req_llm/tool.ex
@@ -56,6 +56,7 @@ defmodule ReqLLM.Tool do
 
     * `new/1` - Creates a new Tool from the given options
     * `new!/1` - Creates a new Tool from the given options, raising on error
+    * `validate_input/2` - Validates input without invoking the callback
     * `execute/2` - Executes a tool with the given input parameters
     * `to_schema/2` - Converts a Tool to provider-specific schema format
     * `to_json_schema/1` - Converts a Tool to JSON Schema format for LLM integration
@@ -276,14 +277,58 @@ defmodule ReqLLM.Tool do
       #=> {:error, %ReqLLM.Error.Validation.Error{...}}
 
   """
-  @spec execute(t(), map()) :: {:ok, term()} | {:error, term()}
-  def execute(%__MODULE__{} = tool, input) when is_map(input) do
+  @spec execute(t(), term()) :: {:ok, term()} | {:error, term()}
+  def execute(%__MODULE__{} = tool, input) do
     with {:ok, validated_input} <- validate_input(tool, input) do
       call_callback(tool.callback, validated_input)
     end
   end
 
-  def execute(%__MODULE__{}, input) do
+  @doc """
+  Validates input parameters without invoking the tool callback.
+
+  This uses the same schema validation and key normalization as `execute/2`.
+  It is useful when inspecting a model-produced tool call before deciding
+  whether to execute it.
+
+  Returns the normalized, validated input on success. Invalid input returns the
+  same error shape as `execute/2` and never invokes the callback.
+  """
+  @spec validate_input(t(), term()) :: {:ok, map()} | {:error, term()}
+  def validate_input(%__MODULE__{compiled: nil}, input) when is_map(input), do: {:ok, input}
+
+  def validate_input(
+        %__MODULE__{compiled: schema, parameter_schema: parameter_schema},
+        input
+      )
+      when is_map(input) do
+    normalized_input = normalize_input_keys(input, parameter_schema)
+
+    try do
+      case NimbleOptions.validate(normalized_input, schema) do
+        {:ok, validated_input} ->
+          {:ok, validated_input}
+
+        {:error, error} ->
+          {:error,
+           ReqLLM.Error.Validation.Error.exception(
+             tag: :parameter_validation,
+             reason: Exception.message(error),
+             context: [input: input]
+           )}
+      end
+    rescue
+      error ->
+        {:error,
+         ReqLLM.Error.Validation.Error.exception(
+           tag: :parameter_validation,
+           reason: Exception.message(error),
+           context: [input: input]
+         )}
+    end
+  end
+
+  def validate_input(%__MODULE__{}, input) do
     {:error,
      ReqLLM.Error.Invalid.Parameter.exception(
        parameter: "Input must be a map, got: #{inspect(input)}"
@@ -462,35 +507,6 @@ defmodule ReqLLM.Tool do
     with {:ok, compiled_result} <- ReqLLM.Schema.compile(parameter_schema) do
       # Return just the compiled NimbleOptions schema (or nil for maps)
       {:ok, compiled_result.compiled}
-    end
-  end
-
-  defp validate_input(%__MODULE__{compiled: nil}, input), do: {:ok, input}
-
-  defp validate_input(%__MODULE__{compiled: schema, parameter_schema: parameter_schema}, input) do
-    normalized_input = normalize_input_keys(input, parameter_schema)
-
-    try do
-      case NimbleOptions.validate(normalized_input, schema) do
-        {:ok, validated_input} ->
-          {:ok, validated_input}
-
-        {:error, error} ->
-          {:error,
-           ReqLLM.Error.Validation.Error.exception(
-             tag: :parameter_validation,
-             reason: Exception.message(error),
-             context: [input: input]
-           )}
-      end
-    rescue
-      error ->
-        {:error,
-         ReqLLM.Error.Validation.Error.exception(
-           tag: :parameter_validation,
-           reason: Exception.message(error),
-           context: [input: input]
-         )}
     end
   end
 

--- a/lib/req_llm/tool_call.ex
+++ b/lib/req_llm/tool_call.ex
@@ -23,6 +23,10 @@ defmodule ReqLLM.ToolCall do
   `call.id`, `call.function.name`, and `call.function.arguments`, or use
   `to_map/1` when a plain map with decoded arguments is more convenient.
 
+  Use `resolve/3` to inspect a call against application tools without invoking
+  a callback. `execute/3` is the explicit single-call execution boundary and
+  only runs calls whose resolution state is `:valid`.
+
   ## Examples
 
       iex> ToolCall.new("call_abc", "get_weather", ~s({"location":"Paris"}))
@@ -47,6 +51,24 @@ defmodule ReqLLM.ToolCall do
           })
 
   @type t :: unquote(Zoi.type_spec(@schema))
+
+  @typedoc "Resolution state for a tool call"
+  @type resolution_state ::
+          :valid | :invalid | :unknown | :provider_executed | :provider_native
+
+  @typedoc "Provider-independent inspection of a tool call"
+  @type resolution :: %{
+          state: resolution_state(),
+          call: t(),
+          id: String.t(),
+          name: String.t(),
+          tool: ReqLLM.Tool.t() | nil,
+          raw_arguments: String.t(),
+          arguments: map() | nil,
+          validated_arguments: map() | nil,
+          metadata: map(),
+          error: term() | nil
+        }
 
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)
@@ -128,6 +150,22 @@ defmodule ReqLLM.ToolCall do
   def builtin?(_), do: false
 
   @doc """
+  Returns true when local tool-call metadata marks a call as provider-native.
+
+  Provider adapters can attach the non-wire marker with
+  `put_metadata(call, %{provider_native: provider})`, where `provider` may be
+  an atom, string, map, or `true`. A false or nil marker is ignored.
+
+  Provider-executed builtins use the separate `builtin?/1` marker.
+  """
+  @spec provider_native?(t() | map()) :: boolean()
+  def provider_native?(tool_call) do
+    tool_call
+    |> metadata()
+    |> provider_native_metadata?()
+  end
+
+  @doc """
   Returns true when the given map carries a truthy `:builtin?` (or
   `"builtin?"`) flag **directly on it**. Does not unwrap a nested
   `:function` map — use it for chunk metadata or raw tool-call shapes
@@ -183,8 +221,167 @@ defmodule ReqLLM.ToolCall do
 
   def put_metadata(%__MODULE__{} = call, _metadata), do: call
 
+  @doc """
+  Resolves a tool call against application tools without invoking a callback.
+
+  The returned map always preserves the original call, raw JSON arguments, and
+  metadata. Application calls are `:valid`, `:invalid`, or `:unknown`.
+  Provider-executed builtins and calls carrying provider-native metadata are
+  returned as `:provider_executed` or `:provider_native` and are never treated
+  as application callbacks.
+
+  JSON repair follows `args_map/2` and can be disabled with
+  `json_repair: false`.
+  """
+  @spec resolve(t(), [ReqLLM.Tool.t()], keyword()) :: resolution()
+  def resolve(%__MODULE__{} = call, available_tools, opts \\ [])
+      when is_list(available_tools) and is_list(opts) do
+    resolution = base_resolution(call)
+
+    cond do
+      builtin?(call) ->
+        resolve_non_application_call(resolution, :provider_executed, opts)
+
+      provider_native?(call) ->
+        resolve_non_application_call(resolution, :provider_native, opts)
+
+      true ->
+        resolve_application_call(resolution, available_tools, opts)
+    end
+  end
+
+  @doc """
+  Executes one resolved application tool call.
+
+  The callback is invoked only when `resolve/3` returns `:valid`. Invalid,
+  unknown, provider-executed, and provider-native calls return
+  `{:error, resolution}` without invoking any callback. Successful and failed
+  callback values retain the existing `ReqLLM.Tool.execute/2` contract.
+  """
+  @spec execute(t(), [ReqLLM.Tool.t()], keyword()) ::
+          {:ok, term()} | {:error, term() | resolution()}
+  def execute(%__MODULE__{} = call, available_tools, opts \\ []) do
+    case resolve(call, available_tools, opts) do
+      %{state: :valid, tool: tool, arguments: arguments} ->
+        ReqLLM.Tool.execute(tool, arguments)
+
+      resolution ->
+        {:error, resolution}
+    end
+  end
+
   defp generate_id do
     "call_#{ReqLLM.ID.uuid7()}"
+  end
+
+  defp base_resolution(%__MODULE__{} = call) do
+    %{
+      state: :unknown,
+      call: call,
+      id: call.id,
+      name: name(call),
+      tool: nil,
+      raw_arguments: args_json(call),
+      arguments: nil,
+      validated_arguments: nil,
+      metadata: metadata(call),
+      error: nil
+    }
+  end
+
+  defp resolve_application_call(resolution, available_tools, opts) do
+    case find_tool(available_tools, resolution.name) do
+      nil -> resolve_unknown_call(resolution, opts)
+      tool -> resolve_known_call(resolution, tool, opts)
+    end
+  end
+
+  defp resolve_non_application_call(resolution, state, opts) do
+    arguments = decode_arguments_or_nil(resolution.raw_arguments, opts)
+    %{resolution | state: state, arguments: arguments}
+  end
+
+  defp resolve_unknown_call(resolution, opts) do
+    arguments = decode_arguments_or_nil(resolution.raw_arguments, opts)
+    error = unknown_tool_error(resolution.name)
+    %{resolution | state: :unknown, arguments: arguments, error: error}
+  end
+
+  defp resolve_known_call(resolution, tool, opts) do
+    case ReqLLM.JSON.decode(resolution.raw_arguments, opts) do
+      {:ok, arguments} when is_map(arguments) ->
+        resolve_validated_call(resolution, tool, arguments)
+
+      {:ok, arguments} ->
+        error = invalid_arguments_error(arguments)
+
+        %{
+          resolution
+          | state: :invalid,
+            tool: tool,
+            arguments: nil,
+            error: error
+        }
+
+      {:error, error} ->
+        %{resolution | state: :invalid, tool: tool, error: error}
+    end
+  end
+
+  defp resolve_validated_call(resolution, tool, arguments) do
+    case ReqLLM.Tool.validate_input(tool, arguments) do
+      {:ok, validated_arguments} ->
+        %{
+          resolution
+          | state: :valid,
+            tool: tool,
+            arguments: arguments,
+            validated_arguments: validated_arguments
+        }
+
+      {:error, error} ->
+        %{
+          resolution
+          | state: :invalid,
+            tool: tool,
+            arguments: arguments,
+            error: error
+        }
+    end
+  end
+
+  defp find_tool(available_tools, name) do
+    Enum.find(available_tools, fn
+      %ReqLLM.Tool{name: ^name} -> true
+      _tool -> false
+    end)
+  end
+
+  defp decode_arguments_or_nil(raw_arguments, opts) do
+    case ReqLLM.JSON.decode(raw_arguments, opts) do
+      {:ok, arguments} when is_map(arguments) -> arguments
+      _other -> nil
+    end
+  end
+
+  defp invalid_arguments_error(arguments) do
+    ReqLLM.Error.Invalid.Parameter.exception(
+      parameter: "Tool call arguments must decode to a map, got: #{inspect(arguments)}"
+    )
+  end
+
+  defp unknown_tool_error(name) do
+    ReqLLM.Error.Invalid.Parameter.exception(parameter: "Tool #{inspect(name)} not found")
+  end
+
+  defp provider_native_metadata?(metadata) do
+    marker =
+      Map.get(metadata, :provider_native) ||
+        Map.get(metadata, "provider_native") ||
+        Map.get(metadata, :provider_native?) ||
+        Map.get(metadata, "provider_native?")
+
+    marker not in [nil, false]
   end
 
   @doc """

--- a/lib/req_llm/tool_result.ex
+++ b/lib/req_llm/tool_result.ex
@@ -1,9 +1,32 @@
 defmodule ReqLLM.ToolResult do
   @moduledoc """
-  ToolResult represents structured and multi-part tool outputs.
+  ToolResult represents structured and multi-part tool outputs while keeping
+  application-visible data separate from model-facing content.
 
-  Tool outputs can include structured data via `output` and/or multimodal
-  content parts via `content`.
+  * `output` is the original application value. Maps and lists remain available
+    to local code and provider adapters without a text round trip.
+  * `content` is the content sent back to the model. It may contain text or
+    `ReqLLM.Message.ContentPart` values for images and files. When omitted,
+    `ReqLLM.Context` derives model-facing text from `output`.
+  * `metadata` carries supplementary application or provider-native data. It is
+    not a substitute for model-facing error or result content.
+
+  These fields may intentionally differ. For example, an application can keep a
+  rich JSON result in `output` while returning a concise explanation, an error,
+  or a multimodal file/image payload in `content`:
+
+      %ReqLLM.ToolResult{
+        output: %{document_id: "doc_123", page_count: 4},
+        content: [
+          ReqLLM.Message.ContentPart.text("The requested document is attached."),
+          ReqLLM.Message.ContentPart.file_id("file_123")
+        ],
+        metadata: %{provider_native: %{request_id: "req_123"}}
+      }
+
+  Tool callbacks retain their existing contract: return `{:ok, result}` for a
+  successful result or `{:error, result}` for an error. Either result may be a
+  plain text/JSON value or a `ToolResult`.
   """
 
   @metadata_key :tool_output

--- a/lib/req_llm/tool_result.ex
+++ b/lib/req_llm/tool_result.ex
@@ -30,6 +30,7 @@ defmodule ReqLLM.ToolResult do
   """
 
   @metadata_key :tool_output
+  @content_source_key :req_llm_tool_result_content_source
 
   @schema Zoi.struct(__MODULE__, %{
             content: Zoi.list(Zoi.any()) |> Zoi.optional(),
@@ -63,5 +64,39 @@ defmodule ReqLLM.ToolResult do
 
   def put_output_metadata(metadata, output) when is_map(metadata) do
     Map.put(metadata, @metadata_key, output)
+  end
+
+  @doc "Preserves a tool result's output and explicit-content provenance in message metadata."
+  @spec put_message_metadata(map(), t()) :: map()
+  def put_message_metadata(metadata, %__MODULE__{} = result) when is_map(metadata) do
+    metadata
+    |> Map.delete(@content_source_key)
+    |> Map.delete(to_string(@content_source_key))
+    |> put_output_metadata(result.output)
+    |> maybe_mark_explicit_content(result.content)
+  end
+
+  @doc "Returns whether a normalized tool message contains explicitly supplied result content."
+  @spec explicit_content?(ReqLLM.Message.t() | map()) :: boolean()
+  def explicit_content?(%ReqLLM.Message{metadata: metadata}) when is_map(metadata) do
+    explicit_content_metadata?(metadata)
+  end
+
+  def explicit_content?(%{metadata: metadata}) when is_map(metadata) do
+    explicit_content_metadata?(metadata)
+  end
+
+  def explicit_content?(_), do: false
+
+  defp maybe_mark_explicit_content(metadata, nil), do: metadata
+  defp maybe_mark_explicit_content(metadata, []), do: metadata
+
+  defp maybe_mark_explicit_content(metadata, _content) do
+    Map.put(metadata, @content_source_key, :explicit)
+  end
+
+  defp explicit_content_metadata?(metadata) do
+    Map.get(metadata, @content_source_key) in [:explicit, "explicit"] or
+      Map.get(metadata, to_string(@content_source_key)) in [:explicit, "explicit"]
   end
 end

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -352,6 +352,31 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert Jason.decode!(tool_output["output"]) == %{"temp" => 72}
     end
 
+    test "prefers explicit model-facing content over application output" do
+      tool_result =
+        ReqLLM.Context.tool_result(
+          "call_1",
+          "search_documents",
+          %ReqLLM.ToolResult{
+            output: %{records: [%{id: 1}], internal_cursor: "cursor_123"},
+            content: [ReqLLM.Message.ContentPart.text("One matching document was found.")]
+          }
+        )
+
+      context = %ReqLLM.Context{messages: [tool_result]}
+      request = build_request(context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      tool_output =
+        Enum.find(body["input"], fn item ->
+          item["type"] == "function_call_output"
+        end)
+
+      assert tool_output["output"] == "One matching document was found."
+    end
+
     test "skips builtin tool calls when replaying assistant context" do
       contexts = [
         %ReqLLM.Context{

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -430,6 +430,43 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert function_response["response"]["temperature"] == 72
     end
 
+    test "encode_body prefers explicit model-facing content over application output" do
+      {:ok, model} = ReqLLM.model("google:gemini-1.5-flash")
+
+      tool_result =
+        Context.tool_result(
+          "call_1",
+          "search_documents",
+          %ReqLLM.ToolResult{
+            output: %{records: [%{id: 1}], internal_cursor: "cursor_123"},
+            content: [ReqLLM.Message.ContentPart.text("One matching document was found.")]
+          }
+        )
+
+      context = Context.new([tool_result])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          operation: :chat
+        ]
+      }
+
+      updated_request = Google.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      [tool_part] =
+        decoded["contents"]
+        |> Enum.flat_map(& &1["parts"])
+        |> Enum.filter(&Map.has_key?(&1, "functionResponse"))
+
+      assert tool_part["functionResponse"]["response"] == %{
+               "content" => "One matching document was found."
+             }
+    end
+
     test "encode_body nests file content in functionResponse.parts for Gemini 3+" do
       {:ok, model} = ReqLLM.model("google:gemini-3-pro-preview")
 

--- a/test/req_llm/context_test.exs
+++ b/test/req_llm/context_test.exs
@@ -1099,6 +1099,7 @@ defmodule ReqLLM.ContextTest do
 
       assert msg.metadata[:request_id] == "req_explicit"
       assert msg.metadata[:tool_output] == %{ok: true, result: %{sum: 3}}
+      assert ReqLLM.ToolResult.explicit_content?(msg)
     end
 
     test "normalizes full tool conversation flow" do

--- a/test/req_llm/tool_call_test.exs
+++ b/test/req_llm/tool_call_test.exs
@@ -220,6 +220,19 @@ defmodule ReqLLM.ToolCallTest do
       refute_received {:tool_executed, _args}
     end
 
+    test "preserves callback error values" do
+      tool =
+        Tool.new!(
+          name: "restricted",
+          description: "Restricted tool",
+          callback: fn _args -> {:error, :permission_denied} end
+        )
+
+      call = ToolCall.new("call_error", "restricted", "{}")
+
+      assert {:error, :permission_denied} = ToolCall.execute(call, [tool])
+    end
+
     test "keeps invalid schema input inspectable and does not execute", %{tool: tool} do
       call = ToolCall.new("call_invalid", "search", ~s({"limit":"many"}))
 
@@ -262,6 +275,23 @@ defmodule ReqLLM.ToolCallTest do
       assert {:error, %{state: :invalid}} =
                ToolCall.execute(call, [tool], json_repair: false)
 
+      refute_received {:tool_executed, _args}
+    end
+
+    test "rejects arguments that decode to a non-map", %{tool: tool} do
+      call = ToolCall.new("call_array", "search", ~s(["elixir"]))
+
+      assert %{
+               state: :invalid,
+               call: ^call,
+               raw_arguments: ~s(["elixir"]),
+               arguments: nil,
+               validated_arguments: nil,
+               error: %ReqLLM.Error.Invalid.Parameter{}
+             } = resolution = ToolCall.resolve(call, [tool])
+
+      assert Exception.message(resolution.error) =~ "must decode to a map"
+      assert {:error, %{state: :invalid}} = ToolCall.execute(call, [tool])
       refute_received {:tool_executed, _args}
     end
 

--- a/test/req_llm/tool_call_test.exs
+++ b/test/req_llm/tool_call_test.exs
@@ -3,7 +3,7 @@ defmodule ReqLLM.ToolCallTest do
 
   @moduletag contract: :public_api
 
-  alias ReqLLM.ToolCall
+  alias ReqLLM.{Tool, ToolCall}
 
   describe "new/3" do
     test "creates a ToolCall with provided id" do
@@ -141,6 +141,215 @@ defmodule ReqLLM.ToolCallTest do
                thought_signature: "sig_123",
                raw_arguments: "{}"
              }
+    end
+  end
+
+  describe "provider_native?/1" do
+    test "recognizes provider-native metadata without changing wire encoding" do
+      tool_call =
+        "call_123"
+        |> ToolCall.new("web_search", ~s({"query":"docs"}))
+        |> ToolCall.put_metadata(%{provider_native: :example, request_id: "req_123"})
+
+      assert ToolCall.provider_native?(tool_call)
+      assert ToolCall.metadata(tool_call).request_id == "req_123"
+
+      decoded = tool_call |> Jason.encode!() |> Jason.decode!()
+      refute Map.has_key?(decoded["function"], "metadata")
+      refute Map.has_key?(decoded["function"], "provider_native")
+    end
+
+    test "does not confuse provider-executed builtins with provider-native metadata" do
+      builtin = ToolCall.new_builtin("call_123", "web_search", "{}")
+
+      assert ToolCall.builtin?(builtin)
+      refute ToolCall.provider_native?(builtin)
+    end
+  end
+
+  describe "resolve/3 and execute/3" do
+    setup do
+      parent = self()
+
+      tool =
+        Tool.new!(
+          name: "search",
+          description: "Search documents",
+          parameter_schema: [
+            query: [type: :string, required: true],
+            limit: [type: :integer, default: 5]
+          ],
+          callback: fn args ->
+            send(parent, {:tool_executed, args})
+            {:ok, %{matches: args.limit}}
+          end
+        )
+
+      %{tool: tool}
+    end
+
+    test "resolves raw, decoded, and validated arguments without executing", %{tool: tool} do
+      raw_arguments = ~s({"query":"elixir"})
+
+      call =
+        "call_valid"
+        |> ToolCall.new("search", raw_arguments)
+        |> ToolCall.put_metadata(%{provider_request_id: "req_123"})
+
+      assert %{
+               state: :valid,
+               call: ^call,
+               id: "call_valid",
+               name: "search",
+               tool: ^tool,
+               raw_arguments: ^raw_arguments,
+               arguments: %{"query" => "elixir"},
+               validated_arguments: %{query: "elixir", limit: 5},
+               metadata: %{provider_request_id: "req_123"},
+               error: nil
+             } = ToolCall.resolve(call, [tool])
+
+      refute_received {:tool_executed, _args}
+    end
+
+    test "executes one valid call with the existing callback contract", %{tool: tool} do
+      call = ToolCall.new("call_valid", "search", ~s({"query":"elixir"}))
+
+      assert {:ok, %{matches: 5}} = ToolCall.execute(call, [tool])
+      assert_received {:tool_executed, %{query: "elixir", limit: 5}}
+      refute_received {:tool_executed, _args}
+    end
+
+    test "keeps invalid schema input inspectable and does not execute", %{tool: tool} do
+      call = ToolCall.new("call_invalid", "search", ~s({"limit":"many"}))
+
+      assert %{
+               state: :invalid,
+               call: ^call,
+               raw_arguments: ~s({"limit":"many"}),
+               arguments: %{"limit" => "many"},
+               validated_arguments: nil,
+               error: %ReqLLM.Error.Validation.Error{}
+             } = resolution = ToolCall.resolve(call, [tool])
+
+      assert {:error,
+              %{
+                state: :invalid,
+                call: ^call,
+                arguments: %{"limit" => "many"},
+                error: %ReqLLM.Error.Validation.Error{}
+              }} = ToolCall.execute(call, [tool])
+
+      assert resolution.state == :invalid
+      refute_received {:tool_executed, _args}
+    end
+
+    test "keeps malformed arguments inspectable and honors JSON repair options", %{tool: tool} do
+      call = ToolCall.new("call_invalid_json", "search", ~s({"query":"elixir",}))
+
+      assert %{state: :valid, arguments: %{"query" => "elixir"}} =
+               ToolCall.resolve(call, [tool])
+
+      assert %{
+               state: :invalid,
+               call: ^call,
+               raw_arguments: ~s({"query":"elixir",}),
+               arguments: nil,
+               validated_arguments: nil,
+               error: %Jason.DecodeError{}
+             } = ToolCall.resolve(call, [tool], json_repair: false)
+
+      assert {:error, %{state: :invalid}} =
+               ToolCall.execute(call, [tool], json_repair: false)
+
+      refute_received {:tool_executed, _args}
+    end
+
+    test "keeps unknown calls inspectable and does not execute another tool", %{tool: tool} do
+      call = ToolCall.new("call_unknown", "missing", ~s({"query":"elixir"}))
+
+      assert %{
+               state: :unknown,
+               call: ^call,
+               name: "missing",
+               tool: nil,
+               raw_arguments: ~s({"query":"elixir"}),
+               arguments: %{"query" => "elixir"},
+               validated_arguments: nil,
+               error: %ReqLLM.Error.Invalid.Parameter{}
+             } = resolution = ToolCall.resolve(call, [tool])
+
+      assert Exception.message(resolution.error) =~ ~s(Tool "missing" not found)
+
+      assert {:error,
+              %{
+                state: :unknown,
+                call: ^call,
+                arguments: %{"query" => "elixir"},
+                error: %ReqLLM.Error.Invalid.Parameter{}
+              }} = ToolCall.execute(call, [tool])
+
+      refute_received {:tool_executed, _args}
+    end
+
+    test "classifies provider-executed builtins before application tools", %{tool: tool} do
+      call = ToolCall.new_builtin("call_builtin", "search", ~s({"query":"elixir"}))
+
+      assert %{
+               state: :provider_executed,
+               call: ^call,
+               tool: nil,
+               raw_arguments: ~s({"query":"elixir"}),
+               arguments: %{"query" => "elixir"},
+               validated_arguments: nil,
+               metadata: %{},
+               error: nil
+             } = resolution = ToolCall.resolve(call, [tool])
+
+      assert {:error, ^resolution} = ToolCall.execute(call, [tool])
+      refute_received {:tool_executed, _args}
+    end
+
+    test "classifies provider-native calls and preserves provider metadata", %{tool: tool} do
+      call =
+        "call_native"
+        |> ToolCall.new("search", ~s({"query":"elixir"}))
+        |> ToolCall.put_metadata(%{
+          provider_native: :example,
+          provider_payload: %{request_id: "req_native"}
+        })
+
+      assert %{
+               state: :provider_native,
+               call: ^call,
+               tool: nil,
+               arguments: %{"query" => "elixir"},
+               validated_arguments: nil,
+               metadata: %{
+                 provider_native: :example,
+                 provider_payload: %{request_id: "req_native"}
+               },
+               error: nil
+             } = resolution = ToolCall.resolve(call, [tool])
+
+      assert {:error, ^resolution} = ToolCall.execute(call, [tool])
+      refute_received {:tool_executed, _args}
+    end
+
+    test "keeps multiple calls independent and executes each callback once", %{tool: tool} do
+      calls = [
+        ToolCall.new("call_1", "search", ~s({"query":"one"})),
+        ToolCall.new("call_2", "search", ~s({"query":"two","limit":2}))
+      ]
+
+      assert Enum.map(calls, &ToolCall.execute(&1, [tool])) == [
+               {:ok, %{matches: 5}},
+               {:ok, %{matches: 2}}
+             ]
+
+      assert_received {:tool_executed, %{query: "one", limit: 5}}
+      assert_received {:tool_executed, %{query: "two", limit: 2}}
+      refute_received {:tool_executed, _args}
     end
   end
 

--- a/test/req_llm/tool_result_test.exs
+++ b/test/req_llm/tool_result_test.exs
@@ -12,6 +12,22 @@ defmodule ReqLLM.ToolResultTest do
     end
   end
 
+  describe "application output and model-facing content" do
+    test "remain independently inspectable" do
+      content = [ReqLLM.Message.ContentPart.text("A concise model-facing result")]
+
+      result = %ToolResult{
+        output: %{records: [%{id: 1}], internal_cursor: "cursor_123"},
+        content: content,
+        metadata: %{provider_native: %{request_id: "req_123"}}
+      }
+
+      assert result.output == %{records: [%{id: 1}], internal_cursor: "cursor_123"}
+      assert result.content == content
+      assert result.metadata.provider_native.request_id == "req_123"
+    end
+  end
+
   describe "output_from_message/1" do
     test "reads atom-key metadata from message structs" do
       message = %Message{role: :tool, metadata: %{tool_output: %{ok: true}}}

--- a/test/req_llm/tool_result_test.exs
+++ b/test/req_llm/tool_result_test.exs
@@ -61,4 +61,30 @@ defmodule ReqLLM.ToolResultTest do
              }
     end
   end
+
+  describe "message metadata" do
+    test "marks non-empty explicit content without changing the output value" do
+      result = %ToolResult{
+        output: %{internal_cursor: "cursor_123"},
+        content: [ReqLLM.Message.ContentPart.text("A concise result")]
+      }
+
+      metadata = ToolResult.put_message_metadata(result.metadata, result)
+      message = %Message{role: :tool, metadata: metadata}
+
+      assert ToolResult.output_from_message(message) == %{internal_cursor: "cursor_123"}
+      assert ToolResult.explicit_content?(message)
+    end
+
+    test "does not mark content derived from output" do
+      result = %ToolResult{
+        output: %{ok: true},
+        metadata: %{req_llm_tool_result_content_source: :explicit}
+      }
+
+      metadata = ToolResult.put_message_metadata(result.metadata, result)
+
+      refute ToolResult.explicit_content?(%Message{role: :tool, metadata: metadata})
+    end
+  end
 end

--- a/test/req_llm/tool_test.exs
+++ b/test/req_llm/tool_test.exs
@@ -483,6 +483,52 @@ defmodule ReqLLM.ToolTest do
     end
   end
 
+  describe "validate_input/2" do
+    test "returns normalized input without invoking the callback" do
+      parent = self()
+
+      tool =
+        Tool.new!(
+          name: "inspectable",
+          description: "Inspectable tool",
+          parameter_schema: [
+            query: [type: :string, required: true],
+            limit: [type: :integer, default: 10]
+          ],
+          callback: fn args ->
+            send(parent, {:tool_executed, args})
+            {:ok, args}
+          end
+        )
+
+      assert {:ok, %{query: "docs", limit: 10}} =
+               Tool.validate_input(tool, %{"query" => "docs"})
+
+      refute_received {:tool_executed, _args}
+    end
+
+    test "returns the same validation errors as execute/2" do
+      tool =
+        Tool.new!(
+          name: "validated",
+          description: "Validated tool",
+          parameter_schema: [query: [type: :string, required: true]],
+          callback: fn args -> {:ok, args} end
+        )
+
+      assert {:error, %ReqLLM.Error.Validation.Error{} = validation_error} =
+               Tool.validate_input(tool, %{})
+
+      assert {:error, %ReqLLM.Error.Validation.Error{} = execution_error} =
+               Tool.execute(tool, %{})
+
+      assert Exception.message(validation_error) == Exception.message(execution_error)
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Tool.validate_input(tool, "not a map")
+    end
+  end
+
   describe "to_schema/2" do
     setup do
       {:ok, simple_tool} =


### PR DESCRIPTION
## Summary

- expose `ReqLLM.Tool.validate_input/2` as the callback-free form of the existing validation path
- add pure `ReqLLM.ToolCall.resolve/3` states for valid, invalid, unknown, provider-executed, and provider-native calls
- add explicit single-call `ReqLLM.ToolCall.execute/3` that only invokes valid application callbacks
- clarify the independent application-visible `ToolResult.output` and model-facing `ToolResult.content` contracts
- make OpenAI Responses and Google honor explicitly supplied model-facing content

## Backward compatibility

This is additive for V1. It does not change public struct fields, existing callback return values, `Tool.execute/2` behavior, JSON encoding, provider builders, or context execution. Invalid, unknown, provider-executed, and provider-native calls remain inspectable and cannot execute through the new helper.

Output-only tool results retain their existing structured/provider-native wire encoding. Only `ToolResult` values that explicitly provide non-empty `content` use that content for OpenAI Responses and Google, matching the existing documented model-facing contract and Anthropic/Bedrock behavior.

## Validation

- `mix test` — 3,843 passed, 11 skipped, 145 excluded
- `mix quality` — format, warnings-as-errors, Credo, and Dialyzer passed
- OpenAI and Anthropic `tool_round_trip` fixture replays
- Google `multimodal_tool_result` fixture replay
- OpenAI and Anthropic `web_search_basic` provider-executed fixture replays
- `mix docs` (one unrelated pre-existing hidden-module reference warning)
- `git diff --check`
- exact-head GitHub CI and review green on `694c2d4b`

Closes #853