### PR TITLE
fix: harden OCR operation observability

### DIFF
--- a/lib/req_llm/ocr.ex
+++ b/lib/req_llm/ocr.ex
@@ -57,6 +57,11 @@ defmodule ReqLLM.OCR do
                    doc: "Req-specific options (keyword list or map)",
                    default: []
                  ],
+                 telemetry: [
+                   type: {:or, [:map, {:list, :any}]},
+                   doc: "ReqLLM telemetry options (for example, [payloads: :raw])",
+                   default: []
+                 ],
                  total_timeout: [
                    type: {:or, [:pos_integer, {:in, [:infinity]}]},
                    doc: "Optional total model-call timeout in milliseconds, including retries"
@@ -112,6 +117,7 @@ defmodule ReqLLM.OCR do
       - `:document_type` — MIME type hint (default `"application/pdf"`)
       - `:pages` — zero-based page indexes to process
       - `:provider_options` — provider-specific options (e.g., `region`, `access_token`)
+      - `:telemetry` — ReqLLM telemetry options (for example, `[payloads: :raw]`)
       - `:total_timeout` — optional whole-call deadline in milliseconds, including retries
 
   ## Examples

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -239,6 +239,19 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
       body = ReqLLM.OCR.build_ocr_body(model_id, document_binary, other_opts)
 
+      telemetry_opts =
+        other_opts
+        |> Keyword.drop([:pages])
+        |> Keyword.put(:ocr_document_bytes, byte_size(document_binary))
+        |> Keyword.put(
+          :ocr_document_type,
+          Keyword.get(other_opts, :document_type, "application/pdf")
+        )
+        |> Keyword.put(:ocr_include_images, Keyword.get(other_opts, :include_images, true))
+        |> Keyword.put(:ocr_page_count, ocr_page_count(other_opts))
+
+      request_opts = Keyword.put(other_opts, :telemetry_original_opts, telemetry_opts)
+
       base_url = build_base_url(region)
       path = build_model_path(model_family, model_id, project_id, region)
       url = "#{base_url}#{path}"
@@ -259,7 +272,7 @@ defmodule ReqLLM.Providers.GoogleVertex do
         |> Req.Request.merge_options(operation: :ocr)
         |> Req.Request.put_private(:gcp_credentials, gcp_creds)
         |> Req.Request.put_private(:model, model)
-        |> attach_ocr(model, gcp_creds, other_opts)
+        |> attach_ocr(model, gcp_creds, request_opts)
 
       {:ok, request}
     end
@@ -413,9 +426,35 @@ defmodule ReqLLM.Providers.GoogleVertex do
     |> Req.Request.merge_options(ReqLLM.Provider.Defaults.finch_option(request))
     |> ReqLLM.Step.Error.attach()
     |> ReqLLM.Step.Retry.attach(opts)
+    |> Req.Request.append_response_steps(ocr_classify_failure: &classify_ocr_failure/1)
+    |> ReqLLM.Step.Usage.attach(model)
+    |> ReqLLM.Step.Telemetry.attach(model, opts)
     |> ReqLLM.Step.Fixture.maybe_attach(model, opts)
     |> put_gcp_auth(gcp_creds)
   end
+
+  defp ocr_page_count(opts) do
+    case Keyword.get(opts, :pages) do
+      pages when is_list(pages) -> length(pages)
+      _ -> nil
+    end
+  end
+
+  defp classify_ocr_failure({request, %Req.Response{status: status} = response})
+       when status not in 200..299 do
+    req_llm =
+      response.private
+      |> Map.get(:req_llm, %{})
+      |> Map.put(:failure_classification, %{
+        operation: :ocr,
+        kind: :provider_http,
+        status: status
+      })
+
+    {request, %{response | private: Map.put(response.private, :req_llm, req_llm)}}
+  end
+
+  defp classify_ocr_failure(request_response), do: request_response
 
   defp attach_embedding(request, model, gcp_creds, opts) do
     request

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -241,7 +241,13 @@ defmodule ReqLLM.Providers.GoogleVertex do
 
       telemetry_opts =
         other_opts
-        |> Keyword.drop([:pages])
+        |> Keyword.take([
+          :document_type,
+          :include_images,
+          :max_retries,
+          :telemetry,
+          :total_timeout
+        ])
         |> Keyword.put(:ocr_document_bytes, byte_size(document_binary))
         |> Keyword.put(
           :ocr_document_type,

--- a/lib/req_llm/telemetry.ex
+++ b/lib/req_llm/telemetry.ex
@@ -707,6 +707,15 @@ defmodule ReqLLM.Telemetry do
     }
   end
 
+  defp request_input(:ocr, opts) do
+    %{
+      document_bytes: opts[:ocr_document_bytes],
+      document_type: opts[:ocr_document_type],
+      include_images: opts[:ocr_include_images],
+      page_count: opts[:ocr_page_count]
+    }
+  end
+
   defp request_input(_operation, opts) do
     opts[:context] || opts[:messages] || opts[:text]
   end
@@ -775,6 +784,8 @@ defmodule ReqLLM.Telemetry do
       language: Map.get(input, :language)
     }
   end
+
+  defp summarize_request(:ocr, input) when is_map(input), do: input
 
   defp summarize_request(_operation, input) when is_binary(input) do
     %{text_bytes: byte_size(input)}
@@ -845,6 +856,8 @@ defmodule ReqLLM.Telemetry do
     input
     |> Map.take([:audio_bytes, :media_type, :language])
   end
+
+  defp request_payload(:ocr, input, :raw) when is_map(input), do: input
 
   defp request_payload(_operation, input, :raw), do: sanitize_generic_payload(input)
 
@@ -1134,6 +1147,22 @@ defmodule ReqLLM.Telemetry do
 
   defp summarize_response(:speech, audio) when is_binary(audio) do
     %{audio_bytes: byte_size(audio)}
+  end
+
+  defp summarize_response(:ocr, body) when is_map(body) do
+    pages = List.wrap(fetch_value(body, :pages))
+
+    %{
+      page_count: length(pages),
+      text_bytes:
+        Enum.reduce(pages, 0, fn page, total ->
+          total + byte_size(to_string(fetch_value(page, :markdown) || ""))
+        end),
+      image_count:
+        Enum.reduce(pages, 0, fn page, total ->
+          total + length(List.wrap(fetch_value(page, :images)))
+        end)
+    }
   end
 
   defp summarize_response(_operation, _response), do: %{}
@@ -2199,8 +2228,13 @@ defmodule ReqLLM.Telemetry do
     summary_state[:finish_reason]
   end
 
-  defp finish_reason_from_response(%Req.Response{body: body}),
-    do: finish_reason_from_response(body)
+  defp finish_reason_from_response(%Req.Response{body: body, private: private}) do
+    if get_in(private, [:req_llm, :failure_classification]) do
+      :error
+    else
+      finish_reason_from_response(body)
+    end
+  end
 
   defp finish_reason_from_response(%Response{} = response),
     do: normalize_finish_reason(response.finish_reason)

--- a/lib/req_llm/telemetry/request_source.ex
+++ b/lib/req_llm/telemetry/request_source.ex
@@ -27,7 +27,7 @@ defimpl ReqLLM.Telemetry.RequestSource, for: Req.Request do
     %{}
     |> put_present(:address, uri.host)
     |> put_present(:port, uri.port)
-    |> put_present(:path, uri.path)
+    |> put_present(:path, sanitize_path(uri.path))
   end
 
   def server(%{url: url}) when is_binary(url) do
@@ -35,6 +35,12 @@ defimpl ReqLLM.Telemetry.RequestSource, for: Req.Request do
   end
 
   def server(_source), do: %{}
+
+  defp sanitize_path(path) when is_binary(path) do
+    Regex.replace(~r{(/projects/)[^/]+}, path, "\\1{project_id}")
+  end
+
+  defp sanitize_path(path), do: path
 
   defp put_present(map, _key, nil), do: map
   defp put_present(map, _key, ""), do: map

--- a/test/providers/google_vertex_ocr_test.exs
+++ b/test/providers/google_vertex_ocr_test.exs
@@ -44,6 +44,42 @@ defmodule ReqLLM.Providers.GoogleVertex.OCRTest do
       assert :llm_fixture in Keyword.keys(request.request_steps)
     end
 
+    test "attaches correlated OCR telemetry and usage steps without retaining document content" do
+      document = "private-document-content"
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(
+          :ocr,
+          @model_spec,
+          document,
+          @base_opts ++
+            [pages: [2, 4], document_type: "image/png", telemetry: [payloads: :raw]]
+        )
+
+      assert :llm_telemetry_start in Keyword.keys(request.request_steps)
+      assert :ocr_classify_failure in Keyword.keys(request.response_steps)
+      assert :llm_usage in Keyword.keys(request.response_steps)
+      assert :llm_telemetry_stop in Keyword.keys(request.response_steps)
+      assert :llm_telemetry_exception in Keyword.keys(request.error_steps)
+
+      context = ReqLLM.Telemetry.request_context(request)
+
+      assert context.operation == :ocr
+
+      assert context.request_summary == %{
+               document_bytes: byte_size(document),
+               document_type: "image/png",
+               include_images: true,
+               page_count: 2
+             }
+
+      assert context.request_payload == context.request_summary
+
+      refute inspect(context) =~ document
+      refute inspect(context) =~ "test-token"
+      refute inspect(context) =~ "test-project"
+    end
+
     test "rejects non-OCR models" do
       assert {:error, error} =
                GoogleVertex.prepare_request(

--- a/test/providers/google_vertex_ocr_test.exs
+++ b/test/providers/google_vertex_ocr_test.exs
@@ -46,6 +46,7 @@ defmodule ReqLLM.Providers.GoogleVertex.OCRTest do
 
     test "attaches correlated OCR telemetry and usage steps without retaining document content" do
       document = "private-document-content"
+      transport_secret = "private-transport-secret"
 
       {:ok, request} =
         GoogleVertex.prepare_request(
@@ -53,9 +54,15 @@ defmodule ReqLLM.Providers.GoogleVertex.OCRTest do
           @model_spec,
           document,
           @base_opts ++
-            [pages: [2, 4], document_type: "image/png", telemetry: [payloads: :raw]]
+            [
+              pages: [2, 4],
+              document_type: "image/png",
+              telemetry: [payloads: :raw],
+              req_http_options: [headers: [{"x-api-key", transport_secret}]]
+            ]
         )
 
+      assert Req.Request.get_header(request, "x-api-key") == [transport_secret]
       assert :llm_telemetry_start in Keyword.keys(request.request_steps)
       assert :ocr_classify_failure in Keyword.keys(request.response_steps)
       assert :llm_usage in Keyword.keys(request.response_steps)
@@ -74,8 +81,10 @@ defmodule ReqLLM.Providers.GoogleVertex.OCRTest do
              }
 
       assert context.request_payload == context.request_summary
+      refute Keyword.has_key?(context.original_opts, :req_http_options)
 
       refute inspect(context) =~ document
+      refute inspect(context) =~ transport_secret
       refute inspect(context) =~ "test-token"
       refute inspect(context) =~ "test-project"
     end

--- a/test/req_llm/ocr_test.exs
+++ b/test/req_llm/ocr_test.exs
@@ -10,13 +10,31 @@ defmodule ReqLLM.OCRTest do
   - ReqLLM facade delegation
   """
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag contract: :public_api
 
   alias ReqLLM.OCR
 
   @tiny_pdf <<"%PDF-1.0\n1 0 obj\n<< /Type /Catalog >>\nendobj\n">>
+
+  defmodule SuccessHTTP do
+  end
+
+  defmodule ErrorHTTP do
+  end
+
+  describe "schema/0" do
+    test "accepts the shared telemetry options without changing defaults" do
+      schema = OCR.schema()
+
+      assert :telemetry in Keyword.keys(schema.schema)
+      assert {:ok, opts} = NimbleOptions.validate([], schema)
+      assert opts[:telemetry] == []
+      assert opts[:include_images] == true
+      assert opts[:document_type] == "application/pdf"
+    end
+  end
 
   describe "validate_model/1" do
     test "rejects non-OCR models" do
@@ -173,12 +191,23 @@ defmodule ReqLLM.OCRTest do
   end
 
   describe "ocr_file/3" do
-    test "returns error for missing file" do
-      result =
-        OCR.ocr_file(%{provider: :google_vertex, id: "mistral-ocr-2505"}, "/nonexistent/file.pdf")
+    test "preserves exact missing-file errors and validation order" do
+      path =
+        Path.join(
+          System.tmp_dir!(),
+          "req_llm_missing_ocr_#{System.unique_integer([:positive])}.pdf"
+        )
 
-      assert {:error, message} = result
-      assert message =~ "Cannot read"
+      expected = "Cannot read #{path}: enoent"
+
+      assert {:error, ^expected} = OCR.ocr_file("invalid:model", path)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          OCR.ocr_file!("invalid:model", path)
+        end
+
+      assert Exception.message(error) == "OCR failed: #{inspect(expected)}"
     end
 
     test "detects document type from extension" do
@@ -205,6 +234,166 @@ defmodule ReqLLM.OCRTest do
   end
 
   describe "ocr/3" do
+    @tag category: :ocr
+    @tag provider: :google_vertex
+    @tag ReqLLM.Test.CompatibilityScenario.tag!(:ocr_basic)
+    test "preserves the exact result while emitting redacted correlated telemetry and usage" do
+      test_pid = self()
+      document = "private-document-content"
+      recognized = "# Private recognized output"
+      access_token = "private-access-token"
+      project_id = "private-project-id"
+      handler_id = attach_ocr_telemetry(test_pid)
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Req.Test.stub(SuccessHTTP, fn conn ->
+        send(test_pid, :ocr_provider_request)
+
+        body = %{
+          "pages" => [
+            %{
+              "index" => 0,
+              "markdown" => recognized,
+              "images" => [%{"id" => "image-1", "image_base64" => "encoded-image"}]
+            }
+          ],
+          "usage" => %{
+            "prompt_tokens" => 7,
+            "completion_tokens" => 3,
+            "total_tokens" => 10
+          }
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(body))
+      end)
+
+      model = %{provider: :google_vertex, id: "mistral-ocr-2505"}
+
+      opts = [
+        provider_options: [
+          access_token: access_token,
+          project_id: project_id,
+          region: "us-central1"
+        ],
+        req_http_options: [plug: {Req.Test, SuccessHTTP}],
+        max_retries: 0
+      ]
+
+      assert {:ok, result} = ReqLLM.ocr(model, document, opts)
+
+      assert result == %{
+               markdown: recognized,
+               pages: [
+                 %{
+                   index: 0,
+                   markdown: recognized,
+                   images: [%{"id" => "image-1", "image_base64" => "encoded-image"}]
+                 }
+               ]
+             }
+
+      assert Enum.sort(Map.keys(result)) == [:markdown, :pages]
+      assert_receive :ocr_provider_request
+      refute_receive :ocr_provider_request, 20
+
+      assert_receive {:ocr_telemetry, [:req_llm, :request, :start], start_meta}
+      assert_receive {:ocr_telemetry, [:req_llm, :token_usage], usage_meta}
+      assert_receive {:ocr_telemetry, [:req_llm, :request, :stop], stop_meta}
+
+      assert start_meta.operation == :ocr
+      assert start_meta.provider == :google_vertex
+      assert start_meta.transport == :req
+
+      assert start_meta.server.path ==
+               "/v1/projects/{project_id}/locations/us-central1/publishers/mistralai/models/mistral-ocr-2505:rawPredict"
+
+      assert start_meta.request_summary == %{
+               document_bytes: byte_size(document),
+               document_type: "application/pdf",
+               include_images: true,
+               page_count: nil
+             }
+
+      refute Map.has_key?(start_meta, :request_payload)
+      assert usage_meta.request_id == start_meta.request_id
+      assert usage_meta.operation == :ocr
+      assert stop_meta.request_id == start_meta.request_id
+      assert stop_meta.http_status == 200
+      assert stop_meta.usage.tokens.input_tokens == 7
+      assert stop_meta.usage.tokens.output_tokens == 3
+      assert stop_meta.usage.tokens.total_tokens == 10
+
+      assert stop_meta.response_summary == %{
+               image_count: 1,
+               page_count: 1,
+               text_bytes: byte_size(recognized)
+             }
+
+      refute Map.has_key?(stop_meta, :response_payload)
+
+      telemetry = inspect({start_meta, usage_meta, stop_meta})
+      refute telemetry =~ document
+      refute telemetry =~ recognized
+      refute telemetry =~ access_token
+      refute telemetry =~ project_id
+      refute telemetry =~ "encoded-image"
+    end
+
+    test "preserves provider failures and classifies them only in telemetry" do
+      test_pid = self()
+      response_body = %{"error" => %{"message" => "invalid document"}}
+      handler_id = attach_ocr_telemetry(test_pid)
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Req.Test.stub(ErrorHTTP, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(422, Jason.encode!(response_body))
+      end)
+
+      model = %{provider: :google_vertex, id: "mistral-ocr-2505"}
+
+      opts = [
+        provider_options: [
+          access_token: "test-token",
+          project_id: "test-project",
+          region: "us-central1"
+        ],
+        req_http_options: [plug: {Req.Test, ErrorHTTP}],
+        max_retries: 0
+      ]
+
+      assert {:error, %ReqLLM.Error.API.Request{} = error} =
+               ReqLLM.ocr(model, @tiny_pdf, opts)
+
+      assert error.reason == "HTTP 422: OCR request failed"
+      assert error.status == 422
+      assert error.response_body == response_body
+      assert error.request_body == nil
+      assert Exception.message(error) == "API request failed (422): HTTP 422: OCR request failed"
+
+      assert_receive {:ocr_telemetry, [:req_llm, :request, :start], start_meta}
+      assert_receive {:ocr_telemetry, [:req_llm, :request, :stop], stop_meta}
+      assert stop_meta.request_id == start_meta.request_id
+      assert stop_meta.http_status == 422
+      assert stop_meta.finish_reason == :error
+      refute_receive {:ocr_telemetry, [:req_llm, :request, :exception], _}
+
+      raised =
+        assert_raise ReqLLM.Error.API.Request, fn ->
+          ReqLLM.ocr!(model, @tiny_pdf, opts)
+        end
+
+      assert raised.reason == error.reason
+      assert raised.status == error.status
+      assert raised.response_body == error.response_body
+      assert Exception.message(raised) == Exception.message(error)
+    end
+
     test "rejects non-OCR models before preparing a request" do
       assert {:error, error} = OCR.ocr("google_vertex:gemini-2.5-flash", "binary")
       assert Exception.message(error) =~ "does not support OCR operations"
@@ -239,5 +428,28 @@ defmodule ReqLLM.OCRTest do
       assert function_exported?(ReqLLM, :ocr_file!, 3)
       assert function_exported?(ReqLLM, :ocr_file!, 2)
     end
+  end
+
+  defp attach_ocr_telemetry(test_pid) do
+    handler_id = "ocr-telemetry-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:req_llm, :request, :start],
+          [:req_llm, :request, :stop],
+          [:req_llm, :request, :exception],
+          [:req_llm, :token_usage]
+        ],
+        fn event, _measurements, metadata, _config ->
+          if metadata.operation == :ocr do
+            send(test_pid, {:ocr_telemetry, event, metadata})
+          end
+        end,
+        nil
+      )
+
+    handler_id
   end
 end

--- a/test/req_llm/telemetry/request_source_test.exs
+++ b/test/req_llm/telemetry/request_source_test.exs
@@ -1,0 +1,30 @@
+defmodule ReqLLM.Telemetry.RequestSourceTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Telemetry.RequestSource
+
+  test "redacts Google Cloud project identifiers from server paths" do
+    request =
+      Req.new(
+        url:
+          "https://us-central1-aiplatform.googleapis.com/v1/projects/private-project/locations/us-central1/publishers/mistralai/models/mistral-ocr-2505:rawPredict"
+      )
+
+    assert RequestSource.server(request) == %{
+             address: "us-central1-aiplatform.googleapis.com",
+             port: 443,
+             path:
+               "/v1/projects/{project_id}/locations/us-central1/publishers/mistralai/models/mistral-ocr-2505:rawPredict"
+           }
+  end
+
+  test "preserves static provider paths" do
+    request = Req.new(url: "https://api.openai.com/v1/chat/completions")
+
+    assert RequestSource.server(request) == %{
+             address: "api.openai.com",
+             port: 443,
+             path: "/v1/chat/completions"
+           }
+  end
+end


### PR DESCRIPTION
Closes #870

## Summary
- attach the stable request lifecycle and usage telemetry pipeline to Google Vertex OCR
- keep OCR document content and Google Cloud project identifiers out of default telemetry
- classify provider HTTP failures privately for telemetry while preserving existing public errors
- add exact success, file-read, provider-error, bang, scenario, correlation, usage, and redaction contracts

## Backwards compatibility
- preserves `ocr/3`, `ocr!/3`, `ocr_file/3`, and `ocr_file!/3` arities and accepted inputs
- preserves the exact `%{markdown: ..., pages: ...}` success map and request body
- preserves public error structs, fields, strings, exception modules/messages, and file-read validation order
- adds only the shared optional `:telemetry` option

## Validation
- `mix test test/req_llm/ocr_test.exs test/providers/google_vertex_ocr_test.exs test/req_llm/telemetry/request_source_test.exs`
- `mix test --max-cases 1` (3,972 passed, 11 skipped, 150 excluded)
- `mix quality`