### PR TITLE
test: restore fixture mode after env tests

### DIFF
--- a/test/req_llm/test/env_test.exs
+++ b/test/req_llm/test/env_test.exs
@@ -126,7 +126,7 @@ defmodule ReqLLM.Test.EnvTest do
     end
   end
 
-  defp set_or_delete(_var, nil), do: :ok
+  defp set_or_delete(var, nil), do: System.delete_env(var)
 
   defp set_or_delete(var, value) do
     System.put_env(var, value)


### PR DESCRIPTION
## Summary

- restore `REQ_LLM_FIXTURES_MODE` by deleting it when the pre-test value was absent
- prevent synchronous tests that follow `ReqLLM.Test.EnvTest` from inheriting fixture record mode
- prevent replay tests from accidentally making live provider requests under seed-dependent module ordering

## Context

Follow-up to #909. Post-merge main run [29600382390](https://github.com/agentjido/req_llm/actions/runs/29600382390) exposed the leak when the OpenAI file replay test followed the environment tests and attempted a live request with a fake key.

## Validation

- `mix test test/req_llm/test/env_test.exs test/providers/openai_files_test.exs --seed 927198` — 19 passed
- `mix quality`

This changes test teardown only; runtime behavior and public APIs are unchanged.