### PR TITLE
feat: add speech call metadata

### DIFF
--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -1494,11 +1494,26 @@ defmodule ReqLLM do
   defdelegate speak(model_spec, text, opts \\ []), to: Speech
 
   @doc """
+  Generates speech and returns the unchanged speech result with sparse metadata
+  for the same provider call.
+
+  See `ReqLLM.Speech.speak_detailed/3` for details.
+  """
+  defdelegate speak_detailed(model_spec, text, opts \\ []), to: Speech
+
+  @doc """
   Generates speech audio from text, raising on error.
 
   Same as `speak/3` but raises on error.
   """
   defdelegate speak!(model_spec, text, opts \\ []), to: Speech
+
+  @doc """
+  Generates speech with call metadata, raising on error.
+
+  Same as `speak_detailed/3` but raises on error.
+  """
+  defdelegate speak_detailed!(model_spec, text, opts \\ []), to: Speech
 
   # ===========================================================================
   # Vercel AI SDK Utility API - Delegated to ReqLLM.Utils

--- a/lib/req_llm/speech.ex
+++ b/lib/req_llm/speech.ex
@@ -31,6 +31,7 @@ defmodule ReqLLM.Speech do
 
   """
 
+  alias ReqLLM.Speech.DetailedResult
   alias ReqLLM.Speech.Result
 
   @output_formats ~w(mp3 opus aac flac wav pcm)a
@@ -141,6 +142,32 @@ defmodule ReqLLM.Speech do
           keyword()
         ) :: {:ok, Result.t()} | {:error, term()}
   def speak(model_spec, text, opts \\ []) do
+    perform_speech(model_spec, text, opts, :result)
+  end
+
+  @doc """
+  Generates speech and returns the unchanged speech result with sparse metadata
+  for the same provider call.
+
+  The returned `ReqLLM.Speech.DetailedResult` keeps the legacy result at
+  `detailed.result`. Its `call_metadata` always identifies the model and provider,
+  then includes status, usage and cost, correlation and provider request IDs,
+  warnings, and timings only when the request pipeline supplied them.
+
+  This function performs one provider request and preserves the provider's audio
+  response without introducing another delivery path. Use `speak/3` when call
+  metadata is not needed.
+  """
+  @spec speak_detailed(
+          ReqLLM.model_input(),
+          String.t(),
+          keyword()
+        ) :: {:ok, DetailedResult.t()} | {:error, term()}
+  def speak_detailed(model_spec, text, opts \\ []) do
+    perform_speech(model_spec, text, opts, :detailed)
+  end
+
+  defp perform_speech(model_spec, text, opts, return_mode) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :speech, opts)
     deadline = ReqLLM.TimeoutBudget.deadline(opts)
 
@@ -154,31 +181,28 @@ defmodule ReqLLM.Speech do
              opts
            ),
          {:ok, request} <-
-           provider_module.prepare_request(:speech, model, text, opts),
-         {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
-           ReqLLM.TimeoutBudget.request(request, deadline) do
-      output_format = Keyword.get(opts, :output_format, :mp3)
-      format_string = to_string(output_format)
+           provider_module.prepare_request(:speech, model, text, opts) do
+      request = maybe_attach_usage(request, model, return_mode)
+      started_at = request_started_at(return_mode)
 
-      {:ok,
-       %Result{
-         audio: body,
-         media_type: format_to_media_type(output_format),
-         format: format_string
-       }}
-    else
-      {:ok, %Req.Response{status: status, body: body}} ->
-        error_body = parse_error_body(body)
+      case ReqLLM.TimeoutBudget.request(request, deadline) do
+        {:ok, %Req.Response{status: status, body: body} = response} when status in 200..299 ->
+          result = build_result(body, Keyword.get(opts, :output_format, :mp3))
+          build_return(result, response, model, text, request_timings(started_at), return_mode)
 
-        {:error,
-         ReqLLM.Error.API.Request.exception(
-           reason: "HTTP #{status}: Speech generation failed",
-           status: status,
-           response_body: error_body
-         )}
+        {:ok, %Req.Response{status: status, body: body}} ->
+          error_body = parse_error_body(body)
 
-      {:error, error} ->
-        {:error, error}
+          {:error,
+           ReqLLM.Error.API.Request.exception(
+             reason: "HTTP #{status}: Speech generation failed",
+             status: status,
+             response_body: error_body
+           )}
+
+        {:error, error} ->
+          {:error, error}
+      end
     end
   end
 
@@ -198,6 +222,71 @@ defmodule ReqLLM.Speech do
       {:error, error} -> raise error
     end
   end
+
+  @doc """
+  Generates speech with call metadata, raising on error.
+
+  Same as `speak_detailed/3` but raises on error.
+  """
+  @spec speak_detailed!(
+          ReqLLM.model_input(),
+          String.t(),
+          keyword()
+        ) :: DetailedResult.t() | no_return()
+  def speak_detailed!(model_spec, text, opts \\ []) do
+    case speak_detailed(model_spec, text, opts) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
+    end
+  end
+
+  defp maybe_attach_usage(request, model, :detailed) do
+    request =
+      request
+      |> Req.Request.register_options([:operation])
+      |> Req.Request.merge_options(operation: :speech)
+
+    if Keyword.has_key?(request.response_steps, :llm_usage) do
+      request
+    else
+      ReqLLM.Step.Usage.attach(request, model, before: :llm_telemetry_stop)
+    end
+  end
+
+  defp maybe_attach_usage(request, _model, :result), do: request
+
+  defp request_started_at(:detailed), do: System.monotonic_time()
+  defp request_started_at(:result), do: nil
+
+  defp build_result(body, output_format) do
+    %Result{
+      audio: body,
+      media_type: format_to_media_type(output_format),
+      format: to_string(output_format)
+    }
+  end
+
+  defp build_return(result, _response, _model, _text, _timings, :result), do: {:ok, result}
+
+  defp build_return(result, response, model, text, timings, :detailed) do
+    call_metadata =
+      ReqLLM.CallMetadata.from_req_response(response, model,
+        include_status: true,
+        timings: timings,
+        sensitive_sources: [%{content: text}]
+      )
+
+    {:ok, %DetailedResult{result: result, call_metadata: call_metadata}}
+  end
+
+  defp request_timings(started_at) when is_integer(started_at) do
+    duration = System.monotonic_time() - started_at
+    microseconds = System.convert_time_unit(duration, :native, :microsecond)
+
+    if microseconds > 0, do: %{request_ms: microseconds / 1_000}
+  end
+
+  defp request_timings(nil), do: nil
 
   @format_media_types %{
     mp3: "audio/mpeg",

--- a/lib/req_llm/speech/detailed_result.ex
+++ b/lib/req_llm/speech/detailed_result.ex
@@ -1,0 +1,36 @@
+defmodule ReqLLM.Speech.DetailedResult do
+  @moduledoc """
+  Opt-in speech result with sparse call metadata.
+
+  The nested `result` is the unchanged `ReqLLM.Speech.Result` returned by
+  `ReqLLM.speak/3`. `call_metadata` contains only values observed for the same
+  provider request. Unavailable usage, identifiers, warnings, timings, and
+  provider metadata are omitted rather than represented by defaults.
+
+  The top-level `request_id` is ReqLLM's telemetry correlation ID. A provider's
+  request ID, when supplied in the response, is kept separately at
+  `call_metadata.provider_metadata.request_id`.
+  """
+
+  alias ReqLLM.Speech.Result
+
+  @type call_metadata :: %{
+          required(:model) => String.t(),
+          required(:provider) => atom(),
+          optional(:status) => non_neg_integer(),
+          optional(:usage) => map(),
+          optional(:request_id) => String.t(),
+          optional(:response_id) => String.t(),
+          optional(:warnings) => [String.t()],
+          optional(:timings) => map(),
+          optional(:provider_metadata) => map()
+        }
+
+  @type t :: %__MODULE__{
+          result: Result.t(),
+          call_metadata: call_metadata()
+        }
+
+  @enforce_keys [:result, :call_metadata]
+  defstruct [:result, :call_metadata]
+end

--- a/test/req_llm/speech_test.exs
+++ b/test/req_llm/speech_test.exs
@@ -143,6 +143,7 @@ defmodule ReqLLM.SpeechTest do
     test "passes text through to provider" do
       assert {:error, error} =
                Speech.speak("openai:tts-1", "Hello world",
+                 api_key: "test-key",
                  req_http_options: [plug: {Req.Test, __MODULE__}]
                )
 

--- a/test/req_llm/speech_test.exs
+++ b/test/req_llm/speech_test.exs
@@ -9,12 +9,70 @@ defmodule ReqLLM.SpeechTest do
   - ReqLLM facade delegation
   """
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag contract: :public_api
 
+  import ReqLLM.Test.Helpers, only: [pricing_from_cost: 1]
+
   alias ReqLLM.Speech
+  alias ReqLLM.Speech.DetailedResult
   alias ReqLLM.Speech.Result
+
+  defmodule DetailedHTTP do
+  end
+
+  defmodule SparseDetailedHTTP do
+  end
+
+  defmodule DetailedProvider do
+    use ReqLLM.Provider,
+      id: :speech_detailed_test,
+      default_base_url: "https://speech.example/v1"
+
+    @impl ReqLLM.Provider
+    def prepare_request(:speech, model, text, opts) do
+      http_opts = Keyword.get(opts, :req_http_options, [])
+
+      request =
+        Req.new(
+          [
+            url: "/audio/speech",
+            method: :post,
+            base_url: default_base_url(),
+            body: text,
+            decode_body: false
+          ] ++ http_opts
+        )
+        |> Req.Request.append_response_steps(
+          speech_test_metadata: &__MODULE__.put_test_metadata/1
+        )
+        |> ReqLLM.Step.Telemetry.attach(model, Keyword.put(opts, :operation, :speech))
+
+      {:ok, request}
+    end
+
+    @impl ReqLLM.Provider
+    def extract_usage(_body, _model) do
+      {:ok, %{input: 10, output: 4, total_tokens: 14}}
+    end
+
+    @doc false
+    def put_test_metadata({request, response}) do
+      private =
+        Map.put(response.private, :req_llm_request_plan, %{
+          warnings: ["input speech-secret was ignored"]
+        })
+
+      {request, %{response | private: private}}
+    end
+  end
+
+  setup_all do
+    assert {:ok, :speech_detailed_test} = ReqLLM.Providers.register(DetailedProvider)
+    on_exit(fn -> ReqLLM.Providers.unregister(:speech_detailed_test) end)
+    :ok
+  end
 
   setup do
     Req.Test.stub(__MODULE__, fn conn ->
@@ -36,6 +94,13 @@ defmodule ReqLLM.SpeechTest do
       assert result.media_type == "audio/mpeg"
       assert result.format == "mp3"
       assert result.duration_in_seconds == nil
+
+      assert Map.from_struct(result) == %{
+               audio: <<>>,
+               media_type: "audio/mpeg",
+               format: "mp3",
+               duration_in_seconds: nil
+             }
     end
 
     test "creates result with all fields" do
@@ -93,6 +158,136 @@ defmodule ReqLLM.SpeechTest do
     end
   end
 
+  describe "speak_detailed/3" do
+    test "wraps the unchanged raw result with redacted metadata from one request" do
+      test_pid = self()
+      audio = <<0, 255, 1, 254, 2, 253>>
+      handler_id = "speech-detailed-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [[:req_llm, :token_usage], [:req_llm, :request, :stop]],
+        fn event, _measurements, metadata, _config ->
+          if metadata.model.id == "speech-metadata-test" do
+            send(test_pid, {event, metadata})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Req.Test.stub(DetailedHTTP, fn conn ->
+        send(test_pid, :detailed_request)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("audio/mpeg")
+        |> Plug.Conn.put_resp_header("x-request-id", "provider_req_123")
+        |> Plug.Conn.put_resp_header("openai-processing-ms", "8")
+        |> Plug.Conn.send_resp(200, audio)
+      end)
+
+      model = %LLMDB.Model{
+        id: "speech-metadata-test",
+        provider: :speech_detailed_test,
+        pricing: pricing_from_cost(%{input: 1.0, output: 2.0})
+      }
+
+      assert {:ok, %DetailedResult{} = detailed} =
+               ReqLLM.speak_detailed(
+                 model,
+                 "speech-secret",
+                 output_format: :mp3,
+                 req_http_options: [plug: {Req.Test, DetailedHTTP}]
+               )
+
+      assert_receive :detailed_request
+      refute_receive :detailed_request, 20
+
+      assert_receive {[:req_llm, :request, :stop], request_stop}
+      assert request_stop.operation == :speech
+      assert request_stop.usage.tokens.input_tokens == 10
+      assert_receive {[:req_llm, :token_usage], %{operation: :speech}}
+
+      assert detailed.result == %Result{
+               audio: audio,
+               media_type: "audio/mpeg",
+               format: "mp3",
+               duration_in_seconds: nil
+             }
+
+      assert Map.from_struct(detailed.result) == %{
+               audio: audio,
+               media_type: "audio/mpeg",
+               format: "mp3",
+               duration_in_seconds: nil
+             }
+
+      metadata = detailed.call_metadata
+      assert metadata.model == "speech-metadata-test"
+      assert metadata.provider == :speech_detailed_test
+      assert metadata.status == 200
+      assert is_binary(metadata.request_id)
+      assert metadata.request_id != "provider_req_123"
+      assert metadata.usage.input_tokens == 10
+      assert metadata.usage.output_tokens == 4
+      assert metadata.usage.total_tokens == 14
+      assert metadata.usage.total_cost > 0
+      assert metadata.warnings == ["input [REDACTED] was ignored"]
+      assert metadata.timings.request_ms > 0
+      assert metadata.timings.provider_ms == 8.0
+      assert metadata.provider_metadata.request_id == "provider_req_123"
+      refute Map.has_key?(metadata, :response_id)
+      refute inspect(detailed) =~ "speech-secret"
+    end
+
+    test "omits metadata that the provider and request pipeline do not supply" do
+      audio = <<1, 2, 3, 4>>
+
+      Req.Test.stub(SparseDetailedHTTP, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("audio/mpeg")
+        |> Plug.Conn.send_resp(200, audio)
+      end)
+
+      assert {:ok, %DetailedResult{result: %Result{audio: ^audio}} = detailed} =
+               ReqLLM.speak_detailed(
+                 %LLMDB.Model{id: "tts-1", provider: :openai},
+                 "Hello",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, SparseDetailedHTTP}]
+               )
+
+      assert detailed.call_metadata.model == "tts-1"
+      assert detailed.call_metadata.provider == :openai
+      assert detailed.call_metadata.status == 200
+      assert is_binary(detailed.call_metadata.request_id)
+      assert detailed.call_metadata.timings.request_ms > 0
+      refute Map.has_key?(detailed.call_metadata, :response_id)
+      refute Map.has_key?(detailed.call_metadata, :usage)
+      refute Map.has_key?(detailed.call_metadata, :warnings)
+      refute Map.has_key?(detailed.call_metadata, :provider_metadata)
+    end
+
+    test "bang variant raises the same HTTP error as the legacy facade" do
+      opts = [api_key: "test-key", req_http_options: [plug: {Req.Test, __MODULE__}]]
+
+      legacy_error =
+        assert_raise ReqLLM.Error.API.Request, fn ->
+          Speech.speak!("openai:tts-1", "Hello", opts)
+        end
+
+      detailed_error =
+        assert_raise ReqLLM.Error.API.Request, fn ->
+          Speech.speak_detailed!("openai:tts-1", "Hello", opts)
+        end
+
+      assert Exception.message(detailed_error) == Exception.message(legacy_error)
+      assert detailed_error.status == legacy_error.status
+      assert detailed_error.response_body == legacy_error.response_body
+    end
+  end
+
   describe "ReqLLM facade delegation" do
     test "speak/3 is delegated" do
       assert function_exported?(ReqLLM, :speak, 3)
@@ -102,6 +297,13 @@ defmodule ReqLLM.SpeechTest do
     test "speak!/3 is delegated" do
       assert function_exported?(ReqLLM, :speak!, 3)
       assert function_exported?(ReqLLM, :speak!, 2)
+    end
+
+    test "detailed speech functions are delegated" do
+      assert function_exported?(ReqLLM, :speak_detailed, 3)
+      assert function_exported?(ReqLLM, :speak_detailed, 2)
+      assert function_exported?(ReqLLM, :speak_detailed!, 3)
+      assert function_exported?(ReqLLM, :speak_detailed!, 2)
     end
   end
 end

--- a/test/support/provider_test/speech.ex
+++ b/test/support/provider_test/speech.ex
@@ -56,6 +56,28 @@ defmodule ReqLLM.ProviderTest.Speech do
             assert is_binary(result.media_type) and
                      String.starts_with?(result.media_type, "audio/")
           end
+
+          @tag category: :speech
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:speech_basic)
+          @tag model: model_spec |> String.split(":", parts: 2) |> List.last()
+          test "detailed speech generation reuses the provider fixture" do
+            {:ok, detailed} =
+              ReqLLM.speak_detailed(
+                @model_spec,
+                "Hello, this is a short fixture test.",
+                fixture_opts(
+                  @provider,
+                  ReqLLM.Test.CompatibilityScenario.fixture!(:speech_basic),
+                  ReqLLM.ProviderTest.Speech.options(@provider)
+                )
+              )
+
+            assert %ReqLLM.Speech.DetailedResult{} = detailed
+            assert is_binary(detailed.result.audio)
+            assert byte_size(detailed.result.audio) > 100
+            assert detailed.call_metadata.provider == @provider
+            assert detailed.call_metadata.status in 200..299
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #868

## Summary
- add opt-in `speak_detailed/3` and bang facade returning the exact legacy speech result plus sparse call metadata
- preserve the existing `ReqLLM.Speech.Result`, raw audio bytes, default facade, requests, errors, and provider fixture behavior
- reuse the shared call-metadata projection for status, observed usage/cost, request IDs, warnings, timings, and provider metadata
- validate OpenAI and ElevenLabs cached fixtures without fixture refreshes

## Compatibility
- additive public API only; no existing arity or option is repurposed
- no fields or defaults added to `ReqLLM.Speech.Result`
- detailed mode makes one provider request and keeps raw audio as the nested source-of-truth result
- unavailable metadata is omitted rather than synthesized

## Validation
- `mix test test/req_llm/speech_test.exs`
- `mix test test/coverage/openai/speech_test.exs test/coverage/elevenlabs/speech_test.exs --include coverage`
- `mix test`
- `mix quality`