### PR TITLE
feat: add owned provider file references

### DIFF
--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -121,6 +121,9 @@ Typed content elements that compose a `Message`. Common variants:
 - `image/2`: `ContentPart.image(binary, "image/png")`
 - `image/3`: `ContentPart.image(binary, "image/png", metadata)` with metadata
 - `file/3`: `ContentPart.file(binary, "name.ext", "mime/type")`
+- `file_id/1`: `ContentPart.file_id("file_123")` for a legacy unowned provider reference
+- `owned_file_id/3`: `ContentPart.owned_file_id("file_123", :openai, purpose: :assistants)`
+  for an explicitly provider-owned reference
 - `thinking/1`: `ContentPart.thinking("...")` for models that expose reasoning tokens
 - `tool_call/2`: `ContentPart.tool_call("name", %{arg: "value"})` for assistant-issued calls
 - `tool_result/2`: `ContentPart.tool_result("tool_call_id", %{...})` for tool outputs
@@ -159,6 +162,42 @@ cached_binary_image = ContentPart.image(
   %{cache_control: %{type: "ephemeral"}}
 )
 ```
+
+### Provider-owned file references
+
+`owned_file_id/3` adds lifecycle information without adding fields to
+`ContentPart` or changing `file_id/1`. Ownership lives under the reserved
+`"req_llm" -> "provider_file"` metadata namespace:
+
+```elixir
+owned_file =
+  ContentPart.owned_file_id("file_123", :openai,
+    media_type: "application/pdf",
+    purpose: :assistants,
+    status: :processed,
+    expires_at: ~U[2030-01-01 00:00:00Z],
+    size: 12_345,
+    sha256: "...",
+    provider_metadata: %{tenant: "documentation"}
+  )
+```
+
+ReqLLM validates only explicitly owned references. Using an owned file with a
+different provider, or using it after a known `expires_at`, returns
+`ReqLLM.Error.Invalid.ProviderFileReference` before a model request starts.
+Plain `file_id/1` references remain unowned and retain their existing routing,
+encoding, errors, struct value, JSON, and inspection behavior.
+
+OpenAI and Anthropic encode a matching owned reference through their existing
+file-ID wire format. Google encodes the reference ID as a Gemini `fileData`
+URI. The constructor does not upload data, read local paths, or infer ownership
+from an ID prefix.
+
+`ContentPart.provider_file_reference/1` returns the complete persisted record.
+Treat it as sensitive because it contains the provider reference ID. Use
+`ContentPart.inspect_provider_file/1` for a redacted diagnostic value; regular
+`Inspect` and telemetry also redact IDs, URLs, and credential-like metadata for
+owned references.
 
 **How this supports normalization**:
 - Discriminated union eliminates polymorphism across providers.

--- a/lib/req_llm/error.ex
+++ b/lib/req_llm/error.ex
@@ -157,6 +157,31 @@ defmodule ReqLLM.Error do
     end
   end
 
+  defmodule Invalid.ProviderFileReference do
+    @moduledoc "Error for an explicitly owned provider file used outside its lifecycle."
+    use Splode.Error,
+      fields: [:reason, :owner, :provider, :expires_at, :status],
+      class: :invalid
+
+    @typedoc "Validation error for an explicitly provider-owned file reference."
+    @type t() :: %__MODULE__{
+            reason: :provider_mismatch | :expired,
+            owner: String.t(),
+            provider: String.t(),
+            expires_at: String.t() | nil,
+            status: String.t() | nil
+          }
+
+    @spec message(t()) :: String.t()
+    def message(%{reason: :provider_mismatch, owner: owner, provider: provider}) do
+      "Owned provider file belongs to #{owner} and cannot be used with #{provider}"
+    end
+
+    def message(%{reason: :expired, owner: owner, expires_at: expires_at}) do
+      "Owned #{owner} provider file expired at #{expires_at}"
+    end
+  end
+
   defmodule Invalid.NotImplemented do
     @moduledoc "Error for unimplemented functionality."
     use Splode.Error, fields: [:feature], class: :invalid

--- a/lib/req_llm/generation.ex
+++ b/lib/req_llm/generation.ex
@@ -115,7 +115,8 @@ defmodule ReqLLM.Generation do
              model,
              opts
            ),
-         {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
+         {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
+         :ok <- ReqLLM.ProviderFileReference.validate_context(context, model.provider) do
       case ReqLLM.Cache.fetch(model, :chat, context, opts) do
         {:hit, response, _cache_ref} ->
           {:ok, response}
@@ -237,7 +238,8 @@ defmodule ReqLLM.Generation do
              model,
              opts
            ),
-         {:ok, context} <- ReqLLM.Context.normalize(messages, opts) do
+         {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
+         :ok <- ReqLLM.ProviderFileReference.validate_context(context, model.provider) do
       case ReqLLM.Cache.fetch(model, :chat, context, opts) do
         {:hit, response, _cache_ref} ->
           {:ok, ReqLLM.Cache.stream_response(response, model, context)}
@@ -387,6 +389,7 @@ defmodule ReqLLM.Generation do
              opts
            ),
          {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
+         :ok <- ReqLLM.ProviderFileReference.validate_context(context, model.provider),
          {:ok, compiled_schema} <- compile_schema_source(schema_source) do
       compiled_opts = Keyword.put(opts, :compiled_schema, compiled_schema)
       contract = ReqLLM.Output.Validation.validation_contract(descriptor, compiled_schema)
@@ -690,6 +693,8 @@ defmodule ReqLLM.Generation do
              model,
              opts
            ),
+         {:ok, context} <- ReqLLM.Context.normalize(messages, opts),
+         :ok <- ReqLLM.ProviderFileReference.validate_context(context, model.provider),
          {:ok, compiled_schema} <- compile_schema_source(schema_source),
          {:ok, prepared_req} <-
            provider_module.prepare_request(

--- a/lib/req_llm/message/content_part.ex
+++ b/lib/req_llm/message/content_part.ex
@@ -10,6 +10,9 @@ defmodule ReqLLM.Message.ContentPart do
   - `:file` - File attachment or uploaded file reference
   - `:thinking` - Chain-of-thought thinking content
 
+  Provider-owned file references are opt-in through `owned_file_id/3`. Legacy
+  `file_id/1` values remain unowned and preserve their existing behavior.
+
   ## See also
 
   - `ReqLLM.Message` - Multi-modal message composition using ContentPart collections
@@ -91,6 +94,58 @@ defmodule ReqLLM.Message.ContentPart do
   def file_id(file_id, media_type, metadata),
     do: %__MODULE__{type: :file, file_id: file_id, media_type: media_type, metadata: metadata}
 
+  @doc """
+  Creates an explicitly provider-owned file reference.
+
+  Ownership is stored in the reserved `"req_llm" -> "provider_file"` metadata
+  namespace. Legacy `file_id/1` references remain unowned and keep their existing
+  behavior.
+
+  Supported options are `:media_type`, `:metadata`, `:purpose`, `:status`,
+  `:expires_at`, `:size`, `:sha256`, and `:provider_metadata`.
+  """
+  @spec owned_file_id(String.t(), atom() | String.t(), keyword()) :: t()
+  def owned_file_id(file_id, provider, opts \\ []) when is_list(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "provider-owned file options must be a keyword list"
+    end
+
+    media_type = Keyword.get(opts, :media_type, "application/pdf")
+    metadata = Keyword.get(opts, :metadata, %{})
+
+    unless is_binary(media_type) and media_type != "" do
+      raise ArgumentError, "media_type must be a non-empty string"
+    end
+
+    unless is_map(metadata) do
+      raise ArgumentError, "metadata must be a map"
+    end
+
+    reference_opts = Keyword.drop(opts, [:media_type, :metadata])
+    reference = ReqLLM.ProviderFileReference.new!(provider, file_id, reference_opts)
+
+    %__MODULE__{
+      type: :file,
+      file_id: file_id,
+      media_type: media_type,
+      metadata: ReqLLM.ProviderFileReference.put(metadata, reference)
+    }
+  end
+
+  @doc "Returns whether a file reference has explicit provider ownership metadata."
+  @spec owned_file?(t() | map()) :: boolean()
+  def owned_file?(part), do: ReqLLM.ProviderFileReference.owned?(part)
+
+  @doc "Returns the full metadata record for an explicitly owned provider file."
+  @spec provider_file_reference(t() | map()) ::
+          {:ok, ReqLLM.ProviderFileReference.t()} | :error
+  def provider_file_reference(part), do: ReqLLM.ProviderFileReference.fetch(part)
+
+  @doc "Returns redacted provider file metadata suitable for logs and diagnostics."
+  @spec inspect_provider_file(t() | map()) ::
+          {:ok, ReqLLM.ProviderFileReference.t()} | :error
+  def inspect_provider_file(part), do: ReqLLM.ProviderFileReference.redacted(part)
+
   defimpl Inspect do
     def inspect(%{type: type} = part, opts) do
       content_desc =
@@ -119,8 +174,14 @@ defmodule ReqLLM.Message.ContentPart do
       if String.length(text) > 30, do: "\"#{truncated}...\"", else: "\"#{truncated}\""
     end
 
-    defp inspect_file(%{file_id: file_id}) when is_binary(file_id) and file_id != "" do
-      "file_id: #{file_id}"
+    defp inspect_file(%{file_id: file_id} = part) when is_binary(file_id) and file_id != "" do
+      case ReqLLM.ProviderFileReference.redacted(part) do
+        {:ok, reference} ->
+          "owned file provider: #{reference["provider"]}, file_id: #{reference["reference_id"]}"
+
+        :error ->
+          "file_id: #{file_id}"
+      end
     end
 
     defp inspect_file(part), do: "#{part.media_type} (#{byte_size(part.data || <<>>)} bytes)"

--- a/lib/req_llm/open_telemetry/content.ex
+++ b/lib/req_llm/open_telemetry/content.ex
@@ -360,9 +360,16 @@ defmodule ReqLLM.OpenTelemetry.Content do
   end
 
   defp file_descriptor_part(part) do
+    file_id =
+      if ReqLLM.ProviderFileReference.owned?(part) do
+        "[REDACTED]"
+      else
+        MapAccess.get(part, :file_id)
+      end
+
     [
       %{"type" => "file"}
-      |> maybe_put("file_id", MapAccess.get(part, :file_id))
+      |> maybe_put("file_id", file_id)
       |> maybe_put("filename", MapAccess.get(part, :filename))
       |> maybe_put("media_type", MapAccess.get(part, :media_type))
       |> maybe_put("bytes", MapAccess.get(part, :bytes))

--- a/lib/req_llm/provider_file_reference.ex
+++ b/lib/req_llm/provider_file_reference.ex
@@ -1,0 +1,394 @@
+defmodule ReqLLM.ProviderFileReference do
+  @moduledoc """
+  Metadata and validation for explicitly provider-owned file references.
+
+  Provider ownership is opt-in. Legacy `ReqLLM.Message.ContentPart.file_id/1`
+  values do not contain this metadata and are never inferred to belong to a
+  provider.
+
+  Owned references store a versioned record below the reserved
+  `"req_llm" -> "provider_file"` metadata namespace. Use
+  `ReqLLM.Message.ContentPart.owned_file_id/3` to create one.
+  """
+
+  alias ReqLLM.Message.ContentPart
+
+  @namespace "req_llm"
+  @metadata_key "provider_file"
+  @redacted "[REDACTED]"
+  @allowed_options [:purpose, :status, :expires_at, :size, :sha256, :provider_metadata]
+  @known_key_atoms %{
+    "schema_version" => :schema_version,
+    "provider" => :provider,
+    "reference_id" => :reference_id,
+    "purpose" => :purpose,
+    "status" => :status,
+    "expires_at" => :expires_at,
+    "size" => :size,
+    "sha256" => :sha256,
+    "metadata" => :metadata
+  }
+  @sensitive_keys ~w(
+    access_token api_key api_token authorization credential credentials data file_id password
+    reference_id secret token url
+  )
+
+  @type t :: %{
+          required(String.t()) => term()
+        }
+
+  @doc "Returns the reserved metadata path used for provider-owned files."
+  @spec metadata_path() :: [String.t()]
+  def metadata_path, do: [@namespace, @metadata_key]
+
+  @doc false
+  @spec new!(atom() | String.t(), String.t(), keyword()) :: t()
+  def new!(provider, reference_id, opts \\ [])
+
+  def new!(provider, reference_id, opts)
+      when (is_atom(provider) or is_binary(provider)) and is_binary(reference_id) and
+             is_list(opts) do
+    validate_options!(opts)
+
+    normalized_provider = normalize_provider!(provider)
+    normalized_reference_id = non_empty_string!(reference_id, :reference_id)
+
+    %{
+      "schema_version" => 1,
+      "provider" => normalized_provider,
+      "reference_id" => normalized_reference_id
+    }
+    |> put_optional("purpose", normalize_label!(opts[:purpose], :purpose))
+    |> put_optional("status", normalize_label!(opts[:status], :status))
+    |> put_optional("expires_at", normalize_expiry!(opts[:expires_at]))
+    |> put_optional("size", normalize_size!(opts[:size]))
+    |> put_optional("sha256", normalize_sha256!(opts[:sha256]))
+    |> put_optional("metadata", normalize_metadata!(opts[:provider_metadata]))
+  end
+
+  def new!(_provider, _reference_id, _opts) do
+    raise ArgumentError,
+          "provider-owned file references require a provider, non-empty reference ID, and keyword options"
+  end
+
+  @doc false
+  @spec put(map(), t()) :: map()
+  def put(metadata, reference) when is_map(metadata) and is_map(reference) do
+    namespace = Map.get(metadata, @namespace, %{})
+
+    unless is_map(namespace) do
+      raise ArgumentError, "reserved #{@namespace} content metadata must be a map"
+    end
+
+    Map.put(metadata, @namespace, Map.put(namespace, @metadata_key, reference))
+  end
+
+  @doc "Returns the full ownership record for an explicitly owned file."
+  @spec fetch(ContentPart.t() | map()) :: {:ok, t()} | :error
+  def fetch(%ContentPart{type: :file, metadata: metadata}), do: fetch_metadata(metadata)
+
+  def fetch(%{type: type} = part) when type in [:file, "file"] do
+    fetch_metadata(Map.get(part, :metadata) || Map.get(part, "metadata") || %{})
+  end
+
+  def fetch(%{"type" => "file"} = part) do
+    fetch_metadata(Map.get(part, "metadata") || Map.get(part, :metadata) || %{})
+  end
+
+  def fetch(_part), do: :error
+
+  @doc "Returns whether a content part was explicitly marked as provider-owned."
+  @spec owned?(ContentPart.t() | map()) :: boolean()
+  def owned?(part), do: match?({:ok, _reference}, fetch(part))
+
+  @doc "Returns a redacted ownership record suitable for logs and diagnostics."
+  @spec redacted(ContentPart.t() | map()) :: {:ok, t()} | :error
+  def redacted(part) do
+    case fetch(part) do
+      {:ok, reference} -> {:ok, redact(reference)}
+      :error -> :error
+    end
+  end
+
+  @doc false
+  @spec reference_id(ContentPart.t() | map(), atom() | String.t() | nil) ::
+          {:ok, String.t()} | :error
+  def reference_id(part, provider \\ nil) do
+    with {:ok, reference} <- fetch(part),
+         true <- provider_matches?(reference, provider),
+         reference_id when is_binary(reference_id) and reference_id != "" <-
+           get_value(reference, "reference_id") do
+      {:ok, reference_id}
+    else
+      _other -> :error
+    end
+  end
+
+  @doc false
+  @spec validate_context(ReqLLM.Context.t(), atom() | String.t(), keyword()) ::
+          :ok | {:error, ReqLLM.Error.Invalid.ProviderFileReference.t()}
+  def validate_context(context, provider, opts \\ [])
+
+  def validate_context(%ReqLLM.Context{messages: messages}, provider, opts) do
+    now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
+
+    messages
+    |> Enum.flat_map(fn message -> List.wrap(Map.get(message, :content, [])) end)
+    |> Enum.reduce_while(:ok, fn part, :ok ->
+      case validate_part(part, provider, now) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  def validate_context(_context, _provider, _opts), do: :ok
+
+  @doc false
+  @spec sanitize_content_part(ContentPart.t()) :: map()
+  def sanitize_content_part(%ContentPart{} = part) do
+    case redacted(part) do
+      {:ok, reference} ->
+        %{
+          type: :file,
+          file_id: @redacted,
+          filename: part.filename,
+          media_type: part.media_type,
+          bytes: binary_size_or_nil(part.data),
+          metadata: %{@namespace => %{@metadata_key => reference}}
+        }
+
+      :error ->
+        %{
+          type: :file,
+          file_id: part.file_id,
+          filename: part.filename,
+          media_type: part.media_type,
+          bytes: binary_size_or_nil(part.data),
+          metadata: part.metadata
+        }
+    end
+  end
+
+  defp fetch_metadata(metadata) when is_map(metadata) do
+    with namespace when is_map(namespace) <-
+           Map.get(metadata, @namespace) || Map.get(metadata, :req_llm),
+         reference when is_map(reference) <-
+           Map.get(namespace, @metadata_key) || Map.get(namespace, :provider_file),
+         provider when is_binary(provider) and provider != "" <- get_value(reference, "provider"),
+         reference_id when is_binary(reference_id) and reference_id != "" <-
+           get_value(reference, "reference_id") do
+      {:ok,
+       reference
+       |> stringify_known_keys()
+       |> Map.put("provider", provider)
+       |> Map.put("reference_id", reference_id)}
+    else
+      _other -> :error
+    end
+  end
+
+  defp fetch_metadata(_metadata), do: :error
+
+  defp stringify_known_keys(reference) do
+    Enum.reduce(@known_key_atoms, reference, fn {key, atom_key}, acc ->
+      case Map.fetch(acc, atom_key) do
+        {:ok, value} -> acc |> Map.delete(atom_key) |> Map.put(key, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  defp validate_part(part, provider, now) do
+    case fetch(part) do
+      {:ok, reference} -> validate_reference(reference, provider, now)
+      :error -> :ok
+    end
+  end
+
+  defp validate_reference(reference, provider, now) do
+    owner = get_value(reference, "provider")
+    expected_provider = normalize_provider!(provider)
+
+    cond do
+      owner != expected_provider ->
+        {:error,
+         ReqLLM.Error.Invalid.ProviderFileReference.exception(
+           reason: :provider_mismatch,
+           owner: owner,
+           provider: expected_provider,
+           expires_at: get_value(reference, "expires_at"),
+           status: get_value(reference, "status")
+         )}
+
+      expired?(get_value(reference, "expires_at"), now) ->
+        {:error,
+         ReqLLM.Error.Invalid.ProviderFileReference.exception(
+           reason: :expired,
+           owner: owner,
+           provider: expected_provider,
+           expires_at: get_value(reference, "expires_at"),
+           status: get_value(reference, "status")
+         )}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp provider_matches?(_reference, nil), do: true
+
+  defp provider_matches?(reference, provider) do
+    get_value(reference, "provider") == normalize_provider!(provider)
+  end
+
+  defp expired?(nil, _now), do: false
+
+  defp expired?(expires_at, %DateTime{} = now) when is_binary(expires_at) do
+    case DateTime.from_iso8601(expires_at) do
+      {:ok, expiry, _offset} -> DateTime.compare(expiry, now) != :gt
+      _invalid -> false
+    end
+  end
+
+  defp expired?(_expires_at, _now), do: false
+
+  defp redact(reference) do
+    reference
+    |> Map.put("reference_id", @redacted)
+    |> Map.update("metadata", nil, &sanitize_value/1)
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp sanitize_value(value) when is_map(value) do
+    Map.new(value, fn {key, entry} ->
+      if sensitive_key?(key), do: {key, @redacted}, else: {key, sanitize_value(entry)}
+    end)
+  end
+
+  defp sanitize_value(value) when is_list(value), do: Enum.map(value, &sanitize_value/1)
+
+  defp sanitize_value(value) when is_binary(value) do
+    if String.starts_with?(value, ["http://", "https://", "gs://"]), do: @redacted, else: value
+  end
+
+  defp sanitize_value(value), do: value
+
+  defp sensitive_key?(key) when is_atom(key) or is_binary(key) do
+    key
+    |> to_string()
+    |> String.downcase()
+    |> then(fn name ->
+      name in @sensitive_keys or String.contains?(name, "credential") or
+        String.contains?(name, "secret") or String.ends_with?(name, "_token")
+    end)
+  end
+
+  defp sensitive_key?(_key), do: false
+
+  defp validate_options!(opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "provider-owned file options must be a keyword list"
+    end
+
+    case Keyword.keys(opts) -- @allowed_options do
+      [] -> :ok
+      unknown -> raise ArgumentError, "unknown provider-owned file options: #{inspect(unknown)}"
+    end
+  end
+
+  defp normalize_provider!(provider) do
+    provider
+    |> to_string()
+    |> String.trim()
+    |> String.downcase()
+    |> non_empty_string!(:provider)
+  end
+
+  defp non_empty_string!(value, _field) when is_binary(value) and value != "", do: value
+
+  defp non_empty_string!(_value, field) do
+    raise ArgumentError, "#{field} must be a non-empty string"
+  end
+
+  defp normalize_label!(nil, _field), do: nil
+  defp normalize_label!(value, _field) when is_atom(value), do: Atom.to_string(value)
+
+  defp normalize_label!(value, field) when is_binary(value) do
+    value |> String.trim() |> non_empty_string!(field)
+  end
+
+  defp normalize_label!(_value, field) do
+    raise ArgumentError, "#{field} must be an atom or non-empty string"
+  end
+
+  defp normalize_expiry!(nil), do: nil
+  defp normalize_expiry!(%DateTime{} = value), do: DateTime.to_iso8601(value)
+
+  defp normalize_expiry!(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, date_time, _offset} -> DateTime.to_iso8601(date_time)
+      _invalid -> raise ArgumentError, "expires_at must be an ISO 8601 UTC timestamp"
+    end
+  end
+
+  defp normalize_expiry!(_value) do
+    raise ArgumentError, "expires_at must be a DateTime or ISO 8601 timestamp"
+  end
+
+  defp normalize_size!(nil), do: nil
+  defp normalize_size!(value) when is_integer(value) and value >= 0, do: value
+  defp normalize_size!(_value), do: raise(ArgumentError, "size must be a non-negative integer")
+
+  defp normalize_sha256!(nil), do: nil
+
+  defp normalize_sha256!(value) when is_binary(value) do
+    value |> String.trim() |> non_empty_string!(:sha256)
+  end
+
+  defp normalize_sha256!(_value), do: raise(ArgumentError, "sha256 must be a non-empty string")
+
+  defp normalize_metadata!(nil), do: nil
+  defp normalize_metadata!(value) when is_map(value), do: normalize_metadata_value!(value)
+  defp normalize_metadata!(_value), do: raise(ArgumentError, "provider_metadata must be a map")
+
+  defp normalize_metadata_value!(value) when is_map(value) do
+    Map.new(value, fn {key, entry} ->
+      {normalize_metadata_key!(key), normalize_metadata_value!(entry)}
+    end)
+  end
+
+  defp normalize_metadata_value!(value) when is_list(value) do
+    Enum.map(value, &normalize_metadata_value!/1)
+  end
+
+  defp normalize_metadata_value!(value)
+       when is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value),
+       do: value
+
+  defp normalize_metadata_value!(value) when is_atom(value), do: Atom.to_string(value)
+
+  defp normalize_metadata_value!(_value) do
+    raise ArgumentError, "provider_metadata values must be JSON-safe"
+  end
+
+  defp normalize_metadata_key!(key) when is_binary(key), do: key
+  defp normalize_metadata_key!(key) when is_atom(key), do: Atom.to_string(key)
+
+  defp normalize_metadata_key!(_key) do
+    raise ArgumentError, "provider_metadata keys must be atoms or strings"
+  end
+
+  defp put_optional(map, _key, nil), do: map
+  defp put_optional(map, key, value), do: Map.put(map, key, value)
+
+  defp get_value(map, key) do
+    Map.get(map, key) || Map.get(map, Map.fetch!(@known_key_atoms, key))
+  end
+
+  defp binary_size_or_nil(nil), do: nil
+  defp binary_size_or_nil(data) when is_binary(data), do: byte_size(data)
+  defp binary_size_or_nil(data) when is_list(data), do: IO.iodata_length(data)
+  defp binary_size_or_nil(_data), do: nil
+end

--- a/lib/req_llm/providers/anthropic/context.ex
+++ b/lib/req_llm/providers/anthropic/context.ex
@@ -310,13 +310,17 @@ defmodule ReqLLM.Providers.Anthropic.Context do
     }
   end
 
-  defp do_encode_content_part(%ReqLLM.Message.ContentPart{
-         type: :file,
-         file_id: file_id,
-         media_type: media_type,
-         metadata: metadata
-       })
-       when is_binary(file_id) and file_id != "" do
+  defp do_encode_content_part(
+         %ReqLLM.Message.ContentPart{
+           type: :file,
+           file_id: legacy_file_id,
+           media_type: media_type,
+           metadata: metadata
+         } = part
+       )
+       when is_binary(legacy_file_id) and legacy_file_id != "" do
+    file_id = provider_file_id(part, :anthropic, legacy_file_id)
+
     %{
       type: file_block_type(media_type),
       source: %{
@@ -347,6 +351,13 @@ defmodule ReqLLM.Providers.Anthropic.Context do
   end
 
   defp do_encode_content_part(_), do: nil
+
+  defp provider_file_id(part, provider, legacy_file_id) do
+    case ReqLLM.ProviderFileReference.reference_id(part, provider) do
+      {:ok, reference_id} -> reference_id
+      :error -> legacy_file_id
+    end
+  end
 
   # Honors an explicit cache breakpoint declared in ContentPart metadata as
   # `%{cache_control: %{type: "ephemeral"}}` (or with `"ttl" => "1h"`). Accepts

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -2093,7 +2093,46 @@ defmodule ReqLLM.Providers.Google do
     encoded
     |> Map.get(:messages, [])
     |> preserve_tool_call_metadata_in_messages(normalized_context)
+    |> preserve_provider_file_metadata_in_messages(normalized_context)
   end
+
+  defp preserve_provider_file_metadata_in_messages(messages, %ReqLLM.Context{
+         messages: context_messages
+       }) do
+    owned_files =
+      context_messages
+      |> Enum.flat_map(fn message -> List.wrap(message.content) end)
+      |> Enum.reduce(%{}, fn part, acc ->
+        case ReqLLM.ProviderFileReference.reference_id(part, :google) do
+          {:ok, reference_id} ->
+            Map.put(acc, reference_id, %{media_type: part.media_type})
+
+          :error ->
+            acc
+        end
+      end)
+
+    Enum.map(messages, &preserve_message_provider_files(&1, owned_files))
+  end
+
+  defp preserve_message_provider_files(message, owned_files) when map_size(owned_files) == 0,
+    do: message
+
+  defp preserve_message_provider_files(%{content: content} = message, owned_files)
+       when is_list(content) do
+    %{message | content: Enum.map(content, &preserve_provider_file(&1, owned_files))}
+  end
+
+  defp preserve_message_provider_files(message, _owned_files), do: message
+
+  defp preserve_provider_file(%{type: "file", file: %{file_id: file_id}} = part, owned_files) do
+    case Map.get(owned_files, file_id) do
+      nil -> part
+      metadata -> Map.put(part, :req_llm_provider_file, metadata)
+    end
+  end
+
+  defp preserve_provider_file(part, _owned_files), do: part
 
   defp preserve_tool_call_metadata_in_messages(messages, %ReqLLM.Context{
          messages: context_messages
@@ -2562,17 +2601,20 @@ defmodule ReqLLM.Providers.Google do
     end
   end
 
-  # Most specific patterns first (file, image, etc.) - for ContentPart structs
-  defp convert_content_part(%{type: :file, data: data, media_type: media_type})
-       when is_binary(data) do
-    encoded_data = Base.encode64(data)
+  defp convert_content_part(%{
+         type: "file",
+         file: %{file_id: reference_id},
+         req_llm_provider_file: metadata
+       }) do
+    build_file_data(metadata, reference_id)
+  end
 
-    %{
-      inline_data: %{
-        mime_type: media_type,
-        data: encoded_data
-      }
-    }
+  # Most specific patterns first (file, image, etc.) - for ContentPart structs
+  defp convert_content_part(%{type: :file} = part) do
+    case ReqLLM.ProviderFileReference.reference_id(part, :google) do
+      {:ok, reference_id} -> build_file_data(part, reference_id)
+      :error -> convert_legacy_file_content_part(part)
+    end
   end
 
   # Specific text patterns
@@ -2585,6 +2627,20 @@ defmodule ReqLLM.Providers.Google do
   defp convert_content_part(text) when is_binary(text), do: %{text: text}
 
   defp convert_content_part(part), do: %{text: to_string(part)}
+
+  defp convert_legacy_file_content_part(%{data: data, media_type: media_type})
+       when is_binary(data) do
+    encoded_data = Base.encode64(data)
+
+    %{
+      inline_data: %{
+        mime_type: media_type,
+        data: encoded_data
+      }
+    }
+  end
+
+  defp convert_legacy_file_content_part(part), do: %{text: to_string(part)}
 
   defp convert_url_content_part(part, url) do
     cond do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -927,10 +927,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   defp encode_input_content_part(
-         %ReqLLM.Message.ContentPart{type: :file, file_id: file_id, filename: filename},
+         %ReqLLM.Message.ContentPart{type: :file, file_id: legacy_file_id, filename: filename} =
+           part,
          _type
        )
-       when is_binary(file_id) and file_id != "" do
+       when is_binary(legacy_file_id) and legacy_file_id != "" do
+    file_id = provider_file_id(part, :openai, legacy_file_id)
+
     file =
       %{"type" => "input_file", "file_id" => file_id}
       |> maybe_put_string("filename", filename)
@@ -958,6 +961,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   end
 
   defp encode_input_content_part(_, _type), do: []
+
+  defp provider_file_id(part, provider, legacy_file_id) do
+    case ReqLLM.ProviderFileReference.reference_id(part, provider) do
+      {:ok, reference_id} -> reference_id
+      :error -> legacy_file_id
+    end
+  end
 
   defp encode_reasoning_details_from_message(
          %ReqLLM.Message{reasoning_details: nil},

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -112,7 +112,8 @@ defmodule ReqLLM.Streaming do
     total_timeout_deadline = ReqLLM.TimeoutBudget.deadline(opts)
     stream_idle_timeout = ReqLLM.TimeoutBudget.stream_idle_timeout(opts)
 
-    with {:ok, server_pid} <-
+    with :ok <- ReqLLM.ProviderFileReference.validate_context(context, model.provider),
+         {:ok, server_pid} <-
            start_stream_server(
              provider_mod,
              model,

--- a/lib/req_llm/telemetry.ex
+++ b/lib/req_llm/telemetry.ex
@@ -1029,14 +1029,7 @@ defmodule ReqLLM.Telemetry do
   end
 
   defp sanitize_content_part(%ContentPart{type: :file} = part) do
-    %{
-      type: :file,
-      file_id: part.file_id,
-      filename: part.filename,
-      media_type: part.media_type,
-      bytes: binary_size_or_nil(part.data),
-      metadata: part.metadata
-    }
+    ReqLLM.ProviderFileReference.sanitize_content_part(part)
   end
 
   defp sanitize_content_part(%{type: :image} = part) when is_map(part) do

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -281,6 +281,31 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              ] = body["input"]
     end
 
+    test "encodes explicitly owned OpenAI file references without ownership metadata" do
+      file_part =
+        ReqLLM.Message.ContentPart.owned_file_id("file-owned", :openai,
+          purpose: :assistants,
+          status: :processed
+        )
+
+      context = %ReqLLM.Context{
+        messages: [
+          %ReqLLM.Message{
+            role: :user,
+            content: [file_part]
+          }
+        ]
+      }
+
+      body = context |> then(&build_request(context: &1)) |> ResponsesAPI.encode_body()
+      decoded = ReqLLM.Test.Helpers.json_body(body)
+
+      assert [%{"content" => [%{"type" => "input_file", "file_id" => "file-owned"}]}] =
+               decoded["input"]
+
+      refute Jason.encode!(decoded) =~ "req_llm"
+    end
+
     test "omits tools when empty list" do
       request = build_request(tools: [])
 

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -631,6 +631,35 @@ defmodule ReqLLM.Providers.AnthropicTest do
              }
     end
 
+    test "encode_body consumes explicitly owned Anthropic file references" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      file_part =
+        ContentPart.owned_file_id("file_owned", :anthropic,
+          metadata: %{title: "Quarterly report"},
+          purpose: :analysis,
+          status: :active
+        )
+
+      context = ReqLLM.Context.new([ReqLLM.Context.user([file_part])])
+
+      request = %Req.Request{
+        options: [context: context, model: model.model, stream: false]
+      }
+
+      decoded = request |> Anthropic.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      assert [%{"content" => [block]}] = decoded["messages"]
+
+      assert block == %{
+               "type" => "document",
+               "source" => %{"type" => "file", "file_id" => "file_owned"},
+               "title" => "Quarterly report"
+             }
+
+      refute Jason.encode!(decoded) =~ "req_llm"
+    end
+
     test "encode_body without tools" do
       {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
       context = context_fixture()

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -2159,6 +2159,38 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert Base.decode64!(part["inline_data"]["data"]) == file_content
     end
 
+    test "encode_body consumes explicitly owned Google file references" do
+      file_part =
+        ReqLLM.Message.ContentPart.owned_file_id(
+          "https://generativelanguage.googleapis.com/v1beta/files/report",
+          :google,
+          media_type: "application/pdf",
+          purpose: :analysis,
+          status: :active
+        )
+
+      context = %ReqLLM.Context{
+        messages: [%ReqLLM.Message{role: :user, content: [file_part]}]
+      }
+
+      request = %Req.Request{
+        options: [context: context, id: "gemini-1.5-flash", stream: false]
+      }
+
+      decoded = request |> Google.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      assert [%{"parts" => [part]}] = decoded["contents"]
+
+      assert part == %{
+               "fileData" => %{
+                 "fileUri" => "https://generativelanguage.googleapis.com/v1beta/files/report",
+                 "mimeType" => "application/pdf"
+               }
+             }
+
+      refute Jason.encode!(decoded) =~ "req_llm"
+    end
+
     test "encode_body handles video ContentPart with inline_data format" do
       video_content = "fake video bytes"
 

--- a/test/req_llm/message/content_part_test.exs
+++ b/test/req_llm/message/content_part_test.exs
@@ -176,6 +176,150 @@ defmodule ReqLLM.Message.ContentPartTest do
     end
   end
 
+  describe "owned_file_id/3" do
+    test "adds versioned provider ownership without changing the ContentPart struct" do
+      expires_at = ~U[2030-01-01 00:00:00Z]
+
+      part =
+        ContentPart.owned_file_id("file-secret", :openai,
+          media_type: "text/plain",
+          metadata: %{title: "Notes"},
+          purpose: :assistants,
+          status: :processed,
+          expires_at: expires_at,
+          size: 12,
+          sha256: "abc123",
+          provider_metadata: %{tenant: "docs"}
+        )
+
+      assert %ContentPart{
+               type: :file,
+               file_id: "file-secret",
+               media_type: "text/plain",
+               metadata: %{
+                 "req_llm" => %{
+                   "provider_file" => %{
+                     "schema_version" => 1,
+                     "provider" => "openai",
+                     "reference_id" => "file-secret",
+                     "purpose" => "assistants",
+                     "status" => "processed",
+                     "expires_at" => "2030-01-01T00:00:00Z",
+                     "size" => 12,
+                     "sha256" => "abc123",
+                     "metadata" => %{"tenant" => "docs"}
+                   }
+                 },
+                 title: "Notes"
+               }
+             } = part
+
+      assert Map.keys(Map.from_struct(part)) |> Enum.sort() ==
+               Map.keys(Map.from_struct(ContentPart.file_id("legacy"))) |> Enum.sort()
+
+      assert ContentPart.owned_file?(part)
+      refute ContentPart.owned_file?(ContentPart.file_id("legacy"))
+    end
+
+    test "provides full and redacted ownership inspection" do
+      part =
+        ContentPart.owned_file_id("file-secret", :openai,
+          provider_metadata: %{
+            url: "https://example.com/private",
+            api_token: "token-secret",
+            tenant: "docs"
+          }
+        )
+
+      assert {:ok, %{"reference_id" => "file-secret"}} =
+               ContentPart.provider_file_reference(part)
+
+      assert {:ok, redacted} = ContentPart.inspect_provider_file(part)
+      assert redacted["reference_id"] == "[REDACTED]"
+      assert redacted["metadata"]["url"] == "[REDACTED]"
+      assert redacted["metadata"]["api_token"] == "[REDACTED]"
+      assert redacted["metadata"]["tenant"] == "docs"
+
+      inspected = inspect(part)
+      assert inspected =~ "owned file provider: openai"
+      assert inspected =~ "file_id: [REDACTED]"
+      refute inspected =~ "file-secret"
+      refute inspected =~ "token-secret"
+    end
+
+    test "round-trips deterministically through JSON and context normalization" do
+      part =
+        ContentPart.owned_file_id("files/report", :google,
+          purpose: "analysis",
+          status: "active",
+          provider_metadata: %{tenant: "docs"}
+        )
+
+      decoded_part = Jason.decode!(Jason.encode!(part))
+
+      assert {:ok, context} =
+               ReqLLM.Context.normalize(
+                 [%{"role" => "user", "content" => [decoded_part]}],
+                 validate: false
+               )
+
+      assert [%ReqLLM.Message{content: [normalized]}] = context.messages
+      assert normalized.file_id == "files/report"
+      assert {:ok, reference} = ContentPart.provider_file_reference(normalized)
+      assert reference["provider"] == "google"
+      assert reference["reference_id"] == "files/report"
+      assert reference["metadata"] == %{"tenant" => "docs"}
+    end
+
+    test "rejects invalid lifecycle metadata" do
+      assert_raise ArgumentError, ~r/expires_at/, fn ->
+        ContentPart.owned_file_id("file-1", :openai, expires_at: "tomorrow")
+      end
+
+      assert_raise ArgumentError, ~r/size/, fn ->
+        ContentPart.owned_file_id("file-1", :openai, size: -1)
+      end
+
+      assert_raise ArgumentError, ~r/unknown provider-owned file options/, fn ->
+        ContentPart.owned_file_id("file-1", :openai, unknown: true)
+      end
+
+      assert_raise ArgumentError, ~r/JSON-safe/, fn ->
+        ContentPart.owned_file_id("file-1", :openai,
+          provider_metadata: %{callback: fn -> :ok end}
+        )
+      end
+    end
+
+    test "preserves exact legacy file reference values and serialization" do
+      legacy = ContentPart.file_id("file-legacy", "application/pdf", %{title: "Report"})
+
+      assert Map.from_struct(legacy) == %{
+               type: :file,
+               text: nil,
+               url: nil,
+               data: nil,
+               file_id: "file-legacy",
+               media_type: "application/pdf",
+               filename: nil,
+               metadata: %{title: "Report"}
+             }
+
+      assert Jason.decode!(Jason.encode!(legacy)) == %{
+               "type" => "file",
+               "text" => nil,
+               "url" => nil,
+               "data" => nil,
+               "file_id" => "file-legacy",
+               "media_type" => "application/pdf",
+               "filename" => nil,
+               "metadata" => %{"title" => "Report"}
+             }
+
+      assert inspect(legacy) == "#ContentPart<:file file_id: file-legacy>"
+    end
+  end
+
   describe "struct validation and edge cases" do
     test "requires type field" do
       assert_raise ArgumentError, fn ->

--- a/test/req_llm/open_telemetry/content_test.exs
+++ b/test/req_llm/open_telemetry/content_test.exs
@@ -170,6 +170,28 @@ defmodule ReqLLM.OpenTelemetry.ContentTest do
       refute part |> Map.values() |> Enum.any?(&(&1 == "RAW_FILE_BYTES_NEVER_TO_BE_EMITTED"))
     end
 
+    test "redacts explicitly owned file IDs in content telemetry" do
+      owned_part =
+        ContentPart.owned_file_id("file-secret", :openai,
+          provider_metadata: %{url: "https://example.com/private", api_token: "token-secret"}
+        )
+
+      messages = [%Message{role: :user, content: [owned_part]}]
+
+      assert [%{"parts" => [part]}] =
+               %{request_payload: %{messages: messages}}
+               |> Content.input_messages()
+               |> decode_all()
+
+      assert part["type"] == "file"
+      assert part["file_id"] == "[REDACTED]"
+
+      encoded = Jason.encode!(part)
+      refute encoded =~ "file-secret"
+      refute encoded =~ "token-secret"
+      refute encoded =~ "example.com"
+    end
+
     test "drops :thinking parts even if text is present" do
       messages = [
         %Message{

--- a/test/req_llm/provider_file_reference_test.exs
+++ b/test/req_llm/provider_file_reference_test.exs
@@ -1,0 +1,94 @@
+defmodule ReqLLM.ProviderFileReferenceTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Error.Invalid.ProviderFileReference
+  alias ReqLLM.Message.ContentPart
+
+  @moduletag contract: :public_api
+
+  test "accepts matching active references and every legacy unowned reference" do
+    owned =
+      ContentPart.owned_file_id("file-secret", :openai, expires_at: ~U[2030-01-01 00:00:00Z])
+
+    context = context([ContentPart.file_id("legacy-file"), owned])
+
+    assert :ok =
+             ReqLLM.ProviderFileReference.validate_context(context, :openai,
+               now: ~U[2029-01-01 00:00:00Z]
+             )
+  end
+
+  test "returns a redacted typed error for a foreign provider before request work" do
+    context = context([ContentPart.owned_file_id("file-secret", :anthropic)])
+
+    assert {:error,
+            %ProviderFileReference{
+              reason: :provider_mismatch,
+              owner: "anthropic",
+              provider: "openai"
+            } = error} =
+             ReqLLM.ProviderFileReference.validate_context(context, :openai)
+
+    refute Exception.message(error) =~ "file-secret"
+  end
+
+  test "returns a redacted typed error for a known expired reference" do
+    context =
+      context([
+        ContentPart.owned_file_id("file-secret", :openai,
+          status: :processed,
+          expires_at: ~U[2028-01-01 00:00:00Z]
+        )
+      ])
+
+    assert {:error,
+            %ProviderFileReference{
+              reason: :expired,
+              owner: "openai",
+              provider: "openai",
+              expires_at: "2028-01-01T00:00:00Z",
+              status: "processed"
+            } = error} =
+             ReqLLM.ProviderFileReference.validate_context(context, :openai,
+               now: ~U[2029-01-01 00:00:00Z]
+             )
+
+    refute Exception.message(error) =~ "file-secret"
+  end
+
+  test "generation and streaming reject explicit foreign ownership without I/O" do
+    context = context([ContentPart.owned_file_id("file-secret", :anthropic)])
+
+    assert {:error, %ProviderFileReference{reason: :provider_mismatch}} =
+             ReqLLM.generate_text("openai:gpt-4o", context)
+
+    assert {:error, %ProviderFileReference{reason: :provider_mismatch}} =
+             ReqLLM.stream_text("openai:gpt-4o", context)
+  end
+
+  test "telemetry sanitization redacts owned references without changing legacy values" do
+    owned =
+      ContentPart.owned_file_id("file-secret", :openai,
+        provider_metadata: %{
+          url: "https://example.com/private",
+          credential: "credential-secret"
+        }
+      )
+
+    sanitized_owned = ReqLLM.ProviderFileReference.sanitize_content_part(owned)
+    encoded_owned = Jason.encode!(sanitized_owned)
+
+    assert sanitized_owned.file_id == "[REDACTED]"
+    refute encoded_owned =~ "file-secret"
+    refute encoded_owned =~ "example.com"
+    refute encoded_owned =~ "credential-secret"
+
+    legacy = ContentPart.file_id("file-legacy")
+    sanitized_legacy = ReqLLM.ProviderFileReference.sanitize_content_part(legacy)
+
+    assert sanitized_legacy.file_id == "file-legacy"
+    assert sanitized_legacy.metadata == %{}
+  end
+
+  defp context(parts), do: ReqLLM.Context.new([ReqLLM.Context.user(parts)])
+end


### PR DESCRIPTION
Closes #864

## Summary

- add an explicit `ContentPart.owned_file_id/3` constructor backed by versioned, namespaced ownership and lifecycle metadata
- reject only explicitly foreign-provider or known-expired references before model I/O with a typed, redacted error
- preserve legacy `ContentPart` values and wire behavior while teaching OpenAI, Anthropic, and Google encoders to consume opt-in ownership
- redact owned IDs, URLs, and credential-like metadata in inspection and telemetry

## Compatibility

- no `ContentPart` fields, defaults, legacy constructors, provider callbacks, return shapes, or operation defaults change
- unowned `file_id`, bytes, URLs, images, files, and loose maps retain their existing normalization, encoding, errors, JSON, and inspection behavior
- uploads and ownership inference remain out of scope

## Validation

- `mix test --max-cases 1` — 3,948 passed, 11 skipped, 145 excluded
- `mix quality`
- `mix docs`
- Hex package dry run
- focused ownership, persistence, redaction, and OpenAI/Anthropic/Google wire tests — 409 passed