### PR TITLE
feat: add OpenAI file uploads

### DIFF
--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -191,7 +191,9 @@ encoding, errors, struct value, JSON, and inspection behavior.
 OpenAI and Anthropic encode a matching owned reference through their existing
 file-ID wire format. Google encodes the reference ID as a Gemini `fileData`
 URI. The constructor does not upload data, read local paths, or infer ownership
-from an ID prefix.
+from an ID prefix. OpenAI callers that need an upload lifecycle can use the
+provider-scoped `ReqLLM.Providers.OpenAI.Files` module; upload support is not
+part of the common provider behaviour.
 
 `ContentPart.provider_file_reference/1` returns the complete persisted record.
 Treat it as sensitive because it contains the provider reference ID. Use

--- a/guides/openai.md
+++ b/guides/openai.md
@@ -105,7 +105,69 @@ Responses Lite is an internal Codex backend contract, not a mode of the public O
 ## Attachments
 
 OpenAI Chat Completions API only supports image attachments (JPEG, PNG, GIF, WebP).
-For document support (PDFs, etc.), use Anthropic or Google providers.
+OpenAI Responses models also support image and PDF file inputs. Inline and URL
+attachments continue to work as before.
+
+### Reusable OpenAI files
+
+`ReqLLM.Providers.OpenAI.Files` exposes the OpenAI Files lifecycle without
+adding uploads to the common provider behaviour. Uploading once can avoid
+repeating a large inline payload across Responses calls:
+
+```elixir
+alias ReqLLM.Message.ContentPart
+alias ReqLLM.Providers.OpenAI.Files
+
+{:ok, file} =
+  Files.upload(
+    ContentPart.file(pdf_bytes, "report.pdf", "application/pdf"),
+    purpose: :user_data,
+    expires_after: 86_400
+  )
+
+context =
+  ReqLLM.Context.new([
+    ReqLLM.Context.user([
+      ContentPart.text("Summarize this report."),
+      file
+    ])
+  ])
+
+{:ok, response} = ReqLLM.generate_text("openai:gpt-5", context)
+```
+
+`Files.upload/2` accepts an inline file `ContentPart`, a local path, or an
+explicit `{:binary, data, filename, media_type}` tuple. It returns the same
+owned `ContentPart` shape documented in [Data Structures](data-structures.md),
+including OpenAI ownership, purpose, filename, media type, size, status, and
+expiry when available. Inline inputs also include a locally calculated SHA-256.
+Local paths are streamed into the multipart request instead of being loaded
+into one large binary.
+
+Lifecycle operations remain provider-scoped:
+
+```elixir
+{:ok, current} = Files.retrieve(file)
+{:ok, %Files.Page{files: files, has_more: has_more}} =
+  Files.list(purpose: :user_data, limit: 100)
+
+{:ok, true} = Files.delete(current)
+```
+
+OpenAI retains most uploaded files until they are deleted. Use
+`:expires_after` when supported by the selected purpose, or delete references
+when they are no longer needed. Deletion accepts a known-expired reference so
+cleanup remains possible. The caller remains responsible for retention,
+pagination, and cleanup; ReqLLM does not run background workers or upload
+inputs automatically.
+
+Treat returned references as sensitive. Regular inspection and ReqLLM
+telemetry redact provider IDs, URLs, credentials, and file contents. Use
+`ContentPart.provider_file_reference/1` only when the complete provider record
+is required.
+
+See the [OpenAI Files API reference](https://platform.openai.com/docs/api-reference/files)
+for current purposes, retention rules, and service limits.
 
 ## Dual API Architecture
 

--- a/lib/req_llm/provider_file_reference.ex
+++ b/lib/req_llm/provider_file_reference.ex
@@ -125,6 +125,19 @@ defmodule ReqLLM.ProviderFileReference do
   end
 
   @doc false
+  @spec validate(ContentPart.t() | map(), atom() | String.t(), keyword()) ::
+          :ok | {:error, ReqLLM.Error.Invalid.ProviderFileReference.t()}
+  def validate(part, provider, opts \\ []) do
+    now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
+    validate_expiry? = Keyword.get(opts, :validate_expiry?, true)
+
+    case fetch(part) do
+      {:ok, reference} -> validate_reference(reference, provider, now, validate_expiry?)
+      :error -> :ok
+    end
+  end
+
+  @doc false
   @spec validate_context(ReqLLM.Context.t(), atom() | String.t(), keyword()) ::
           :ok | {:error, ReqLLM.Error.Invalid.ProviderFileReference.t()}
   def validate_context(context, provider, opts \\ [])
@@ -135,7 +148,7 @@ defmodule ReqLLM.ProviderFileReference do
     messages
     |> Enum.flat_map(fn message -> List.wrap(Map.get(message, :content, [])) end)
     |> Enum.reduce_while(:ok, fn part, :ok ->
-      case validate_part(part, provider, now) do
+      case validate(part, provider, now: now) do
         :ok -> {:cont, :ok}
         {:error, error} -> {:halt, {:error, error}}
       end
@@ -199,14 +212,7 @@ defmodule ReqLLM.ProviderFileReference do
     end)
   end
 
-  defp validate_part(part, provider, now) do
-    case fetch(part) do
-      {:ok, reference} -> validate_reference(reference, provider, now)
-      :error -> :ok
-    end
-  end
-
-  defp validate_reference(reference, provider, now) do
+  defp validate_reference(reference, provider, now, validate_expiry?) do
     owner = get_value(reference, "provider")
     expected_provider = normalize_provider!(provider)
 
@@ -221,7 +227,7 @@ defmodule ReqLLM.ProviderFileReference do
            status: get_value(reference, "status")
          )}
 
-      expired?(get_value(reference, "expires_at"), now) ->
+      validate_expiry? and expired?(get_value(reference, "expires_at"), now) ->
         {:error,
          ReqLLM.Error.Invalid.ProviderFileReference.exception(
            reason: :expired,

--- a/lib/req_llm/providers/openai/files.ex
+++ b/lib/req_llm/providers/openai/files.ex
@@ -1,0 +1,804 @@
+defmodule ReqLLM.Providers.OpenAI.Files do
+  @moduledoc """
+  OpenAI-scoped lifecycle operations for reusable provider files.
+
+  Uploaded and retrieved files are returned as explicitly owned
+  `ReqLLM.Message.ContentPart` values. They can be passed directly to an
+  OpenAI Responses request without changing ReqLLM's common provider
+  behaviour or legacy `ContentPart.file_id/1` contract.
+
+  ## Upload and reuse
+
+      alias ReqLLM.Message.ContentPart
+      alias ReqLLM.Providers.OpenAI.Files
+
+      {:ok, file} =
+        Files.upload(
+          ContentPart.file(pdf_bytes, "report.pdf", "application/pdf"),
+          purpose: :user_data
+        )
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user([
+            ContentPart.text("Summarize this report."),
+            file
+          ])
+        ])
+
+      {:ok, response} = ReqLLM.generate_text("openai:gpt-5", context)
+      {:ok, true} = Files.delete(file)
+
+  `upload/2` also accepts a local path or an explicit
+  `{:binary, data, filename, media_type}` tuple. The default purpose is
+  `:user_data`.
+
+  OpenAI retains most files until they are deleted. Pass `:expires_after` as
+  a number of seconds from creation when automatic expiry is appropriate, or
+  call `delete/2` when the file is no longer needed.
+  """
+
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.ProviderFileReference
+  alias ReqLLM.Providers.OpenAI
+
+  @files_model %LLMDB.Model{id: "files", provider: :openai}
+  @default_media_type "application/octet-stream"
+  @default_receive_timeout 120_000
+  @minimum_expiry 3_600
+  @maximum_expiry 2_592_000
+  @request_private_key :req_llm_openai_files
+  @known_response_key_atoms %{
+    "bytes" => :bytes,
+    "created_at" => :created_at,
+    "data" => :data,
+    "deleted" => :deleted,
+    "error" => :error,
+    "expires_at" => :expires_at,
+    "filename" => :filename,
+    "has_more" => :has_more,
+    "id" => :id,
+    "message" => :message,
+    "mime_type" => :mime_type,
+    "object" => :object,
+    "purpose" => :purpose,
+    "status" => :status,
+    "status_details" => :status_details
+  }
+  @sensitive_error_keys ~w(
+    access_token api_key api_token authorization credential credentials data file file_id id
+    password reference_id secret token url
+  )
+
+  @type source ::
+          String.t()
+          | ContentPart.t()
+          | {:binary, binary(), String.t()}
+          | {:binary, binary(), String.t(), String.t()}
+
+  defmodule Page do
+    @moduledoc "A page returned by `ReqLLM.Providers.OpenAI.Files.list/1`."
+
+    @type t :: %__MODULE__{
+            files: [ReqLLM.Message.ContentPart.t()],
+            has_more: boolean()
+          }
+
+    defstruct files: [], has_more: false
+  end
+
+  @doc """
+  Uploads a file to OpenAI and returns its owned provider reference.
+
+  Sources may be a local path, an inline file `ContentPart`,
+  `{:binary, data, filename}`, or `{:binary, data, filename, media_type}`.
+
+  ## Options
+
+    * `:purpose` - OpenAI file purpose; defaults to `:user_data`
+    * `:expires_after` - seconds after creation, from 3,600 through 2,592,000
+    * `:media_type` - override the inferred media type
+    * `:base_url` - override the OpenAI API base URL
+    * `:api_key`, `:auth_mode`, `:access_token`, `:provider_options` - normal
+      OpenAI authentication options
+    * `:receive_timeout`, `:total_timeout`, `:max_retries` - request controls
+    * `:req_http_options` - options merged into the Req request
+    * `:telemetry` - ReqLLM telemetry options
+    * `:fixture` - ReqLLM fixture name for tests
+  """
+  @spec upload(source(), keyword()) :: {:ok, ContentPart.t()} | {:error, Exception.t()}
+  def upload(source, opts \\ [])
+
+  def upload(source, opts) when is_list(opts) do
+    with :ok <- validate_keyword_options(opts),
+         deadline = ReqLLM.TimeoutBudget.deadline(opts),
+         {:ok, upload} <- resolve_upload(source, opts),
+         {:ok, request} <- build_upload_request(upload, opts),
+         {:ok, %Req.Response{body: %ContentPart{} = file}} <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, file}
+    else
+      {:error, error} -> {:error, normalize_error(error)}
+      other -> {:error, unexpected_result(:upload, other)}
+    end
+  end
+
+  def upload(_source, _opts) do
+    {:error, invalid_parameter("options must be a keyword list")}
+  end
+
+  @doc "Same as `upload/2`, but raises on error."
+  @spec upload!(source(), keyword()) :: ContentPart.t() | no_return()
+  def upload!(source, opts \\ []) do
+    upload(source, opts) |> unwrap!()
+  end
+
+  @doc """
+  Retrieves current metadata for an OpenAI file.
+
+  Accepts either a file ID or a `ContentPart`. Explicitly owned references are
+  checked for OpenAI ownership and known expiry before any HTTP request.
+  """
+  @spec retrieve(String.t() | ContentPart.t(), keyword()) ::
+          {:ok, ContentPart.t()} | {:error, Exception.t()}
+  def retrieve(file, opts \\ [])
+
+  def retrieve(file, opts) when is_list(opts) do
+    with :ok <- validate_keyword_options(opts),
+         deadline = ReqLLM.TimeoutBudget.deadline(opts),
+         {:ok, file_id} <- resolve_file_id(file),
+         {:ok, request} <-
+           build_request(:file_retrieve, :get, file_path(file_id), opts,
+             fallback: %{media_type: opts[:media_type]}
+           ),
+         {:ok, %Req.Response{body: %ContentPart{} = reference}} <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, reference}
+    else
+      {:error, error} -> {:error, normalize_error(error)}
+      other -> {:error, unexpected_result(:retrieve, other)}
+    end
+  end
+
+  def retrieve(_file, _opts) do
+    {:error, invalid_parameter("options must be a keyword list")}
+  end
+
+  @doc "Same as `retrieve/2`, but raises on error."
+  @spec retrieve!(String.t() | ContentPart.t(), keyword()) :: ContentPart.t() | no_return()
+  def retrieve!(file, opts \\ []) do
+    retrieve(file, opts) |> unwrap!()
+  end
+
+  @doc """
+  Lists OpenAI files as canonical owned references.
+
+  Supports the OpenAI query options `:after`, `:limit`, `:order`, and
+  `:purpose`, alongside the shared request and authentication options accepted
+  by `upload/2`. `:after` accepts either a file ID or a returned file reference.
+  """
+  @spec list(keyword()) :: {:ok, Page.t()} | {:error, Exception.t()}
+  def list(opts \\ [])
+
+  def list(opts) when is_list(opts) do
+    with :ok <- validate_keyword_options(opts),
+         deadline = ReqLLM.TimeoutBudget.deadline(opts),
+         {:ok, params} <- list_params(opts),
+         {:ok, request} <- build_request(:file_list, :get, "/files", opts, params: params),
+         {:ok, %Req.Response{body: %Page{} = page}} <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, page}
+    else
+      {:error, error} -> {:error, normalize_error(error)}
+      other -> {:error, unexpected_result(:list, other)}
+    end
+  end
+
+  def list(_opts), do: {:error, invalid_parameter("options must be a keyword list")}
+
+  @doc "Same as `list/1`, but raises on error."
+  @spec list!(keyword()) :: Page.t() | no_return()
+  def list!(opts \\ []) do
+    list(opts) |> unwrap!()
+  end
+
+  @doc """
+  Deletes an OpenAI file.
+
+  Returns `{:ok, true}` when OpenAI confirms deletion. Explicitly owned
+  references are checked for OpenAI ownership before any HTTP request.
+  """
+  @spec delete(String.t() | ContentPart.t(), keyword()) ::
+          {:ok, boolean()} | {:error, Exception.t()}
+  def delete(file, opts \\ [])
+
+  def delete(file, opts) when is_list(opts) do
+    with :ok <- validate_keyword_options(opts),
+         deadline = ReqLLM.TimeoutBudget.deadline(opts),
+         {:ok, file_id} <- resolve_file_id(file, validate_expiry?: false),
+         {:ok, request} <- build_request(:file_delete, :delete, file_path(file_id), opts),
+         {:ok, %Req.Response{body: deleted}} when is_boolean(deleted) <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, deleted}
+    else
+      {:error, error} -> {:error, normalize_error(error)}
+      other -> {:error, unexpected_result(:delete, other)}
+    end
+  end
+
+  def delete(_file, _opts) do
+    {:error, invalid_parameter("options must be a keyword list")}
+  end
+
+  @doc "Same as `delete/2`, but raises on error."
+  @spec delete!(String.t() | ContentPart.t(), keyword()) :: boolean() | no_return()
+  def delete!(file, opts \\ []) do
+    delete(file, opts) |> unwrap!()
+  end
+
+  @doc false
+  @spec decode_response({Req.Request.t(), Req.Response.t()}) ::
+          {Req.Request.t(), Req.Response.t() | Exception.t()}
+  def decode_response({request, %Req.Response{status: status} = response})
+      when status in 200..299 do
+    case request.private[@request_private_key] do
+      %{operation: :file_upload, fallback: fallback} ->
+        decode_file_response(request, response, fallback)
+
+      %{operation: :file_retrieve, fallback: fallback} ->
+        decode_file_response(request, response, fallback)
+
+      %{operation: :file_list} ->
+        decode_list_response(request, response)
+
+      %{operation: :file_delete} ->
+        decode_delete_response(request, response)
+
+      _other ->
+        {request, malformed_response(response, "missing file operation metadata")}
+    end
+  end
+
+  def decode_response({request, %Req.Response{} = response}) do
+    {request,
+     ReqLLM.Error.API.Request.exception(
+       reason: api_error_reason(response.body),
+       status: response.status,
+       response_body: sanitize_error_body(response.body),
+       request_body: nil,
+       headers: response.headers
+     )}
+  end
+
+  @doc false
+  @spec handle_error({Req.Request.t(), Exception.t() | term()}) ::
+          {Req.Request.t(), Exception.t()}
+  def handle_error({request, %ReqLLM.Error.API.Request{} = error}), do: {request, error}
+
+  def handle_error({request, %ReqLLM.Error.API.Response{} = error}) do
+    {request,
+     ReqLLM.Error.API.Request.exception(
+       reason: Exception.message(error),
+       status: error.status,
+       response_body: error.response_body,
+       request_body: nil,
+       cause: error
+     )}
+  end
+
+  def handle_error({request, error}) when is_exception(error) do
+    {request,
+     ReqLLM.Error.API.Request.exception(
+       reason: Exception.message(error),
+       request_body: nil,
+       cause: error
+     )}
+  end
+
+  def handle_error({request, error}) do
+    {request,
+     ReqLLM.Error.API.Request.exception(
+       reason: "OpenAI file request failed",
+       request_body: nil,
+       cause: error
+     )}
+  end
+
+  defp build_upload_request(upload, opts) do
+    with {:ok, purpose} <- normalize_purpose(Keyword.get(opts, :purpose, :user_data)),
+         {:ok, expires_after} <- normalize_expires_after(opts[:expires_after]) do
+      form_multipart =
+        [
+          file:
+            {upload.data,
+             filename: upload.filename, content_type: upload.media_type, size: upload.size},
+          purpose: purpose
+        ] ++ expiry_parts(expires_after)
+
+      fallback = %{
+        filename: upload.filename,
+        media_type: upload.media_type,
+        metadata: upload.metadata,
+        purpose: purpose,
+        size: upload.size,
+        sha256: upload.sha256
+      }
+
+      build_request(:file_upload, :post, "/files", opts,
+        form_multipart: form_multipart,
+        fallback: fallback
+      )
+    end
+  end
+
+  defp build_request(operation, method, path, opts, request_opts \\ []) do
+    with {:ok, credential} <- resolve_credential(opts),
+         {:ok, http_opts} <- req_http_options(opts) do
+      receive_timeout = Keyword.get(opts, :receive_timeout, @default_receive_timeout)
+      fallback = Keyword.get(request_opts, :fallback, %{})
+
+      request_options =
+        [
+          method: method,
+          url: path,
+          base_url: Keyword.get(opts, :base_url, OpenAI.base_url()),
+          receive_timeout: receive_timeout,
+          pool_timeout: receive_timeout
+        ] ++
+          Keyword.take(request_opts, [:form_multipart, :params]) ++
+          OpenAI.auth_req_options(credential) ++ http_opts
+
+      request =
+        Req.new(request_options)
+        |> Req.Request.put_header("authorization", "Bearer #{credential.token}")
+        |> Req.Request.put_private(@request_private_key, %{
+          operation: operation,
+          fallback: fallback
+        })
+        |> ReqLLM.Step.Retry.attach(opts)
+        |> Req.Request.append_response_steps(openai_files_decode: &decode_response/1)
+        |> Req.Request.append_error_steps(openai_files_error: &handle_error/1)
+        |> ReqLLM.Step.Telemetry.attach(@files_model, Keyword.put(opts, :operation, operation))
+        |> ReqLLM.Step.Fixture.maybe_attach(@files_model, opts)
+
+      {:ok, request}
+    end
+  end
+
+  defp resolve_upload(%ContentPart{type: :file, data: data} = part, opts)
+       when is_binary(data) do
+    filename = Keyword.get(opts, :filename, part.filename)
+    media_type = Keyword.get(opts, :media_type, part.media_type || @default_media_type)
+
+    with {:ok, filename} <- non_empty_string(filename, "filename"),
+         {:ok, media_type} <- non_empty_string(media_type, "media_type") do
+      {:ok,
+       %{
+         data: data,
+         filename: filename,
+         media_type: media_type,
+         metadata: part.metadata || %{},
+         size: byte_size(data),
+         sha256: sha256(data)
+       }}
+    end
+  end
+
+  defp resolve_upload(%ContentPart{type: :file}, _opts) do
+    {:error, invalid_parameter("source file ContentPart must contain inline data")}
+  end
+
+  defp resolve_upload({:binary, data, filename}, opts) when is_binary(data) do
+    resolve_upload(
+      {:binary, data, filename, Keyword.get(opts, :media_type, media_type_from_path(filename))},
+      opts
+    )
+  end
+
+  defp resolve_upload({:binary, data, filename, media_type}, opts) when is_binary(data) do
+    resolve_upload(ContentPart.file(data, filename, media_type), opts)
+  end
+
+  defp resolve_upload(path, opts) when is_binary(path) do
+    case File.stat(path) do
+      {:ok, %{type: :regular, size: size}} ->
+        filename = Keyword.get(opts, :filename, Path.basename(path))
+        media_type = Keyword.get(opts, :media_type, media_type_from_path(path))
+
+        with {:ok, filename} <- non_empty_string(filename, "filename"),
+             {:ok, media_type} <- non_empty_string(media_type, "media_type") do
+          {:ok,
+           %{
+             data: file_stream(path),
+             filename: filename,
+             media_type: media_type,
+             metadata: %{},
+             size: size,
+             sha256: nil
+           }}
+        end
+
+      {:error, reason} ->
+        {:error, invalid_parameter("source file could not be read (#{reason})")}
+
+      {:ok, _stat} ->
+        {:error, invalid_parameter("source path must be a regular file")}
+    end
+  end
+
+  defp resolve_upload(_source, _opts) do
+    {:error,
+     invalid_parameter("source must be a path, inline file ContentPart, or explicit binary tuple")}
+  end
+
+  defp resolve_file_id(file, opts \\ [])
+
+  defp resolve_file_id(%ContentPart{type: :file} = part, opts) do
+    validate_expiry? = Keyword.get(opts, :validate_expiry?, true)
+
+    with :ok <- ProviderFileReference.validate(part, :openai, validate_expiry?: validate_expiry?) do
+      content_part_file_id(part)
+    end
+  end
+
+  defp resolve_file_id(file_id, _opts) when is_binary(file_id) do
+    non_empty_string(file_id, "file ID")
+  end
+
+  defp resolve_file_id(_file, _opts) do
+    {:error, invalid_parameter("file must be a file ID or file ContentPart")}
+  end
+
+  defp content_part_file_id(%ContentPart{} = part) do
+    case ProviderFileReference.reference_id(part, :openai) do
+      {:ok, file_id} -> {:ok, file_id}
+      :error -> non_empty_string(part.file_id, "file ID")
+    end
+  end
+
+  defp decode_file_response(request, response, fallback) do
+    case file_reference(response.body, fallback) do
+      {:ok, file} -> {request, %{response | body: file}}
+      {:error, reason} -> {request, malformed_response(response, reason)}
+    end
+  end
+
+  defp decode_list_response(request, response) do
+    body = response.body
+
+    with data when is_list(data) <- value(body, "data"),
+         {:ok, files} <- map_file_references(data) do
+      page = %Page{
+        files: files,
+        has_more: value(body, "has_more") == true
+      }
+
+      {request, %{response | body: page}}
+    else
+      _other -> {request, malformed_response(response, "invalid file list payload")}
+    end
+  end
+
+  defp decode_delete_response(request, response) do
+    case value(response.body, "deleted") do
+      deleted when is_boolean(deleted) -> {request, %{response | body: deleted}}
+      _other -> {request, malformed_response(response, "invalid file deletion payload")}
+    end
+  end
+
+  defp map_file_references(data) do
+    Enum.reduce_while(data, {:ok, []}, fn item, {:ok, files} ->
+      case file_reference(item, %{}) do
+        {:ok, file} -> {:cont, {:ok, [file | files]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> then(fn
+      {:ok, files} -> {:ok, Enum.reverse(files)}
+      error -> error
+    end)
+  end
+
+  defp file_reference(body, fallback) when is_map(body) do
+    with {:ok, file_id} <- non_empty_string(value(body, "id"), "response file ID"),
+         {:ok, purpose} <- response_purpose(body, fallback),
+         {:ok, media_type} <- response_media_type(body, fallback) do
+      filename = value(body, "filename") || fallback[:filename]
+      expires_at = normalize_response_expiry(value(body, "expires_at"))
+      status = value(body, "status")
+      size = value(body, "bytes") || fallback[:size]
+
+      file =
+        ContentPart.owned_file_id(file_id, :openai,
+          media_type: media_type,
+          metadata: fallback[:metadata] || %{},
+          purpose: purpose,
+          status: status,
+          expires_at: expires_at,
+          size: size,
+          sha256: fallback[:sha256],
+          provider_metadata: provider_metadata(body)
+        )
+
+      {:ok, %{file | filename: filename}}
+    end
+  rescue
+    error in ArgumentError -> {:error, Exception.message(error)}
+  end
+
+  defp file_reference(_body, _fallback), do: {:error, "invalid file payload"}
+
+  defp response_purpose(body, fallback) do
+    normalize_purpose(value(body, "purpose") || fallback[:purpose] || :user_data)
+  end
+
+  defp response_media_type(body, fallback) do
+    filename = value(body, "filename") || fallback[:filename]
+
+    non_empty_string(
+      value(body, "mime_type") || fallback[:media_type] || media_type_from_path(filename),
+      "response media type"
+    )
+  end
+
+  defp provider_metadata(body) do
+    %{}
+    |> put_present("object", value(body, "object"))
+    |> put_present("created_at", value(body, "created_at"))
+    |> put_present("status_details", value(body, "status_details"))
+  end
+
+  defp list_params(opts) do
+    with {:ok, order} <- normalize_order(opts[:order]),
+         {:ok, limit} <- normalize_limit(opts[:limit]),
+         {:ok, purpose} <- normalize_optional_purpose(opts[:purpose]),
+         {:ok, after_id} <- normalize_after(opts[:after]) do
+      {:ok,
+       []
+       |> put_keyword(:after, after_id)
+       |> put_keyword(:limit, limit)
+       |> put_keyword(:order, order)
+       |> put_keyword(:purpose, purpose)}
+    end
+  end
+
+  defp normalize_purpose(value) when is_atom(value), do: normalize_purpose(Atom.to_string(value))
+
+  defp normalize_purpose(value) when is_binary(value) do
+    non_empty_string(String.trim(value), "purpose")
+  end
+
+  defp normalize_purpose(_value) do
+    {:error, invalid_parameter("purpose must be an atom or non-empty string")}
+  end
+
+  defp normalize_optional_purpose(nil), do: {:ok, nil}
+  defp normalize_optional_purpose(value), do: normalize_purpose(value)
+
+  defp normalize_after(nil), do: {:ok, nil}
+  defp normalize_after(%ContentPart{} = part), do: resolve_file_id(part, validate_expiry?: false)
+  defp normalize_after(value), do: non_empty_string(value, "after")
+
+  defp normalize_expires_after(nil), do: {:ok, nil}
+
+  defp normalize_expires_after(seconds)
+       when is_integer(seconds) and seconds >= @minimum_expiry and seconds <= @maximum_expiry,
+       do: {:ok, seconds}
+
+  defp normalize_expires_after(_seconds) do
+    {:error,
+     invalid_parameter(
+       "expires_after must be an integer from #{@minimum_expiry} through #{@maximum_expiry} seconds"
+     )}
+  end
+
+  defp normalize_response_expiry(nil), do: nil
+
+  defp normalize_response_expiry(unix) when is_integer(unix) do
+    case DateTime.from_unix(unix) do
+      {:ok, date_time} -> date_time
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp normalize_response_expiry(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {unix, ""} -> normalize_response_expiry(unix)
+      _other -> value
+    end
+  end
+
+  defp normalize_response_expiry(_value), do: nil
+
+  defp normalize_order(nil), do: {:ok, nil}
+  defp normalize_order(order) when order in [:asc, :desc], do: {:ok, Atom.to_string(order)}
+  defp normalize_order(order) when order in ["asc", "desc"], do: {:ok, order}
+
+  defp normalize_order(_order) do
+    {:error, invalid_parameter("order must be :asc or :desc")}
+  end
+
+  defp normalize_limit(nil), do: {:ok, nil}
+  defp normalize_limit(limit) when is_integer(limit) and limit in 1..10_000, do: {:ok, limit}
+
+  defp normalize_limit(_limit) do
+    {:error, invalid_parameter("limit must be an integer from 1 through 10000")}
+  end
+
+  defp non_empty_string(value, _name) when is_binary(value) and value != "", do: {:ok, value}
+
+  defp non_empty_string(_value, name) do
+    {:error, invalid_parameter("#{name} must be a non-empty string")}
+  end
+
+  defp req_http_options(opts) do
+    case Keyword.get(opts, :req_http_options, []) do
+      value when is_list(value) ->
+        if Keyword.keyword?(value) do
+          {:ok, value}
+        else
+          {:error, invalid_parameter("req_http_options must be a keyword list or map")}
+        end
+
+      value when is_map(value) ->
+        {:ok, Map.to_list(value)}
+
+      _value ->
+        {:error, invalid_parameter("req_http_options must be a keyword list or map")}
+    end
+  end
+
+  defp validate_keyword_options(opts) do
+    if Keyword.keyword?(opts) do
+      :ok
+    else
+      {:error, invalid_parameter("options must be a keyword list")}
+    end
+  end
+
+  defp resolve_credential(opts) do
+    case ReqLLM.Auth.resolve(@files_model, opts) do
+      {:ok, credential} -> {:ok, credential}
+      {:error, message} -> {:error, invalid_parameter(message)}
+    end
+  end
+
+  defp normalize_error(error) when is_exception(error), do: error
+  defp normalize_error(error), do: ReqLLM.Error.to_class(error)
+
+  defp unexpected_result(operation, result) do
+    ReqLLM.Error.API.Response.exception(
+      reason: "unexpected OpenAI file #{operation} result",
+      response_body: sanitize_unexpected_result(result)
+    )
+  end
+
+  defp sanitize_unexpected_result({:ok, %Req.Response{} = response}) do
+    %{status: response.status, body_type: response_body_type(response.body)}
+  end
+
+  defp response_body_type(value) when is_map(value), do: :map
+  defp response_body_type(value) when is_list(value), do: :list
+  defp response_body_type(value) when is_binary(value), do: :binary
+  defp response_body_type(value) when is_boolean(value), do: :boolean
+  defp response_body_type(_value), do: :other
+
+  defp malformed_response(response, reason) do
+    ReqLLM.Error.API.Response.exception(
+      reason: "OpenAI Files API returned #{reason}",
+      status: response.status,
+      response_body: %{body_type: response_body_type(response.body)}
+    )
+  end
+
+  defp api_error_reason(body) when is_map(body) do
+    value(body, "error")
+    |> then(fn
+      error when is_map(error) -> value(error, "message")
+      error when is_binary(error) -> error
+      _other -> value(body, "message")
+    end)
+    |> case do
+      message when is_binary(message) and message != "" -> message
+      _other -> "OpenAI file request failed"
+    end
+  end
+
+  defp api_error_reason(_body), do: "OpenAI file request failed"
+
+  defp sanitize_error_body(value) when is_map(value) do
+    Map.new(value, fn {key, entry} ->
+      if sensitive_error_key?(key) do
+        {key, "[REDACTED]"}
+      else
+        {key, sanitize_error_body(entry)}
+      end
+    end)
+  end
+
+  defp sanitize_error_body(value) when is_list(value), do: Enum.map(value, &sanitize_error_body/1)
+
+  defp sanitize_error_body(value) when is_binary(value) do
+    if String.starts_with?(value, ["http://", "https://"]), do: "[REDACTED]", else: value
+  end
+
+  defp sanitize_error_body(value), do: value
+
+  defp sensitive_error_key?(key) when is_atom(key) or is_binary(key) do
+    name = key |> to_string() |> String.downcase()
+
+    name in @sensitive_error_keys or String.contains?(name, "credential") or
+      String.contains?(name, "secret") or String.ends_with?(name, "_token")
+  end
+
+  defp sensitive_error_key?(_key), do: false
+
+  defp invalid_parameter(message) do
+    ReqLLM.Error.Invalid.Parameter.exception(parameter: "OpenAI files: #{message}")
+  end
+
+  defp unwrap!({:ok, value}), do: value
+  defp unwrap!({:error, error}), do: raise(error)
+
+  defp expiry_parts(nil), do: []
+
+  defp expiry_parts(seconds) do
+    [
+      {:"expires_after[anchor]", "created_at"},
+      {:"expires_after[seconds]", Integer.to_string(seconds)}
+    ]
+  end
+
+  defp file_path(file_id) do
+    "/files/" <> URI.encode(file_id, &URI.char_unreserved?/1)
+  end
+
+  defp media_type_from_path(path) when is_binary(path) do
+    case Path.extname(path) |> String.downcase() do
+      ".pdf" -> "application/pdf"
+      ".png" -> "image/png"
+      ".jpg" -> "image/jpeg"
+      ".jpeg" -> "image/jpeg"
+      ".gif" -> "image/gif"
+      ".webp" -> "image/webp"
+      ".json" -> "application/json"
+      ".jsonl" -> "application/jsonl"
+      ".csv" -> "text/csv"
+      ".txt" -> "text/plain"
+      ".md" -> "text/markdown"
+      _other -> @default_media_type
+    end
+  end
+
+  defp media_type_from_path(_path), do: @default_media_type
+
+  defp file_stream(path) do
+    arguments =
+      if Version.compare(System.version(), "1.18.0") == :lt do
+        [path, [], 64 * 1024]
+      else
+        [path, 64 * 1024, []]
+      end
+
+    apply(File, :stream!, arguments)
+  end
+
+  defp sha256(data) do
+    :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
+  end
+
+  defp value(map, key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Map.fetch!(@known_response_key_atoms, key))
+    end
+  end
+
+  defp value(_map, _key), do: nil
+
+  defp put_present(map, _key, nil), do: map
+  defp put_present(map, key, value), do: Map.put(map, key, value)
+
+  defp put_keyword(keyword, _key, nil), do: keyword
+  defp put_keyword(keyword, key, value), do: Keyword.put(keyword, key, value)
+end

--- a/test/providers/openai_files_test.exs
+++ b/test/providers/openai_files_test.exs
@@ -1,0 +1,296 @@
+defmodule ReqLLM.Providers.OpenAI.FilesTest do
+  use ExUnit.Case, async: false
+
+  alias ReqLLM.Error.Invalid.ProviderFileReference
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Providers.OpenAI.Files
+  alias ReqLLM.Providers.OpenAI.ResponsesAPI
+
+  @api_key "test-openai-file-key"
+  @http_opts [plug: {Req.Test, __MODULE__}]
+
+  test "uploads once, preserves lifecycle metadata, and reuses the reference" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/v1/files"
+      assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer #{@api_key}"]
+
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      assert body =~ "private-pdf-bytes"
+      assert body =~ "report.pdf"
+      assert body =~ "application/pdf"
+      assert body =~ "user_data"
+      assert body =~ "expires_after[anchor]"
+      assert body =~ "expires_after[seconds]"
+      assert body =~ "3600"
+
+      Req.Test.json(conn, %{
+        "id" => "file-uploaded-secret",
+        "object" => "file",
+        "bytes" => 17,
+        "created_at" => 1_783_000_000,
+        "expires_at" => 1_783_003_600,
+        "filename" => "report.pdf",
+        "purpose" => "user_data",
+        "status" => "processed"
+      })
+    end)
+
+    source = ContentPart.file("private-pdf-bytes", "report.pdf", "application/pdf")
+
+    assert {:ok, %ContentPart{} = file} =
+             Files.upload(source,
+               purpose: :user_data,
+               expires_after: 3_600,
+               api_key: @api_key,
+               req_http_options: @http_opts
+             )
+
+    assert file.type == :file
+    assert file.file_id == "file-uploaded-secret"
+    assert file.data == nil
+    assert file.filename == "report.pdf"
+    assert file.media_type == "application/pdf"
+
+    assert {:ok, reference} = ContentPart.provider_file_reference(file)
+    assert reference["provider"] == "openai"
+    assert reference["reference_id"] == "file-uploaded-secret"
+    assert reference["purpose"] == "user_data"
+    assert reference["status"] == "processed"
+    assert reference["size"] == 17
+    assert reference["expires_at"] == "2026-07-02T14:46:40Z"
+    assert reference["sha256"] == sha256("private-pdf-bytes")
+    assert reference["metadata"]["object"] == "file"
+    assert reference["metadata"]["created_at"] == 1_783_000_000
+
+    context = ReqLLM.Context.new([ReqLLM.Context.user([ContentPart.text("Summarize"), file])])
+
+    request = %Req.Request{
+      options: [context: context, model: "gpt-5", api_mod: ResponsesAPI]
+    }
+
+    body = request |> ResponsesAPI.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+    assert [%{"content" => content}] = body["input"]
+
+    assert Enum.any?(content, fn part ->
+             part["type"] == "input_file" and part["file_id"] == "file-uploaded-secret"
+           end)
+  end
+
+  test "supports fixture-backed upload responses" do
+    assert {:ok, file} =
+             Files.upload(
+               {:binary, "fixture-bytes", "fixture.pdf", "application/pdf"},
+               api_key: @api_key,
+               fixture: "upload"
+             )
+
+    assert file.file_id == "file-fixture-upload"
+    assert file.filename == "fixture.pdf"
+    assert file.media_type == "application/pdf"
+    assert ContentPart.owned_file?(file)
+  end
+
+  test "streams local paths into multipart uploads" do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "req_llm_openai_files_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    path = Path.join(tmp_dir, "streamed.pdf")
+    File.write!(path, "streamed-path-bytes")
+
+    Req.Test.stub(__MODULE__, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert body =~ "streamed-path-bytes"
+      assert body =~ "streamed.pdf"
+      Req.Test.json(conn, file_payload("file-streamed-path", "streamed.pdf"))
+    end)
+
+    assert {:ok, file} =
+             Files.upload(path, api_key: @api_key, req_http_options: @http_opts)
+
+    assert file.file_id == "file-streamed-path"
+    assert file.filename == "streamed.pdf"
+    assert file.media_type == "application/pdf"
+  end
+
+  test "retrieves, lists, paginates, and deletes owned files" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      case {conn.method, conn.request_path} do
+        {"GET", "/v1/files/file-retrieve"} ->
+          Req.Test.json(conn, file_payload("file-retrieve", "retrieved.pdf"))
+
+        {"GET", "/v1/files"} ->
+          assert conn.query_params["after"] == "file-retrieve"
+          assert conn.query_params["limit"] == "2"
+          assert conn.query_params["order"] == "asc"
+          assert conn.query_params["purpose"] == "user_data"
+
+          Req.Test.json(conn, %{
+            "object" => "list",
+            "data" => [
+              file_payload("file-list-1", "one.pdf"),
+              file_payload("file-list-2", "two.png")
+            ],
+            "first_id" => "file-list-1",
+            "last_id" => "file-list-2",
+            "has_more" => true
+          })
+
+        {"DELETE", "/v1/files/file-retrieve"} ->
+          Req.Test.json(conn, %{
+            "id" => "file-retrieve",
+            "object" => "file",
+            "deleted" => true
+          })
+      end
+    end)
+
+    opts = [api_key: @api_key, req_http_options: @http_opts]
+
+    assert {:ok, retrieved} = Files.retrieve("file-retrieve", opts)
+    assert retrieved.filename == "retrieved.pdf"
+    assert retrieved.media_type == "application/pdf"
+
+    assert {:ok, %Files.Page{files: [first, second], has_more: true}} =
+             Files.list(
+               opts ++
+                 [after: retrieved, limit: 2, order: :asc, purpose: :user_data]
+             )
+
+    assert first.file_id == "file-list-1"
+    assert first.media_type == "application/pdf"
+    assert second.file_id == "file-list-2"
+    assert second.media_type == "image/png"
+
+    assert {:ok, true} = Files.delete(retrieved, opts)
+  end
+
+  test "rejects foreign references before I/O and permits expired-file cleanup" do
+    foreign = ContentPart.owned_file_id("file-foreign-secret", :anthropic)
+
+    assert {:error, %ProviderFileReference{reason: :provider_mismatch} = mismatch} =
+             Files.retrieve(foreign,
+               api_key: @api_key,
+               req_http_options: [plug: fn _conn -> flunk("unexpected request") end]
+             )
+
+    refute Exception.message(mismatch) =~ "file-foreign-secret"
+
+    expired =
+      ContentPart.owned_file_id("file-expired", :openai, expires_at: ~U[2020-01-01 00:00:00Z])
+
+    assert {:error, %ProviderFileReference{reason: :expired}} = Files.retrieve(expired)
+
+    Req.Test.stub(__MODULE__, fn conn ->
+      assert conn.method == "DELETE"
+      assert conn.request_path == "/v1/files/file-expired"
+      Req.Test.json(conn, %{"id" => "file-expired", "deleted" => true})
+    end)
+
+    assert {:ok, true} =
+             Files.delete(expired, api_key: @api_key, req_http_options: @http_opts)
+  end
+
+  test "returns typed, redacted upload errors" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      conn
+      |> Plug.Conn.put_status(400)
+      |> Req.Test.json(%{
+        "error" => %{
+          "message" => "unsupported file",
+          "file_id" => "file-provider-secret",
+          "url" => "https://private.example/file"
+        }
+      })
+    end)
+
+    assert {:error, %ReqLLM.Error.API.Request{status: 400} = error} =
+             Files.upload(
+               {:binary, "private-upload-contents", "secret.pdf", "application/pdf"},
+               api_key: @api_key,
+               req_http_options: @http_opts
+             )
+
+    rendered = inspect(error)
+
+    assert Exception.message(error) =~ "unsupported file"
+    refute rendered =~ "private-upload-contents"
+    refute rendered =~ @api_key
+    refute rendered =~ "file-provider-secret"
+    refute rendered =~ "private.example"
+    assert error.request_body == nil
+  end
+
+  test "raw telemetry reports metadata without file bytes or provider IDs" do
+    handler_id = "openai-files-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [[:req_llm, :request, :start], [:req_llm, :request, :stop]],
+      fn event, measurements, metadata, pid ->
+        send(pid, {event, measurements, metadata})
+      end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, file_payload("file-telemetry-secret", "telemetry.pdf"))
+    end)
+
+    assert {:ok, _file} =
+             Files.upload(
+               {:binary, "telemetry-private-bytes", "telemetry.pdf", "application/pdf"},
+               api_key: @api_key,
+               telemetry: [payloads: :raw],
+               req_http_options: @http_opts
+             )
+
+    assert_receive {[:req_llm, :request, :start], _measurements, start_metadata}
+    assert start_metadata.operation == :file_upload
+    refute inspect(start_metadata) =~ "telemetry-private-bytes"
+    refute inspect(start_metadata) =~ @api_key
+
+    assert_receive {[:req_llm, :request, :stop], _measurements, stop_metadata}
+    assert stop_metadata.operation == :file_upload
+    assert stop_metadata.response_payload.file_id == "[REDACTED]"
+    refute inspect(stop_metadata) =~ "file-telemetry-secret"
+    refute inspect(stop_metadata) =~ "telemetry-private-bytes"
+  end
+
+  test "validates upload and list controls without I/O" do
+    assert {:error, %ReqLLM.Error.Invalid.Parameter{} = expiry_error} =
+             Files.upload(
+               {:binary, "data", "data.txt", "text/plain"},
+               expires_after: 10
+             )
+
+    assert Exception.message(expiry_error) =~ "expires_after"
+
+    assert {:error, %ReqLLM.Error.Invalid.Parameter{} = limit_error} = Files.list(limit: 0)
+    assert Exception.message(limit_error) =~ "limit"
+  end
+
+  defp file_payload(id, filename) do
+    %{
+      "id" => id,
+      "object" => "file",
+      "bytes" => 12,
+      "created_at" => 1_783_000_000,
+      "expires_at" => 1_900_000_000,
+      "filename" => filename,
+      "purpose" => "user_data",
+      "status" => "processed"
+    }
+  end
+
+  defp sha256(data) do
+    :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
+  end
+end

--- a/test/support/fixture.ex
+++ b/test/support/fixture.ex
@@ -250,6 +250,16 @@ defmodule ReqLLM.Step.Fixture.Backend do
           }
         }
 
+      {key, {%File.Stream{} = stream, opts}} when is_list(opts) ->
+        %{
+          name: to_string(key),
+          file: %{
+            filename: Keyword.get(opts, :filename, Path.basename(stream.path)),
+            content_type: Keyword.get(opts, :content_type),
+            bytes: Keyword.get(opts, :size, File.stat!(stream.path).size)
+          }
+        }
+
       {key, value} ->
         %{name: to_string(key), value: to_string(value)}
     end)

--- a/test/support/fixtures/openai/files/upload.json
+++ b/test/support/fixtures/openai/files/upload.json
@@ -1,0 +1,48 @@
+{
+  "model_spec": "openai:files",
+  "provider": "openai",
+  "request": {
+    "body": {
+      "canonical_json": [
+        {
+          "file": {
+            "bytes": 13,
+            "content_type": "application/pdf",
+            "filename": "fixture.pdf"
+          },
+          "name": "file"
+        },
+        {
+          "name": "purpose",
+          "value": "user_data"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "multipart/form-data"
+      ]
+    },
+    "method": "post",
+    "url": "https://api.openai.com/v1/files"
+  },
+  "response": {
+    "body": {
+      "id": "file-fixture-upload",
+      "object": "file",
+      "bytes": 13,
+      "created_at": 1783000000,
+      "filename": "fixture.pdf",
+      "purpose": "user_data",
+      "status": "processed"
+    },
+    "headers": {
+      "content-type": [
+        "application/json"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}


### PR DESCRIPTION
## Summary

- add an OpenAI-scoped upload, retrieve, list, and delete lifecycle that returns canonical owned file references
- reuse uploaded references through the existing OpenAI Responses content path without changing the common provider behavior
- preserve existing authentication, retry, timeout, fixture, telemetry, typed error, and redaction conventions
- document retention, cleanup, pagination, and sensitive-reference responsibilities

## Compatibility

This is additive V1 API surface under `ReqLLM.Providers.OpenAI.Files`. Existing inline, URL, and legacy file-ID inputs are unchanged. The common `ReqLLM.Provider` behavior is unchanged. Local path uploads stream on both the Elixir 1.15-1.17 and current `File.stream!/3` calling conventions.

## Validation

- `mix test` — 3,957 passed, 11 skipped, 145 excluded
- `mix test test/providers/openai_files_test.exs` — 8 passed
- `mix quality`
- `mix docs` (one pre-existing hidden-module warning)
- package dry-run includes the new module and guide
- isolated streaming check on Elixir 1.17.2 and 1.20.2

Closes #865