### PR TITLE
feat: add the V2 migration audit

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -52,6 +52,14 @@ Stable runtime APIs are not removed during V1 merely because the overlap window
 has elapsed. Their removal belongs to a major release. The window creates a
 usable V1 bridge before that release.
 
+The versioned
+[`priv/deprecations.json`](https://github.com/agentjido/req_llm/blob/main/priv/deprecations.json)
+ledger records
+every active deprecation and its owner, replacement, window, target, approved or
+unapproved V2 scope status, guide, and precise detector. Run
+`mix req_llm.migration_audit` to inventory mechanical V2 work without evaluating
+or rewriting application source.
+
 ### Internal
 
 A surface is internal only when it is hidden from public documentation or

--- a/guides/mix-tasks.md
+++ b/guides/mix-tasks.md
@@ -74,7 +74,7 @@ mix req_llm.migration_audit --format json
 ```
 
 Actionable findings exit with status `1`; unreadable or invalid source exits
-with status `2`. Clean and provider-extension-advisory-only reports exit with
+with status `2`. Clean and advisory-only reports exit with
 status `0`. See the [V2 migration audit guide](v2-migration-audit.md) for the
 ledger schema, before/after examples, and static-analysis limitations.
 

--- a/guides/mix-tasks.md
+++ b/guides/mix-tasks.md
@@ -9,6 +9,7 @@ ReqLLM includes these main Mix tasks:
 | Task | Alias | Purpose |
 |------|-------|---------|
 | `mix req_llm.doctor` | — | Diagnose installation and runtime configuration without provider calls |
+| `mix req_llm.migration_audit` | — | Find precise, mechanical V2 migration work without rewriting source |
 | `mix req_llm.gen` | `mix llm` | Generate text/objects from the command line |
 | `mix req_llm.model_compat` | `mix mc` | Validate model coverage with fixtures |
 | `mix req_llm.model_support` | — | Inspect and verify evidence-derived support tiers |
@@ -58,6 +59,24 @@ Top-level status is `ok`, `warning`, or `error`. Each check always includes
 `id`, `layer`, `status`, `message`, `remediation`, and `details`. New check IDs or
 detail fields may be added without changing schema version; existing common fields
 retain their meaning for schema version 1.
+
+## mix req_llm.migration_audit
+
+Scan Elixir source for active ReqLLM deprecations and precise V2-readiness
+patterns. The task parses source without evaluating or rewriting it and makes no
+provider requests.
+
+```bash
+mix req_llm.migration_audit
+mix req_llm.migration_audit lib test
+mix req_llm.migration_audit --exclude test/fixtures
+mix req_llm.migration_audit --format json
+```
+
+Actionable findings exit with status `1`; unreadable or invalid source exits
+with status `2`. Clean and provider-extension-advisory-only reports exit with
+status `0`. See the [V2 migration audit guide](v2-migration-audit.md) for the
+ledger schema, before/after examples, and static-analysis limitations.
 
 ## mix req_llm.gen
 

--- a/guides/v2-migration-audit.md
+++ b/guides/v2-migration-audit.md
@@ -1,0 +1,296 @@
+# V2 Migration Audit
+
+ReqLLM ships a versioned deprecation ledger and a read-only source audit so an
+application can prepare for V2 without changing its V1 behavior. V1 deprecated
+APIs continue to work for their documented overlap window.
+
+Run the audit from an application root:
+
+```bash
+mix req_llm.migration_audit
+mix req_llm.migration_audit lib test
+mix req_llm.migration_audit --exclude test/fixtures
+mix req_llm.migration_audit --format json
+```
+
+The default command recursively scans `.ex` and `.exs` files. It ignores
+dependency, build, VCS, coverage, generated documentation, and Node dependency
+directories. It parses source but never evaluates or rewrites it, starts ReqLLM,
+loads credentials, or makes a provider request.
+
+Exit status `0` means the report is clean or contains provider-extension
+advisories only. Status `1` means actionable migration findings are present.
+Status `2` means a requested path could not be read, source could not be parsed,
+or the bundled ledger was invalid.
+
+## Machine-readable ledger
+
+[`priv/deprecations.json`](https://github.com/agentjido/req_llm/blob/main/priv/deprecations.json)
+is the source of truth. Schema version 1 records the owner, deprecated contract,
+replacement, introduction release, target major, V2 scope status, minimum overlap
+window, guide, and static detector for every active deprecation. An
+`introduced_version` of `unreleased` identifies a deprecation added after the
+latest tagged release.
+
+`target_major: 2` identifies the next major in which a removal could be
+compatible; it is not approval by itself. Only records with
+`v2_scope: "approved"` belong to the breaking scope accepted by the V2
+roadmap. An `unapproved` record remains an active deprecation and must not be
+removed in V2 without a separate scope decision.
+
+Applications and tooling can inspect the exact shipped data:
+
+```elixir
+ledger = ReqLLM.Migration.ledger()
+deprecations = ReqLLM.Migration.deprecations()
+checks = ReqLLM.Migration.migration_checks()
+```
+
+`ReqLLM.Migration.audit/2` returns the same schema-versioned report as the Mix
+task. Reports contain source locations and migration guidance, never source
+snippets or evaluated values.
+
+Schema version 1 has stable common fields:
+
+```json
+{
+  "schema_version": 1,
+  "status": "findings",
+  "summary": {
+    "files_scanned": 12,
+    "actionable": 1,
+    "advisory": 0,
+    "errors": 0
+  },
+  "findings": [
+    {
+      "id": "req_llm.stream_text_bang",
+      "category": "deprecated_api",
+      "actionable": true,
+      "file": "lib/client.ex",
+      "line": 12,
+      "column": 5,
+      "contract": "ReqLLM.stream_text!/2",
+      "owner": "ReqLLM core maintainers",
+      "message": "ReqLLM.stream_text!/3 is deprecated.",
+      "replacement": "ReqLLM.stream_text/3 and a ReqLLM.StreamResponse projection",
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#bang-streaming-apis"
+    }
+  ],
+  "errors": []
+}
+```
+
+Top-level status is `clean`, `advisory`, `findings`, or `error`. Every finding
+retains the common fields shown above. Errors contain `file` and `message`.
+Additional finding IDs may be added without changing schema version; existing
+common fields retain their meaning. Precompile a newly changed project with
+`mix compile --quiet` before piping the task's standard output to another
+process.
+
+## Bang streaming APIs
+
+The deprecated bang functions return `:ok`; they do not return an enumerable.
+Choose the projection needed by the consumer.
+
+Before:
+
+```elixir
+ReqLLM.stream_text!(model, prompt)
+```
+
+After, for text deltas:
+
+```elixir
+{:ok, response} = ReqLLM.stream_text(model, prompt)
+Enum.each(ReqLLM.StreamResponse.tokens(response), &IO.write/1)
+```
+
+After, for canonical lifecycle and output events:
+
+```elixir
+{:ok, response} = ReqLLM.stream_text(model, prompt)
+Enum.each(ReqLLM.StreamResponse.events(response), &handle_event/1)
+```
+
+The same replacement applies to `ReqLLM.Generation.stream_text!/3`,
+`ReqLLM.stream_object!/4`, and `ReqLLM.Generation.stream_object!/4` using their
+non-bang counterparts.
+
+## Context tool-call helpers
+
+Before:
+
+```elixir
+ReqLLM.Context.assistant_with_tools(tool_calls, "Checking")
+ReqLLM.Context.assistant_tool_call("weather", %{city: "Chicago"})
+ReqLLM.Context.assistant_tool_calls(calls)
+```
+
+After:
+
+```elixir
+ReqLLM.Context.assistant("Checking", tool_calls: tool_calls)
+ReqLLM.Context.assistant("", tool_calls: [{"weather", %{city: "Chicago"}}])
+ReqLLM.Context.assistant("", tool_calls: calls)
+```
+
+Preserve any IDs and metadata in the supported `assistant/2` option shape.
+
+## Key lookup aliases
+
+Before:
+
+```elixir
+ReqLLM.Keys.fetch(:openai)
+ReqLLM.Keys.fetch!(:openai)
+```
+
+After:
+
+```elixir
+ReqLLM.Keys.get(:openai)
+ReqLLM.Keys.get!(:openai)
+```
+
+## Tool-call flag helper
+
+Before:
+
+```elixir
+ReqLLM.ToolCall.builtin_flag?(value)
+```
+
+After:
+
+```elixir
+ReqLLM.ToolCall.flagged_builtin?(value)
+```
+
+The replacement retains the original flag-only behavior and names it
+explicitly.
+
+## Meta Llama delegates
+
+The compatibility delegates on `ReqLLM.Providers.Meta` move to the module that
+owns the Llama wire format. For example:
+
+```elixir
+ReqLLM.Providers.Meta.format_request(context, options)
+ReqLLM.Providers.Meta.Llama.format_request(context, options)
+```
+
+Apply the same module move to `format_llama_prompt/1`, `parse_response/2`,
+`extract_usage/1`, and `parse_stop_reason/1`.
+
+## Provider option namespaces
+
+The V1 flat shape remains supported. A literal provider model and literal flat
+options can be migrated mechanically to the additive provider-keyed shape.
+
+Before:
+
+```elixir
+ReqLLM.generate_text("openai:gpt-4o", prompt,
+  provider_options: [store: false]
+)
+```
+
+After:
+
+```elixir
+ReqLLM.generate_text("openai:gpt-4o", prompt,
+  provider_options: [openai: [store: false]]
+)
+```
+
+The audit reports this only when the provider identity and option container are
+both literal. Hosted providers use the selected ReqLLM provider identity, such
+as `azure` or `google_vertex`, as the outer key.
+
+## Raw stream assumptions
+
+`StreamResponse.stream` remains stable throughout V1. V2 may make canonical
+events the primary raw stream, so code that explicitly matches the struct field
+should choose a named projection now.
+
+Before:
+
+```elixir
+%ReqLLM.StreamResponse{stream: chunks} = response
+Enum.each(chunks, &handle_chunk/1)
+```
+
+After:
+
+```elixir
+response
+|> ReqLLM.StreamResponse.events()
+|> Enum.each(&handle_event/1)
+```
+
+Use `tokens/1`, `tool_calls/1`, or another documented projection when those
+semantics are the real dependency. The audit detects explicit struct field
+matching; it does not infer the type of an arbitrary `value.stream` expression.
+
+## Provider extension inventory
+
+Direct `use ReqLLM.Provider` and `@behaviour ReqLLM.Provider` declarations are
+reported as advisories. The provider behavior remains stable in V1 and the V2
+replacement is not frozen. There is no code migration to perform yet.
+
+Keep the existing provider conformance suite green, record the extension in the
+V2 ecosystem survey, and follow the
+[provider extension decision](provider-extension-decision.md). Advisory-only
+reports exit successfully.
+
+## Structured-output validation default
+
+V1 preserves compatible validation. V2 may make strict final validation the
+default. Set the intended policy explicitly on statically structured calls.
+
+Before:
+
+```elixir
+ReqLLM.generate_text(model, prompt,
+  output: ReqLLM.Output.object(name: [type: :string])
+)
+```
+
+After, preserving V1 behavior:
+
+```elixir
+ReqLLM.generate_text(model, prompt,
+  output: ReqLLM.Output.object(name: [type: :string]),
+  output_validation: :compatible
+)
+```
+
+After, opting into the proposed V2 safety default now:
+
+```elixir
+ReqLLM.generate_text(model, prompt,
+  output: ReqLLM.Output.object(name: [type: :string]),
+  output_validation: :strict
+)
+```
+
+The check also covers literal `generate_object` and streaming object calls when
+their option source is statically visible.
+
+## Limitations and false positives
+
+The audit deliberately avoids general Elixir data-flow analysis. It detects
+fully qualified remote calls, literal model and option shapes, explicit
+`ReqLLM.StreamResponse` struct matching, and direct fully qualified provider
+behavior declarations.
+
+It does not resolve imported functions, local aliases, macro-generated calls,
+computed model specifications, variable option containers, or the runtime type
+of field access. These cases require manual review. A computed value is not
+reported merely because it could contain a legacy shape.
+
+Comments and strings are ignored because the audit parses syntax. A source file
+that cannot be parsed is an error rather than a partial success. Findings are
+deterministically ordered by file and source location, making JSON output stable
+for CI and editor integrations.

--- a/guides/v2-migration-audit.md
+++ b/guides/v2-migration-audit.md
@@ -18,8 +18,8 @@ dependency, build, VCS, coverage, generated documentation, and Node dependency
 directories. It parses source but never evaluates or rewrites it, starts ReqLLM,
 loads credentials, or makes a provider request.
 
-Exit status `0` means the report is clean or contains provider-extension
-advisories only. Status `1` means actionable migration findings are present.
+Exit status `0` means the report is clean or contains advisories only. Status
+`1` means actionable migration findings are present.
 Status `2` means a requested path could not be read, source could not be parsed,
 or the bundled ledger was invalid.
 
@@ -36,7 +36,9 @@ latest tagged release.
 compatible; it is not approval by itself. Only records with
 `v2_scope: "approved"` belong to the breaking scope accepted by the V2
 roadmap. An `unapproved` record remains an active deprecation and must not be
-removed in V2 without a separate scope decision.
+removed in V2 without a separate scope decision. The audit reports those
+records as non-blocking advisories so they remain visible without expanding the
+approved V2 migration plan.
 
 Applications and tooling can inspect the exact shipped data:
 

--- a/lib/mix/tasks/req_llm.migration_audit.ex
+++ b/lib/mix/tasks/req_llm.migration_audit.ex
@@ -1,0 +1,51 @@
+defmodule Mix.Tasks.ReqLlm.MigrationAudit do
+  @shortdoc "Audit source for mechanical ReqLLM V2 migration work"
+  @moduledoc """
+  Scans Elixir source for precise ReqLLM V2 migration patterns without evaluating
+  or rewriting application code.
+
+      mix req_llm.migration_audit
+      mix req_llm.migration_audit lib test
+      mix req_llm.migration_audit --exclude test/fixtures --format json
+
+  Actionable findings exit with status 1, audit errors with status 2, and clean
+  or advisory-only reports with status 0.
+  """
+
+  use Mix.Task
+
+  @switches [format: :string, json: :boolean, exclude: :keep]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, paths, invalid} = OptionParser.parse(args, strict: @switches)
+
+    validate_arguments!(invalid)
+
+    format = output_format!(opts)
+    audit_opts = [exclude: Keyword.get_values(opts, :exclude)]
+    report = ReqLLM.Migration.audit(paths, audit_opts)
+
+    Mix.shell().info(render(report, format))
+    finish!(ReqLLM.Migration.exit_status(report))
+  end
+
+  defp validate_arguments!([]), do: :ok
+  defp validate_arguments!(invalid), do: Mix.raise("Invalid arguments: #{inspect(invalid)}")
+
+  defp output_format!(opts) do
+    format = if opts[:json], do: "json", else: Keyword.get(opts, :format, "human")
+
+    case format do
+      "human" -> :human
+      "json" -> :json
+      _other -> Mix.raise("--format must be human or json")
+    end
+  end
+
+  defp render(report, :human), do: ReqLLM.Migration.format_human(report)
+  defp render(report, :json), do: Jason.encode!(report, pretty: true)
+
+  defp finish!(0), do: :ok
+  defp finish!(status) when status in [1, 2], do: exit({:shutdown, status})
+end

--- a/lib/req_llm/migration.ex
+++ b/lib/req_llm/migration.ex
@@ -1,0 +1,213 @@
+defmodule ReqLLM.Migration do
+  @moduledoc """
+  Read-only V2 migration inventory for ReqLLM applications.
+
+  `ledger/0` exposes the versioned, JSON-compatible deprecation ledger shipped
+  with ReqLLM. `audit/2` scans Elixir source without evaluating it and reports
+  only the precise patterns represented in that ledger.
+
+  The audit never rewrites source, starts ReqLLM, resolves credentials, or makes
+  provider requests. Its result is safe to encode directly as JSON.
+  """
+
+  @ledger_path Path.expand("../../priv/deprecations.json", __DIR__)
+  @external_resource @ledger_path
+  @ledger @ledger_path |> File.read!() |> Jason.decode!()
+
+  @deprecation_keys ~w(id owner contract replacement introduced_version target_major v2_scope minimum_window guide detector)
+  @migration_check_keys ~w(id owner contract replacement target_major v2_scope actionable guide detector)
+  @migration_detector_types ~w(implicit_output_validation legacy_provider_options provider_behavior stream_response_field)
+
+  @type report :: %{required(String.t()) => term()}
+
+  @doc "Returns the complete machine-readable deprecation and migration ledger."
+  @spec ledger() :: map()
+  def ledger, do: @ledger
+
+  @doc "Returns the active deprecation records in ledger order."
+  @spec deprecations() :: [map()]
+  def deprecations, do: @ledger["deprecations"]
+
+  @doc "Returns the precise V2-readiness checks in ledger order."
+  @spec migration_checks() :: [map()]
+  def migration_checks, do: @ledger["migration_checks"]
+
+  @doc """
+  Audits Elixir source paths for mechanical V2 migration work.
+
+  A path may be a file or directory. Directories are scanned recursively for
+  `.ex` and `.exs` files. Dependency, build, VCS, coverage, and generated-doc
+  directories are ignored by default.
+
+  ## Options
+
+    * `:exclude` - a path or list of paths to omit
+  """
+  @spec audit(Path.t() | [Path.t()], keyword()) :: report()
+  def audit(paths \\ ["."], opts \\ []) do
+    ReqLLM.Migration.Audit.run(paths, opts)
+  end
+
+  @doc "Returns `0` for clean or advisory-only reports, `1` for migration work, and `2` for errors."
+  @spec exit_status(report()) :: 0 | 1 | 2
+  def exit_status(%{"status" => "error"}), do: 2
+  def exit_status(%{"status" => "findings"}), do: 1
+  def exit_status(_report), do: 0
+
+  @doc "Formats an audit report for terminal output."
+  @spec format_human(report()) :: String.t()
+  def format_human(report), do: ReqLLM.Migration.Audit.format_human(report)
+
+  @doc false
+  @spec validate_ledger() :: :ok | {:error, [String.t()]}
+  def validate_ledger do
+    errors =
+      schema_errors(@ledger) ++
+        record_errors(@ledger["deprecations"], @deprecation_keys, "deprecation") ++
+        record_errors(@ledger["migration_checks"], @migration_check_keys, "migration check") ++
+        identity_errors(@ledger)
+
+    case errors do
+      [] -> :ok
+      errors -> {:error, errors}
+    end
+  end
+
+  defp schema_errors(%{
+         "schema_version" => 1,
+         "deprecations" => deprecations,
+         "migration_checks" => checks
+       })
+       when is_list(deprecations) and is_list(checks),
+       do: []
+
+  defp schema_errors(_ledger),
+    do: ["The ledger must use schema version 1 and contain both record lists."]
+
+  defp record_errors(records, keys, kind) when is_list(records) do
+    records
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {record, index} -> record_errors(record, keys, kind, index) end)
+  end
+
+  defp record_errors(_records, _keys, kind), do: ["The #{kind} records must be a list."]
+
+  defp record_errors(record, keys, kind, index) when is_map(record) do
+    missing = keys -- Map.keys(record)
+
+    value_errors =
+      if valid_common_record?(record) do
+        []
+      else
+        ["#{kind} #{index} contains invalid common field values."]
+      end
+
+    detector_errors =
+      if valid_detector?(record["detector"]) do
+        []
+      else
+        ["#{kind} #{index} has an invalid detector."]
+      end
+
+    kind_errors = kind_errors(record, kind, index)
+
+    missing_errors =
+      if missing == [],
+        do: [],
+        else: ["#{kind} #{index} is missing: #{Enum.join(missing, ", ")}."]
+
+    missing_errors ++ value_errors ++ detector_errors ++ kind_errors
+  end
+
+  defp record_errors(_record, _keys, kind, index),
+    do: ["#{kind} #{index} must be a JSON object."]
+
+  defp valid_common_record?(record) when is_map(record) do
+    Enum.all?(
+      ~w(id owner contract replacement guide),
+      &(is_binary(record[&1]) and record[&1] != "")
+    ) and record["target_major"] == 2 and record["v2_scope"] in ~w(approved unapproved)
+  end
+
+  defp valid_detector?(%{"type" => type}) when is_binary(type), do: type != ""
+  defp valid_detector?(_detector), do: false
+
+  defp kind_errors(record, "deprecation", index) do
+    errors =
+      []
+      |> require_introduction(record, index)
+      |> require_window(record, index)
+      |> require_remote_call_detector(record, index)
+
+    Enum.reverse(errors)
+  end
+
+  defp kind_errors(record, "migration check", index) do
+    detector_type = get_in(record, ["detector", "type"])
+
+    cond do
+      not is_boolean(record["actionable"]) ->
+        ["migration check #{index} must declare whether it is actionable."]
+
+      detector_type not in @migration_detector_types ->
+        ["migration check #{index} has an unsupported detector type."]
+
+      true ->
+        []
+    end
+  end
+
+  defp kind_errors(_record, _kind, _index), do: []
+
+  defp require_introduction(errors, record, index) do
+    introduced_version = record["introduced_version"]
+
+    if introduced_version == "unreleased" or valid_version?(introduced_version) do
+      errors
+    else
+      ["deprecation #{index} has an invalid introduced version." | errors]
+    end
+  end
+
+  defp require_window(errors, record, index) do
+    case record["minimum_window"] do
+      %{"minor_releases" => releases} when is_integer(releases) and releases >= 2 ->
+        errors
+
+      _window ->
+        ["deprecation #{index} must retain at least two minor releases of overlap." | errors]
+    end
+  end
+
+  defp require_remote_call_detector(errors, record, index) do
+    case record["detector"] do
+      %{"type" => "remote_call", "module" => module, "function" => function}
+      when is_binary(module) and module != "" and is_binary(function) and function != "" ->
+        errors
+
+      _detector ->
+        ["deprecation #{index} must use a complete remote-call detector." | errors]
+    end
+  end
+
+  defp valid_version?(version) when is_binary(version),
+    do: match?({:ok, _version}, Version.parse(version))
+
+  defp valid_version?(_version), do: false
+
+  defp identity_errors(%{"deprecations" => deprecations, "migration_checks" => checks}) do
+    ids =
+      Enum.map(deprecations ++ checks, fn
+        record when is_map(record) -> record["id"]
+        _record -> nil
+      end)
+
+    cond do
+      Enum.any?(ids, &is_nil/1) -> ["Every ledger record must have an id."]
+      length(ids) != length(Enum.uniq(ids)) -> ["Ledger ids must be unique."]
+      true -> []
+    end
+  end
+
+  defp identity_errors(_ledger), do: []
+end

--- a/lib/req_llm/migration/audit.ex
+++ b/lib/req_llm/migration/audit.ex
@@ -1,0 +1,557 @@
+defmodule ReqLLM.Migration.Audit do
+  @moduledoc false
+
+  @schema_version 1
+  @ignored_directories ~w(.git .elixir_ls _build cover deps doc node_modules)
+  @operation_modules [
+    "ReqLLM",
+    "ReqLLM.Embedding",
+    "ReqLLM.Generation",
+    "ReqLLM.Images",
+    "ReqLLM.OCR",
+    "ReqLLM.Rerank",
+    "ReqLLM.Speech",
+    "ReqLLM.Transcription"
+  ]
+  @structured_functions ~w(generate_text stream_text)
+  @object_functions ~w(generate_object stream_object)
+  @structured_constructors ~w(array choice json object)
+
+  @spec run(Path.t() | [Path.t()], keyword()) :: ReqLLM.Migration.report()
+  def run(paths, opts) do
+    with :ok <- ReqLLM.Migration.validate_ledger(),
+         {:ok, normalized_paths, excluded_paths} <- validate_input(paths, opts) do
+      {files, path_errors} = collect_files(normalized_paths, excluded_paths)
+      {findings, source_errors} = scan_files(files)
+      report(files, findings, sort_errors(path_errors ++ source_errors))
+    else
+      {:error, errors} when is_list(errors) -> report([], [], input_errors(errors))
+      {:error, message} -> report([], [], input_errors([message]))
+    end
+  end
+
+  @spec format_human(ReqLLM.Migration.report()) :: String.t()
+  def format_human(report) do
+    heading = "ReqLLM V2 migration audit: #{String.upcase(report["status"])}"
+    finding_lines = Enum.flat_map(report["findings"], &format_finding/1)
+    error_lines = Enum.map(report["errors"], &format_error/1)
+    summary = report["summary"]
+
+    footer =
+      "#{summary["files_scanned"]} files, #{summary["actionable"]} actionable, " <>
+        "#{summary["advisory"]} advisory, #{summary["errors"]} errors"
+
+    Enum.join([heading] ++ finding_lines ++ error_lines ++ [footer], "\n")
+  end
+
+  defp validate_input(paths, opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      unknown = Keyword.keys(opts) -- [:exclude]
+
+      if unknown == [] do
+        with {:ok, normalized_paths} <- normalize_paths(paths),
+             {:ok, excluded_paths} <- normalize_excludes(Keyword.get(opts, :exclude, [])) do
+          {:ok, normalized_paths, excluded_paths}
+        end
+      else
+        {:error, "Unknown audit options: #{Enum.map_join(unknown, ", ", &inspect/1)}."}
+      end
+    else
+      {:error, "Audit options must be a keyword list."}
+    end
+  end
+
+  defp validate_input(_paths, _opts), do: {:error, "Audit options must be a keyword list."}
+
+  defp normalize_paths(path) when is_binary(path), do: {:ok, [Path.expand(path)]}
+
+  defp normalize_paths(paths) when is_list(paths) do
+    cond do
+      paths == [] -> {:ok, [Path.expand(".")]}
+      Enum.all?(paths, &is_binary/1) -> {:ok, paths |> Enum.map(&Path.expand/1) |> Enum.uniq()}
+      true -> {:error, "Audit paths must be strings."}
+    end
+  end
+
+  defp normalize_paths(_paths), do: {:error, "Audit paths must be a string or list of strings."}
+
+  defp normalize_excludes(path) when is_binary(path), do: {:ok, [Path.expand(path)]}
+
+  defp normalize_excludes(paths) when is_list(paths) do
+    if Enum.all?(paths, &is_binary/1) do
+      {:ok, paths |> Enum.map(&Path.expand/1) |> Enum.uniq()}
+    else
+      {:error, "Excluded paths must be strings."}
+    end
+  end
+
+  defp normalize_excludes(_paths),
+    do: {:error, "Excluded paths must be a string or list of strings."}
+
+  defp collect_files(paths, excluded_paths) do
+    paths
+    |> Enum.reduce({[], []}, fn path, {files, errors} ->
+      {path_files, path_errors} = collect_path(path, excluded_paths)
+      {path_files ++ files, path_errors ++ errors}
+    end)
+    |> then(fn {files, errors} -> {files |> Enum.uniq() |> Enum.sort(), Enum.reverse(errors)} end)
+  end
+
+  defp collect_path(path, excluded_paths) do
+    cond do
+      excluded?(path, excluded_paths) ->
+        {[], []}
+
+      ignored_directory?(path) ->
+        {[], []}
+
+      true ->
+        collect_path_info(path, excluded_paths)
+    end
+  end
+
+  defp collect_path_info(path, excluded_paths) do
+    case File.lstat(path) do
+      {:ok, %{type: :regular}} ->
+        if source_file?(path), do: {[path], []}, else: {[], []}
+
+      {:ok, %{type: :directory}} ->
+        collect_directory(path, excluded_paths)
+
+      {:ok, _stat} ->
+        {[], []}
+
+      {:error, reason} ->
+        {[], [source_error(path, "Path could not be read: #{:file.format_error(reason)}")]}
+    end
+  end
+
+  defp collect_directory(path, excluded_paths) do
+    case File.ls(path) do
+      {:ok, entries} ->
+        entries
+        |> Enum.sort()
+        |> Enum.reduce({[], []}, fn entry, {files, errors} ->
+          {entry_files, entry_errors} = collect_path(Path.join(path, entry), excluded_paths)
+          {entry_files ++ files, entry_errors ++ errors}
+        end)
+
+      {:error, reason} ->
+        {[], [source_error(path, "Directory could not be read: #{:file.format_error(reason)}")]}
+    end
+  end
+
+  defp ignored_directory?(path), do: Path.basename(path) in @ignored_directories
+
+  defp excluded?(path, excluded_paths) do
+    Enum.any?(excluded_paths, fn excluded ->
+      path == excluded or String.starts_with?(path, excluded <> "/")
+    end)
+  end
+
+  defp source_file?(path), do: Path.extname(path) in [".ex", ".exs"]
+
+  defp scan_files(files) do
+    index = deprecation_index()
+    checks = migration_check_index()
+
+    files
+    |> Enum.reduce({[], []}, fn file, {findings, errors} ->
+      case scan_file(file, index, checks) do
+        {:ok, file_findings} -> {file_findings ++ findings, errors}
+        {:error, error} -> {findings, [error | errors]}
+      end
+    end)
+    |> then(fn {findings, errors} -> {sort_findings(findings), Enum.reverse(errors)} end)
+  end
+
+  defp scan_file(file, deprecations, checks) do
+    with {:ok, source} <- File.read(file),
+         {:ok, ast} <- Code.string_to_quoted(source, columns: true, token_metadata: true) do
+      findings =
+        ast
+        |> Macro.prewalk([], fn node, findings ->
+          {node, node_findings(node, file, deprecations, checks) ++ findings}
+        end)
+        |> elem(1)
+
+      {:ok, findings}
+    else
+      {:error, {line, error, _token}} ->
+        message = "Source could not be parsed at line #{line}: #{parse_error_message(error)}"
+        {:error, source_error(file, message)}
+
+      {:error, reason} ->
+        {:error, source_error(file, "Source could not be read: #{:file.format_error(reason)}")}
+    end
+  rescue
+    error ->
+      {:error, source_error(file, "Source could not be audited: #{Exception.message(error)}")}
+  end
+
+  defp node_findings(node, file, deprecations, checks) do
+    deprecated_call_findings(node, file, deprecations) ++
+      provider_options_findings(node, file, checks) ++
+      raw_stream_findings(node, file, checks) ++
+      provider_behavior_findings(node, file, checks) ++
+      output_policy_findings(node, file, checks)
+  end
+
+  defp deprecated_call_findings(node, file, deprecations) do
+    case remote_call(node) do
+      {:ok, module, function, args, metadata} ->
+        case Map.get(deprecations, {module, function}) do
+          nil -> []
+          entry -> [deprecated_finding(entry, module, function, length(args), file, metadata)]
+        end
+
+      :error ->
+        []
+    end
+  end
+
+  defp provider_options_findings(node, file, checks) do
+    with {:ok, module, _function, args, metadata} <- remote_call(node),
+         true <- module in @operation_modules,
+         [model | _rest] <- args,
+         provider when is_binary(provider) <- model_provider(model),
+         true <- legacy_provider_options?(args, provider) do
+      [check_finding(checks["v2.legacy_provider_options"], file, metadata)]
+    else
+      _other -> []
+    end
+  end
+
+  defp raw_stream_findings({:%, metadata, [module_ast, map_ast]}, file, checks) do
+    if module_name(module_ast) == "ReqLLM.StreamResponse" and stream_field?(map_ast) do
+      [check_finding(checks["v2.raw_stream_field"], file, metadata)]
+    else
+      []
+    end
+  end
+
+  defp raw_stream_findings(_node, _file, _checks), do: []
+
+  defp provider_behavior_findings({:@, metadata, [{:behaviour, _, [module_ast]}]}, file, checks) do
+    if module_name(module_ast) == "ReqLLM.Provider" do
+      [check_finding(checks["v2.provider_behaviour"], file, metadata)]
+    else
+      []
+    end
+  end
+
+  defp provider_behavior_findings({:use, metadata, [module_ast | _arguments]}, file, checks) do
+    if module_name(module_ast) == "ReqLLM.Provider" do
+      [check_finding(checks["v2.provider_behaviour"], file, metadata)]
+    else
+      []
+    end
+  end
+
+  defp provider_behavior_findings(_node, _file, _checks), do: []
+
+  defp output_policy_findings(node, file, checks) do
+    with {:ok, module, function, args, metadata} <- remote_call(node),
+         true <- module in ["ReqLLM", "ReqLLM.Generation"],
+         true <- function in (@structured_functions ++ @object_functions),
+         true <- statically_known_model?(List.first(args)),
+         true <- implicit_output_policy?(function, args) do
+      [check_finding(checks["v2.implicit_output_validation"], file, metadata)]
+    else
+      _other -> []
+    end
+  end
+
+  defp remote_call({{:., _, [module_ast, function]}, metadata, args})
+       when is_atom(function) and is_list(args) do
+    case module_name(module_ast) do
+      nil -> :error
+      module -> {:ok, module, Atom.to_string(function), args, metadata}
+    end
+  end
+
+  defp remote_call(_node), do: :error
+
+  defp module_name({:__aliases__, _, parts}) when is_list(parts) do
+    if Enum.all?(parts, &is_atom/1) do
+      Enum.map_join(parts, ".", &Atom.to_string/1)
+    end
+  end
+
+  defp module_name(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.trim_leading("Elixir.")
+  end
+
+  defp module_name(_module), do: nil
+
+  defp model_provider({model, opts}) when is_list(opts), do: model_provider(model)
+  defp model_provider({:{}, _, [model, opts]}) when is_list(opts), do: model_provider(model)
+
+  defp model_provider(model) when is_binary(model) do
+    case String.split(model, ":", parts: 2) do
+      [provider, model_id] when provider != "" and model_id != "" -> provider
+      _other -> nil
+    end
+  end
+
+  defp model_provider({provider, model_id})
+       when (is_atom(provider) or is_binary(provider)) and is_binary(model_id),
+       do: to_string(provider)
+
+  defp model_provider({:%{}, _, fields}), do: provider_from_fields(fields)
+  defp model_provider({:%, _, [_module, {:%{}, _, fields}]}), do: provider_from_fields(fields)
+  defp model_provider(_model), do: nil
+
+  defp provider_from_fields(fields) when is_list(fields) do
+    case Enum.find(fields, fn {key, _value} -> key in [:provider, "provider"] end) do
+      {_key, provider} when is_atom(provider) or is_binary(provider) -> to_string(provider)
+      _other -> nil
+    end
+  end
+
+  defp provider_from_fields(_fields), do: nil
+
+  defp legacy_provider_options?(args, provider) do
+    args
+    |> literal_option_sources()
+    |> Enum.any?(fn opts ->
+      case Keyword.fetch(opts, :provider_options) do
+        {:ok, provider_options} -> flat_provider_options?(provider_options, provider)
+        :error -> false
+      end
+    end)
+  end
+
+  defp flat_provider_options?(provider_options, provider) do
+    case container_entries(provider_options) do
+      :dynamic ->
+        false
+
+      [] ->
+        false
+
+      entries ->
+        literal_container_entries?(entries) and
+          not namespaced_provider_options?(entries, provider)
+    end
+  end
+
+  defp literal_container_entries?(entries) do
+    Enum.all?(entries, fn
+      {key, _value} when is_atom(key) or is_binary(key) -> true
+      _entry -> false
+    end)
+  end
+
+  defp namespaced_provider_options?([{key, value}], provider) do
+    to_string(key) == provider and literal_container?(value)
+  rescue
+    Protocol.UndefinedError -> false
+  end
+
+  defp namespaced_provider_options?(_entries, _provider), do: false
+
+  defp literal_container?(value), do: container_entries(value) != :dynamic
+
+  defp container_entries(value) when is_list(value) do
+    if Keyword.keyword?(value), do: value, else: :dynamic
+  end
+
+  defp container_entries({:%{}, _, fields}) when is_list(fields), do: fields
+  defp container_entries(_value), do: :dynamic
+
+  defp stream_field?({:%{}, _, fields}), do: fields_contain_stream?(fields)
+  defp stream_field?(_map_ast), do: false
+
+  defp fields_contain_stream?(fields) when is_list(fields) do
+    Enum.any?(fields, fn
+      {:stream, _value} -> true
+      {:|, _, [_base, updates]} -> fields_contain_stream?(updates)
+      _field -> false
+    end)
+  end
+
+  defp fields_contain_stream?(_fields), do: false
+
+  defp statically_known_model?(model), do: is_binary(model_provider(model))
+
+  defp implicit_output_policy?(function, args) when function in @object_functions do
+    case object_call_options(args) do
+      :default -> not option_present?(args, :output_validation)
+      {:literal, _opts} -> not option_present?(args, :output_validation)
+      :dynamic -> false
+    end
+  end
+
+  defp implicit_output_policy?(_function, args) do
+    structured_output_present?(args) and not option_present?(args, :output_validation)
+  end
+
+  defp object_call_options(args) do
+    case length(args) do
+      3 -> :default
+      4 -> if literal_keyword?(List.last(args)), do: {:literal, List.last(args)}, else: :dynamic
+      _arity -> :dynamic
+    end
+  end
+
+  defp structured_output_present?(args) do
+    args
+    |> literal_option_sources()
+    |> Enum.any?(fn opts ->
+      case Keyword.fetch(opts, :output) do
+        {:ok, output} -> structured_output_constructor?(output)
+        :error -> false
+      end
+    end)
+  end
+
+  defp structured_output_constructor?(node) do
+    case remote_call(node) do
+      {:ok, "ReqLLM.Output", function, _args, _metadata} -> function in @structured_constructors
+      _other -> false
+    end
+  end
+
+  defp option_present?(args, key) do
+    args
+    |> literal_option_sources()
+    |> Enum.any?(&Keyword.has_key?(&1, key))
+  end
+
+  defp literal_option_sources(args) do
+    direct = Enum.filter(args, &literal_keyword?/1)
+
+    tuple_options =
+      case List.first(args) do
+        {_model, opts} when is_list(opts) ->
+          if literal_keyword?(opts), do: [opts], else: []
+
+        {:{}, _, [_model, opts]} when is_list(opts) ->
+          if literal_keyword?(opts), do: [opts], else: []
+
+        _model ->
+          []
+      end
+
+    direct ++ tuple_options
+  end
+
+  defp literal_keyword?(value), do: is_list(value) and Keyword.keyword?(value)
+
+  defp deprecation_index do
+    Map.new(ReqLLM.Migration.deprecations(), fn entry ->
+      detector = entry["detector"]
+      {{detector["module"], detector["function"]}, entry}
+    end)
+  end
+
+  defp migration_check_index do
+    Map.new(ReqLLM.Migration.migration_checks(), &{&1["id"], &1})
+  end
+
+  defp deprecated_finding(entry, module, function, arity, file, metadata) do
+    finding(entry, file, metadata, %{
+      "actionable" => true,
+      "category" => "deprecated_api",
+      "contract" => "#{module}.#{function}/#{arity}",
+      "message" => "#{entry["contract"]} is deprecated."
+    })
+  end
+
+  defp check_finding(entry, file, metadata) do
+    category = if entry["actionable"], do: "migration", else: "advisory"
+
+    finding(entry, file, metadata, %{
+      "actionable" => entry["actionable"],
+      "category" => category,
+      "contract" => entry["contract"],
+      "message" => entry["contract"] <> "."
+    })
+  end
+
+  defp finding(entry, file, metadata, fields) do
+    Map.merge(
+      %{
+        "id" => entry["id"],
+        "file" => display_path(file),
+        "line" => Keyword.get(metadata, :line, 1),
+        "column" => Keyword.get(metadata, :column, 1),
+        "owner" => entry["owner"],
+        "replacement" => entry["replacement"],
+        "guide" => entry["guide"]
+      },
+      fields
+    )
+  end
+
+  defp sort_findings(findings) do
+    findings
+    |> Enum.uniq_by(&{&1["id"], &1["file"], &1["line"], &1["column"], &1["contract"]})
+    |> Enum.sort_by(&{&1["file"], &1["line"], &1["column"], &1["id"]})
+  end
+
+  defp sort_errors(errors), do: Enum.sort_by(errors, &{&1["file"] || "", &1["message"]})
+
+  defp parse_error_message(error) when is_binary(error), do: error
+  defp parse_error_message(error), do: inspect(error)
+
+  defp report(files, findings, errors) do
+    actionable = Enum.count(findings, & &1["actionable"])
+    advisory = length(findings) - actionable
+
+    status =
+      cond do
+        errors != [] -> "error"
+        actionable > 0 -> "findings"
+        advisory > 0 -> "advisory"
+        true -> "clean"
+      end
+
+    %{
+      "schema_version" => @schema_version,
+      "status" => status,
+      "summary" => %{
+        "files_scanned" => length(files),
+        "actionable" => actionable,
+        "advisory" => advisory,
+        "errors" => length(errors)
+      },
+      "findings" => findings,
+      "errors" => errors
+    }
+  end
+
+  defp input_errors(messages) do
+    Enum.map(messages, &source_error(nil, &1))
+  end
+
+  defp source_error(file, message) do
+    %{"file" => optional_display_path(file), "message" => message}
+  end
+
+  defp optional_display_path(nil), do: nil
+  defp optional_display_path(file), do: display_path(file)
+
+  defp display_path(file), do: Path.relative_to_cwd(file)
+
+  defp format_finding(finding) do
+    marker = if finding["actionable"], do: "!", else: "i"
+
+    [
+      "#{marker} #{finding["file"]}:#{finding["line"]}:#{finding["column"]} #{finding["id"]}",
+      "  #{finding["message"]}",
+      "  Replace: #{finding["replacement"]}",
+      "  Guide: #{finding["guide"]}"
+    ]
+  end
+
+  defp format_error(error) do
+    case error["file"] do
+      nil -> "x #{error["message"]}"
+      file -> "x #{file}: #{error["message"]}"
+    end
+  end
+end

--- a/lib/req_llm/migration/audit.ex
+++ b/lib/req_llm/migration/audit.ex
@@ -453,13 +453,20 @@ defmodule ReqLLM.Migration.Audit do
   end
 
   defp deprecated_finding(entry, module, function, arity, file, metadata) do
+    actionable = entry["v2_scope"] == "approved"
+
     finding(entry, file, metadata, %{
-      "actionable" => true,
+      "actionable" => actionable,
       "category" => "deprecated_api",
       "contract" => "#{module}.#{function}/#{arity}",
-      "message" => "#{entry["contract"]} is deprecated."
+      "message" => deprecated_message(entry, actionable)
     })
   end
+
+  defp deprecated_message(entry, true), do: "#{entry["contract"]} is deprecated."
+
+  defp deprecated_message(entry, false),
+    do: "#{entry["contract"]} is deprecated but is not approved for removal in V2."
 
   defp check_finding(entry, file, metadata) do
     category = if entry["actionable"], do: "migration", else: "advisory"

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule ReqLLM.MixProject do
           "guides/image-generation.md",
           "guides/model-metadata.md",
           "guides/model-support.md",
+          "guides/v2-migration-audit.md",
           "guides/getting-started.livemd",
           "guides/image-generation.livemd",
           "guides/mix-tasks.md",
@@ -105,7 +106,8 @@ defmodule ReqLLM.MixProject do
             "guides/usage-and-billing.md",
             "guides/image-generation.md",
             "guides/model-metadata.md",
-            "guides/model-support.md"
+            "guides/model-support.md",
+            "guides/v2-migration-audit.md"
           ],
           Livebooks: [
             "guides/getting-started.livemd",
@@ -162,7 +164,8 @@ defmodule ReqLLM.MixProject do
             ReqLLM.Usage,
             ReqLLM.Error,
             ReqLLM.Debug,
-            ReqLLM.ParamTransform
+            ReqLLM.ParamTransform,
+            ReqLLM.Migration
           ],
           "Data Structures": [
             ReqLLM.Message,

--- a/priv/deprecations.json
+++ b/priv/deprecations.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": 1,
+  "deprecations": [
+    {
+      "id": "req_llm.stream_text_bang",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.stream_text!/3",
+      "replacement": "ReqLLM.stream_text/3 and a ReqLLM.StreamResponse projection",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#bang-streaming-apis",
+      "detector": {"type": "remote_call", "module": "ReqLLM", "function": "stream_text!"}
+    },
+    {
+      "id": "req_llm.generation.stream_text_bang",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Generation.stream_text!/3",
+      "replacement": "ReqLLM.Generation.stream_text/3 and a ReqLLM.StreamResponse projection",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#bang-streaming-apis",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Generation", "function": "stream_text!"}
+    },
+    {
+      "id": "req_llm.stream_object_bang",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.stream_object!/4",
+      "replacement": "ReqLLM.stream_object/4 and a ReqLLM.StreamResponse projection",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#bang-streaming-apis",
+      "detector": {"type": "remote_call", "module": "ReqLLM", "function": "stream_object!"}
+    },
+    {
+      "id": "req_llm.generation.stream_object_bang",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Generation.stream_object!/4",
+      "replacement": "ReqLLM.Generation.stream_object/4 and a ReqLLM.StreamResponse projection",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#bang-streaming-apis",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Generation", "function": "stream_object!"}
+    },
+    {
+      "id": "req_llm.context.assistant_with_tools",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Context.assistant_with_tools/2",
+      "replacement": "ReqLLM.Context.assistant/2 with the :tool_calls option",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#context-tool-call-helpers",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Context", "function": "assistant_with_tools"}
+    },
+    {
+      "id": "req_llm.context.assistant_tool_call",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Context.assistant_tool_call/3",
+      "replacement": "ReqLLM.Context.assistant/2 with one :tool_calls entry",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#context-tool-call-helpers",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Context", "function": "assistant_tool_call"}
+    },
+    {
+      "id": "req_llm.context.assistant_tool_calls",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Context.assistant_tool_calls/2",
+      "replacement": "ReqLLM.Context.assistant/2 with the :tool_calls option",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#context-tool-call-helpers",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Context", "function": "assistant_tool_calls"}
+    },
+    {
+      "id": "req_llm.keys.fetch_bang",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Keys.fetch!/2",
+      "replacement": "ReqLLM.Keys.get!/2",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#key-lookup-aliases",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Keys", "function": "fetch!"}
+    },
+    {
+      "id": "req_llm.keys.fetch",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.Keys.fetch/2",
+      "replacement": "ReqLLM.Keys.get/2",
+      "introduced_version": "0.2.10",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#key-lookup-aliases",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Keys", "function": "fetch"}
+    },
+    {
+      "id": "req_llm.tool_call.builtin_flag",
+      "owner": "ReqLLM core maintainers",
+      "contract": "ReqLLM.ToolCall.builtin_flag?/1",
+      "replacement": "ReqLLM.ToolCall.flagged_builtin?/1",
+      "introduced_version": "1.12.0",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#tool-call-flag-helper",
+      "detector": {"type": "remote_call", "module": "ReqLLM.ToolCall", "function": "builtin_flag?"}
+    },
+    {
+      "id": "req_llm.providers.meta.format_request",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "ReqLLM.Providers.Meta.format_request/2",
+      "replacement": "ReqLLM.Providers.Meta.Llama.format_request/2",
+      "introduced_version": "unreleased",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#meta-llama-delegates",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Providers.Meta", "function": "format_request"}
+    },
+    {
+      "id": "req_llm.providers.meta.format_llama_prompt",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "ReqLLM.Providers.Meta.format_llama_prompt/1",
+      "replacement": "ReqLLM.Providers.Meta.Llama.format_llama_prompt/1",
+      "introduced_version": "unreleased",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#meta-llama-delegates",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Providers.Meta", "function": "format_llama_prompt"}
+    },
+    {
+      "id": "req_llm.providers.meta.parse_response",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "ReqLLM.Providers.Meta.parse_response/2",
+      "replacement": "ReqLLM.Providers.Meta.Llama.parse_response/2",
+      "introduced_version": "unreleased",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#meta-llama-delegates",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Providers.Meta", "function": "parse_response"}
+    },
+    {
+      "id": "req_llm.providers.meta.extract_usage",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "ReqLLM.Providers.Meta.extract_usage/1",
+      "replacement": "ReqLLM.Providers.Meta.Llama.extract_usage/1",
+      "introduced_version": "unreleased",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#meta-llama-delegates",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Providers.Meta", "function": "extract_usage"}
+    },
+    {
+      "id": "req_llm.providers.meta.parse_stop_reason",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "ReqLLM.Providers.Meta.parse_stop_reason/1",
+      "replacement": "ReqLLM.Providers.Meta.Llama.parse_stop_reason/1",
+      "introduced_version": "unreleased",
+      "target_major": 2,
+      "v2_scope": "unapproved",
+      "minimum_window": {"minor_releases": 2},
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#meta-llama-delegates",
+      "detector": {"type": "remote_call", "module": "ReqLLM.Providers.Meta", "function": "parse_stop_reason"}
+    }
+  ],
+  "migration_checks": [
+    {
+      "id": "v2.legacy_provider_options",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "Literal flat provider_options paired with a literal provider model",
+      "replacement": "Wrap provider-specific options in the selected provider namespace",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "actionable": true,
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#provider-option-namespaces",
+      "detector": {"type": "legacy_provider_options"}
+    },
+    {
+      "id": "v2.raw_stream_field",
+      "owner": "ReqLLM streaming maintainers",
+      "contract": "Explicit matching on the ReqLLM.StreamResponse.stream field",
+      "replacement": "Select ReqLLM.StreamResponse.events/1, tokens/1, or another named projection",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "actionable": true,
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#raw-stream-assumptions",
+      "detector": {"type": "stream_response_field"}
+    },
+    {
+      "id": "v2.provider_behaviour",
+      "owner": "ReqLLM provider maintainers",
+      "contract": "A module that directly uses or declares the ReqLLM.Provider behavior",
+      "replacement": "No V2 replacement is frozen; inventory the extension and keep the V1 conformance suite green",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "actionable": false,
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#provider-extension-inventory",
+      "detector": {"type": "provider_behavior"}
+    },
+    {
+      "id": "v2.implicit_output_validation",
+      "owner": "ReqLLM structured-output maintainers",
+      "contract": "A statically structured output call without an explicit output_validation policy",
+      "replacement": "Set output_validation to :compatible, :warn, or :strict explicitly",
+      "target_major": 2,
+      "v2_scope": "approved",
+      "actionable": true,
+      "guide": "https://hexdocs.pm/req_llm/v2-migration-audit.html#structured-output-validation-default",
+      "detector": {"type": "implicit_output_validation"}
+    }
+  ]
+}

--- a/test/mix/tasks/req_llm.migration_audit_test.exs
+++ b/test/mix/tasks/req_llm.migration_audit_test.exs
@@ -1,0 +1,97 @@
+defmodule Mix.Tasks.ReqLlm.MigrationAuditTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.ReqLlm.MigrationAudit, as: MigrationAuditTask
+
+  setup do
+    directory =
+      Path.join(System.tmp_dir!(), "req-llm-migration-task-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+
+    on_exit(fn ->
+      File.rm_rf!(directory)
+      Mix.Task.reenable("req_llm.migration_audit")
+    end)
+
+    %{directory: directory}
+  end
+
+  test "prints a clean human report", %{directory: directory} do
+    File.write!(Path.join(directory, "clean.ex"), "defmodule CleanTaskFixture do\nend\n")
+
+    output = capture_io(fn -> MigrationAuditTask.run([directory]) end)
+
+    assert output =~ "ReqLLM V2 migration audit: CLEAN"
+    assert output =~ "1 files, 0 actionable, 0 advisory, 0 errors"
+  end
+
+  test "prints stable JSON before failing for actionable findings", %{directory: directory} do
+    File.write!(
+      Path.join(directory, "deprecated.ex"),
+      "defmodule DeprecatedTaskFixture do\n  def run, do: ReqLLM.Keys.fetch(:openai)\nend\n"
+    )
+
+    output =
+      capture_io(fn ->
+        assert catch_exit(MigrationAuditTask.run([directory, "--json"])) == {:shutdown, 1}
+      end)
+
+    report = Jason.decode!(output)
+
+    assert report["schema_version"] == 1
+    assert report["status"] == "findings"
+    assert hd(report["findings"])["id"] == "req_llm.keys.fetch"
+  end
+
+  test "uses exit status 2 for audit errors", %{directory: directory} do
+    missing = Path.join(directory, "missing")
+
+    output =
+      capture_io(fn ->
+        assert catch_exit(MigrationAuditTask.run([missing, "--json"])) == {:shutdown, 2}
+      end)
+
+    report = Jason.decode!(output)
+    assert report["status"] == "error"
+    assert report["summary"]["errors"] == 1
+  end
+
+  test "supports repeated exclusions", %{directory: directory} do
+    first = Path.join(directory, "first")
+    second = Path.join(directory, "second")
+    File.mkdir_p!(first)
+    File.mkdir_p!(second)
+    File.write!(Path.join(first, "one.ex"), "ReqLLM.Keys.fetch(:openai)\n")
+    File.write!(Path.join(second, "two.ex"), "ReqLLM.Keys.fetch(:openai)\n")
+
+    output =
+      capture_io(fn ->
+        MigrationAuditTask.run([
+          directory,
+          "--exclude",
+          first,
+          "--exclude",
+          second,
+          "--format",
+          "json"
+        ])
+      end)
+
+    report = Jason.decode!(output)
+    assert report["status"] == "clean"
+    assert report["summary"]["files_scanned"] == 0
+  end
+
+  test "rejects invalid command options" do
+    assert_raise Mix.Error, ~r/Invalid arguments/, fn ->
+      MigrationAuditTask.run(["--unknown"])
+    end
+
+    assert_raise Mix.Error, ~r/format must be human or json/, fn ->
+      MigrationAuditTask.run(["--format", "yaml"])
+    end
+  end
+end

--- a/test/mix/tasks/req_llm.migration_audit_test.exs
+++ b/test/mix/tasks/req_llm.migration_audit_test.exs
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.ReqLlm.MigrationAuditTest do
   test "prints stable JSON before failing for actionable findings", %{directory: directory} do
     File.write!(
       Path.join(directory, "deprecated.ex"),
-      "defmodule DeprecatedTaskFixture do\n  def run, do: ReqLLM.Keys.fetch(:openai)\nend\n"
+      "defmodule DeprecatedTaskFixture do\n  def run, do: ReqLLM.stream_text!(\"openai:gpt-4o\", \"hello\")\nend\n"
     )
 
     output =
@@ -43,7 +43,21 @@ defmodule Mix.Tasks.ReqLlm.MigrationAuditTest do
 
     assert report["schema_version"] == 1
     assert report["status"] == "findings"
-    assert hd(report["findings"])["id"] == "req_llm.keys.fetch"
+    assert hd(report["findings"])["id"] == "req_llm.stream_text_bang"
+  end
+
+  test "exits successfully for unapproved deprecation advisories", %{directory: directory} do
+    File.write!(
+      Path.join(directory, "advisory.ex"),
+      "defmodule AdvisoryTaskFixture do\n  def run, do: ReqLLM.Keys.fetch(:openai)\nend\n"
+    )
+
+    output = capture_io(fn -> MigrationAuditTask.run([directory, "--json"]) end)
+    report = Jason.decode!(output)
+
+    assert report["status"] == "advisory"
+    assert report["summary"]["actionable"] == 0
+    assert report["summary"]["advisory"] == 1
   end
 
   test "uses exit status 2 for audit errors", %{directory: directory} do

--- a/test/req_llm/migration_test.exs
+++ b/test/req_llm/migration_test.exs
@@ -155,6 +155,27 @@ defmodule ReqLLM.MigrationTest do
     assert Migration.exit_status(report) == 0
   end
 
+  test "reports unapproved deprecations without blocking V2 readiness", %{directory: directory} do
+    path = Path.join(directory, "unapproved.ex")
+
+    File.write!(path, """
+    defmodule UnapprovedDeprecation do
+      def run, do: ReqLLM.Keys.fetch(:openai)
+    end
+    """)
+
+    report = Migration.audit(path)
+    finding = hd(report["findings"])
+
+    assert report["status"] == "advisory"
+    assert report["summary"]["actionable"] == 0
+    assert report["summary"]["advisory"] == 1
+    assert finding["id"] == "req_llm.keys.fetch"
+    assert finding["actionable"] == false
+    assert finding["message"] =~ "not approved for removal in V2"
+    assert Migration.exit_status(report) == 0
+  end
+
   test "detects every ledger-backed deprecated remote call", %{directory: directory} do
     path = Path.join(directory, "deprecated.ex")
 
@@ -177,6 +198,9 @@ defmodule ReqLLM.MigrationTest do
     ledger_ids = Migration.deprecations() |> Enum.map(& &1["id"]) |> Enum.sort()
 
     assert detected_ids == ledger_ids
+
+    assert report["summary"]["actionable"] == 4
+    assert report["summary"]["advisory"] == 11
   end
 
   test "ignores dynamic migration shapes it cannot prove", %{directory: directory} do

--- a/test/req_llm/migration_test.exs
+++ b/test/req_llm/migration_test.exs
@@ -1,0 +1,273 @@
+defmodule ReqLLM.MigrationTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Migration
+
+  setup do
+    directory =
+      Path.join(System.tmp_dir!(), "req-llm-migration-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf!(directory) end)
+
+    %{directory: directory}
+  end
+
+  test "ships a valid JSON ledger with unique owned records" do
+    assert :ok = Migration.validate_ledger()
+
+    ledger = Migration.ledger()
+    records = ledger["deprecations"] ++ ledger["migration_checks"]
+
+    assert ledger["schema_version"] == 1
+    assert length(records) == length(Enum.uniq_by(records, & &1["id"]))
+    assert Enum.all?(records, &is_binary(&1["owner"]))
+    assert Enum.all?(records, &is_binary(&1["guide"]))
+    assert Jason.decode!(Jason.encode!(ledger)) == ledger
+  end
+
+  test "keeps the approved removal set aligned with the V2 roadmap" do
+    approved_deprecations =
+      Migration.deprecations()
+      |> Enum.filter(&(&1["v2_scope"] == "approved"))
+      |> Enum.map(& &1["contract"])
+      |> Enum.sort()
+
+    assert approved_deprecations == [
+             "ReqLLM.Generation.stream_object!/4",
+             "ReqLLM.Generation.stream_text!/3",
+             "ReqLLM.stream_object!/4",
+             "ReqLLM.stream_text!/3"
+           ]
+
+    approved_checks =
+      Migration.migration_checks()
+      |> Enum.filter(&(&1["v2_scope"] == "approved"))
+      |> Enum.map(& &1["id"])
+      |> Enum.sort()
+
+    assert approved_checks == [
+             "v2.implicit_output_validation",
+             "v2.legacy_provider_options",
+             "v2.provider_behaviour",
+             "v2.raw_stream_field"
+           ]
+  end
+
+  test "records every active compiled ReqLLM deprecation" do
+    {:ok, modules} = :application.get_key(:req_llm, :modules)
+
+    compiled_contracts =
+      modules
+      |> Enum.flat_map(&deprecated_contracts/1)
+      |> Enum.sort()
+
+    ledger_contracts =
+      Migration.deprecations()
+      |> Enum.map(& &1["contract"])
+      |> Enum.sort()
+
+    assert ledger_contracts == compiled_contracts
+  end
+
+  test "detects each precise migration pattern without evaluating source", %{directory: directory} do
+    path = Path.join(directory, "sample.ex")
+
+    File.write!(path, """
+    defmodule Sample do
+      @behaviour ReqLLM.Provider
+
+      def run(value) do
+        ReqLLM.stream_text!("openai:gpt-4o", "hello")
+
+        ReqLLM.generate_text("openai:gpt-4o", "hello",
+          provider_options: [store: false]
+        )
+
+        ReqLLM.generate_text("openai:gpt-4o", "hello",
+          output: ReqLLM.Output.object(name: [type: :string])
+        )
+
+        case value do
+          %ReqLLM.StreamResponse{stream: stream} -> stream
+        end
+      end
+    end
+    """)
+
+    report = Migration.audit(directory)
+    ids = Enum.map(report["findings"], & &1["id"])
+
+    assert report["status"] == "findings"
+
+    assert report["summary"] == %{
+             "files_scanned" => 1,
+             "actionable" => 4,
+             "advisory" => 1,
+             "errors" => 0
+           }
+
+    assert "req_llm.stream_text_bang" in ids
+    assert "v2.legacy_provider_options" in ids
+    assert "v2.raw_stream_field" in ids
+    assert "v2.provider_behaviour" in ids
+    assert "v2.implicit_output_validation" in ids
+    assert Migration.exit_status(report) == 1
+    assert Jason.encode!(report)
+  end
+
+  test "accepts namespaced options and explicit structured-output policy", %{directory: directory} do
+    path = Path.join(directory, "clean.ex")
+
+    File.write!(path, """
+    defmodule Clean do
+      def run do
+        ReqLLM.generate_text("openai:gpt-4o", "hello",
+          provider_options: [openai: [store: false]],
+          output: ReqLLM.Output.object(name: [type: :string]),
+          output_validation: :strict
+        )
+      end
+    end
+    """)
+
+    report = Migration.audit(path)
+
+    assert report["status"] == "clean"
+    assert report["findings"] == []
+    assert Migration.exit_status(report) == 0
+  end
+
+  test "reports provider extensions as non-failing advisories", %{directory: directory} do
+    path = Path.join(directory, "provider.ex")
+
+    File.write!(path, """
+    defmodule CustomProvider do
+      use ReqLLM.Provider, id: :custom_provider
+    end
+    """)
+
+    report = Migration.audit(path)
+
+    assert report["status"] == "advisory"
+    assert report["summary"]["advisory"] == 1
+    assert report["summary"]["actionable"] == 0
+    assert Migration.exit_status(report) == 0
+  end
+
+  test "detects every ledger-backed deprecated remote call", %{directory: directory} do
+    path = Path.join(directory, "deprecated.ex")
+
+    calls =
+      Enum.map_join(Migration.deprecations(), "\n", fn entry ->
+        detector = entry["detector"]
+        "#{detector["module"]}.#{detector["function"]}()"
+      end)
+
+    File.write!(path, "defmodule DeprecatedCalls do\n  def run do\n#{calls}\n  end\nend\n")
+
+    report = Migration.audit(path)
+
+    detected_ids =
+      report["findings"]
+      |> Enum.filter(&(&1["category"] == "deprecated_api"))
+      |> Enum.map(& &1["id"])
+      |> Enum.sort()
+
+    ledger_ids = Migration.deprecations() |> Enum.map(& &1["id"]) |> Enum.sort()
+
+    assert detected_ids == ledger_ids
+  end
+
+  test "ignores dynamic migration shapes it cannot prove", %{directory: directory} do
+    path = Path.join(directory, "dynamic.ex")
+
+    File.write!(path, """
+    defmodule Dynamic do
+      def run(model, options, output) do
+        ReqLLM.generate_text(model, "hello", options)
+        ReqLLM.generate_text("openai:gpt-4o", "hello", output: output)
+        ReqLLM.generate_text("openai:gpt-4o", "hello", provider_options: options)
+        ReqLLM.generate_text("openai:gpt-4o", "hello", provider_options: %{output => true})
+        __MODULE__.Helpers.run()
+      end
+    end
+    """)
+
+    report = Migration.audit(path)
+
+    assert report["status"] == "clean"
+    assert report["findings"] == []
+  end
+
+  test "does not change audited files or create artifacts", %{directory: directory} do
+    path = Path.join(directory, "read_only.ex")
+    body = "defmodule ReadOnly do\n  def run, do: :ok\nend\n"
+    File.write!(path, body)
+    entries_before = File.ls!(directory)
+    stat_before = File.stat!(path)
+
+    report = Migration.audit(directory)
+
+    assert report["status"] == "clean"
+    assert File.read!(path) == body
+    assert File.ls!(directory) == entries_before
+    assert File.stat!(path).mtime == stat_before.mtime
+  end
+
+  test "reports parse and path failures with exit status 2", %{directory: directory} do
+    invalid_path = Path.join(directory, "invalid.ex")
+    missing_path = Path.join(directory, "missing")
+    File.write!(invalid_path, "defmodule Invalid do")
+
+    report = Migration.audit([invalid_path, missing_path])
+
+    assert report["status"] == "error"
+    assert report["summary"]["errors"] == 2
+    assert Migration.exit_status(report) == 2
+  end
+
+  test "returns machine-readable errors for invalid public API input" do
+    invalid_options = Migration.audit(".", ["invalid"])
+    invalid_paths = Migration.audit([:invalid])
+
+    assert invalid_options["status"] == "error"
+    assert invalid_paths["status"] == "error"
+    assert invalid_options["summary"]["files_scanned"] == 0
+    assert Migration.exit_status(invalid_options) == 2
+    assert Jason.encode!(invalid_options)
+  end
+
+  test "honors explicit excluded paths", %{directory: directory} do
+    included = Path.join(directory, "included.ex")
+    excluded = Path.join(directory, "excluded")
+    File.mkdir_p!(excluded)
+    File.write!(included, "defmodule Included do\n  def run, do: :ok\nend\n")
+
+    File.write!(
+      Path.join(excluded, "deprecated.ex"),
+      "defmodule Excluded do\n  def run, do: ReqLLM.stream_text!(\"openai:gpt-4o\", \"hi\")\nend\n"
+    )
+
+    report = Migration.audit(directory, exclude: excluded)
+
+    assert report["status"] == "clean"
+    assert report["summary"]["files_scanned"] == 1
+  end
+
+  defp deprecated_contracts(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        Enum.flat_map(docs, fn
+          {{:function, name, arity}, _, _, _, %{deprecated: _message}} ->
+            ["#{inspect(module)}.#{name}/#{arity}"]
+
+          _doc ->
+            []
+        end)
+
+      _docs ->
+        []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- publish a schema-versioned ledger covering every active compiled ReqLLM deprecation, including ownership, replacement, overlap window, target major, and explicit V2 scope status
- add the read-only ReqLLM.Migration API and mix req_llm.migration_audit with deterministic human and JSON reports
- detect only precise source patterns: deprecated remote calls, literal legacy provider options, explicit StreamResponse stream matching, direct provider behavior declarations, and statically ambiguous structured-output validation
- document before/after migrations, stable machine output, exit statuses, and intentional static-analysis limitations

## Compatibility

This is additive V1 tooling. It does not remove or change any existing API, option, provider behavior, stream shape, or structured-output default. Only the bang streaming removals already approved by the V2 roadmap are marked in approved V2 scope; all other active deprecations remain explicitly unapproved for V2 removal.

## Validation

- focused migration and Mix task tests: 17 passed
- full suite: 3,933 passed, 11 skipped, 145 excluded
- mix quality
- mix docs
- Hex package dry run includes the task, ledger, and guide

Closes #863