### PR TITLE
feat: add tool context continuation helpers

### DIFF
--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -201,6 +201,30 @@ Defines callable functions (aka "tools" or "function calling") with validation.
 
 `ReqLLM.ToolCall` represents assistant tool-call requests. Most tool calls are local work your app should execute, but some providers also return server-side builtin calls (for example OpenAI Responses API `web_search_call`). ReqLLM preserves those with `ReqLLM.ToolCall.new_builtin/3`; detect them with `ReqLLM.ToolCall.builtin?/1` and do not replay them as local tools.
 
+### Continuing with matched tool results
+
+`ReqLLM.Context.append_tool_exchange/3` appends a canonical assistant message
+and its tool-result messages without executing tools or making another model
+call. It validates IDs and names atomically, ignores provider-executed calls,
+and orders results to match the assistant calls:
+
+```elixir
+results = [
+  ReqLLM.Context.tool_result("call_2", "get_time", "10:00 CEST"),
+  ReqLLM.Context.tool_result("call_1", "get_weather", "72°F and sunny")
+]
+
+{:ok, continued_context} =
+  ReqLLM.Context.append_tool_exchange(input_context, response, results)
+
+{:ok, next_response} =
+  ReqLLM.generate_text(model, continued_context, tools: tools)
+```
+
+The second model call remains explicit and application-owned. The helper also
+accepts `response.message`; when passed `response.context`, it recognizes the
+assistant message already present and appends only the matched results.
+
 ## 6) ReqLLM.StreamChunk
 
 Unified streaming event payloads emitted during `stream_text`.

--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -205,8 +205,9 @@ Defines callable functions (aka "tools" or "function calling") with validation.
 
 `ReqLLM.Context.append_tool_exchange/3` appends a canonical assistant message
 and its tool-result messages without executing tools or making another model
-call. It validates IDs and names atomically, ignores provider-executed calls,
-and orders results to match the assistant calls:
+call. It validates IDs and names atomically, ignores provider-executed
+builtins, and orders results to match the assistant calls. Provider-native
+calls remain explicit and require matching results:
 
 ```elixir
 results = [

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -218,10 +218,11 @@ defmodule ReqLLM.Context do
   order. A result without a name inherits the matched call name. Explicit
   result names must match.
 
-  Provider-executed builtins and provider-native calls do not require local
-  results. The assistant and result messages otherwise retain their content,
-  reasoning details, and metadata unchanged. This function never executes a
-  tool or starts another model call.
+  Provider-executed builtins do not require local results. Provider-native
+  calls remain explicit and require a matching result before continuation.
+  The assistant and result messages otherwise retain their content, reasoning
+  details, and metadata unchanged. This function never executes a tool or
+  starts another model call.
 
   If the context already ends with the exact assistant message, only the
   results are appended. This supports both the original input context and the

--- a/lib/req_llm/context.ex
+++ b/lib/req_llm/context.ex
@@ -206,6 +206,42 @@ defmodule ReqLLM.Context do
     end
   end
 
+  @doc """
+  Appends one assistant tool-call message and its matched tool results.
+
+  Accepts either the canonical assistant `ReqLLM.Message` or its
+  `ReqLLM.Response`. Tool results must be canonical tool messages built with
+  `tool_result/2`, `tool_result/3`, or `tool_result_message/4`.
+
+  The exchange is validated before the context changes. Results are matched by
+  `tool_call_id` and appended in assistant call order, regardless of input
+  order. A result without a name inherits the matched call name. Explicit
+  result names must match.
+
+  Provider-executed builtins and provider-native calls do not require local
+  results. The assistant and result messages otherwise retain their content,
+  reasoning details, and metadata unchanged. This function never executes a
+  tool or starts another model call.
+
+  If the context already ends with the exact assistant message, only the
+  results are appended. This supports both the original input context and the
+  `response.context` returned by generation functions.
+
+  ## Examples
+
+      results = [
+        ReqLLM.Context.tool_result("call_1", "get_weather", "72°F and sunny")
+      ]
+
+      {:ok, continued_context} =
+        ReqLLM.Context.append_tool_exchange(input_context, response, results)
+  """
+  @spec append_tool_exchange(t(), Message.t() | ReqLLM.Response.t(), [Message.t()]) ::
+          {:ok, t()} | {:error, ReqLLM.Error.Validation.Error.t()}
+  def append_tool_exchange(%__MODULE__{} = context, source, results) do
+    ReqLLM.Context.ToolExchange.append(context, source, results)
+  end
+
   # Role helpers
 
   @doc """

--- a/lib/req_llm/context/tool_exchange.ex
+++ b/lib/req_llm/context/tool_exchange.ex
@@ -122,9 +122,7 @@ defmodule ReqLLM.Context.ToolExchange do
     end
   end
 
-  defp non_application_call?(call) do
-    ToolCall.builtin?(call) or ToolCall.provider_native?(call)
-  end
+  defp provider_executed_call?(call), do: ToolCall.builtin?(call)
 
   defp valid_call?(%ToolCall{
          type: "function",
@@ -147,7 +145,7 @@ defmodule ReqLLM.Context.ToolExchange do
     if duplicate_ids == [] do
       application_calls =
         calls
-        |> Enum.reject(&non_application_call?/1)
+        |> Enum.reject(&provider_executed_call?/1)
         |> Enum.map(&call_identity/1)
 
       {:ok, application_calls}
@@ -230,7 +228,7 @@ defmodule ReqLLM.Context.ToolExchange do
 
   defp pending_calls?(%Message{role: :assistant, tool_calls: tool_calls})
        when is_list(tool_calls) do
-    Enum.any?(tool_calls, &(not non_application_call?(&1)))
+    Enum.any?(tool_calls, &(not provider_executed_call?(&1)))
   end
 
   defp pending_calls?(_message), do: false

--- a/lib/req_llm/context/tool_exchange.ex
+++ b/lib/req_llm/context/tool_exchange.ex
@@ -1,0 +1,246 @@
+defmodule ReqLLM.Context.ToolExchange do
+  @moduledoc false
+
+  alias ReqLLM.Context
+  alias ReqLLM.Error.Validation.Error
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Response
+  alias ReqLLM.ToolCall
+
+  @spec append(Context.t(), Message.t() | Response.t(), [Message.t()]) ::
+          {:ok, Context.t()} | {:error, Error.t()}
+  def append(%Context{} = context, source, results) do
+    with {:ok, assistant} <- assistant(source),
+         {:ok, calls} <- calls(assistant),
+         {:ok, ordered_results} <- results(calls, results),
+         {:ok, context} <- append_assistant(context, source, assistant) do
+      {:ok, Context.append(context, ordered_results)}
+    end
+  end
+
+  defp assistant(%Response{message: %Message{} = message}), do: validate_assistant(message)
+  defp assistant(%Message{} = message), do: validate_assistant(message)
+
+  defp assistant(_source) do
+    error(
+      :invalid_assistant,
+      "Tool exchange requires an assistant message or response with an assistant message"
+    )
+  end
+
+  defp validate_assistant(%Message{role: :assistant} = message) do
+    if Message.valid?(message) do
+      {:ok, message}
+    else
+      error(:invalid_assistant, "Tool exchange assistant message is invalid")
+    end
+  end
+
+  defp validate_assistant(_message) do
+    error(:invalid_assistant, "Tool exchange message must have role :assistant")
+  end
+
+  defp calls(%Message{tool_calls: tool_calls}) when is_list(tool_calls) do
+    invalid_index = Enum.find_index(tool_calls, &(not valid_call?(&1)))
+
+    cond do
+      tool_calls == [] ->
+        error(:missing_tool_calls, "Tool exchange assistant message has no tool calls")
+
+      invalid_index != nil ->
+        error(
+          :invalid_tool_calls,
+          "Tool exchange contains an invalid canonical tool call",
+          index: invalid_index
+        )
+
+      true ->
+        normalize_calls(tool_calls)
+    end
+  end
+
+  defp calls(_assistant) do
+    error(
+      :invalid_tool_calls,
+      "Tool exchange assistant message must contain a list of tool calls"
+    )
+  end
+
+  defp results(_calls, results) when not is_list(results) do
+    error(:invalid_tool_results, "Tool exchange results must be a list")
+  end
+
+  defp results(calls, results) do
+    invalid_index = Enum.find_index(results, &(not valid_result?(&1)))
+
+    if invalid_index == nil do
+      match_results(calls, results)
+    else
+      error(
+        :invalid_tool_results,
+        "Tool exchange contains an invalid canonical tool-result message",
+        index: invalid_index
+      )
+    end
+  end
+
+  defp match_results(calls, results) do
+    call_ids = Enum.map(calls, & &1.id)
+    result_ids = Enum.map(results, & &1.tool_call_id)
+    duplicates = duplicates(result_ids)
+    unknown = result_ids -- call_ids
+    missing = call_ids -- result_ids
+    results_by_id = Map.new(results, &{&1.tool_call_id, &1})
+    mismatches = mismatches(calls, results_by_id)
+
+    cond do
+      duplicates != [] ->
+        error(:duplicate_tool_results, "Tool exchange contains duplicate tool-result IDs",
+          ids: duplicates
+        )
+
+      unknown != [] ->
+        error(:unknown_tool_results, "Tool exchange contains results for unknown tool-call IDs",
+          ids: unknown
+        )
+
+      missing != [] ->
+        error(:missing_tool_results, "Tool exchange is missing results for assistant tool calls",
+          ids: missing
+        )
+
+      mismatches != [] ->
+        error(
+          :mismatched_tool_results,
+          "Tool exchange result names do not match their assistant tool calls",
+          mismatches: mismatches
+        )
+
+      true ->
+        {:ok, ordered_results(calls, results_by_id)}
+    end
+  end
+
+  defp non_application_call?(call) do
+    ToolCall.builtin?(call) or ToolCall.provider_native?(call)
+  end
+
+  defp valid_call?(%ToolCall{
+         type: "function",
+         id: id,
+         function: %{name: name, arguments: arguments}
+       }) do
+    non_empty_string?(id) and non_empty_string?(name) and is_binary(arguments)
+  end
+
+  defp valid_call?(_call), do: false
+
+  defp call_identity(%ToolCall{id: id, function: %{name: name}}) do
+    %{id: id, name: name}
+  end
+
+  defp normalize_calls(calls) do
+    normalized = Enum.map(calls, &call_identity/1)
+    duplicate_ids = normalized |> Enum.map(& &1.id) |> duplicates()
+
+    if duplicate_ids == [] do
+      application_calls =
+        calls
+        |> Enum.reject(&non_application_call?/1)
+        |> Enum.map(&call_identity/1)
+
+      {:ok, application_calls}
+    else
+      error(
+        :duplicate_tool_calls,
+        "Tool exchange contains duplicate assistant tool-call IDs",
+        ids: duplicate_ids
+      )
+    end
+  end
+
+  defp valid_result?(%Message{
+         role: :tool,
+         tool_call_id: id,
+         name: name,
+         content: content,
+         metadata: metadata
+       }) do
+    non_empty_string?(id) and valid_optional_name?(name) and valid_content?(content) and
+      is_map(metadata)
+  end
+
+  defp valid_result?(_result), do: false
+
+  defp valid_optional_name?(nil), do: true
+  defp valid_optional_name?(name), do: non_empty_string?(name)
+
+  defp valid_content?(content) when is_list(content),
+    do: Enum.all?(content, &ContentPart.valid?/1)
+
+  defp valid_content?(_content), do: false
+
+  defp non_empty_string?(value), do: is_binary(value) and value != ""
+
+  defp mismatches(calls, results_by_id) do
+    Enum.flat_map(calls, fn call ->
+      case Map.get(results_by_id, call.id) do
+        %Message{name: nil} -> []
+        %Message{name: name} when name == call.name -> []
+        %Message{name: name} -> [%{id: call.id, expected: call.name, actual: name}]
+        nil -> []
+      end
+    end)
+  end
+
+  defp ordered_results(calls, results_by_id) do
+    Enum.map(calls, fn call ->
+      case Map.fetch!(results_by_id, call.id) do
+        %Message{name: nil} = message -> %{message | name: call.name}
+        %Message{} = message -> message
+      end
+    end)
+  end
+
+  defp duplicates(ids), do: (ids -- Enum.uniq(ids)) |> Enum.uniq()
+
+  defp append_assistant(%Context{messages: messages} = context, source, assistant) do
+    case List.last(messages) do
+      ^assistant ->
+        {:ok, context}
+
+      last_message ->
+        if pending_calls?(last_message) do
+          error(
+            :pending_tool_calls,
+            "Context already ends with a different unresolved assistant tool-call message"
+          )
+        else
+          {:ok, append_source(context, source, assistant)}
+        end
+    end
+  end
+
+  defp append_source(context, %Response{} = response, _assistant) do
+    Context.merge_response(context, response).context
+  end
+
+  defp append_source(context, _source, assistant), do: Context.append(context, assistant)
+
+  defp pending_calls?(%Message{role: :assistant, tool_calls: tool_calls})
+       when is_list(tool_calls) do
+    Enum.any?(tool_calls, &(not non_application_call?(&1)))
+  end
+
+  defp pending_calls?(_message), do: false
+
+  defp error(kind, reason, details \\ []) do
+    {:error,
+     Error.exception(
+       tag: :tool_context_continuation,
+       reason: reason,
+       context: [kind: kind] ++ details
+     )}
+  end
+end

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -419,6 +419,46 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       end
     end
 
+    test "requires and encodes explicit results for provider-native calls" do
+      base_context = ReqLLM.Context.new([ReqLLM.Context.user("Search provider data")])
+
+      provider_native_call =
+        "native_1"
+        |> ReqLLM.ToolCall.new("provider_search", ~s({"query":"elixir"}))
+        |> ReqLLM.ToolCall.put_metadata(%{provider_native: :openai})
+
+      assistant =
+        ReqLLM.Context.assistant("", tool_calls: [provider_native_call])
+
+      assert {:error, %ReqLLM.Error.Validation.Error{context: error_context}} =
+               ReqLLM.Context.append_tool_exchange(base_context, assistant, [])
+
+      assert error_context[:kind] == :missing_tool_results
+
+      result =
+        ReqLLM.Context.tool_result(
+          "native_1",
+          "provider_search",
+          "provider search complete"
+        )
+
+      assert {:ok, context} =
+               ReqLLM.Context.append_tool_exchange(base_context, assistant, [result])
+
+      request = build_request(context: context)
+      body = request |> ResponsesAPI.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      function_items =
+        Enum.filter(body["input"], &(&1["type"] in ["function_call", "function_call_output"]))
+
+      assert Enum.map(function_items, & &1["type"]) == [
+               "function_call",
+               "function_call_output"
+             ]
+
+      assert Enum.map(function_items, & &1["call_id"]) == ["native_1", "native_1"]
+    end
+
     test "encodes multimodal tool results as array function_call_output" do
       tool_call = %ReqLLM.ToolCall{
         id: "call_1",

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -497,6 +497,41 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert result2["tool_use_id"] == "tool_2"
     end
 
+    test "encode_body round trips matched tool exchanges in assistant call order" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+      base_context = ReqLLM.Context.new([ReqLLM.Context.user("Get weather and time")])
+
+      assistant =
+        ReqLLM.Context.assistant("",
+          tool_calls: [
+            {"get_weather", %{city: "Paris"}, id: "tool_1"},
+            {"get_time", %{timezone: "Europe/Paris"}, id: "tool_2"}
+          ],
+          metadata: %{provider_native: %{request_id: "req_123"}}
+        )
+
+      results = [
+        ReqLLM.Context.tool_result("tool_2", "get_time", "10:00 CEST"),
+        ReqLLM.Context.tool_result("tool_1", "72°F and sunny")
+      ]
+
+      assert {:ok, context} =
+               ReqLLM.Context.append_tool_exchange(base_context, assistant, results)
+
+      mock_request = %Req.Request{
+        options: [context: context, model: model.model, stream: false]
+      }
+
+      decoded = mock_request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      tool_result_blocks =
+        decoded["messages"]
+        |> List.last()
+        |> Map.fetch!("content")
+
+      assert Enum.map(tool_result_blocks, & &1["tool_use_id"]) == ["tool_1", "tool_2"]
+    end
+
     test "encode_body preserves multimodal tool_result content blocks" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
 

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -682,6 +682,38 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert tool_message["tool_call_id"] == "functions.add:0"
     end
 
+    test "encode_body round trips matched tool exchanges in assistant call order" do
+      {:ok, model} = ReqLLM.model("openai:gpt-4o")
+      base_context = Context.new([Context.user("Get weather and time")])
+
+      assistant =
+        Context.assistant("",
+          tool_calls: [
+            {"get_weather", %{city: "Paris"}, id: "call_1"},
+            {"get_time", %{timezone: "Europe/Paris"}, id: "call_2"}
+          ],
+          metadata: %{provider_native: %{response_id: "resp_123"}}
+        )
+
+      results = [
+        Context.tool_result("call_2", "get_time", "10:00 CEST"),
+        Context.tool_result("call_1", "72°F and sunny")
+      ]
+
+      assert {:ok, context} = Context.append_tool_exchange(base_context, assistant, results)
+
+      mock_request = %Req.Request{
+        options: [context: context, model: model.model, stream: false]
+      }
+
+      decoded = mock_request |> OpenAI.encode_body() |> ReqLLM.Test.Helpers.json_body()
+      assistant_message = Enum.find(decoded["messages"], &(&1["role"] == "assistant"))
+      tool_messages = Enum.filter(decoded["messages"], &(&1["role"] == "tool"))
+
+      assert Enum.map(assistant_message["tool_calls"], & &1["id"]) == ["call_1", "call_2"]
+      assert Enum.map(tool_messages, & &1["tool_call_id"]) == ["call_1", "call_2"]
+    end
+
     test "encode_body for o1 models uses max_completion_tokens" do
       {:ok, model} = ReqLLM.model("openai:o1-mini")
       context = context_fixture()

--- a/test/req_llm/context_tool_continuation_test.exs
+++ b/test/req_llm/context_tool_continuation_test.exs
@@ -1,0 +1,314 @@
+defmodule ReqLLM.ContextToolContinuationTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Context
+  alias ReqLLM.Error.Validation.Error
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Response
+  alias ReqLLM.ToolCall
+  alias ReqLLM.ToolResult
+
+  setup do
+    first_call =
+      "call_1"
+      |> ToolCall.new("get_weather", ~s({"city":"Paris"}))
+      |> ToolCall.put_metadata(%{thought_signature: "sig_123"})
+
+    builtin_call = ToolCall.new_builtin("builtin_1", "web_search_call", ~s({"query":"weather"}))
+
+    provider_native_call =
+      "native_1"
+      |> ToolCall.new("provider_search", ~s({"query":"weather"}))
+      |> ToolCall.put_metadata(%{provider_native: :example, request_id: "req_native"})
+
+    second_call = ToolCall.new("call_2", "get_time", ~s({"timezone":"Europe/Paris"}))
+
+    assistant = %Message{
+      role: :assistant,
+      content: [ContentPart.text("I will check both.")],
+      tool_calls: [first_call, builtin_call, provider_native_call, second_call],
+      metadata: %{provider_native: %{response_id: "resp_123"}},
+      reasoning_details: [
+        %Message.ReasoningDetails{
+          provider: :anthropic,
+          signature: "reasoning_signature",
+          format: "anthropic-v1"
+        }
+      ]
+    }
+
+    first_result =
+      Context.tool_result(
+        "call_1",
+        %ToolResult{
+          output: %{temperature_f: 72, internal_cursor: "cursor_123"},
+          content: [ContentPart.text("72°F and sunny")],
+          metadata: %{provider_native: %{request_id: "req_result_1"}}
+        }
+      )
+
+    second_result = Context.tool_result("call_2", "get_time", "10:00 CEST")
+    base_context = Context.new([Context.user("Weather and time in Paris?")])
+
+    %{
+      assistant: assistant,
+      base_context: base_context,
+      first_result: first_result,
+      second_result: second_result
+    }
+  end
+
+  describe "append_tool_exchange/3" do
+    test "appends canonical messages in assistant call order", setup do
+      results = [setup.second_result, setup.first_result]
+
+      assert {:ok, context} =
+               Context.append_tool_exchange(setup.base_context, setup.assistant, results)
+
+      assert [user, assistant, first_result, second_result] = context.messages
+      assert user == hd(setup.base_context.messages)
+      assert assistant == setup.assistant
+      assert Enum.map([first_result, second_result], & &1.tool_call_id) == ["call_1", "call_2"]
+      assert first_result.name == "get_weather"
+      assert second_result.name == "get_time"
+      assert first_result.content == setup.first_result.content
+      assert first_result.metadata == setup.first_result.metadata
+      assert assistant.metadata == setup.assistant.metadata
+      assert assistant.reasoning_details == setup.assistant.reasoning_details
+      assert length(assistant.tool_calls) == 4
+    end
+
+    test "produces equal contexts from a message, response, or merged response context", setup do
+      response = %Response{
+        id: "resp_123",
+        model: "test:model",
+        context: setup.base_context,
+        message: setup.assistant
+      }
+
+      results = [setup.second_result, setup.first_result]
+      merged_context = Context.merge_response(setup.base_context, response).context
+
+      assert {:ok, from_message} =
+               Context.append_tool_exchange(setup.base_context, setup.assistant, results)
+
+      assert {:ok, from_response} =
+               Context.append_tool_exchange(setup.base_context, response, results)
+
+      assert {:ok, from_merged_context} =
+               Context.append_tool_exchange(merged_context, response, results)
+
+      assert from_message == from_response
+      assert from_response == from_merged_context
+      assert Enum.count(from_merged_context.messages, &(&1 == setup.assistant)) == 1
+    end
+
+    test "returns a serializable context with no live-process state", setup do
+      assert {:ok, context} =
+               Context.append_tool_exchange(
+                 setup.base_context,
+                 setup.assistant,
+                 [setup.first_result, setup.second_result]
+               )
+
+      assert is_binary(Jason.encode!(context))
+      assert context == context |> :erlang.term_to_binary() |> :erlang.binary_to_term()
+    end
+
+    test "rejects duplicate result IDs", setup do
+      assert_exchange_error(
+        :duplicate_tool_results,
+        Context.append_tool_exchange(
+          setup.base_context,
+          setup.assistant,
+          [setup.first_result, setup.first_result, setup.second_result]
+        )
+      )
+    end
+
+    test "rejects missing results", setup do
+      assert_exchange_error(
+        :missing_tool_results,
+        Context.append_tool_exchange(
+          setup.base_context,
+          setup.assistant,
+          [setup.first_result]
+        )
+      )
+    end
+
+    test "rejects invalid results", setup do
+      assert_exchange_error(
+        :invalid_tool_results,
+        Context.append_tool_exchange(
+          setup.base_context,
+          setup.assistant,
+          [Context.user("not a tool result"), setup.second_result]
+        )
+      )
+
+      assert_exchange_error(
+        :invalid_tool_results,
+        Context.append_tool_exchange(setup.base_context, setup.assistant, :not_a_list)
+      )
+    end
+
+    test "rejects results for unknown calls", setup do
+      unknown_result = Context.tool_result("unknown_call", "unknown_tool", "unknown")
+
+      assert_exchange_error(
+        :unknown_tool_results,
+        Context.append_tool_exchange(
+          setup.base_context,
+          setup.assistant,
+          [setup.first_result, unknown_result]
+        )
+      )
+    end
+
+    test "rejects result names that do not match their calls", setup do
+      mismatched = %{setup.first_result | name: "get_time"}
+
+      assert_exchange_error(
+        :mismatched_tool_results,
+        Context.append_tool_exchange(
+          setup.base_context,
+          setup.assistant,
+          [mismatched, setup.second_result]
+        )
+      )
+    end
+
+    test "rejects duplicate or invalid assistant calls", setup do
+      duplicate_call = ToolCall.new("call_1", "duplicate", ~s({}))
+
+      duplicate_assistant = %{
+        setup.assistant
+        | tool_calls: setup.assistant.tool_calls ++ [duplicate_call]
+      }
+
+      assert_exchange_error(
+        :duplicate_tool_calls,
+        Context.append_tool_exchange(
+          setup.base_context,
+          duplicate_assistant,
+          [setup.first_result, setup.second_result]
+        )
+      )
+
+      invalid_call = %ToolCall{
+        id: "",
+        type: "function",
+        function: %{name: "broken", arguments: "{}"}
+      }
+
+      invalid_assistant = %{setup.assistant | tool_calls: [invalid_call]}
+
+      assert_exchange_error(
+        :invalid_tool_calls,
+        Context.append_tool_exchange(setup.base_context, invalid_assistant, [])
+      )
+
+      raw_builtin = %{
+        id: "raw_builtin",
+        type: "function",
+        function: %{name: "web_search_call", arguments: "{}", builtin?: true}
+      }
+
+      raw_assistant = %{setup.assistant | tool_calls: [raw_builtin]}
+
+      assert_exchange_error(
+        :invalid_tool_calls,
+        Context.append_tool_exchange(setup.base_context, raw_assistant, [])
+      )
+
+      duplicate_builtin = ToolCall.new_builtin("call_1", "web_search_call", ~s({}))
+
+      cross_kind_duplicate = %{
+        setup.assistant
+        | tool_calls: [hd(setup.assistant.tool_calls), duplicate_builtin]
+      }
+
+      assert_exchange_error(
+        :duplicate_tool_calls,
+        Context.append_tool_exchange(setup.base_context, cross_kind_duplicate, [
+          setup.first_result
+        ])
+      )
+    end
+
+    test "rejects noncanonical tool-result content", setup do
+      invalid_result = %{setup.first_result | content: [%{type: :text, text: "raw map"}]}
+
+      assert_exchange_error(
+        :invalid_tool_results,
+        Context.append_tool_exchange(
+          setup.base_context,
+          setup.assistant,
+          [invalid_result, setup.second_result]
+        )
+      )
+    end
+
+    test "rejects a different pending assistant tool turn", setup do
+      pending =
+        Context.append(
+          setup.base_context,
+          Context.assistant("", tool_calls: [{"other_tool", %{}, id: "other_call"}])
+        )
+
+      assert_exchange_error(
+        :pending_tool_calls,
+        Context.append_tool_exchange(
+          pending,
+          setup.assistant,
+          [setup.first_result, setup.second_result]
+        )
+      )
+    end
+
+    test "allows completed provider-executed calls without local results", setup do
+      builtin_assistant = %{
+        setup.assistant
+        | tool_calls: [ToolCall.new_builtin("builtin", "web_search_call", ~s({}))]
+      }
+
+      assert {:ok, context} =
+               Context.append_tool_exchange(setup.base_context, builtin_assistant, [])
+
+      assert List.last(context.messages) == builtin_assistant
+
+      local_result = Context.tool_result("builtin", "web_search_call", "not allowed")
+
+      assert_exchange_error(
+        :unknown_tool_results,
+        Context.append_tool_exchange(setup.base_context, builtin_assistant, [local_result])
+      )
+    end
+
+    test "rejects sources without tool calls or an assistant message", setup do
+      empty_assistant = %{setup.assistant | tool_calls: []}
+
+      assert_exchange_error(
+        :missing_tool_calls,
+        Context.append_tool_exchange(setup.base_context, empty_assistant, [])
+      )
+
+      assert_exchange_error(
+        :invalid_assistant,
+        Context.append_tool_exchange(setup.base_context, Context.user("wrong role"), [])
+      )
+    end
+  end
+
+  defp assert_exchange_error(expected_kind, result) do
+    assert {:error,
+            %Error{
+              tag: :tool_context_continuation,
+              context: error_context
+            }} = result
+
+    assert error_context[:kind] == expected_kind
+  end
+end

--- a/test/req_llm/context_tool_continuation_test.exs
+++ b/test/req_llm/context_tool_continuation_test.exs
@@ -48,6 +48,14 @@ defmodule ReqLLM.ContextToolContinuationTest do
         }
       )
 
+    native_result =
+      Context.tool_result_message(
+        "provider_search",
+        "native_1",
+        "provider search complete",
+        %{provider_native: %{request_id: "req_native_result"}}
+      )
+
     second_result = Context.tool_result("call_2", "get_time", "10:00 CEST")
     base_context = Context.new([Context.user("Weather and time in Paris?")])
 
@@ -55,25 +63,34 @@ defmodule ReqLLM.ContextToolContinuationTest do
       assistant: assistant,
       base_context: base_context,
       first_result: first_result,
+      native_result: native_result,
       second_result: second_result
     }
   end
 
   describe "append_tool_exchange/3" do
     test "appends canonical messages in assistant call order", setup do
-      results = [setup.second_result, setup.first_result]
+      results = [setup.second_result, setup.native_result, setup.first_result]
 
       assert {:ok, context} =
                Context.append_tool_exchange(setup.base_context, setup.assistant, results)
 
-      assert [user, assistant, first_result, second_result] = context.messages
+      assert [user, assistant, first_result, native_result, second_result] = context.messages
       assert user == hd(setup.base_context.messages)
       assert assistant == setup.assistant
-      assert Enum.map([first_result, second_result], & &1.tool_call_id) == ["call_1", "call_2"]
+
+      assert Enum.map([first_result, native_result, second_result], & &1.tool_call_id) == [
+               "call_1",
+               "native_1",
+               "call_2"
+             ]
+
       assert first_result.name == "get_weather"
+      assert native_result.name == "provider_search"
       assert second_result.name == "get_time"
       assert first_result.content == setup.first_result.content
       assert first_result.metadata == setup.first_result.metadata
+      assert native_result.metadata == setup.native_result.metadata
       assert assistant.metadata == setup.assistant.metadata
       assert assistant.reasoning_details == setup.assistant.reasoning_details
       assert length(assistant.tool_calls) == 4
@@ -87,7 +104,7 @@ defmodule ReqLLM.ContextToolContinuationTest do
         message: setup.assistant
       }
 
-      results = [setup.second_result, setup.first_result]
+      results = [setup.second_result, setup.native_result, setup.first_result]
       merged_context = Context.merge_response(setup.base_context, response).context
 
       assert {:ok, from_message} =
@@ -109,7 +126,7 @@ defmodule ReqLLM.ContextToolContinuationTest do
                Context.append_tool_exchange(
                  setup.base_context,
                  setup.assistant,
-                 [setup.first_result, setup.second_result]
+                 [setup.first_result, setup.native_result, setup.second_result]
                )
 
       assert is_binary(Jason.encode!(context))
@@ -122,7 +139,12 @@ defmodule ReqLLM.ContextToolContinuationTest do
         Context.append_tool_exchange(
           setup.base_context,
           setup.assistant,
-          [setup.first_result, setup.first_result, setup.second_result]
+          [
+            setup.first_result,
+            setup.first_result,
+            setup.native_result,
+            setup.second_result
+          ]
         )
       )
     end
@@ -175,7 +197,7 @@ defmodule ReqLLM.ContextToolContinuationTest do
         Context.append_tool_exchange(
           setup.base_context,
           setup.assistant,
-          [mismatched, setup.second_result]
+          [mismatched, setup.native_result, setup.second_result]
         )
       )
     end
@@ -263,9 +285,29 @@ defmodule ReqLLM.ContextToolContinuationTest do
         Context.append_tool_exchange(
           pending,
           setup.assistant,
-          [setup.first_result, setup.second_result]
+          [setup.first_result, setup.native_result, setup.second_result]
         )
       )
+    end
+
+    test "requires explicit results for provider-native calls", setup do
+      provider_native_call = Enum.at(setup.assistant.tool_calls, 2)
+      provider_native_assistant = %{setup.assistant | tool_calls: [provider_native_call]}
+
+      assert_exchange_error(
+        :missing_tool_results,
+        Context.append_tool_exchange(setup.base_context, provider_native_assistant, [])
+      )
+
+      assert {:ok, context} =
+               Context.append_tool_exchange(
+                 setup.base_context,
+                 provider_native_assistant,
+                 [setup.native_result]
+               )
+
+      assert [_, ^provider_native_assistant, native_result] = context.messages
+      assert native_result == setup.native_result
     end
 
     test "allows completed provider-executed calls without local results", setup do


### PR DESCRIPTION
Closes #854

## Summary

- add a pure `ReqLLM.Context.append_tool_exchange/3` helper for canonical assistant tool calls and results
- validate and deterministically order matched local results while preserving message metadata
- ignore provider-executed calls for local matching and reject malformed, duplicate, missing, unknown, or mismatched inputs with typed errors
- document explicit application-owned continuation and cover OpenAI/Anthropic encoding round trips

## Compatibility

This is additive. Existing Context structs, constructors, manual continuation, provider APIs, and explicit follow-up model calls remain unchanged. The helper executes no callbacks and makes no model calls.

## Validation

- `mix quality`
- `mix test` (3,858 passed, 11 skipped, 145 excluded)
- `mix test test/req_llm/context_tool_continuation_test.exs test/providers/openai_test.exs test/providers/anthropic_test.exs` (208 passed)
- `mix test test/coverage/openai/comprehensive_test.exs test/coverage/anthropic/comprehensive_test.exs --only scenario:tool_round_trip` (2 passed)
- `mix docs` (passes with the pre-existing hidden HTTP2DuplexSession reference warning)
- `git diff --check`