### PR TITLE
feat: add transcription call metadata

### DIFF
--- a/guides/host-integration.md
+++ b/guides/host-integration.md
@@ -71,6 +71,25 @@ available when exception-based control flow is intentional.
 The call performs no follow-up work. If `outcome.type` is `:tool_calls`, the
 host decides whether each call is allowed, rejected, deferred, or executed.
 
+Transcription keeps its established compact result by default. A host that
+needs call-level observability can opt into the detailed facade without making
+a second provider request or changing the nested result:
+
+```elixir
+{:ok, detailed} =
+  ReqLLM.transcribe_detailed(model, audio,
+    telemetry: [conversation_id: conversation_id]
+  )
+
+transcript = detailed.result
+call = detailed.call_metadata
+```
+
+`call` always identifies the resolved model and provider. Usage and cost,
+request or response identifiers, warnings, timings, and provider metadata are
+present only when observed. The top-level `request_id` is ReqLLM's telemetry
+correlation ID; a provider request ID remains under `provider_metadata`.
+
 ## Inspect, execute, and continue explicitly
 
 The host can inspect calls before any callback runs:

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -1431,6 +1431,21 @@ defmodule ReqLLM do
   """
   defdelegate transcribe!(model_spec, audio, opts \\ []), to: Transcription
 
+  @doc """
+  Transcribes audio with sparse metadata for the same provider call.
+
+  The returned `ReqLLM.Transcription.DetailedResult` wraps the unchanged
+  `ReqLLM.Transcription.Result`. Unavailable metadata is omitted.
+  """
+  defdelegate transcribe_detailed(model_spec, audio, opts \\ []), to: Transcription
+
+  @doc """
+  Transcribes audio with call metadata, raising on error.
+
+  Same as `transcribe_detailed/3` but raises on error.
+  """
+  defdelegate transcribe_detailed!(model_spec, audio, opts \\ []), to: Transcription
+
   # ===========================================================================
   # Speech API - Delegated to ReqLLM.Speech
   # ===========================================================================

--- a/lib/req_llm/call_metadata.ex
+++ b/lib/req_llm/call_metadata.ex
@@ -1,0 +1,171 @@
+defmodule ReqLLM.CallMetadata do
+  @moduledoc false
+
+  alias ReqLLM.Response.Projection
+
+  @cost_keys [:cost, :input_cost, :output_cost, :reasoning_cost, :total_cost]
+  @provider_request_id_headers [
+    "x-request-id",
+    "request-id",
+    "x-correlation-id",
+    "x-amzn-requestid"
+  ]
+
+  @spec from_req_response(Req.Response.t(), LLMDB.Model.t(), keyword()) :: map()
+  def from_req_response(%Req.Response{} = response, %LLMDB.Model{} = model, opts \\ []) do
+    sources = metadata_sources(response, opts)
+
+    %{
+      model: model.provider_model_id || model.id || model.model,
+      provider: model.provider
+    }
+    |> put_available(:status, status(response, opts))
+    |> put_available(:request_id, req_llm_request_id(response))
+    |> put_available(:response_id, response_id(response.body))
+    |> put_available(:usage, usage(response))
+    |> put_available(:warnings, Projection.warnings(sources))
+    |> put_available(:timings, timings(response, opts))
+    |> put_available(:provider_metadata, provider_metadata(response))
+  end
+
+  defp metadata_sources(response, opts) do
+    req_llm_private = Map.get(response.private, :req_llm, %{})
+    request_plan = Map.get(response.private, :req_llm_request_plan, %{})
+
+    [response.body, response.private, req_llm_private, request_plan] ++
+      Keyword.get(opts, :sensitive_sources, [])
+  end
+
+  defp status(response, opts) do
+    if Keyword.get(opts, :include_status, false), do: response.status
+  end
+
+  defp req_llm_request_id(response) do
+    case get_in(response.private, [:req_llm, :request_id]) do
+      request_id when is_binary(request_id) and request_id != "" -> request_id
+      _other -> nil
+    end
+  end
+
+  defp response_id(body) when is_map(body) do
+    case Map.get(body, :id) || Map.get(body, "id") do
+      response_id when is_binary(response_id) and response_id != "" -> response_id
+      _other -> nil
+    end
+  end
+
+  defp response_id(_body), do: nil
+
+  defp usage(response) do
+    case get_in(response.private, [:req_llm, :usage]) do
+      %{tokens: tokens} = details when is_map(tokens) ->
+        details
+        |> Map.take(@cost_keys)
+        |> reject_unavailable()
+        |> then(&Map.merge(tokens, &1))
+
+      _other ->
+        nil
+    end
+  end
+
+  defp timings(response, opts) do
+    opts
+    |> Keyword.get(:timings)
+    |> Kernel.||(%{})
+    |> put_available(:provider_ms, provider_processing_ms(response.headers))
+    |> reject_unavailable()
+    |> non_empty_map()
+  end
+
+  defp provider_processing_ms(headers) do
+    headers
+    |> first_header(["openai-processing-ms", "x-envoy-upstream-service-time"])
+    |> parse_number()
+  end
+
+  defp provider_metadata(response) do
+    response.body
+    |> body_provider_metadata()
+    |> put_available(:request_id, provider_request_id(response))
+    |> reject_unavailable()
+    |> non_empty_map()
+    |> case do
+      nil -> nil
+      metadata -> Projection.safe_metadata(metadata)
+    end
+  end
+
+  defp body_provider_metadata(body) when is_map(body) do
+    case Map.get(body, :provider_metadata) || Map.get(body, "provider_metadata") do
+      metadata when is_map(metadata) -> metadata
+      _other -> %{}
+    end
+  end
+
+  defp body_provider_metadata(_body), do: %{}
+
+  defp provider_request_id(response) do
+    first_header(response.headers, @provider_request_id_headers) || body_request_id(response.body)
+  end
+
+  defp body_request_id(body) when is_map(body) do
+    case Map.get(body, :request_id) || Map.get(body, "request_id") do
+      request_id when is_binary(request_id) and request_id != "" -> request_id
+      _other -> nil
+    end
+  end
+
+  defp body_request_id(_body), do: nil
+
+  defp first_header(headers, names) do
+    Enum.find_value(names, &header_value(headers, &1))
+  end
+
+  defp header_value(headers, name) when is_map(headers) do
+    headers
+    |> Enum.find_value(fn {key, value} ->
+      if String.downcase(to_string(key)) == name, do: normalize_header_value(value)
+    end)
+  end
+
+  defp header_value(headers, name) when is_list(headers) do
+    headers
+    |> Enum.find_value(fn
+      {key, value} ->
+        if String.downcase(to_string(key)) == name, do: normalize_header_value(value)
+
+      _other ->
+        nil
+    end)
+  end
+
+  defp header_value(_headers, _name), do: nil
+
+  defp normalize_header_value([value | _rest]), do: normalize_header_value(value)
+
+  defp normalize_header_value(value) when is_binary(value) and value != "", do: value
+  defp normalize_header_value(_value), do: nil
+
+  defp parse_number(value) when is_binary(value) do
+    case Float.parse(value) do
+      {number, ""} -> number
+      _other -> nil
+    end
+  end
+
+  defp parse_number(value) when is_number(value), do: value
+  defp parse_number(_value), do: nil
+
+  defp put_available(map, _key, value) when value in [nil, "", [], %{}], do: map
+  defp put_available(map, key, value), do: Map.put(map, key, value)
+
+  defp reject_unavailable(map) do
+    map
+    |> Enum.reject(fn {_key, value} -> value in [nil, "", [], %{}] end)
+    |> Map.new()
+  end
+
+  defp non_empty_map(map) when map_size(map) == 0, do: nil
+  defp non_empty_map(map), do: map
+end

--- a/lib/req_llm/step/usage.ex
+++ b/lib/req_llm/step/usage.ex
@@ -31,20 +31,36 @@ defmodule ReqLLM.Step.Usage do
 
   - `req` - The Req.Request struct
   - `model` - Optional ReqLLM.Model struct for cost calculation
+  - `opts` - Optional placement settings. `:before` inserts the step before a
+    named response step and appends it when that name is absent.
 
   ## Examples
 
       request
       |> ReqLLM.Step.Usage.attach(model)
 
+      request
+      |> ReqLLM.Step.Usage.attach(model, before: :llm_telemetry_stop)
+
   """
-  @spec attach(Req.Request.t(), LLMDB.Model.t() | nil) :: Req.Request.t()
-  def attach(%Req.Request{} = req, model \\ nil) do
+  @spec attach(Req.Request.t(), LLMDB.Model.t() | nil, keyword()) :: Req.Request.t()
+  def attach(%Req.Request{} = req, model \\ nil, opts \\ []) do
     req
-    |> Req.Request.append_response_steps(llm_usage: &__MODULE__.handle/1)
+    |> attach_response_step(Keyword.get(opts, :before))
     |> then(fn r ->
       if model, do: Req.Request.put_private(r, :req_llm_model, model), else: r
     end)
+  end
+
+  defp attach_response_step(req, nil) do
+    Req.Request.append_response_steps(req, llm_usage: &__MODULE__.handle/1)
+  end
+
+  defp attach_response_step(req, before) when is_atom(before) do
+    {leading, trailing} =
+      Enum.split_while(req.response_steps, fn {name, _step} -> name != before end)
+
+    %{req | response_steps: leading ++ [llm_usage: &__MODULE__.handle/1] ++ trailing}
   end
 
   @doc false

--- a/lib/req_llm/transcription.ex
+++ b/lib/req_llm/transcription.ex
@@ -248,7 +248,7 @@ defmodule ReqLLM.Transcription do
     if Keyword.has_key?(request.response_steps, :llm_usage) do
       request
     else
-      ReqLLM.Step.Usage.attach(request, model)
+      ReqLLM.Step.Usage.attach(request, model, before: :llm_telemetry_stop)
     end
   end
 

--- a/lib/req_llm/transcription.ex
+++ b/lib/req_llm/transcription.ex
@@ -40,6 +40,7 @@ defmodule ReqLLM.Transcription do
 
   """
 
+  alias ReqLLM.Transcription.DetailedResult
   alias ReqLLM.Transcription.Result
 
   @base_schema NimbleOptions.new!(
@@ -137,6 +138,31 @@ defmodule ReqLLM.Transcription do
           keyword()
         ) :: {:ok, Result.t()} | {:error, term()}
   def transcribe(model_spec, audio, opts \\ []) do
+    perform_transcription(model_spec, audio, opts, :result)
+  end
+
+  @doc """
+  Transcribes audio and returns the unchanged transcription result with sparse
+  metadata for the same provider call.
+
+  The returned `ReqLLM.Transcription.DetailedResult` keeps the legacy result at
+  `detailed.result`. Its `call_metadata` includes model and provider identity,
+  then adds usage and cost, correlation and provider request IDs, warnings, and
+  timings only when the request pipeline supplied them.
+
+  This function performs one provider request. Use `transcribe/3` when call
+  metadata is not needed.
+  """
+  @spec transcribe_detailed(
+          ReqLLM.model_input(),
+          String.t() | {:binary, binary(), String.t()} | {:base64, String.t(), String.t()},
+          keyword()
+        ) :: {:ok, DetailedResult.t()} | {:error, term()}
+  def transcribe_detailed(model_spec, audio, opts \\ []) do
+    perform_transcription(model_spec, audio, opts, :detailed)
+  end
+
+  defp perform_transcription(model_spec, audio, opts, return_mode) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :transcription, opts)
     deadline = ReqLLM.TimeoutBudget.deadline(opts)
 
@@ -153,21 +179,29 @@ defmodule ReqLLM.Transcription do
          {:ok, request} <-
            provider_module.prepare_request(:transcription, model, audio_data, [
              {:media_type, media_type} | opts
-           ]),
-         {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
-           ReqLLM.TimeoutBudget.request(request, deadline) do
-      parse_transcription_response(body)
-    else
-      {:ok, %Req.Response{status: status, body: body}} ->
-        {:error,
-         ReqLLM.Error.API.Request.exception(
-           reason: "HTTP #{status}: Transcription request failed",
-           status: status,
-           response_body: body
-         )}
+           ]) do
+      request = maybe_attach_usage(request, model, return_mode)
+      started_at = request_started_at(return_mode)
 
-      {:error, error} ->
-        {:error, error}
+      case ReqLLM.TimeoutBudget.request(request, deadline) do
+        {:ok, %Req.Response{status: status, body: body} = response} when status in 200..299 ->
+          timings = request_timings(started_at)
+
+          with {:ok, result} <- parse_transcription_response(body) do
+            build_return(result, response, model, timings, return_mode)
+          end
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          {:error,
+           ReqLLM.Error.API.Request.exception(
+             reason: "HTTP #{status}: Transcription request failed",
+             status: status,
+             response_body: body
+           )}
+
+        {:error, error} ->
+          {:error, error}
+      end
     end
   end
 
@@ -187,6 +221,62 @@ defmodule ReqLLM.Transcription do
       {:error, error} -> raise error
     end
   end
+
+  @doc """
+  Transcribes audio with call metadata, raising on error.
+
+  Same as `transcribe_detailed/3` but raises on error.
+  """
+  @spec transcribe_detailed!(
+          ReqLLM.model_input(),
+          String.t() | {:binary, binary(), String.t()} | {:base64, String.t(), String.t()},
+          keyword()
+        ) :: DetailedResult.t() | no_return()
+  def transcribe_detailed!(model_spec, audio, opts \\ []) do
+    case transcribe_detailed(model_spec, audio, opts) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
+
+  defp maybe_attach_usage(request, model, :detailed) do
+    request =
+      request
+      |> Req.Request.register_options([:operation])
+      |> Req.Request.merge_options(operation: :transcription)
+
+    if Keyword.has_key?(request.response_steps, :llm_usage) do
+      request
+    else
+      ReqLLM.Step.Usage.attach(request, model)
+    end
+  end
+
+  defp maybe_attach_usage(request, _model, :result), do: request
+
+  defp request_started_at(:detailed), do: System.monotonic_time()
+  defp request_started_at(:result), do: nil
+
+  defp build_return(result, _response, _model, _timings, :result), do: {:ok, result}
+
+  defp build_return(result, response, model, timings, :detailed) do
+    call_metadata =
+      ReqLLM.CallMetadata.from_req_response(response, model,
+        timings: timings,
+        sensitive_sources: [%{content: result.text}]
+      )
+
+    {:ok, %DetailedResult{result: result, call_metadata: call_metadata}}
+  end
+
+  defp request_timings(started_at) when is_integer(started_at) do
+    duration = System.monotonic_time() - started_at
+    microseconds = System.convert_time_unit(duration, :native, :microsecond)
+
+    if microseconds > 0, do: %{request_ms: microseconds / 1_000}
+  end
+
+  defp request_timings(nil), do: nil
 
   defp resolve_audio(path) when is_binary(path) do
     case File.read(path) do

--- a/lib/req_llm/transcription/detailed_result.ex
+++ b/lib/req_llm/transcription/detailed_result.ex
@@ -1,0 +1,35 @@
+defmodule ReqLLM.Transcription.DetailedResult do
+  @moduledoc """
+  Opt-in transcription result with sparse call metadata.
+
+  The nested `result` is the unchanged `ReqLLM.Transcription.Result` returned by
+  `ReqLLM.transcribe/3`. `call_metadata` contains only values observed for the
+  same provider request. Unavailable usage, identifiers, warnings, timings, and
+  provider metadata are omitted rather than represented by defaults.
+
+  The top-level `request_id` is ReqLLM's telemetry correlation ID. A provider's
+  request ID, when supplied in the response, is kept separately at
+  `call_metadata.provider_metadata.request_id`.
+  """
+
+  alias ReqLLM.Transcription.Result
+
+  @type call_metadata :: %{
+          required(:model) => String.t(),
+          required(:provider) => atom(),
+          optional(:usage) => map(),
+          optional(:request_id) => String.t(),
+          optional(:response_id) => String.t(),
+          optional(:warnings) => [String.t()],
+          optional(:timings) => map(),
+          optional(:provider_metadata) => map()
+        }
+
+  @type t :: %__MODULE__{
+          result: Result.t(),
+          call_metadata: call_metadata()
+        }
+
+  @enforce_keys [:result, :call_metadata]
+  defstruct [:result, :call_metadata]
+end

--- a/test/req_llm/step/usage_test.exs
+++ b/test/req_llm/step/usage_test.exs
@@ -74,6 +74,17 @@ defmodule ReqLLM.Step.UsageTest do
       assert Keyword.has_key?(updated_request.response_steps, :llm_usage)
       assert updated_request.private[:req_llm_model] == nil
     end
+
+    test "can insert usage before an existing response step" do
+      request = %Req.Request{
+        response_steps: [decode: &Function.identity/1, telemetry: &Function.identity/1]
+      }
+
+      updated_request = Usage.attach(request, nil, before: :telemetry)
+
+      assert Keyword.keys(updated_request.response_steps) == [:decode, :llm_usage, :telemetry]
+      assert updated_request.response_steps[:llm_usage] == (&Usage.handle/1)
+    end
   end
 
   describe "handle/1 - usage extraction and processing" do

--- a/test/req_llm/transcription_test.exs
+++ b/test/req_llm/transcription_test.exs
@@ -177,12 +177,12 @@ defmodule ReqLLM.TranscriptionTest do
       test_pid = self()
       handler_id = "transcription-detailed-#{System.unique_integer([:positive])}"
 
-      :telemetry.attach(
+      :telemetry.attach_many(
         handler_id,
-        [:req_llm, :token_usage],
-        fn _event, _measurements, metadata, _config ->
+        [[:req_llm, :token_usage], [:req_llm, :request, :stop]],
+        fn event, _measurements, metadata, _config ->
           if metadata.model.id == "transcription-metadata-test" do
-            send(test_pid, {:usage_telemetry, metadata})
+            send(test_pid, {event, metadata})
           end
         end,
         nil
@@ -227,7 +227,12 @@ defmodule ReqLLM.TranscriptionTest do
 
       assert_receive :detailed_request
       refute_receive :detailed_request, 20
-      assert_receive {:usage_telemetry, %{operation: :transcription}}
+
+      assert_receive {[:req_llm, :request, :stop], request_stop}
+      assert request_stop.operation == :transcription
+      assert request_stop.usage.tokens.input_tokens == 10
+
+      assert_receive {[:req_llm, :token_usage], %{operation: :transcription}}
 
       assert detailed.result == %Result{
                text: "Hello world",

--- a/test/req_llm/transcription_test.exs
+++ b/test/req_llm/transcription_test.exs
@@ -15,8 +15,17 @@ defmodule ReqLLM.TranscriptionTest do
 
   @moduletag contract: :public_api
 
+  import ReqLLM.Test.Helpers, only: [pricing_from_cost: 1]
+
   alias ReqLLM.Transcription
+  alias ReqLLM.Transcription.DetailedResult
   alias ReqLLM.Transcription.Result
+
+  defmodule DetailedHTTP do
+  end
+
+  defmodule SparseDetailedHTTP do
+  end
 
   describe "Result struct" do
     test "creates result with defaults" do
@@ -25,6 +34,13 @@ defmodule ReqLLM.TranscriptionTest do
       assert result.segments == []
       assert result.language == nil
       assert result.duration_in_seconds == nil
+
+      assert Map.from_struct(result) == %{
+               text: "",
+               segments: [],
+               language: nil,
+               duration_in_seconds: nil
+             }
     end
 
     test "creates result with all fields" do
@@ -156,6 +172,137 @@ defmodule ReqLLM.TranscriptionTest do
     end
   end
 
+  describe "transcribe_detailed/3" do
+    test "wraps the unchanged result with redacted metadata from one request" do
+      test_pid = self()
+      handler_id = "transcription-detailed-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:req_llm, :token_usage],
+        fn _event, _measurements, metadata, _config ->
+          if metadata.model.id == "transcription-metadata-test" do
+            send(test_pid, {:usage_telemetry, metadata})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Req.Test.stub(DetailedHTTP, fn conn ->
+        send(test_pid, :detailed_request)
+
+        conn
+        |> Plug.Conn.put_resp_header("x-request-id", "provider_req_123")
+        |> Plug.Conn.put_resp_header("openai-processing-ms", "8")
+        |> Req.Test.json(%{
+          "id" => "transcription_123",
+          "text" => "Hello world",
+          "segments" => [%{"text" => "Hello world", "start" => 0.0, "end" => 1.0}],
+          "language" => "english",
+          "duration" => 1.0,
+          "usage" => %{"input_tokens" => 10, "output_tokens" => 4, "total_tokens" => 14},
+          "warnings" => ["credential sk-secret was ignored"],
+          "provider_metadata" => %{
+            "api_key" => "sk-secret",
+            "url" => "https://example.com/transcription?token=sk-secret"
+          }
+        })
+      end)
+
+      model = %LLMDB.Model{
+        id: "transcription-metadata-test",
+        provider: :openai,
+        pricing: pricing_from_cost(%{input: 1.0, output: 2.0})
+      }
+
+      assert {:ok, %DetailedResult{} = detailed} =
+               ReqLLM.transcribe_detailed(
+                 model,
+                 {:binary, "audio", "audio/mpeg"},
+                 api_key: "sk-secret",
+                 req_http_options: [plug: {Req.Test, DetailedHTTP}]
+               )
+
+      assert_receive :detailed_request
+      refute_receive :detailed_request, 20
+      assert_receive {:usage_telemetry, %{operation: :transcription}}
+
+      assert detailed.result == %Result{
+               text: "Hello world",
+               segments: [%{text: "Hello world", start_second: 0.0, end_second: 1.0}],
+               language: "en",
+               duration_in_seconds: 1.0
+             }
+
+      assert Map.from_struct(detailed.result) == %{
+               text: "Hello world",
+               segments: [%{text: "Hello world", start_second: 0.0, end_second: 1.0}],
+               language: "en",
+               duration_in_seconds: 1.0
+             }
+
+      metadata = detailed.call_metadata
+      assert metadata.model == "transcription-metadata-test"
+      assert metadata.provider == :openai
+      assert is_binary(metadata.request_id)
+      assert metadata.request_id != "provider_req_123"
+      assert metadata.response_id == "transcription_123"
+      assert metadata.usage.input_tokens == 10
+      assert metadata.usage.output_tokens == 4
+      assert metadata.usage.total_tokens == 14
+      assert metadata.usage.total_cost > 0
+      assert metadata.warnings == ["credential [REDACTED] was ignored"]
+      assert metadata.timings.request_ms > 0
+      assert metadata.timings.provider_ms == 8.0
+      assert metadata.provider_metadata.request_id == "provider_req_123"
+      assert metadata.provider_metadata["api_key"] == "[REDACTED]"
+
+      assert metadata.provider_metadata["url"] ==
+               "https://example.com/transcription?token=[REDACTED]"
+
+      refute inspect(detailed) =~ "sk-secret"
+    end
+
+    test "omits metadata that the provider and request pipeline do not supply" do
+      Req.Test.stub(SparseDetailedHTTP, fn conn ->
+        Req.Test.json(conn, %{"text" => "Hello"})
+      end)
+
+      assert {:ok, %DetailedResult{result: %Result{text: "Hello"}} = detailed} =
+               ReqLLM.transcribe_detailed(
+                 %LLMDB.Model{id: "whisper-1", provider: :openai},
+                 {:binary, "audio", "audio/mpeg"},
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, SparseDetailedHTTP}]
+               )
+
+      assert detailed.call_metadata.model == "whisper-1"
+      assert detailed.call_metadata.provider == :openai
+      assert is_binary(detailed.call_metadata.request_id)
+      assert detailed.call_metadata.timings.request_ms > 0
+      refute Map.has_key?(detailed.call_metadata, :response_id)
+      refute Map.has_key?(detailed.call_metadata, :usage)
+      refute Map.has_key?(detailed.call_metadata, :warnings)
+      refute Map.has_key?(detailed.call_metadata, :provider_metadata)
+    end
+
+    test "bang variant raises the same error as the legacy facade" do
+      legacy_error =
+        assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+          Transcription.transcribe!("openai:whisper-1", "/nonexistent/audio.mp3")
+        end
+
+      detailed_error =
+        assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+          Transcription.transcribe_detailed!("openai:whisper-1", "/nonexistent/audio.mp3")
+        end
+
+      assert Exception.message(detailed_error) == Exception.message(legacy_error)
+    end
+  end
+
   describe "ReqLLM facade delegation" do
     test "transcribe/3 is delegated" do
       assert function_exported?(ReqLLM, :transcribe, 3)
@@ -165,6 +312,13 @@ defmodule ReqLLM.TranscriptionTest do
     test "transcribe!/3 is delegated" do
       assert function_exported?(ReqLLM, :transcribe!, 3)
       assert function_exported?(ReqLLM, :transcribe!, 2)
+    end
+
+    test "detailed transcription functions are delegated" do
+      assert function_exported?(ReqLLM, :transcribe_detailed, 3)
+      assert function_exported?(ReqLLM, :transcribe_detailed, 2)
+      assert function_exported?(ReqLLM, :transcribe_detailed!, 3)
+      assert function_exported?(ReqLLM, :transcribe_detailed!, 2)
     end
   end
 end

--- a/test/support/provider_test/transcription.ex
+++ b/test/support/provider_test/transcription.ex
@@ -54,6 +54,27 @@ defmodule ReqLLM.ProviderTest.Transcription do
             assert is_binary(result.text)
             assert result.text != ""
           end
+
+          @tag category: :transcription
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:transcription_basic)
+          @tag model: model_spec |> String.split(":", parts: 2) |> List.last()
+          test "detailed audio transcription reuses the provider fixture" do
+            {:ok, detailed} =
+              ReqLLM.transcribe_detailed(
+                @model_spec,
+                {:binary, ReqLLM.ProviderTest.Transcription.sample_audio(), "audio/wav"},
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:transcription_basic),
+                  language: "en"
+                )
+              )
+
+            assert %ReqLLM.Transcription.DetailedResult{} = detailed
+            assert is_binary(detailed.result.text)
+            assert detailed.result.text != ""
+            assert detailed.call_metadata.provider == @provider
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #867

## Summary

- add opt-in `transcribe_detailed/3` and `transcribe_detailed!/3` facades
- wrap the unchanged `ReqLLM.Transcription.Result` in a sparse detailed result
- expose only evidence-backed normalized usage/cost, correlation and provider IDs, redacted warnings/provider metadata, and request timings
- preserve the legacy transcription result, request body, errors, defaults, and telemetry behavior
- reuse the same provider request and existing fixtures without a second call

## Compatibility

This is additive. Existing `transcribe/3`, `transcribe!/3`, `ReqLLM.Transcription.Result`, request payloads, errors, and default telemetry remain unchanged. Usage extraction and its additive telemetry event run only through the explicit detailed facade.

## Validation

- `mix test test/req_llm/transcription_test.exs`
- OpenAI, Groq, and OpenRouter transcription coverage fixtures: 6 passing
- `mix test`: 3961 passing, 11 skipped, 148 excluded
- `mix quality`
- `mix docs` (one pre-existing hidden-module reference warning)