### PR TITLE
refactor: separate OpenAI Chat Completions provider seams

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -110,6 +110,26 @@ OpenAI provider automatically routes between two APIs based on model metadata:
 - **Chat Completions API**: Standard GPT models (gpt-4o, gpt-4-turbo, gpt-3.5-turbo)
 - **Responses API**: Reasoning models (o1, o3, o4-mini, gpt-5) with extended thinking
 
+### Chat Completions responsibilities
+
+The V1 provider callbacks and transports remain unchanged. Internally, Chat
+Completions responsibilities are intentionally narrow:
+
+| Responsibility | Before | Current owner |
+| --- | --- | --- |
+| Select Chat Completions or Responses and attach the Req pipeline | `ReqLLM.Providers.OpenAI` | `ReqLLM.Providers.OpenAI` |
+| Implement the Chat Completions driver callbacks and assemble its Finch request | `ReqLLM.Providers.OpenAI.ChatAPI` | `ReqLLM.Providers.OpenAI.ChatAPI` |
+| Build the exact request envelope used by both Req and Finch | private functions mixed into `ChatAPI` | <code>ReqLLM.Providers.OpenAI.ChatAPI.Request</code> |
+| Encode OpenAI-compatible messages and decode buffered/SSE wire data | `ReqLLM.Provider.Defaults` | `ReqLLM.Provider.Defaults` |
+| Accumulate chunks and materialize canonical responses | `ReqLLM.Provider.ChunkAccumulator` and response builders | unchanged shared modules |
+
+The request-envelope seam removes duplicate strict-tool and parallel-tool
+normalization by reusing `ReqLLM.Providers.OpenAI.AdapterHelpers`. SSE decoding,
+transport construction, and response handoff already have single owners, so they
+remain in place. This is an internal refactor: Req remains the buffered
+transport, Finch remains the streaming transport, and the existing
+`ReqLLM.Provider` callbacks and request/response shapes are preserved.
+
 ## Provider Options
 
 Passed via `:provider_options` keyword:

--- a/lib/req_llm/providers/openai/chat_api.ex
+++ b/lib/req_llm/providers/openai/chat_api.ex
@@ -39,9 +39,9 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
   """
   @behaviour ReqLLM.Providers.OpenAI.API
 
-  import ReqLLM.Provider.Utils, only: [maybe_put: 3]
-
   require ReqLLM.Debug, as: Debug
+
+  alias ReqLLM.Providers.OpenAI.ChatAPI.Request
 
   @impl true
   def path, do: "/chat/completions"
@@ -53,7 +53,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
     operation = request.options[:operation] || :chat
     opts = if is_map(request.options), do: Map.to_list(request.options), else: request.options
 
-    enhanced_body = build_request_body(context, model_name, opts, operation)
+    enhanced_body = Request.build_body(context, model_name, opts, operation)
 
     Debug.dbug(
       fn -> "OpenAI ChatAPI request body: #{Jason.encode!(enhanced_body, pretty: true)}" end,
@@ -73,50 +73,11 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
     ReqLLM.Provider.Defaults.default_decode_stream_event(event, model)
   end
 
-  # ========================================================================
-  # Shared Request Building Helpers (used by both Req and Finch paths)
-  # ========================================================================
-
   defp build_request_headers(model, opts) do
     ReqLLM.Providers.OpenAI.auth_header_list(
       ReqLLM.Providers.OpenAI.resolve_request_credential!(model, opts)
     ) ++
       [{"Content-Type", "application/json"}]
-  end
-
-  defp build_request_body(context, model_name, opts, operation \\ :chat) do
-    temp_request =
-      Req.new(method: :post, url: URI.parse("https://example.com/temp"))
-      |> Map.put(:body, {:json, %{}})
-      |> Map.put(
-        :options,
-        Map.new([model: model_name, context: context, operation: operation] ++ opts)
-      )
-
-    body = ReqLLM.Provider.Defaults.default_build_body(temp_request)
-
-    # Convert opts to map for helper functions that expect request.options
-    opts_map = if is_list(opts), do: Map.new(opts), else: opts
-
-    # Apply ChatAPI-specific enhancements
-    case operation do
-      :embedding ->
-        add_embedding_options(body, opts_map)
-
-      _ ->
-        body
-        |> add_token_limits(model_name, opts_map)
-        |> add_stream_options(opts_map)
-        |> add_reasoning_effort(opts_map)
-        |> add_service_tier(opts_map)
-        |> add_verbosity(opts_map)
-        |> add_response_format(opts_map)
-        |> add_parallel_tool_calls(opts_map)
-        |> add_logprobs(opts_map)
-        |> add_audio_output(opts_map)
-        |> ReqLLM.Providers.OpenAI.AdapterHelpers.translate_tool_choice_format()
-        |> add_strict_to_tools()
-    end
   end
 
   defp build_request_url(opts) do
@@ -125,8 +86,6 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
       base_url -> "#{base_url}#{path()}"
     end
   end
-
-  # ========================================================================
 
   @impl true
   def attach_stream(model, context, opts, _finch_name) do
@@ -143,7 +102,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
       |> Keyword.put(:stream, true)
       |> Keyword.put(:base_url, base_url)
 
-    body = build_request_body(context, model.id, cleaned_opts)
+    body = Request.build_body(context, model.id, cleaned_opts, :chat)
     url = build_request_url(cleaned_opts)
 
     encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
@@ -154,171 +113,5 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI do
        ReqLLM.Error.API.Request.exception(
          reason: "Failed to build streaming request: #{Exception.message(error)}"
        )}
-  end
-
-  defp add_embedding_options(body, request_options) do
-    body
-    |> maybe_put(:dimensions, request_options[:dimensions])
-    |> maybe_put(:encoding_format, request_options[:encoding_format])
-  end
-
-  defp add_token_limits(body, model_name, request_options) do
-    body =
-      body
-      |> Map.drop([:max_tokens, :max_completion_tokens, "max_tokens", "max_completion_tokens"])
-
-    if reasoning_model_name?(model_name) do
-      maybe_put(
-        body,
-        :max_completion_tokens,
-        request_options[:max_completion_tokens] || request_options[:max_tokens]
-      )
-    else
-      body
-      |> maybe_put(:max_tokens, request_options[:max_tokens])
-      |> maybe_put(:max_completion_tokens, request_options[:max_completion_tokens])
-    end
-  end
-
-  defp reasoning_model_name?("gpt-5-chat-latest"), do: false
-  defp reasoning_model_name?(<<"gpt-5", _::binary>>), do: true
-  defp reasoning_model_name?(<<"gpt-4.1", _::binary>>), do: true
-  defp reasoning_model_name?(<<"o1", _::binary>>), do: true
-  defp reasoning_model_name?(<<"o3", _::binary>>), do: true
-  defp reasoning_model_name?(<<"o4", _::binary>>), do: true
-  defp reasoning_model_name?(_), do: false
-
-  defp add_stream_options(body, request_options) do
-    if request_options[:stream] do
-      maybe_put(body, :stream_options, %{include_usage: true})
-    else
-      body
-    end
-  end
-
-  defp add_reasoning_effort(body, request_options) do
-    maybe_put(body, :reasoning_effort, request_options[:reasoning_effort])
-  end
-
-  defp add_service_tier(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-    service_tier = request_options[:service_tier] || provider_opts[:service_tier]
-    maybe_put(body, :service_tier, service_tier)
-  end
-
-  defp add_verbosity(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-    verbosity = provider_opts[:verbosity]
-    maybe_put(body, :verbosity, normalize_verbosity(verbosity))
-  end
-
-  defp normalize_verbosity(nil), do: nil
-  defp normalize_verbosity(v) when is_atom(v), do: Atom.to_string(v)
-  defp normalize_verbosity(v) when is_binary(v), do: v
-
-  defp add_response_format(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-    rf = provider_opts[:response_format]
-
-    normalized =
-      case rf do
-        %{type: "json_schema", json_schema: %{schema: schema}} = m when is_list(schema) ->
-          put_in(m, [:json_schema, :schema], ReqLLM.Schema.to_json(schema))
-
-        %{"type" => "json_schema", "json_schema" => %{"schema" => schema}} = m
-        when is_list(schema) ->
-          js = ReqLLM.Schema.to_json(schema)
-          %{m | "json_schema" => Map.put(m["json_schema"], "schema", js)}
-
-        _ ->
-          rf
-      end
-
-    body
-    |> Map.drop(["response_format", :response_format])
-    |> maybe_put(:response_format, normalized)
-  end
-
-  defp add_logprobs(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-
-    body
-    |> maybe_put(:logprobs, provider_opts[:openai_logprobs])
-    |> maybe_put(:top_logprobs, provider_opts[:openai_top_logprobs])
-  end
-
-  defp add_parallel_tool_calls(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-
-    ptc =
-      request_options[:parallel_tool_calls] ||
-        provider_opts[:openai_parallel_tool_calls] ||
-        provider_opts[:parallel_tool_calls]
-
-    maybe_put(body, :parallel_tool_calls, ptc)
-  end
-
-  defp add_audio_output(body, request_options) do
-    provider_opts = request_options[:provider_options] || []
-
-    body
-    |> maybe_put(:modalities, request_options[:modalities] || provider_opts[:modalities])
-    |> maybe_put(:audio, request_options[:audio] || provider_opts[:audio])
-  end
-
-  defp add_strict_to_tools(body) do
-    tools = body[:tools]
-
-    if tools && is_list(tools) do
-      updated_tools =
-        Enum.map(tools, fn tool ->
-          function = tool["function"]
-
-          if function && function["strict"] do
-            function_with_strict =
-              if is_map_key(tool, :function) do
-                function
-                |> Map.put(:strict, true)
-                |> ensure_all_properties_required()
-              else
-                function
-                |> Map.put("strict", true)
-                |> ensure_all_properties_required()
-              end
-
-            if is_map_key(tool, :function) do
-              Map.put(tool, :function, function_with_strict)
-            else
-              Map.put(tool, "function", function_with_strict)
-            end
-          else
-            tool
-          end
-        end)
-
-      if is_map_key(body, :tools) do
-        Map.put(body, :tools, updated_tools)
-      else
-        Map.put(body, "tools", updated_tools)
-      end
-    else
-      body
-    end
-  end
-
-  defp ensure_all_properties_required(function) do
-    params = function["parameters"]
-
-    if params do
-      updated_params = ReqLLM.Providers.OpenAI.AdapterHelpers.enforce_strict_recursive(params)
-
-      if is_map_key(function, :parameters) do
-        Map.put(function, :parameters, updated_params)
-      else
-        Map.put(function, "parameters", updated_params)
-      end
-    else
-      function
-    end
   end
 end

--- a/lib/req_llm/providers/openai/chat_api/request.ex
+++ b/lib/req_llm/providers/openai/chat_api/request.ex
@@ -1,0 +1,156 @@
+defmodule ReqLLM.Providers.OpenAI.ChatAPI.Request do
+  @moduledoc false
+
+  import ReqLLM.Provider.Utils, only: [maybe_put: 3]
+
+  alias ReqLLM.Providers.OpenAI.AdapterHelpers
+
+  @doc false
+  @spec build_body(ReqLLM.Context.t(), String.t(), keyword(), atom()) :: map()
+  def build_body(context, model_name, opts, operation) do
+    request =
+      Req.new(method: :post, url: URI.parse("https://example.com/temp"))
+      |> Map.put(:body, {:json, %{}})
+      |> Map.put(
+        :options,
+        Map.new([model: model_name, context: context, operation: operation] ++ opts)
+      )
+
+    body = %{} = ReqLLM.Provider.Defaults.default_build_body(request)
+    request_options = opts |> Map.new() |> Map.to_list()
+
+    case operation do
+      :embedding ->
+        add_embedding_options(body, request_options)
+
+      _ ->
+        body
+        |> add_token_limits(model_name, request_options)
+        |> add_stream_options(request_options)
+        |> add_reasoning_effort(request_options)
+        |> add_service_tier(request_options)
+        |> add_verbosity(request_options)
+        |> add_response_format(request_options)
+        |> add_parallel_tool_calls(request_options)
+        |> add_logprobs(request_options)
+        |> add_audio_output(request_options)
+        |> AdapterHelpers.translate_tool_choice_format()
+        |> AdapterHelpers.add_strict_to_tools()
+    end
+  end
+
+  defp add_embedding_options(body, request_options) do
+    body
+    |> maybe_put(:dimensions, request_options[:dimensions])
+    |> maybe_put(:encoding_format, request_options[:encoding_format])
+  end
+
+  defp add_token_limits(body, model_name, request_options) do
+    body =
+      Map.drop(body, [
+        :max_tokens,
+        :max_completion_tokens,
+        "max_tokens",
+        "max_completion_tokens"
+      ])
+
+    if completion_token_limit_model?(model_name) do
+      maybe_put(
+        body,
+        :max_completion_tokens,
+        request_options[:max_completion_tokens] || request_options[:max_tokens]
+      )
+    else
+      body
+      |> maybe_put(:max_tokens, request_options[:max_tokens])
+      |> maybe_put(:max_completion_tokens, request_options[:max_completion_tokens])
+    end
+  end
+
+  defp completion_token_limit_model?("gpt-5-chat-latest"), do: false
+  defp completion_token_limit_model?(<<"gpt-5", _::binary>>), do: true
+  defp completion_token_limit_model?(<<"gpt-4.1", _::binary>>), do: true
+  defp completion_token_limit_model?(<<"o1", _::binary>>), do: true
+  defp completion_token_limit_model?(<<"o3", _::binary>>), do: true
+  defp completion_token_limit_model?(<<"o4", _::binary>>), do: true
+  defp completion_token_limit_model?(_model_name), do: false
+
+  defp add_stream_options(body, request_options) do
+    if request_options[:stream] do
+      maybe_put(body, :stream_options, %{include_usage: true})
+    else
+      body
+    end
+  end
+
+  defp add_reasoning_effort(body, request_options) do
+    maybe_put(body, :reasoning_effort, request_options[:reasoning_effort])
+  end
+
+  defp add_service_tier(body, request_options) do
+    provider_options = provider_options(request_options)
+    service_tier = request_options[:service_tier] || provider_options[:service_tier]
+    maybe_put(body, :service_tier, service_tier)
+  end
+
+  defp add_verbosity(body, request_options) do
+    provider_options = provider_options(request_options)
+    maybe_put(body, :verbosity, normalize_verbosity(provider_options[:verbosity]))
+  end
+
+  defp normalize_verbosity(nil), do: nil
+  defp normalize_verbosity(verbosity) when is_atom(verbosity), do: Atom.to_string(verbosity)
+  defp normalize_verbosity(verbosity) when is_binary(verbosity), do: verbosity
+
+  defp add_response_format(body, request_options) do
+    provider_options = provider_options(request_options)
+    response_format = provider_options[:response_format]
+
+    normalized =
+      case response_format do
+        %{type: "json_schema", json_schema: %{schema: schema}} = format when is_list(schema) ->
+          put_in(format, [:json_schema, :schema], ReqLLM.Schema.to_json(schema))
+
+        %{"type" => "json_schema", "json_schema" => %{"schema" => schema}} = format
+        when is_list(schema) ->
+          json_schema = Map.put(format["json_schema"], "schema", ReqLLM.Schema.to_json(schema))
+          %{format | "json_schema" => json_schema}
+
+        _other ->
+          response_format
+      end
+
+    body
+    |> Map.drop(["response_format", :response_format])
+    |> maybe_put(:response_format, normalized)
+  end
+
+  defp add_parallel_tool_calls(body, request_options) do
+    provider_options = provider_options(request_options)
+    AdapterHelpers.add_parallel_tool_calls(body, request_options, provider_options)
+  end
+
+  defp add_logprobs(body, request_options) do
+    provider_options = provider_options(request_options)
+
+    body
+    |> maybe_put(:logprobs, provider_options[:openai_logprobs])
+    |> maybe_put(:top_logprobs, provider_options[:openai_top_logprobs])
+  end
+
+  defp add_audio_output(body, request_options) do
+    provider_options = provider_options(request_options)
+
+    body
+    |> maybe_put(:modalities, request_options[:modalities] || provider_options[:modalities])
+    |> maybe_put(:audio, request_options[:audio] || provider_options[:audio])
+  end
+
+  defp provider_options(request_options) do
+    case request_options[:provider_options] do
+      nil -> []
+      options when is_list(options) -> options
+      options when is_map(options) -> Map.to_list(options)
+    end
+  end
+end

--- a/test/providers/openai_chat_request_test.exs
+++ b/test/providers/openai_chat_request_test.exs
@@ -1,0 +1,92 @@
+defmodule ReqLLM.Providers.OpenAI.ChatRequestTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Context
+  alias ReqLLM.Providers.OpenAI.ChatAPI
+  alias ReqLLM.Providers.OpenAI.ChatAPI.Request
+  alias ReqLLM.Tool
+
+  test "builds the exact Chat Completions envelope for canonical options" do
+    tool =
+      Tool.new!(
+        name: "lookup",
+        description: "Look up a value",
+        parameter_schema: [query: [type: :string, required: true]],
+        callback: fn _arguments -> {:ok, "found"} end,
+        strict: true
+      )
+
+    context = Context.new([Context.user("Find it")])
+
+    body =
+      Request.build_body(
+        context,
+        "gpt-4-turbo",
+        [
+          tools: [tool],
+          tool_choice: %{type: "tool", name: "lookup"},
+          max_tokens: 64,
+          stream: true,
+          reasoning_effort: "low",
+          service_tier: "flex",
+          provider_options: [
+            openai_parallel_tool_calls: true,
+            openai_logprobs: true,
+            openai_top_logprobs: 3,
+            verbosity: :high,
+            modalities: ["text"]
+          ]
+        ],
+        :chat
+      )
+
+    assert body.model == "gpt-4-turbo"
+    assert body.messages == [%{role: "user", content: "Find it"}]
+    assert body.max_tokens == 64
+    assert body.stream == true
+    assert body.stream_options == %{include_usage: true}
+    assert body.reasoning_effort == "low"
+    assert body.service_tier == "flex"
+    assert body.parallel_tool_calls == true
+    assert body.logprobs == true
+    assert body.top_logprobs == 3
+    assert body.verbosity == "high"
+    assert body.modalities == ["text"]
+
+    assert body.tool_choice == %{type: "function", function: %{name: "lookup"}}
+    assert [encoded_tool] = body.tools
+    assert encoded_tool["function"]["strict"] == true
+    assert encoded_tool["function"]["parameters"]["required"] == ["query"]
+    assert encoded_tool["function"]["parameters"]["additionalProperties"] == false
+  end
+
+  test "Req and Finch paths use the same streaming envelope" do
+    model = %LLMDB.Model{
+      provider: :openai,
+      id: "gpt-4-turbo",
+      extra: %{wire: %{protocol: "openai_chat"}}
+    }
+
+    context = Context.new([Context.system("Be concise"), Context.user("Hello")])
+
+    opts = [
+      api_key: "test-key",
+      max_tokens: 32,
+      temperature: 0.2,
+      provider_options: [openai_parallel_tool_calls: false, verbosity: "low"]
+    ]
+
+    req =
+      Req.new(method: :post, url: ChatAPI.path())
+      |> Map.put(
+        :options,
+        Map.new([model: model.id, context: context, operation: :chat, stream: true] ++ opts)
+      )
+
+    req_body = req |> ChatAPI.encode_body() |> ReqLLM.Test.Helpers.json_body()
+    assert {:ok, finch_request} = ChatAPI.attach_stream(model, context, opts, ReqLLM.Finch)
+    finch_body = ReqLLM.Test.Helpers.json_body(finch_request)
+
+    assert req_body == finch_body
+  end
+end


### PR DESCRIPTION
Closes #856

## Summary

- extract the exact OpenAI Chat Completions request envelope into one hidden internal owner shared by Req and Finch
- reuse the existing strict-tool and parallel-tool normalization helpers, deleting private copies
- document before/current responsibility boundaries while leaving routing, callbacks, transport, SSE decoding, and response materialization unchanged
- add direct envelope coverage and Req/Finch request parity coverage

## Backward compatibility

This is an internal V1 refactor. It does not change the public API, `ReqLLM.Provider` callbacks, Req/Finch transport ownership, request option precedence, request/response shapes, or fixture formats. Legacy token-limit and response-format rules are intentionally preserved instead of adopting broader helper behavior.

## Validation

- `mix test test/providers/openai_chat_request_test.exs test/providers/openai_test.exs test/provider/openai_structured_output_test.exs test/providers/openai_chat_streaming_usage_test.exs test/providers/openai_request_plan_test.exs test/req_llm/provider/openai_chat_materialization_test.exs` — 151 passed
- provider-extension and compatibility evidence/drift/scenario suites — 192 passed
- `mix test` — 3,864 passed, 11 skipped, 145 excluded
- `mix quality` — formatter, warnings-as-errors, Credo, and Dialyzer clean
- `mix docs` — succeeds with only the pre-existing hidden `HTTP2DuplexSession` reference warning
- cached OpenAI comprehensive fixtures — 9/10 pass; the stream metadata-handle lifecycle case fails identically on exact base SHA `bce30343`, confirming a pre-existing non-regression
