### PR TITLE
feat: add ReqLLM environment diagnostics

### DIFF
--- a/guides/mix-tasks.md
+++ b/guides/mix-tasks.md
@@ -8,10 +8,56 @@ ReqLLM includes these main Mix tasks:
 
 | Task | Alias | Purpose |
 |------|-------|---------|
+| `mix req_llm.doctor` | — | Diagnose installation and runtime configuration without provider calls |
 | `mix req_llm.gen` | `mix llm` | Generate text/objects from the command line |
 | `mix req_llm.model_compat` | `mix mc` | Validate model coverage with fixtures |
 | `mix req_llm.model_support` | — | Inspect and verify evidence-derived support tiers |
 | `mix req_llm.provider_drift` | — | Run bounded, read-only live anchor verification |
+
+## mix req_llm.doctor
+
+Inspect the local ReqLLM runtime, provider registration, credential presence,
+model resolution, selected request surface, and Finch configuration. The default
+command performs no network probe or paid provider request and never prints
+credential values.
+
+```bash
+mix req_llm.doctor
+mix req_llm.doctor --provider anthropic
+mix req_llm.doctor --model openai:gpt-4o-mini --operation chat
+mix req_llm.doctor --format json
+```
+
+Warnings such as missing optional credentials exit successfully. Invalid required
+configuration, an unknown requested provider or model, an unavailable selected
+surface, or an unhealthy Finch runtime produces a non-zero exit status.
+
+### Machine-readable output
+
+Use `--format json` or `--json` for the stable schema-versioned result. Schema
+version 1 contains only redacted, JSON-safe data:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "checks": [
+    {
+      "id": "runtime.application",
+      "layer": "runtime",
+      "status": "ok",
+      "message": "ReqLLM and its supervision tree are running.",
+      "remediation": null,
+      "details": {}
+    }
+  ]
+}
+```
+
+Top-level status is `ok`, `warning`, or `error`. Each check always includes
+`id`, `layer`, `status`, `message`, `remediation`, and `details`. New check IDs or
+detail fields may be added without changing schema version; existing common fields
+retain their meaning for schema version 1.
 
 ## mix req_llm.gen
 

--- a/lib/mix/tasks/req_llm.doctor.ex
+++ b/lib/mix/tasks/req_llm.doctor.ex
@@ -62,6 +62,7 @@ defmodule Mix.Tasks.ReqLlm.Doctor do
     |> put_if_present(:model, opts[:model])
     |> put_if_present(:provider, opts[:provider])
     |> put_if_present(:operation, operation)
+    |> Keyword.put(:start_application?, true)
   end
 
   defp operation!(nil), do: nil

--- a/lib/mix/tasks/req_llm.doctor.ex
+++ b/lib/mix/tasks/req_llm.doctor.ex
@@ -1,0 +1,77 @@
+defmodule Mix.Tasks.ReqLlm.Doctor do
+  @shortdoc "Diagnose ReqLLM installation and runtime configuration"
+  @moduledoc """
+  Runs read-only ReqLLM installation and runtime diagnostics.
+
+      mix req_llm.doctor
+      mix req_llm.doctor --model openai:gpt-4o-mini
+      mix req_llm.doctor --provider anthropic
+      mix req_llm.doctor --format json
+
+  The default command performs no provider requests or network probes. Warning-only
+  results exit successfully; diagnostic errors produce a non-zero exit status.
+  """
+
+  use Mix.Task
+
+  @switches [
+    model: :string,
+    provider: :string,
+    operation: :string,
+    format: :string,
+    json: :boolean
+  ]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, positional, invalid} = OptionParser.parse(args, strict: @switches)
+
+    validate_arguments!(positional, invalid)
+
+    format = output_format!(opts)
+    doctor_opts = doctor_options!(opts)
+    result = ReqLLM.Doctor.run(doctor_opts)
+
+    Mix.shell().info(render(result, format))
+
+    if ReqLLM.Doctor.exit_status(result) != 0 do
+      Mix.raise("ReqLLM diagnostics failed")
+    end
+  end
+
+  defp validate_arguments!([], []), do: :ok
+
+  defp validate_arguments!(positional, invalid) do
+    Mix.raise("Invalid arguments: #{inspect(positional ++ invalid)}")
+  end
+
+  defp output_format!(opts) do
+    format = if opts[:json], do: "json", else: Keyword.get(opts, :format, "human")
+
+    case format do
+      "human" -> :human
+      "json" -> :json
+      _other -> Mix.raise("--format must be human or json")
+    end
+  end
+
+  defp doctor_options!(opts) do
+    operation = operation!(opts[:operation])
+
+    []
+    |> put_if_present(:model, opts[:model])
+    |> put_if_present(:provider, opts[:provider])
+    |> put_if_present(:operation, operation)
+  end
+
+  defp operation!(nil), do: nil
+  defp operation!("chat"), do: :chat
+  defp operation!("object"), do: :object
+  defp operation!(_operation), do: Mix.raise("--operation must be chat or object")
+
+  defp put_if_present(opts, _key, nil), do: opts
+  defp put_if_present(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp render(result, :human), do: ReqLLM.Doctor.format_human(result)
+  defp render(result, :json), do: Jason.encode!(result, pretty: true)
+end

--- a/lib/req_llm/doctor.ex
+++ b/lib/req_llm/doctor.ex
@@ -2,7 +2,9 @@ defmodule ReqLLM.Doctor do
   @moduledoc """
   Read-only installation and runtime diagnostics for ReqLLM.
 
-  `run/1` never performs provider requests or changes application configuration. Its
+  `run/1` never performs provider requests. By default it also never starts applications
+  or changes runtime configuration. Callers may explicitly opt into normal ReqLLM startup
+  with `start_application?: true`, which is useful for short-lived command processes. Its
   result is JSON-serializable and contains no credential values, request payloads, or
   provider response data.
 
@@ -52,6 +54,10 @@ defmodule ReqLLM.Doctor do
     * `:model` - optional model input to resolve and inspect
     * `:provider` - optional provider atom or provider-name string to require
     * `:operation` - `:chat` or `:object`; defaults to `:chat` when a model is supplied
+    * `:start_application?` - explicitly allow ReqLLM startup; defaults to `false`
+
+  When ReqLLM is not already running, the default returns warnings for runtime-only
+  checks instead of starting applications or changing runtime configuration.
   """
   @spec run(keyword()) :: result()
   def run(opts \\ [])
@@ -108,23 +114,23 @@ defmodule ReqLLM.Doctor do
   end
 
   defp run_checks(opts) do
-    {application_check, application_ready?} = application_check()
-    {model_check, model} = model_check(opts)
-    {provider_check, provider} = provider_check(opts, model, application_ready?)
+    {application_check, application_state} = application_check(opts)
+    {model_check, model} = model_check(opts, application_state)
+    {provider_check, provider} = provider_check(opts, model, application_state)
 
     checks =
       [versions_check(), application_check] ++
         optional_check(model_check) ++
         [provider_check] ++
-        credential_checks(provider, application_ready?) ++
-        surface_checks(model, opts, application_ready?) ++
-        [finch_configuration_check(), finch_runtime_check(application_ready?)]
+        credential_checks(provider, application_state) ++
+        surface_checks(model, opts, application_state) ++
+        [finch_configuration_check(), finch_runtime_check(application_state)]
 
     result(checks)
   end
 
   defp validate_options(opts) do
-    allowed = [:model, :provider, :operation]
+    allowed = [:model, :provider, :operation, :start_application?]
 
     if Keyword.keyword?(opts) do
       unknown = Keyword.keys(opts) -- allowed
@@ -136,6 +142,9 @@ defmodule ReqLLM.Doctor do
 
         operation not in @operations ->
           {:error, "Operation must be :chat or :object."}
+
+        not is_boolean(Keyword.get(opts, :start_application?, false)) ->
+          {:error, ":start_application? must be a boolean."}
 
         Keyword.has_key?(opts, :operation) and not Keyword.has_key?(opts, :model) ->
           {:error, "Operation inspection requires a model."}
@@ -168,15 +177,29 @@ defmodule ReqLLM.Doctor do
     )
   end
 
-  defp application_check do
-    case safe_start_application() do
-      {:ok, _applications} ->
+  defp application_check(opts) do
+    cond do
+      application_running?() ->
+        {application_running_check(), :running}
+
+      Keyword.get(opts, :start_application?, false) ->
+        start_application_check()
+
+      true ->
         {check(
            "runtime.application",
            "runtime",
-           "ok",
-           "ReqLLM and its supervision tree are running."
-         ), true}
+           "warning",
+           "ReqLLM is not running; runtime-only checks were not performed.",
+           "Start :req_llm or pass start_application?: true to explicitly allow startup."
+         ), :not_running}
+    end
+  end
+
+  defp start_application_check do
+    case safe_start_application() do
+      {:ok, _applications} ->
+        {application_running_check(), :running}
 
       {:error, _reason} ->
         {check(
@@ -185,8 +208,23 @@ defmodule ReqLLM.Doctor do
            "error",
            "ReqLLM could not start.",
            "Review application configuration and startup logs, then rerun mix req_llm.doctor."
-         ), false}
+         ), :startup_error}
     end
+  end
+
+  defp application_running_check do
+    check(
+      "runtime.application",
+      "runtime",
+      "ok",
+      "ReqLLM and its supervision tree are running."
+    )
+  end
+
+  defp application_running? do
+    Enum.any?(Application.started_applications(), fn {app, _description, _version} ->
+      app == :req_llm
+    end)
   end
 
   defp safe_start_application do
@@ -197,7 +235,7 @@ defmodule ReqLLM.Doctor do
     _kind, _reason -> {:error, :startup_failure}
   end
 
-  defp model_check(opts) do
+  defp model_check(opts, :running) do
     case Keyword.fetch(opts, :model) do
       :error ->
         {nil, nil}
@@ -226,20 +264,45 @@ defmodule ReqLLM.Doctor do
     end
   end
 
-  defp provider_check(opts, model, application_ready?) do
-    providers = if application_ready?, do: ReqLLM.Providers.list(), else: []
+  defp model_check(opts, _application_state) do
+    if Keyword.has_key?(opts, :model) do
+      {check(
+         "model.resolution",
+         "model",
+         "warning",
+         "Model resolution was not inspected because ReqLLM is not running.",
+         "Start :req_llm or explicitly allow diagnostic startup."
+       ), nil}
+    else
+      {nil, nil}
+    end
+  end
+
+  defp provider_check(_opts, _model, :not_running) do
+    {check(
+       "providers.registry",
+       "provider",
+       "warning",
+       "Provider registration was not inspected because ReqLLM is not running.",
+       "Start :req_llm or explicitly allow diagnostic startup."
+     ), nil}
+  end
+
+  defp provider_check(_opts, _model, :startup_error) do
+    {check(
+       "providers.registry",
+       "provider",
+       "error",
+       "Provider registration could not be inspected because ReqLLM failed to start.",
+       "Resolve the application startup error first."
+     ), nil}
+  end
+
+  defp provider_check(opts, model, :running) do
+    providers = ReqLLM.Providers.list()
     requested = requested_provider(opts, model, providers)
 
     cond do
-      not application_ready? ->
-        {check(
-           "providers.registry",
-           "provider",
-           "error",
-           "Provider registration could not be inspected because ReqLLM is not running.",
-           "Resolve the application startup error first."
-         ), nil}
-
       match?({:error, _name}, requested) ->
         {check(
            "providers.registry",
@@ -322,9 +385,9 @@ defmodule ReqLLM.Doctor do
   defp requested_provider_value({:ok, provider}), do: provider
   defp requested_provider_value(_requested), do: nil
 
-  defp credential_checks(_provider, false), do: []
+  defp credential_checks(_provider, application_state) when application_state != :running, do: []
 
-  defp credential_checks(nil, true) do
+  defp credential_checks(nil, :running) do
     configured = configured_credential_providers()
 
     if configured == [] do
@@ -352,7 +415,7 @@ defmodule ReqLLM.Doctor do
     end
   end
 
-  defp credential_checks(provider, true) do
+  defp credential_checks(provider, :running) do
     case credential_requirement(provider) do
       :none ->
         [
@@ -460,7 +523,8 @@ defmodule ReqLLM.Doctor do
   defp configured_provider?(:openai_codex), do: oauth_credential_present?(:openai_codex)
 
   defp configured_provider?(provider) do
-    api_key_present?(provider) or oauth_credential_present?(provider)
+    api_key_present?(provider) or
+      (default_oauth_mode?(provider) and oauth_credential_present?(provider))
   rescue
     _error -> false
   end
@@ -500,6 +564,19 @@ defmodule ReqLLM.Doctor do
   defp auth_mode_declared?(module) do
     function_exported?(module, :provider_schema, 0) and
       Keyword.has_key?(module.provider_schema().schema, :auth_mode)
+  rescue
+    _error -> false
+  end
+
+  defp default_oauth_mode?(provider) do
+    with {:ok, module} <- ReqLLM.provider(provider),
+         true <- function_exported?(module, :provider_schema, 0),
+         schema when is_list(schema) <- module.provider_schema().schema,
+         auth_mode when is_list(auth_mode) <- Keyword.get(schema, :auth_mode) do
+      Keyword.get(auth_mode, :default) == :oauth
+    else
+      _not_default_oauth -> false
+    end
   rescue
     _error -> false
   end
@@ -582,10 +659,10 @@ defmodule ReqLLM.Doctor do
   defp present?(value) when is_map(value), do: map_size(value) > 0
   defp present?(_value), do: false
 
-  defp surface_checks(nil, _opts, _application_ready?), do: []
-  defp surface_checks(_model, _opts, false), do: []
+  defp surface_checks(nil, _opts, _application_state), do: []
+  defp surface_checks(_model, _opts, application_state) when application_state != :running, do: []
 
-  defp surface_checks(%LLMDB.Model{provider: provider} = model, opts, true)
+  defp surface_checks(%LLMDB.Model{provider: provider} = model, opts, :running)
        when provider in [:openai, :anthropic] do
     operation = Keyword.get(opts, :operation, :chat)
 
@@ -619,7 +696,7 @@ defmodule ReqLLM.Doctor do
     end
   end
 
-  defp surface_checks(%LLMDB.Model{provider: provider}, opts, true) do
+  defp surface_checks(%LLMDB.Model{provider: provider}, opts, :running) do
     operation = Keyword.get(opts, :operation, :chat)
 
     case ReqLLM.provider(provider) do
@@ -736,17 +813,27 @@ defmodule ReqLLM.Doctor do
   defp safe_pool_name(name) when is_atom(name), do: Atom.to_string(name)
   defp safe_pool_name(_name), do: "configured_origin"
 
-  defp finch_runtime_check(false) do
+  defp finch_runtime_check(:not_running) do
+    check(
+      "finch.runtime",
+      "finch",
+      "warning",
+      "Finch runtime availability was not inspected because ReqLLM is not running.",
+      "Start :req_llm or explicitly allow diagnostic startup."
+    )
+  end
+
+  defp finch_runtime_check(:startup_error) do
     check(
       "finch.runtime",
       "finch",
       "error",
-      "Finch runtime availability could not be inspected because ReqLLM is not running.",
+      "Finch runtime availability could not be inspected because ReqLLM failed to start.",
       "Resolve the application startup error first."
     )
   end
 
-  defp finch_runtime_check(true) do
+  defp finch_runtime_check(:running) do
     name = ReqLLM.Application.finch_name()
 
     case GenServer.whereis(name) do
@@ -822,6 +909,6 @@ defmodule ReqLLM.Doctor do
   defp status_icon("error"), do: "ERROR"
 
   defp input_remediation do
-    "Use :model, :provider, and :operation options supported by ReqLLM.Doctor.run/1."
+    "Use :model, :provider, :operation, and :start_application? options supported by ReqLLM.Doctor.run/1."
   end
 end

--- a/lib/req_llm/doctor.ex
+++ b/lib/req_llm/doctor.ex
@@ -1,0 +1,827 @@
+defmodule ReqLLM.Doctor do
+  @moduledoc """
+  Read-only installation and runtime diagnostics for ReqLLM.
+
+  `run/1` never performs provider requests or changes application configuration. Its
+  result is JSON-serializable and contains no credential values, request payloads, or
+  provider response data.
+
+  The result uses schema version `1` and has three top-level fields:
+
+    * `"schema_version"` - the integer result schema version
+    * `"status"` - `"ok"`, `"warning"`, or `"error"`
+    * `"checks"` - ordered diagnostic checks with stable common fields
+
+  Warning-only results are successful. An error result should produce a non-zero exit
+  status when used from a command-line tool.
+  """
+
+  @schema_version 1
+  @status_order %{"ok" => 0, "warning" => 1, "error" => 2}
+  @operations [:chat, :object]
+  @version_apps [:req_llm, :llm_db, :req, :finch]
+  @azure_api_key_env_vars [
+    "AZURE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_ANTHROPIC_API_KEY",
+    "AZURE_DEEPSEEK_API_KEY",
+    "AZURE_MAI_API_KEY"
+  ]
+  @azure_base_url_env_vars [
+    "AZURE_BASE_URL",
+    "AZURE_OPENAI_BASE_URL",
+    "AZURE_ANTHROPIC_BASE_URL",
+    "AZURE_DEEPSEEK_BASE_URL",
+    "AZURE_MAI_BASE_URL"
+  ]
+  @oauth_default_files ["oauth.json", "auth.json"]
+
+  @type status :: String.t()
+  @type check :: %{
+          required(String.t()) => String.t() | map() | nil
+        }
+  @type result :: %{
+          required(String.t()) => pos_integer() | status() | [check()]
+        }
+
+  @doc """
+  Runs safe ReqLLM diagnostics.
+
+  ## Options
+
+    * `:model` - optional model input to resolve and inspect
+    * `:provider` - optional provider atom or provider-name string to require
+    * `:operation` - `:chat` or `:object`; defaults to `:chat` when a model is supplied
+  """
+  @spec run(keyword()) :: result()
+  def run(opts \\ [])
+
+  def run(opts) when is_list(opts) do
+    case validate_options(opts) do
+      :ok ->
+        run_checks(opts)
+
+      {:error, message} ->
+        result([check("input", "configuration", "error", message, input_remediation())])
+    end
+  end
+
+  def run(_opts) do
+    result([
+      check(
+        "input",
+        "configuration",
+        "error",
+        "Doctor options must be a keyword list.",
+        input_remediation()
+      )
+    ])
+  end
+
+  @doc """
+  Returns `0` for ok and warning results and `1` for error results.
+  """
+  @spec exit_status(result()) :: 0 | 1
+  def exit_status(%{"status" => "error"}), do: 1
+  def exit_status(_result), do: 0
+
+  @doc false
+  @spec format_human(result()) :: String.t()
+  def format_human(%{"status" => status, "checks" => checks}) do
+    lines =
+      Enum.map(checks, fn check ->
+        line =
+          "#{status_icon(check["status"])} #{check["id"]}: #{check["message"]}"
+
+        case check["remediation"] do
+          nil -> line
+          remediation -> line <> "\n  Remedy: " <> remediation
+        end
+      end)
+
+    counts = Enum.frequencies_by(checks, & &1["status"])
+
+    summary =
+      "#{Map.get(counts, "error", 0)} errors, #{Map.get(counts, "warning", 0)} warnings"
+
+    Enum.join(["ReqLLM doctor: #{String.upcase(status)}" | lines] ++ [summary], "\n")
+  end
+
+  defp run_checks(opts) do
+    {application_check, application_ready?} = application_check()
+    {model_check, model} = model_check(opts)
+    {provider_check, provider} = provider_check(opts, model, application_ready?)
+
+    checks =
+      [versions_check(), application_check] ++
+        optional_check(model_check) ++
+        [provider_check] ++
+        credential_checks(provider, application_ready?) ++
+        surface_checks(model, opts, application_ready?) ++
+        [finch_configuration_check(), finch_runtime_check(application_ready?)]
+
+    result(checks)
+  end
+
+  defp validate_options(opts) do
+    allowed = [:model, :provider, :operation]
+
+    if Keyword.keyword?(opts) do
+      unknown = Keyword.keys(opts) -- allowed
+      operation = Keyword.get(opts, :operation, :chat)
+
+      cond do
+        unknown != [] ->
+          {:error, "Unknown doctor options were provided."}
+
+        operation not in @operations ->
+          {:error, "Operation must be :chat or :object."}
+
+        Keyword.has_key?(opts, :operation) and not Keyword.has_key?(opts, :model) ->
+          {:error, "Operation inspection requires a model."}
+
+        true ->
+          :ok
+      end
+    else
+      {:error, "Doctor options must be a keyword list."}
+    end
+  end
+
+  defp versions_check do
+    versions =
+      Map.new(@version_apps, fn app ->
+        {Atom.to_string(app), application_version(app)}
+      end)
+      |> Map.merge(%{
+        "elixir" => System.version(),
+        "otp" => System.otp_release()
+      })
+
+    check(
+      "runtime.versions",
+      "runtime",
+      "ok",
+      "Runtime and dependency versions are available.",
+      nil,
+      versions
+    )
+  end
+
+  defp application_check do
+    case safe_start_application() do
+      {:ok, _applications} ->
+        {check(
+           "runtime.application",
+           "runtime",
+           "ok",
+           "ReqLLM and its supervision tree are running."
+         ), true}
+
+      {:error, _reason} ->
+        {check(
+           "runtime.application",
+           "runtime",
+           "error",
+           "ReqLLM could not start.",
+           "Review application configuration and startup logs, then rerun mix req_llm.doctor."
+         ), false}
+    end
+  end
+
+  defp safe_start_application do
+    Application.ensure_all_started(:req_llm)
+  rescue
+    _error -> {:error, :startup_exception}
+  catch
+    _kind, _reason -> {:error, :startup_failure}
+  end
+
+  defp model_check(opts) do
+    case Keyword.fetch(opts, :model) do
+      :error ->
+        {nil, nil}
+
+      {:ok, model_input} ->
+        case ReqLLM.model(model_input) do
+          {:ok, %LLMDB.Model{} = model} ->
+            {check(
+               "model.resolution",
+               "model",
+               "ok",
+               "Model resolved to #{model.provider}:#{model.id}.",
+               nil,
+               %{"id" => model.id, "provider" => Atom.to_string(model.provider)}
+             ), model}
+
+          {:error, _reason} ->
+            {check(
+               "model.resolution",
+               "model",
+               "error",
+               "The requested model could not be resolved.",
+               "Use a catalog provider:model value or a complete inline model specification."
+             ), nil}
+        end
+    end
+  end
+
+  defp provider_check(opts, model, application_ready?) do
+    providers = if application_ready?, do: ReqLLM.Providers.list(), else: []
+    requested = requested_provider(opts, model, providers)
+
+    cond do
+      not application_ready? ->
+        {check(
+           "providers.registry",
+           "provider",
+           "error",
+           "Provider registration could not be inspected because ReqLLM is not running.",
+           "Resolve the application startup error first."
+         ), nil}
+
+      match?({:error, _name}, requested) ->
+        {check(
+           "providers.registry",
+           "provider",
+           "error",
+           "The requested provider is not registered.",
+           "Choose one of the registered providers reported by mix req_llm.doctor."
+         ), nil}
+
+      match?({:mismatch, _, _}, requested) ->
+        {check(
+           "providers.registry",
+           "provider",
+           "error",
+           "The requested provider does not match the resolved model provider.",
+           "Remove --provider or select the provider named by the model specification."
+         ), nil}
+
+      providers == [] ->
+        {check(
+           "providers.registry",
+           "provider",
+           "error",
+           "No provider implementations are registered.",
+           "Restart ReqLLM and verify custom provider registration configuration."
+         ), nil}
+
+      true ->
+        provider = requested_provider_value(requested)
+
+        details = %{
+          "count" => length(providers),
+          "providers" => Enum.map(providers, &Atom.to_string/1),
+          "selected" => optional_atom_string(provider)
+        }
+
+        message =
+          if provider do
+            "Provider #{provider} is registered."
+          else
+            "#{length(providers)} provider implementations are registered."
+          end
+
+        {check("providers.registry", "provider", "ok", message, nil, details), provider}
+    end
+  end
+
+  defp requested_provider(opts, model, providers) do
+    option_provider = provider_option(Keyword.get(opts, :provider), providers)
+    model_provider = if model, do: model.provider
+
+    case {option_provider, model_provider} do
+      {{:error, name}, _model_provider} -> {:error, name}
+      {{:ok, provider}, nil} -> {:ok, provider}
+      {{:ok, provider}, provider} -> {:ok, provider}
+      {{:ok, provider}, model_provider} -> {:mismatch, provider, model_provider}
+      {nil, nil} -> nil
+      {nil, model_provider} -> {:ok, model_provider}
+    end
+  end
+
+  defp provider_option(nil, _providers), do: nil
+
+  defp provider_option(provider, providers) when is_atom(provider),
+    do: provider_match(provider, providers)
+
+  defp provider_option(provider, providers) when is_binary(provider) do
+    case Enum.find(providers, &(Atom.to_string(&1) == provider)) do
+      nil -> {:error, provider}
+      matched -> {:ok, matched}
+    end
+  end
+
+  defp provider_option(_provider, _providers), do: {:error, :invalid}
+
+  defp provider_match(provider, providers) do
+    if provider in providers, do: {:ok, provider}, else: {:error, provider}
+  end
+
+  defp requested_provider_value({:ok, provider}), do: provider
+  defp requested_provider_value(_requested), do: nil
+
+  defp credential_checks(_provider, false), do: []
+
+  defp credential_checks(nil, true) do
+    configured = configured_credential_providers()
+
+    if configured == [] do
+      [
+        check(
+          "credentials.configuration",
+          "credentials",
+          "warning",
+          "No optional provider credentials were detected; credential-free providers may still be usable.",
+          "Configure a provider credential when you are ready to make provider requests.",
+          %{"configured_providers" => [], "credential_free_providers" => ["ollama"]}
+        )
+      ]
+    else
+      [
+        check(
+          "credentials.configuration",
+          "credentials",
+          "ok",
+          "Configuration is present for #{length(configured)} providers.",
+          nil,
+          %{"configured_providers" => Enum.map(configured, &Atom.to_string/1)}
+        )
+      ]
+    end
+  end
+
+  defp credential_checks(provider, true) do
+    case credential_requirement(provider) do
+      :none ->
+        [
+          check(
+            "credentials.selected_provider",
+            "credentials",
+            "ok",
+            "Provider #{provider} does not require credentials.",
+            nil,
+            %{"provider" => Atom.to_string(provider), "required" => false}
+          )
+        ]
+
+      :unknown ->
+        [
+          check(
+            "credentials.selected_provider",
+            "credentials",
+            "warning",
+            "Provider #{provider} does not declare a credential source ReqLLM can inspect.",
+            "Verify the custom provider's credential configuration before making a request.",
+            %{"provider" => Atom.to_string(provider), "required" => nil}
+          )
+        ]
+
+      :required ->
+        required_credential_check(provider)
+    end
+  end
+
+  defp required_credential_check(provider) do
+    if configured_provider?(provider) do
+      [
+        check(
+          "credentials.selected_provider",
+          "credentials",
+          "ok",
+          "Credential configuration for provider #{provider} is present.",
+          nil,
+          %{"provider" => Atom.to_string(provider), "required" => true}
+        )
+      ]
+    else
+      [
+        check(
+          "credentials.selected_provider",
+          "credentials",
+          "error",
+          "Required configuration for provider #{provider} was not detected.",
+          credential_remediation(provider),
+          %{"provider" => Atom.to_string(provider), "required" => true}
+        )
+      ]
+    end
+  end
+
+  defp configured_credential_providers do
+    ReqLLM.Providers.list()
+    |> Enum.reject(&(&1 == :ollama))
+    |> Enum.filter(&configured_provider?/1)
+  end
+
+  defp configured_provider?(:amazon_bedrock) do
+    present?(System.get_env("AWS_BEARER_TOKEN_BEDROCK")) or
+      (present?(System.get_env("AWS_ACCESS_KEY_ID")) and
+         present?(System.get_env("AWS_SECRET_ACCESS_KEY")))
+  end
+
+  defp configured_provider?(:azure) do
+    azure_config = Application.get_env(:req_llm, :azure, [])
+
+    key_present? =
+      present?(Application.get_env(:req_llm, :azure_api_key)) or
+        any_env_present?(@azure_api_key_env_vars)
+
+    base_url_present? =
+      present?(config_value(azure_config, :base_url)) or
+        any_env_present?(@azure_base_url_env_vars)
+
+    key_present? and base_url_present?
+  end
+
+  defp configured_provider?(:github_copilot) do
+    present?(Application.get_env(:req_llm, :github_copilot_api_key)) or
+      any_env_present?(["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"])
+  end
+
+  defp configured_provider?(:google_vertex) do
+    config = Application.get_env(:req_llm, :google_vertex, [])
+
+    project_present? =
+      present?(config_value(config, :project_id)) or
+        present?(System.get_env("GOOGLE_CLOUD_PROJECT"))
+
+    credential_present? =
+      present?(config_value(config, :service_account_json)) or
+        present?(config_value(config, :access_token)) or
+        ReqLLM.Providers.GoogleVertex.Auth.adc_credentials_present?()
+
+    project_present? and credential_present?
+  end
+
+  defp configured_provider?(:ollama), do: true
+
+  defp configured_provider?(:openai_codex), do: oauth_credential_present?(:openai_codex)
+
+  defp configured_provider?(provider) do
+    api_key_present?(provider) or oauth_credential_present?(provider)
+  rescue
+    _error -> false
+  end
+
+  defp api_key_present?(provider) do
+    env_var = ReqLLM.Keys.env_var_name(provider)
+    config_key = ReqLLM.Keys.config_key(provider)
+
+    present?(System.get_env(env_var)) or present?(Application.get_env(:req_llm, config_key))
+  end
+
+  defp oauth_credential_present?(provider) do
+    if oauth_supported?(provider) do
+      with path when is_binary(path) <- oauth_file_path(),
+           {:ok, body} <- File.read(path),
+           {:ok, payload} when is_map(payload) <- Jason.decode(body) do
+        oauth_provider_keys(provider)
+        |> Enum.any?(fn key -> credential_record_present?(Map.get(payload, key)) end)
+      else
+        _missing_or_invalid -> false
+      end
+    else
+      false
+    end
+  end
+
+  defp oauth_supported?(provider) do
+    case ReqLLM.provider(provider) do
+      {:ok, module} ->
+        function_exported?(module, :oauth_provider_id, 0) or auth_mode_declared?(module)
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  defp auth_mode_declared?(module) do
+    function_exported?(module, :provider_schema, 0) and
+      Keyword.has_key?(module.provider_schema().schema, :auth_mode)
+  rescue
+    _error -> false
+  end
+
+  defp oauth_provider_keys(provider) do
+    {:ok, module} = ReqLLM.provider(provider)
+
+    [
+      if(function_exported?(module, :oauth_provider_id, 0), do: module.oauth_provider_id()),
+      Atom.to_string(provider)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp credential_record_present?(credentials) when is_map(credentials) do
+    ["access", "access_token", "refresh", "refresh_token"]
+    |> Enum.any?(fn key -> present?(Map.get(credentials, key)) end)
+  end
+
+  defp credential_record_present?(_credentials), do: false
+
+  defp oauth_file_path do
+    configured =
+      [
+        Application.get_env(:req_llm, :oauth_file),
+        Application.get_env(:req_llm, :auth_file),
+        System.get_env("REQ_LLM_OAUTH_FILE"),
+        System.get_env("REQ_LLM_AUTH_FILE")
+      ]
+      |> Enum.find(&present?/1)
+
+    if configured do
+      Path.expand(configured)
+    else
+      Enum.find_value(@oauth_default_files, fn path ->
+        expanded = Path.expand(path)
+        if File.exists?(expanded), do: expanded
+      end)
+    end
+  end
+
+  defp credential_requirement(:ollama), do: :none
+  defp credential_requirement(:openai_codex), do: :required
+
+  defp credential_requirement(provider) do
+    case ReqLLM.provider(provider) do
+      {:ok, module} ->
+        if function_exported?(module, :default_env_key, 0) or oauth_supported?(provider),
+          do: :required,
+          else: :unknown
+
+      {:error, _reason} ->
+        :unknown
+    end
+  end
+
+  defp credential_remediation(:openai_codex) do
+    "Configure an openai-codex entry in oauth.json, auth.json, or REQ_LLM_OAUTH_FILE."
+  end
+
+  defp credential_remediation(provider) do
+    env_var = ReqLLM.Keys.env_var_name(provider)
+    config_key = ReqLLM.Keys.config_key(provider)
+
+    "Configure #{env_var} or config :req_llm, :#{config_key}; provider-specific auth may require additional settings."
+  end
+
+  defp any_env_present?(names), do: Enum.any?(names, &present?(System.get_env(&1)))
+
+  defp config_value(config, key) when is_list(config), do: Keyword.get(config, key)
+
+  defp config_value(config, key) when is_map(config) do
+    Map.get(config, key) || Map.get(config, Atom.to_string(key))
+  end
+
+  defp config_value(_config, _key), do: nil
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(value) when is_map(value), do: map_size(value) > 0
+  defp present?(_value), do: false
+
+  defp surface_checks(nil, _opts, _application_ready?), do: []
+  defp surface_checks(_model, _opts, false), do: []
+
+  defp surface_checks(%LLMDB.Model{provider: provider} = model, opts, true)
+       when provider in [:openai, :anthropic] do
+    operation = Keyword.get(opts, :operation, :chat)
+
+    case ReqLLM.plan(model, operation) do
+      {:ok, plan} ->
+        [
+          check(
+            "model.surface",
+            "model",
+            "ok",
+            "The selected #{operation} surface is available.",
+            nil,
+            %{
+              "operation" => Atom.to_string(operation),
+              "surface" => Atom.to_string(plan.surface),
+              "transport" => Atom.to_string(plan.transport)
+            }
+          )
+        ]
+
+      {:error, _reason} ->
+        [
+          check(
+            "model.surface",
+            "model",
+            "error",
+            "The selected #{operation} surface is unavailable for this model.",
+            "Inspect ReqLLM.plan/3 with this model and operation for a sanitized route diagnosis."
+          )
+        ]
+    end
+  end
+
+  defp surface_checks(%LLMDB.Model{provider: provider}, opts, true) do
+    operation = Keyword.get(opts, :operation, :chat)
+
+    case ReqLLM.provider(provider) do
+      {:ok, module} ->
+        [
+          check(
+            "model.surface",
+            "model",
+            "ok",
+            "The registered provider owns the selected #{operation} operation.",
+            nil,
+            %{
+              "operation" => Atom.to_string(operation),
+              "surface" => "provider_default",
+              "provider" => Atom.to_string(provider),
+              "implementation" => inspect(module)
+            }
+          )
+        ]
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp finch_configuration_check do
+    case safe_finch_config() do
+      {:ok, config} ->
+        case validate_finch_config(config) do
+          :ok ->
+            check(
+              "finch.configuration",
+              "finch",
+              "ok",
+              "Finch pool configuration is valid.",
+              nil,
+              safe_finch_details(config)
+            )
+
+          {:error, message} ->
+            check(
+              "finch.configuration",
+              "finch",
+              "error",
+              message,
+              "Use positive pool size/count values and only :http1 and :http2 protocols."
+            )
+        end
+
+      {:error, _reason} ->
+        check(
+          "finch.configuration",
+          "finch",
+          "error",
+          "Finch pool configuration could not be loaded.",
+          "Review config :req_llm Finch and stream pool settings."
+        )
+    end
+  end
+
+  defp safe_finch_config do
+    {:ok, ReqLLM.Application.get_finch_config()}
+  rescue
+    _error -> {:error, :invalid_config}
+  end
+
+  defp validate_finch_config(config) when is_list(config) do
+    with true <- Keyword.keyword?(config),
+         name when is_atom(name) <- Keyword.get(config, :name),
+         pools when is_map(pools) <- Keyword.get(config, :pools),
+         true <- map_size(pools) > 0,
+         true <- Enum.all?(pools, fn {_name, pool} -> valid_pool_config?(pool) end) do
+      :ok
+    else
+      _invalid -> {:error, "Finch pool configuration is invalid."}
+    end
+  end
+
+  defp valid_pool_config?(pool) when is_list(pool) do
+    protocols = Keyword.get(pool, :protocols, [:http1])
+    size = Keyword.get(pool, :size, 50)
+    count = Keyword.get(pool, :count, 1)
+
+    Keyword.keyword?(pool) and is_list(protocols) and protocols != [] and
+      Enum.all?(protocols, &(&1 in [:http1, :http2])) and
+      is_integer(size) and size > 0 and is_integer(count) and count > 0
+  end
+
+  defp valid_pool_config?(_pool), do: false
+
+  defp safe_finch_details(config) do
+    pools = Keyword.fetch!(config, :pools)
+
+    %{
+      "name" => safe_finch_name(Keyword.fetch!(config, :name)),
+      "pools" =>
+        pools
+        |> Enum.map(fn {name, pool} ->
+          %{
+            "name" => safe_pool_name(name),
+            "protocols" => Enum.map(Keyword.get(pool, :protocols, [:http1]), &Atom.to_string/1),
+            "size" => Keyword.get(pool, :size, 50),
+            "count" => Keyword.get(pool, :count, 1)
+          }
+        end)
+        |> Enum.sort_by(& &1["name"])
+    }
+  end
+
+  defp safe_finch_name(name) when is_atom(name), do: Atom.to_string(name)
+  defp safe_finch_name(_name), do: "custom"
+
+  defp safe_pool_name(:default), do: "default"
+  defp safe_pool_name(name) when is_atom(name), do: Atom.to_string(name)
+  defp safe_pool_name(_name), do: "configured_origin"
+
+  defp finch_runtime_check(false) do
+    check(
+      "finch.runtime",
+      "finch",
+      "error",
+      "Finch runtime availability could not be inspected because ReqLLM is not running.",
+      "Resolve the application startup error first."
+    )
+  end
+
+  defp finch_runtime_check(true) do
+    name = ReqLLM.Application.finch_name()
+
+    case GenServer.whereis(name) do
+      pid when is_pid(pid) ->
+        check(
+          "finch.runtime",
+          "finch",
+          "ok",
+          "The configured Finch process is reachable locally.",
+          nil,
+          %{"name" => safe_finch_name(name), "network_probe" => false}
+        )
+
+      nil ->
+        check(
+          "finch.runtime",
+          "finch",
+          "error",
+          "The configured Finch process is not running.",
+          "Ensure ReqLLM owns or starts the configured Finch name."
+        )
+    end
+  rescue
+    _error ->
+      check(
+        "finch.runtime",
+        "finch",
+        "error",
+        "The configured Finch process name is invalid.",
+        "Configure Finch with a valid registered process name."
+      )
+  end
+
+  defp result(checks) do
+    status =
+      checks
+      |> Enum.map(& &1["status"])
+      |> Enum.max_by(&Map.fetch!(@status_order, &1), fn -> "ok" end)
+
+    %{
+      "schema_version" => @schema_version,
+      "status" => status,
+      "checks" => checks
+    }
+  end
+
+  defp check(id, layer, status, message, remediation \\ nil, details \\ %{}) do
+    %{
+      "id" => id,
+      "layer" => layer,
+      "status" => status,
+      "message" => message,
+      "remediation" => remediation,
+      "details" => details
+    }
+  end
+
+  defp application_version(app) do
+    case Application.spec(app, :vsn) do
+      nil -> "unavailable"
+      version -> to_string(version)
+    end
+  end
+
+  defp optional_check(nil), do: []
+  defp optional_check(check), do: [check]
+
+  defp optional_atom_string(nil), do: nil
+  defp optional_atom_string(value), do: Atom.to_string(value)
+
+  defp status_icon("ok"), do: "OK"
+  defp status_icon("warning"), do: "WARN"
+  defp status_icon("error"), do: "ERROR"
+
+  defp input_remediation do
+    "Use :model, :provider, and :operation options supported by ReqLLM.Doctor.run/1."
+  end
+end

--- a/test/mix/tasks/req_llm.doctor_test.exs
+++ b/test/mix/tasks/req_llm.doctor_test.exs
@@ -1,0 +1,78 @@
+defmodule Mix.Tasks.ReqLlm.DoctorTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.ReqLlm.Doctor, as: DoctorTask
+
+  setup do
+    on_exit(fn -> Mix.Task.reenable("req_llm.doctor") end)
+    :ok
+  end
+
+  test "prints concise human diagnostics and exits successfully when healthy" do
+    output = capture_io(fn -> DoctorTask.run([]) end)
+
+    assert output =~ "ReqLLM doctor:"
+    assert output =~ "runtime.application"
+    assert output =~ "finch.runtime"
+    assert output =~ ~r/\d+ errors, \d+ warnings/
+  end
+
+  test "prints the stable machine-readable shape" do
+    output = capture_io(fn -> DoctorTask.run(["--format", "json"]) end)
+    result = Jason.decode!(output)
+
+    assert result["schema_version"] == 1
+    assert result["status"] in ["ok", "warning"]
+    assert is_list(result["checks"])
+  end
+
+  test "supports model and operation inspection" do
+    original_key = Application.get_env(:req_llm, :openai_api_key)
+    Application.put_env(:req_llm, :openai_api_key, "doctor-task-test-key")
+
+    on_exit(fn -> restore_app_env(:req_llm, :openai_api_key, original_key) end)
+
+    output =
+      capture_io(fn ->
+        DoctorTask.run([
+          "--model",
+          "openai:gpt-4o-mini",
+          "--operation",
+          "chat",
+          "--json"
+        ])
+      end)
+
+    result = Jason.decode!(output)
+    surface = Enum.find(result["checks"], &(&1["id"] == "model.surface"))
+
+    assert surface["status"] == "ok"
+  end
+
+  test "prints diagnostics before returning a failing exit" do
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, ~r/diagnostics failed/, fn ->
+          DoctorTask.run(["--provider", "not-a-provider", "--json"])
+        end
+      end)
+
+    result = Jason.decode!(output)
+    assert result["status"] == "error"
+  end
+
+  test "rejects invalid command options" do
+    assert_raise Mix.Error, ~r/Invalid arguments/, fn ->
+      DoctorTask.run(["--unknown"])
+    end
+
+    assert_raise Mix.Error, ~r/format must be human or json/, fn ->
+      DoctorTask.run(["--format", "yaml"])
+    end
+  end
+
+  defp restore_app_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_app_env(app, key, value), do: Application.put_env(app, key, value)
+end

--- a/test/req_llm/doctor_test.exs
+++ b/test/req_llm/doctor_test.exs
@@ -1,0 +1,214 @@
+defmodule ReqLLM.DoctorTest do
+  use ExUnit.Case, async: false
+
+  alias ReqLLM.Doctor
+
+  setup do
+    original_finch = Application.get_env(:req_llm, :finch)
+    original_oauth_file = Application.get_env(:req_llm, :oauth_file)
+    original_auth_file = Application.get_env(:req_llm, :auth_file)
+    original_openai_key = Application.get_env(:req_llm, :openai_api_key)
+    original_xai_key = Application.get_env(:req_llm, :xai_api_key)
+    original_xai_env = System.get_env("XAI_API_KEY")
+
+    on_exit(fn ->
+      restore_app_env(:req_llm, :finch, original_finch)
+      restore_app_env(:req_llm, :oauth_file, original_oauth_file)
+      restore_app_env(:req_llm, :auth_file, original_auth_file)
+      restore_app_env(:req_llm, :openai_api_key, original_openai_key)
+      restore_app_env(:req_llm, :xai_api_key, original_xai_key)
+      restore_system_env("XAI_API_KEY", original_xai_env)
+      ReqLLM.Providers.initialize()
+    end)
+
+    :ok
+  end
+
+  test "returns a stable JSON-safe result with runtime versions" do
+    result = Doctor.run()
+
+    assert result["schema_version"] == 1
+    assert result["status"] in ["ok", "warning"]
+    assert Doctor.exit_status(result) == 0
+
+    assert Enum.all?(result["checks"], fn check ->
+             Map.keys(check) |> Enum.sort() ==
+               ~w(details id layer message remediation status)
+           end)
+
+    versions = find_check(result, "runtime.versions")
+    assert versions["status"] == "ok"
+    assert versions["details"]["req_llm"] == to_string(Application.spec(:req_llm, :vsn))
+    assert versions["details"]["elixir"] == System.version()
+    assert versions["details"]["otp"] == System.otp_release()
+    assert Jason.encode!(result)
+  end
+
+  test "treats absent optional credentials as a warning with a successful exit" do
+    retain_only_provider(:xai)
+    delete_xai_credentials()
+
+    result = Doctor.run()
+    check = find_check(result, "credentials.configuration")
+
+    assert result["status"] == "warning"
+    assert check["status"] == "warning"
+    assert check["details"]["configured_providers"] == []
+    assert Doctor.exit_status(result) == 0
+  end
+
+  test "reports missing selected-provider credentials as a required error" do
+    delete_xai_credentials()
+
+    result = Doctor.run(provider: :xai)
+    check = find_check(result, "credentials.selected_provider")
+
+    assert result["status"] == "error"
+    assert check["layer"] == "credentials"
+    assert check["status"] == "error"
+    assert check["remediation"] =~ "XAI_API_KEY"
+    assert Doctor.exit_status(result) == 1
+  end
+
+  test "does not mistake invalid required credential configuration for presence" do
+    System.delete_env("XAI_API_KEY")
+    Application.put_env(:req_llm, :xai_api_key, 123)
+
+    result = Doctor.run(provider: :xai)
+
+    assert find_check(result, "credentials.selected_provider")["status"] == "error"
+    assert result["status"] == "error"
+  end
+
+  test "never includes credential values in human or machine output" do
+    secret = "doctor-secret-value-that-must-not-leak"
+    Application.put_env(:req_llm, :xai_api_key, secret)
+    System.put_env("XAI_API_KEY", secret)
+
+    result = Doctor.run(provider: :xai)
+    encoded = Jason.encode!(result)
+    human = Doctor.format_human(result)
+
+    assert find_check(result, "credentials.selected_provider")["status"] == "ok"
+    refute encoded =~ secret
+    refute human =~ secret
+  end
+
+  test "inspects OAuth credential presence without refreshes or file changes" do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "req-llm-doctor-oauth-#{System.unique_integer([:positive])}.json"
+      )
+
+    body =
+      Jason.encode!(%{
+        "openai-codex" => %{
+          "access" => "expired-doctor-access-secret",
+          "refresh" => "doctor-refresh-secret",
+          "expires" => 0
+        }
+      })
+
+    File.write!(path, body)
+    Application.put_env(:req_llm, :oauth_file, path)
+    on_exit(fn -> File.rm(path) end)
+
+    result = Doctor.run(provider: :openai_codex)
+
+    assert find_check(result, "credentials.selected_provider")["status"] == "ok"
+    assert File.read!(path) == body
+    refute Jason.encode!(result) =~ "doctor-refresh-secret"
+    refute Jason.encode!(result) =~ path
+  end
+
+  test "locates invalid models and missing providers without echoing inputs" do
+    invalid_model = "unknown:doctor-sensitive-model-fragment"
+    model_result = Doctor.run(model: invalid_model)
+    provider_result = Doctor.run(provider: "doctor-provider-that-does-not-exist")
+
+    assert find_check(model_result, "model.resolution")["status"] == "error"
+    assert find_check(model_result, "model.resolution")["remediation"]
+    refute Jason.encode!(model_result) =~ invalid_model
+
+    assert find_check(provider_result, "providers.registry")["status"] == "error"
+    assert find_check(provider_result, "providers.registry")["layer"] == "provider"
+    refute Jason.encode!(provider_result) =~ "doctor-provider-that-does-not-exist"
+  end
+
+  test "reports the selected request surface without making a request" do
+    Application.put_env(:req_llm, :xai_api_key, "doctor-test-key")
+    Application.put_env(:req_llm, :openai_api_key, "doctor-test-key")
+
+    result = Doctor.run(model: "openai:gpt-4o-mini", operation: :chat)
+    check = find_check(result, "model.surface")
+
+    assert check["status"] == "ok"
+    assert check["details"]["surface"] in ["openai_chat_completions", "openai_responses"]
+    assert check["details"]["transport"] == "req"
+  end
+
+  test "validates Finch pool configuration and only exposes safe fields" do
+    Application.put_env(:req_llm, :finch,
+      name: ReqLLM.Finch,
+      pools: %{
+        default: [
+          protocols: [:http1],
+          size: 2,
+          count: 3,
+          conn_opts: [proxy_headers: [{"authorization", "doctor-secret"}]]
+        ]
+      }
+    )
+
+    valid = Doctor.run()
+    check = find_check(valid, "finch.configuration")
+
+    assert check["status"] == "ok"
+
+    assert check["details"]["pools"] == [
+             %{"name" => "default", "protocols" => ["http1"], "size" => 2, "count" => 3}
+           ]
+
+    refute Jason.encode!(valid) =~ "doctor-secret"
+
+    Application.put_env(:req_llm, :finch,
+      name: ReqLLM.Finch,
+      pools: %{default: [protocols: [:http3], size: 0, count: 0]}
+    )
+
+    invalid = Doctor.run()
+    invalid_check = find_check(invalid, "finch.configuration")
+
+    assert invalid_check["status"] == "error"
+    assert invalid_check["layer"] == "finch"
+    assert invalid_check["remediation"]
+  end
+
+  test "rejects invalid doctor options as configuration errors" do
+    result = Doctor.run(operation: :embed)
+
+    assert result["status"] == "error"
+    assert find_check(result, "input")["layer"] == "configuration"
+    assert Doctor.exit_status(result) == 1
+  end
+
+  defp find_check(result, id), do: Enum.find(result["checks"], &(&1["id"] == id))
+
+  defp retain_only_provider(provider) do
+    ReqLLM.Providers.list()
+    |> Enum.reject(&(&1 == provider))
+    |> Enum.each(&ReqLLM.Providers.unregister/1)
+  end
+
+  defp delete_xai_credentials do
+    Application.delete_env(:req_llm, :xai_api_key)
+    System.delete_env("XAI_API_KEY")
+  end
+
+  defp restore_app_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_app_env(app, key, value), do: Application.put_env(app, key, value)
+
+  defp restore_system_env(key, nil), do: System.delete_env(key)
+  defp restore_system_env(key, value), do: System.put_env(key, value)
+end

--- a/test/req_llm/doctor_test.exs
+++ b/test/req_llm/doctor_test.exs
@@ -5,19 +5,24 @@ defmodule ReqLLM.DoctorTest do
 
   setup do
     original_finch = Application.get_env(:req_llm, :finch)
+    original_llm_db_load_dotenv = Application.get_env(:llm_db, :load_dotenv)
     original_oauth_file = Application.get_env(:req_llm, :oauth_file)
     original_auth_file = Application.get_env(:req_llm, :auth_file)
     original_openai_key = Application.get_env(:req_llm, :openai_api_key)
+    original_openai_env = System.get_env("OPENAI_API_KEY")
     original_xai_key = Application.get_env(:req_llm, :xai_api_key)
     original_xai_env = System.get_env("XAI_API_KEY")
 
     on_exit(fn ->
       restore_app_env(:req_llm, :finch, original_finch)
+      restore_app_env(:llm_db, :load_dotenv, original_llm_db_load_dotenv)
       restore_app_env(:req_llm, :oauth_file, original_oauth_file)
       restore_app_env(:req_llm, :auth_file, original_auth_file)
       restore_app_env(:req_llm, :openai_api_key, original_openai_key)
       restore_app_env(:req_llm, :xai_api_key, original_xai_key)
+      restore_system_env("OPENAI_API_KEY", original_openai_env)
       restore_system_env("XAI_API_KEY", original_xai_env)
+      Application.ensure_all_started(:req_llm)
       ReqLLM.Providers.initialize()
     end)
 
@@ -42,6 +47,23 @@ defmodule ReqLLM.DoctorTest do
     assert versions["details"]["elixir"] == System.version()
     assert versions["details"]["otp"] == System.otp_release()
     assert Jason.encode!(result)
+  end
+
+  test "does not start ReqLLM or mutate runtime configuration by default" do
+    Application.delete_env(:llm_db, :load_dotenv)
+    assert :ok = Application.stop(:req_llm)
+
+    result = Doctor.run()
+
+    refute Enum.any?(Application.started_applications(), fn {app, _description, _version} ->
+             app == :req_llm
+           end)
+
+    assert Application.get_env(:llm_db, :load_dotenv) == nil
+    assert find_check(result, "runtime.application")["status"] == "warning"
+    assert find_check(result, "providers.registry")["status"] == "warning"
+    assert find_check(result, "finch.runtime")["status"] == "warning"
+    assert Doctor.exit_status(result) == 0
   end
 
   test "treats absent optional credentials as a warning with a successful exit" do
@@ -116,7 +138,12 @@ defmodule ReqLLM.DoctorTest do
 
     result = Doctor.run(provider: :openai_codex)
 
+    Application.delete_env(:req_llm, :openai_api_key)
+    System.delete_env("OPENAI_API_KEY")
+    default_openai_result = Doctor.run(provider: :openai)
+
     assert find_check(result, "credentials.selected_provider")["status"] == "ok"
+    assert find_check(default_openai_result, "credentials.selected_provider")["status"] == "error"
     assert File.read!(path) == body
     refute Jason.encode!(result) =~ "doctor-refresh-secret"
     refute Jason.encode!(result) =~ path


### PR DESCRIPTION
## Summary

- add `ReqLLM.Doctor.run/1` and `mix req_llm.doctor` for runtime, provider, credential-presence, model/surface, and Finch diagnostics
- provide concise human output plus a documented, schema-versioned JSON format and useful success/error exit statuses
- keep diagnostics safe for CI and support logs: no provider calls, remote probes, credential values, auth resolution, OAuth refreshes, or user config/file writes
- keep the public API non-mutating by default; the short-lived Mix command explicitly opts into normal ReqLLM application startup so it can validate the live supervision tree
- document the command and machine-readable contract in the Mix tasks guide

## Compatibility

This is an additive V1 API and Mix task. Existing request execution, provider registration, authentication, model resolution, and Finch configuration behavior are unchanged.

## Validation

- `mix test` — 3,916 passed, 11 skipped, 145 excluded
- `mix test test/req_llm/doctor_test.exs test/mix/tasks/req_llm.doctor_test.exs` — 16 passed
- `mix quality`
- `mix docs` — succeeds with the pre-existing hidden `ReqLLM.Streaming.HTTP2DuplexSession` warning
- direct command checks confirm healthy JSON exits 0 and invalid required provider input prints diagnostics then exits 1
- regressions prove default `ReqLLM.Doctor.run/1` does not start a stopped application or mutate LLMDB config, and default OpenAI auth does not accept an unrelated OAuth record

Closes #861
