### PR TITLE
refactor: normalize OpenAI realtime events

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -357,7 +357,40 @@ ReqLLM also exposes an experimental low-level Realtime WebSocket client for sess
 :ok = ReqLLM.OpenAI.Realtime.close(session)
 ```
 
-This API is intentionally low-level. You send JSON events, receive JSON events, and manage the session lifecycle explicitly.
+This API is intentionally low-level. You send JSON events, receive JSON events, and manage the session lifecycle explicitly. Existing `next_event/2` calls continue to return the decoded OpenAI event unchanged.
+
+For consumers that already understand `ReqLLM.StreamEvent`, use the additive projected view:
+
+```elixir
+{:ok, projected} = ReqLLM.OpenAI.Realtime.next_projected_event(session)
+
+projected.type
+#=> "response.output_text.delta"
+
+projected.native
+#=> the native event with sensitive payloads redacted
+
+projected.stream_events
+#=> [%ReqLLM.StreamEvent{type: :text_delta, data: "[REDACTED]", ...}]
+```
+
+Pass `payloads: :raw` only when that consumer is authorized to retain text, audio transcripts, tool arguments/results, and provider error messages. Raw audio deltas, input transcription, session/control events, rate limits, MCP and other provider-native tools, and recoverable session errors remain native-only because ReqLLM has no exact portable event for them.
+
+The experimental projection is intentionally narrow:
+
+| OpenAI Realtime event | Portable projection |
+| --- | --- |
+| `response.created` | `:start` when the resolved session model is available |
+| `response.output_text.delta` | `:text_delta` |
+| `response.output_audio_transcript.delta` | `:text_delta` with `modality: :audio_transcript` |
+| application `response.output_item.added` | `:tool_call_start` |
+| `response.function_call_arguments.delta` / `.done` | `:tool_call_delta` / `:tool_call` |
+| application `conversation.item.done` function output | `:tool_result` |
+| `response.done` | optional `:usage`, then one `:finish`, `:cancelled`, or terminal `:error` |
+
+All other events have an empty `stream_events` list and remain available through `native`. This includes top-level `error` events because OpenAI defines many of them as recoverable session errors, while canonical `StreamEvent` errors are terminal. See the [OpenAI Realtime server-event reference](https://platform.openai.com/docs/api-reference/realtime-server-events) for the provider event catalog.
+
+`response.created` starts a canonical response lifecycle, and `response.done` contributes usage followed by exactly one completion, cancellation, or terminal error event. OpenAI event, response, item, call, conversation, session, index, and sequence identifiers are retained for correlation. Reconnecting creates a new provider session; ReqLLM does not hide reconnection or replay events. Applications or Jido continue to own session hosting, reconnection, tool execution, and follow-up calls.
 
 ## Usage Metrics
 

--- a/lib/req_llm/openai/realtime.ex
+++ b/lib/req_llm/openai/realtime.ex
@@ -6,9 +6,29 @@ defmodule ReqLLM.OpenAI.Realtime do
   do not map cleanly onto `ReqLLM.stream_text/3`. It is intentionally low-level:
   you connect a session, send JSON events, receive JSON events, and close the
   socket when you are done.
+
+  `next_event/2` remains the raw provider-event API. Use
+  `next_projected_event/3` or `project_event/2` for an additive view that keeps
+  the sanitized native event alongside any exact `ReqLLM.StreamEvent` overlap.
+  Session, transport, audio, MCP, rate-limit, and other provider-native events
+  are not forced into portable event types.
   """
 
+  alias ReqLLM.OpenAI.Realtime.Event
+  alias ReqLLM.OpenAI.Realtime.EventProjector
   alias ReqLLM.Streaming.WebSocketSession
+
+  @projection_schema NimbleOptions.new!(
+                       payloads: [
+                         type: {:in, [:none, :raw]},
+                         default: :none,
+                         doc: "Include raw text, audio transcript, tool, and error payloads"
+                       ],
+                       model: [
+                         type: {:struct, LLMDB.Model},
+                         doc: "Resolved model used to project response.created as :start"
+                       ]
+                     )
 
   defmodule Session do
     @moduledoc """
@@ -52,6 +72,49 @@ defmodule ReqLLM.OpenAI.Realtime do
     with {:ok, message} <- WebSocketSession.next_message(pid, timeout) do
       Jason.decode(message)
     end
+  end
+
+  @doc """
+  Receives one raw event and returns its provider-native and exact portable views.
+
+  Sensitive text, audio transcript, tool, and error payloads are redacted by
+  default. Pass `payloads: :raw` only when the consumer is authorized to retain
+  model and tool content. This function does not loop, reconnect, execute tools,
+  or continue a response.
+  """
+  @spec next_projected_event(Session.t()) :: {:ok, Event.t()} | :halt | {:error, term()}
+  def next_projected_event(%Session{} = session), do: next_projected_event(session, 30_000, [])
+
+  @spec next_projected_event(Session.t(), non_neg_integer() | keyword()) ::
+          {:ok, Event.t()} | :halt | {:error, term()}
+  def next_projected_event(%Session{} = session, opts) when is_list(opts),
+    do: next_projected_event(session, 30_000, opts)
+
+  def next_projected_event(%Session{} = session, timeout)
+      when is_integer(timeout) and timeout >= 0,
+      do: next_projected_event(session, timeout, [])
+
+  @spec next_projected_event(Session.t(), non_neg_integer(), keyword()) ::
+          {:ok, Event.t()} | :halt | {:error, term()}
+  def next_projected_event(%Session{} = session, timeout, opts)
+      when is_integer(timeout) and timeout >= 0 and is_list(opts) do
+    with {:ok, event} <- next_event(session, timeout) do
+      {:ok, project_event(event, Keyword.put(opts, :model, session.model))}
+    end
+  end
+
+  @doc """
+  Projects one already-decoded OpenAI Realtime server event.
+
+  The returned `ReqLLM.OpenAI.Realtime.Event` always retains a native view.
+  `stream_events` is empty when no exact provider-neutral meaning exists.
+  Supplying the resolved `:model` allows `response.created` to project to the
+  canonical `:start` event.
+  """
+  @spec project_event(map(), keyword()) :: Event.t()
+  def project_event(event, opts \\ []) when is_map(event) and is_list(opts) do
+    opts = NimbleOptions.validate!(opts, @projection_schema)
+    EventProjector.project(event, opts)
   end
 
   @spec session_update(Session.t(), map()) :: :ok | {:error, term()}

--- a/lib/req_llm/openai/realtime/event.ex
+++ b/lib/req_llm/openai/realtime/event.ex
@@ -1,0 +1,30 @@
+defmodule ReqLLM.OpenAI.Realtime.Event do
+  @moduledoc """
+  An experimental view of one OpenAI Realtime server event.
+
+  `native` preserves the provider event shape with sensitive payloads redacted
+  by default. `stream_events` contains only the exact overlap with
+  `ReqLLM.StreamEvent`; provider-specific session and transport events remain
+  native instead of being mislabeled as portable.
+  """
+
+  alias ReqLLM.StreamEvent
+
+  @enforce_keys [:type, :native, :stream_events]
+  defstruct [:type, :native, :stream_events]
+
+  @type t :: %__MODULE__{
+          type: String.t() | nil,
+          native: map(),
+          stream_events: [StreamEvent.t()]
+        }
+
+  @doc "Returns whether the provider event has exact canonical overlap."
+  @spec portable?(t()) :: boolean()
+  def portable?(%__MODULE__{stream_events: events}), do: events != []
+
+  @doc "Returns whether the projection contains a canonical terminal event."
+  @spec terminal?(t()) :: boolean()
+  def terminal?(%__MODULE__{stream_events: events}),
+    do: Enum.any?(events, &StreamEvent.terminal?/1)
+end

--- a/lib/req_llm/openai/realtime/event_projector.ex
+++ b/lib/req_llm/openai/realtime/event_projector.ex
@@ -1,0 +1,339 @@
+defmodule ReqLLM.OpenAI.Realtime.EventProjector do
+  @moduledoc false
+
+  alias ReqLLM.Context
+  alias ReqLLM.OpenAI.Realtime.Event
+  alias ReqLLM.Response.Projection
+  alias ReqLLM.StreamEvent
+
+  @redacted "[REDACTED]"
+  @payload_keys MapSet.new(
+                  ~w(arguments audio content delta input instructions message output text transcript)
+                )
+  @secret_keys MapSet.new(~w(
+    access_token api_key api_token authorization client_secret cookie credential credentials header headers
+    password secret signature token
+  ))
+  @correlation_keys [
+    {"call_id", :call_id},
+    {"content_index", :content_index},
+    {"conversation_id", :conversation_id},
+    {"event_id", :event_id},
+    {"item_id", :item_id},
+    {"output_index", :output_index},
+    {"previous_item_id", :previous_item_id},
+    {"response_id", :response_id},
+    {"sequence_number", :sequence_number},
+    {"session_id", :session_id}
+  ]
+
+  @spec project(map(), keyword()) :: Event.t()
+  def project(event, opts) when is_map(event) and is_list(opts) do
+    payloads = Keyword.fetch!(opts, :payloads)
+
+    %Event{
+      type: value(event, "type"),
+      native: native_event(event, payloads),
+      stream_events: stream_events(event, opts)
+    }
+  end
+
+  defp stream_events(event, opts) do
+    case value(event, "type") do
+      "response.created" -> response_started(event, opts)
+      "response.output_text.delta" -> text_delta(event, opts, :text)
+      "response.output_audio_transcript.delta" -> text_delta(event, opts, :audio_transcript)
+      "response.output_item.added" -> tool_call_started(event)
+      "response.function_call_arguments.delta" -> tool_call_delta(event, opts)
+      "response.function_call_arguments.done" -> tool_call_done(event, opts)
+      "conversation.item.done" -> tool_result(event, opts)
+      "response.done" -> response_done(event, opts)
+      _type -> []
+    end
+  end
+
+  defp response_started(event, opts) do
+    case Keyword.get(opts, :model) do
+      %LLMDB.Model{} = model ->
+        data = %{
+          model: %{id: model.provider_model_id || model.id || model.model, provider: :openai}
+        }
+
+        [StreamEvent.new(:start, data, correlation(event))]
+
+      _model ->
+        []
+    end
+  end
+
+  defp text_delta(event, opts, modality) do
+    case value(event, "delta") do
+      delta when is_binary(delta) ->
+        metadata = Map.put(correlation(event), :modality, modality)
+        [StreamEvent.new(:text_delta, payload(delta, opts), metadata)]
+
+      _delta ->
+        []
+    end
+  end
+
+  defp tool_call_started(event) do
+    item = map_value(event, "item")
+
+    with "function_call" <- value(item, "type"),
+         id when is_binary(id) and id != "" <- value(item, "call_id") || value(item, "id"),
+         name when is_binary(name) and name != "" <- value(item, "name") do
+      data = %{
+        id: id,
+        index: non_negative_index(event),
+        name: name,
+        arguments: %{}
+      }
+
+      [StreamEvent.new(:tool_call_start, data, correlation(event, item))]
+    else
+      _item -> []
+    end
+  end
+
+  defp tool_call_delta(event, opts) do
+    with id when is_binary(id) and id != "" <- event_call_id(event),
+         delta when is_binary(delta) <- value(event, "delta") do
+      data = %{
+        id: id,
+        index: non_negative_index(event),
+        fragment: payload(delta, opts)
+      }
+
+      [StreamEvent.new(:tool_call_delta, data, correlation(event))]
+    else
+      _event -> []
+    end
+  end
+
+  defp tool_call_done(event, opts) do
+    with id when is_binary(id) and id != "" <- event_call_id(event),
+         name when is_binary(name) and name != "" <- value(event, "name"),
+         arguments when is_binary(arguments) <- value(event, "arguments"),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(arguments) do
+      data = %{
+        id: id,
+        name: name,
+        arguments: if(raw_payloads?(opts), do: decoded, else: %{"redacted" => true})
+      }
+
+      [StreamEvent.new(:tool_call, data, correlation(event))]
+    else
+      _event -> []
+    end
+  end
+
+  defp tool_result(event, opts) do
+    item = map_value(event, "item")
+
+    with "function_call_output" <- value(item, "type"),
+         id when is_binary(id) and id != "" <- value(item, "call_id"),
+         output when is_binary(output) <- value(item, "output") do
+      result = Context.tool_result(id, payload(output, opts))
+      [StreamEvent.new(:tool_result, result, correlation(event, item))]
+    else
+      _item -> []
+    end
+  end
+
+  defp response_done(event, opts) do
+    response = map_value(event, "response")
+    usage_events = usage_events(event, response)
+
+    case value(response, "status") do
+      "completed" ->
+        finish_reason = if function_call_output?(response), do: :tool_calls, else: :stop
+        usage_events ++ [terminal_event(:finish, finish_reason, event, response)]
+
+      "cancelled" ->
+        usage_events ++ [terminal_event(:cancelled, :cancelled, event, response)]
+
+      "failed" ->
+        error = response_error(response, opts)
+        usage_events ++ [StreamEvent.new(:error, error, terminal_metadata(event, response))]
+
+      "incomplete" ->
+        finish_reason = incomplete_finish_reason(response)
+        usage_events ++ [terminal_event(:finish, finish_reason, event, response)]
+
+      _status ->
+        []
+    end
+  end
+
+  defp usage_events(event, response) do
+    case map_value(response, "usage") do
+      usage when map_size(usage) > 0 ->
+        normalized =
+          usage
+          |> copy_realtime_cached_tokens()
+          |> ReqLLM.Usage.normalize()
+
+        [StreamEvent.new(:usage, normalized, correlation(event, response))]
+
+      _usage ->
+        []
+    end
+  end
+
+  defp terminal_event(type, finish_reason, event, response) do
+    StreamEvent.new(type, %{finish_reason: finish_reason}, terminal_metadata(event, response))
+  end
+
+  defp terminal_metadata(event, response) do
+    event
+    |> correlation(response)
+    |> put_available(:status, value(response, "status"))
+    |> put_available(:status_reason, status_reason(response))
+  end
+
+  defp response_error(response, opts) do
+    error = response |> map_value("status_details") |> map_value("error")
+
+    cond do
+      map_size(error) == 0 -> %{type: "realtime_response_failed"}
+      raw_payloads?(opts) -> error
+      true -> sanitize_native(error)
+    end
+  end
+
+  defp incomplete_finish_reason(response) do
+    case status_reason(response) do
+      "max_output_tokens" -> :length
+      "content_filter" -> :content_filter
+      _reason -> :incomplete
+    end
+  end
+
+  defp status_reason(response) do
+    response
+    |> map_value("status_details")
+    |> value("reason")
+  end
+
+  defp function_call_output?(response) do
+    response
+    |> list_value("output")
+    |> Enum.any?(&(value(&1, "type") == "function_call"))
+  end
+
+  defp copy_realtime_cached_tokens(usage) do
+    case usage |> map_value("input_token_details") |> value("cached_tokens") do
+      cached when is_number(cached) -> Map.put(usage, "cached_tokens", cached)
+      _cached -> usage
+    end
+  end
+
+  defp native_event(event, :raw), do: event
+  defp native_event(event, :none), do: sanitize_native(event)
+
+  defp sanitize_native(value) when is_map(value) do
+    Map.new(value, fn {key, nested} -> {key, sanitize_native_value(key, nested)} end)
+  end
+
+  defp sanitize_native(value) when is_list(value), do: Enum.map(value, &sanitize_native/1)
+  defp sanitize_native(value), do: value
+
+  defp sanitize_native_value(key, value) when is_map(value) do
+    if sensitive_key?(key),
+      do: @redacted,
+      else: sanitize_native(value)
+  end
+
+  defp sanitize_native_value(key, value) when is_list(value) do
+    if sensitive_key?(key) do
+      @redacted
+    else
+      Enum.map(value, &sanitize_native/1)
+    end
+  end
+
+  defp sanitize_native_value(key, value) when is_binary(value) do
+    if sensitive_key?(key) do
+      @redacted
+    else
+      safe_leaf(key, value)
+    end
+  end
+
+  defp sanitize_native_value(key, value) do
+    if sensitive_key?(key),
+      do: @redacted,
+      else: safe_leaf(key, value)
+  end
+
+  defp safe_leaf(key, value) do
+    %{key => value}
+    |> Projection.safe_metadata()
+    |> Map.fetch!(key)
+  end
+
+  defp correlation(event, nested \\ %{}) do
+    @correlation_keys
+    |> Enum.reduce(%{provider_event_type: value(event, "type")}, fn {key, field}, metadata ->
+      put_available(metadata, field, value(event, key) || value(nested, key))
+    end)
+    |> put_available(:item_id, item_id(event, nested))
+    |> put_available(:response_id, response_id(event, nested))
+  end
+
+  defp item_id(event, nested) do
+    value(event, "item_id") || value(nested, "item_id") || value(nested, "id")
+  end
+
+  defp response_id(event, nested) do
+    value(event, "response_id") || value(nested, "response_id") ||
+      event |> map_value("response") |> value("id")
+  end
+
+  defp event_call_id(event), do: value(event, "call_id") || value(event, "item_id")
+
+  defp non_negative_index(event) do
+    case value(event, "output_index") do
+      index when is_integer(index) and index >= 0 -> index
+      _index -> 0
+    end
+  end
+
+  defp payload(value, opts), do: if(raw_payloads?(opts), do: value, else: @redacted)
+  defp raw_payloads?(opts), do: Keyword.fetch!(opts, :payloads) == :raw
+
+  defp put_available(map, _key, nil), do: map
+  defp put_available(map, key, value), do: Map.put(map, key, value)
+
+  defp map_value(map, key) do
+    case value(map, key) do
+      nested when is_map(nested) -> nested
+      _nested -> %{}
+    end
+  end
+
+  defp list_value(map, key) do
+    case value(map, key) do
+      nested when is_list(nested) -> nested
+      _nested -> []
+    end
+  end
+
+  defp value(map, key) when is_map(map) do
+    Map.get(map, key) || Map.get(map, String.to_existing_atom(key))
+  rescue
+    ArgumentError -> Map.get(map, key)
+  end
+
+  defp value(_map, _key), do: nil
+
+  defp normalized_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalized_key(key) when is_binary(key), do: key
+  defp normalized_key(key), do: to_string(key)
+
+  defp sensitive_key?(key) do
+    normalized = normalized_key(key)
+    MapSet.member?(@payload_keys, normalized) or MapSet.member?(@secret_keys, normalized)
+  end
+end

--- a/test/contracts/README.md
+++ b/test/contracts/README.md
@@ -48,8 +48,10 @@ this contract suite.
 
 ## Intentionally not frozen by this suite
 
-- `ReqLLM.OpenAI.Realtime` is explicitly experimental. Its current session and
-  event shapes are not promoted to stable V1 contracts here.
+- `ReqLLM.OpenAI.Realtime` is explicitly experimental. Its raw session and
+  event shapes are not promoted to stable V1 contracts here. Its additive
+  projected view reuses stable `ReqLLM.StreamEvent` values only for exact
+  overlap while preserving provider-native events separately.
 - Venice search-result stream chunks enabled by its explicitly experimental
   provider option are not promoted to stable V1 stream semantics here.
 - Private modules, intermediate request maps, and first-party module layout are

--- a/test/req_llm/openai/fixtures/realtime_events.json
+++ b/test/req_llm/openai/fixtures/realtime_events.json
@@ -1,0 +1,144 @@
+[
+  {
+    "type": "session.created",
+    "event_id": "evt_session",
+    "session": {
+      "id": "sess_1",
+      "instructions": "private session instructions",
+      "api_key": "sk-session-secret"
+    }
+  },
+  {
+    "type": "response.created",
+    "event_id": "evt_start",
+    "response": {
+      "id": "resp_1",
+      "status": "in_progress",
+      "conversation_id": "conv_1"
+    }
+  },
+  {
+    "type": "response.output_text.delta",
+    "event_id": "evt_text",
+    "response_id": "resp_1",
+    "item_id": "msg_1",
+    "output_index": 0,
+    "content_index": 0,
+    "delta": "private text output"
+  },
+  {
+    "type": "response.output_audio_transcript.delta",
+    "event_id": "evt_transcript",
+    "response_id": "resp_1",
+    "item_id": "msg_2",
+    "output_index": 1,
+    "content_index": 0,
+    "delta": "private audio transcript"
+  },
+  {
+    "type": "response.output_audio.delta",
+    "event_id": "evt_audio",
+    "response_id": "resp_1",
+    "item_id": "msg_2",
+    "output_index": 1,
+    "content_index": 0,
+    "delta": "cHJpdmF0ZSBhdWRpbw=="
+  },
+  {
+    "type": "response.output_item.added",
+    "event_id": "evt_tool_start",
+    "response_id": "resp_1",
+    "output_index": 2,
+    "item": {
+      "id": "fc_1",
+      "call_id": "call_1",
+      "type": "function_call",
+      "name": "lookup",
+      "arguments": ""
+    }
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "event_id": "evt_tool_delta",
+    "response_id": "resp_1",
+    "item_id": "fc_1",
+    "call_id": "call_1",
+    "output_index": 2,
+    "delta": "{\"query\":\"private query\"}"
+  },
+  {
+    "type": "response.function_call_arguments.done",
+    "event_id": "evt_tool_done",
+    "response_id": "resp_1",
+    "item_id": "fc_1",
+    "call_id": "call_1",
+    "output_index": 2,
+    "name": "lookup",
+    "arguments": "{\"query\":\"private query\"}"
+  },
+  {
+    "type": "conversation.item.done",
+    "event_id": "evt_tool_result",
+    "previous_item_id": "fc_1",
+    "item": {
+      "id": "fco_1",
+      "call_id": "call_1",
+      "type": "function_call_output",
+      "output": "private tool result"
+    }
+  },
+  {
+    "type": "error",
+    "event_id": "evt_recoverable_error",
+    "error": {
+      "type": "invalid_request_error",
+      "code": "response_cancel_not_active",
+      "message": "private recoverable error"
+    }
+  },
+  {
+    "type": "rate_limits.updated",
+    "event_id": "evt_limits",
+    "rate_limits": [
+      {
+        "name": "tokens",
+        "limit": 50000,
+        "remaining": 49950,
+        "reset_seconds": 60
+      }
+    ]
+  },
+  {
+    "type": "response.done",
+    "event_id": "evt_done",
+    "response": {
+      "id": "resp_1",
+      "status": "completed",
+      "status_details": null,
+      "conversation_id": "conv_1",
+      "output": [
+        {
+          "id": "fc_1",
+          "call_id": "call_1",
+          "type": "function_call",
+          "name": "lookup",
+          "arguments": "{\"query\":\"private query\"}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 12,
+        "output_tokens": 5,
+        "total_tokens": 17,
+        "input_token_details": {
+          "text_tokens": 9,
+          "audio_tokens": 3,
+          "cached_tokens": 4
+        },
+        "output_token_details": {
+          "text_tokens": 5,
+          "audio_tokens": 0
+        }
+      }
+    }
+  }
+]

--- a/test/req_llm/openai/realtime_event_test.exs
+++ b/test/req_llm/openai/realtime_event_test.exs
@@ -1,0 +1,226 @@
+defmodule ReqLLM.OpenAI.Realtime.EventTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.OpenAI.Realtime
+  alias ReqLLM.OpenAI.Realtime.Event
+  alias ReqLLM.StreamEvent
+
+  @model %LLMDB.Model{provider: :openai, id: "gpt-realtime"}
+  @fixture Path.join(__DIR__, "fixtures/realtime_events.json")
+
+  describe "project_event/2" do
+    test "projects only exact portable overlap in provider order" do
+      raw_events = fixture_events()
+
+      projected =
+        Enum.map(raw_events, &Realtime.project_event(&1, model: @model, payloads: :raw))
+
+      assert Enum.map(projected, & &1.type) == Enum.map(raw_events, & &1["type"])
+      assert Enum.map(projected, & &1.native) == raw_events
+
+      stream_events = Enum.flat_map(projected, & &1.stream_events)
+
+      assert Enum.map(stream_events, & &1.type) == [
+               :start,
+               :text_delta,
+               :text_delta,
+               :tool_call_start,
+               :tool_call_delta,
+               :tool_call,
+               :tool_result,
+               :usage,
+               :finish
+             ]
+
+      assert %StreamEvent{
+               type: :start,
+               data: %{model: %{id: "gpt-realtime", provider: :openai}},
+               metadata: %{event_id: "evt_start", response_id: "resp_1"}
+             } = Enum.at(stream_events, 0)
+
+      assert %StreamEvent{
+               type: :text_delta,
+               data: "private text output",
+               metadata: %{modality: :text, item_id: "msg_1", response_id: "resp_1"}
+             } = Enum.at(stream_events, 1)
+
+      assert %StreamEvent{
+               type: :text_delta,
+               data: "private audio transcript",
+               metadata: %{modality: :audio_transcript}
+             } = Enum.at(stream_events, 2)
+
+      assert %StreamEvent{
+               type: :tool_call,
+               data: %{id: "call_1", name: "lookup", arguments: %{"query" => "private query"}},
+               metadata: %{item_id: "fc_1"}
+             } = Enum.at(stream_events, 5)
+
+      assert %StreamEvent{type: :tool_result, data: %Message{} = result} =
+               Enum.at(stream_events, 6)
+
+      assert Enum.at(stream_events, 6).metadata.item_id == "fco_1"
+
+      assert result.role == :tool
+      assert result.tool_call_id == "call_1"
+      assert [%ContentPart{type: :text, text: "private tool result"}] = result.content
+
+      assert %StreamEvent{
+               type: :usage,
+               data: %{input_tokens: 12, output_tokens: 5, total_tokens: 17, cached_tokens: 4},
+               metadata: %{event_id: "evt_done", response_id: "resp_1"}
+             } = Enum.at(stream_events, 7)
+
+      assert %StreamEvent{
+               type: :finish,
+               data: %{finish_reason: :tool_calls},
+               metadata: %{response_id: "resp_1", status: "completed"}
+             } = Enum.at(stream_events, 8)
+
+      refute Enum.at(projected, 4) |> Event.portable?()
+      refute Enum.at(projected, 9) |> Event.portable?()
+      refute Enum.at(projected, 10) |> Event.portable?()
+      assert Enum.at(projected, 11) |> Event.terminal?()
+    end
+
+    test "redacts native and canonical payloads by default" do
+      projected =
+        fixture_events()
+        |> Enum.map(&Realtime.project_event(&1, model: @model))
+
+      rendered = inspect(projected)
+
+      refute rendered =~ "private session instructions"
+      refute rendered =~ "sk-session-secret"
+      refute rendered =~ "private text output"
+      refute rendered =~ "private audio transcript"
+      refute rendered =~ "cHJpdmF0ZSBhdWRpbw=="
+      refute rendered =~ "private query"
+      refute rendered =~ "private tool result"
+      refute rendered =~ "private recoverable error"
+
+      assert rendered =~ "[REDACTED]"
+
+      text = projected |> Enum.at(2) |> Map.fetch!(:stream_events) |> List.first()
+      assert text.data == "[REDACTED]"
+
+      tool = projected |> Enum.at(7) |> Map.fetch!(:stream_events) |> List.first()
+      assert tool.data.arguments == %{"redacted" => true}
+
+      recoverable_error = Enum.at(projected, 9)
+      assert recoverable_error.stream_events == []
+      assert get_in(recoverable_error.native, ["error", "message"]) == "[REDACTED]"
+
+      rate_limits = Enum.at(projected, 10)
+      assert get_in(rate_limits.native, ["rate_limits", Access.at(0), "remaining"]) == 49_950
+    end
+
+    test "redacts structured payload values" do
+      event = %{
+        "type" => "session.updated",
+        "arguments" => %{"query" => "private query"},
+        "audio" => [1, 2, 3],
+        "content" => [%{"value" => "private content"}],
+        "instructions" => 12_345,
+        "metadata" => %{"visible" => "retained"}
+      }
+
+      assert %Event{
+               native: %{
+                 "arguments" => "[REDACTED]",
+                 "audio" => "[REDACTED]",
+                 "content" => "[REDACTED]",
+                 "instructions" => "[REDACTED]",
+                 "metadata" => %{"visible" => "retained"}
+               }
+             } = Realtime.project_event(event)
+    end
+
+    test "does not project response start without a resolved model" do
+      event = %{
+        "type" => "response.created",
+        "event_id" => "evt_1",
+        "response" => %{"id" => "resp_1", "status" => "in_progress"}
+      }
+
+      assert %Event{stream_events: []} = Realtime.project_event(event)
+    end
+
+    test "maps terminal status without treating recoverable errors as terminal" do
+      cancelled = response_done("cancelled", %{"reason" => "client_cancelled"})
+
+      failed =
+        response_done("failed", %{"error" => %{"code" => "server_error", "message" => "private"}})
+
+      length = response_done("incomplete", %{"reason" => "max_output_tokens"})
+      filtered = response_done("incomplete", %{"reason" => "content_filter"})
+      recoverable = %{"type" => "error", "error" => %{"message" => "try again"}}
+
+      assert [%StreamEvent{type: :cancelled, metadata: %{status_reason: "client_cancelled"}}] =
+               Realtime.project_event(cancelled).stream_events
+
+      assert [
+               %StreamEvent{
+                 type: :error,
+                 data: %{"code" => "server_error", "message" => "[REDACTED]"}
+               }
+             ] =
+               Realtime.project_event(failed).stream_events
+
+      assert [%StreamEvent{type: :error, data: %{"message" => "private"}}] =
+               Realtime.project_event(failed, payloads: :raw).stream_events
+
+      assert [%StreamEvent{type: :finish, data: %{finish_reason: :length}}] =
+               Realtime.project_event(length).stream_events
+
+      assert [%StreamEvent{type: :finish, data: %{finish_reason: :content_filter}}] =
+               Realtime.project_event(filtered).stream_events
+
+      assert Realtime.project_event(recoverable).stream_events == []
+    end
+
+    test "leaves invalid or provider-native tool input unprojected" do
+      invalid_arguments = %{
+        "type" => "response.function_call_arguments.done",
+        "call_id" => "call_1",
+        "name" => "lookup",
+        "arguments" => "not-json"
+      }
+
+      mcp_arguments = %{
+        "type" => "response.mcp_call_arguments.done",
+        "item_id" => "mcp_1",
+        "arguments" => "{\"query\":\"private\"}"
+      }
+
+      assert Realtime.project_event(invalid_arguments).stream_events == []
+      assert Realtime.project_event(mcp_arguments).stream_events == []
+    end
+
+    test "validates payload mode" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Realtime.project_event(%{"type" => "session.created"}, payloads: :unsafe)
+      end
+    end
+  end
+
+  defp fixture_events do
+    @fixture
+    |> File.read!()
+    |> Jason.decode!()
+  end
+
+  defp response_done(status, status_details) do
+    %{
+      "type" => "response.done",
+      "event_id" => "evt_done",
+      "response" => %{
+        "id" => "resp_1",
+        "status" => status,
+        "status_details" => status_details
+      }
+    }
+  end
+end

--- a/test/req_llm/openai_websocket_test.exs
+++ b/test/req_llm/openai_websocket_test.exs
@@ -220,6 +220,30 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     assert :ok = Realtime.close(session)
   end
 
+  test "Realtime session can receive the additive projected event view", %{base_url: base_url} do
+    {:ok, session} =
+      Realtime.connect("gpt-realtime",
+        base_url: base_url,
+        receive_timeout: 5_000
+      )
+
+    assert :ok = Realtime.response_create(session, %{"instructions" => "Say hi"})
+
+    assert {:ok, projected} = Realtime.next_projected_event(session, payloads: :raw)
+
+    assert projected.type == "response.created"
+
+    assert projected.native == %{
+             "type" => "response.created",
+             "response" => %{"id" => "resp_rt_123"}
+           }
+
+    assert [%ReqLLM.StreamEvent{type: :start, metadata: %{response_id: "resp_rt_123"}}] =
+             projected.stream_events
+
+    assert :ok = Realtime.close(session)
+  end
+
   defp reserve_port do
     {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
     {:ok, port} = :inet.port(socket)


### PR DESCRIPTION
Closes #871

## Summary

- add an experimental projected Realtime event view while preserving every native OpenAI server event
- map only exact shared response, text/transcript, application tool, usage, cancellation, failure, and completion semantics
- retain correlation identifiers and default-redact text, audio transcript, structured tool, credential, and error payloads
- keep provider-native session, transport, raw audio, input transcription, MCP, rate-limit, control, and recoverable error events native-only
- document ordering, terminal behavior, reconnection ownership, and the Jido/application host boundary

## Compatibility

This is additive. Existing next_event/2 behavior, Session shape, send helpers, and application-owned session lifecycle are unchanged. The new API reads one event at a time and does not add a loop, reconnect, execute a tool, or issue a follow-up model call.

## Validation

- 11 focused Realtime projector and WebSocket tests
- mix quality
- complete serial fixture-backed test suite
- git diff --check

Event semantics were checked against the current official OpenAI Realtime server-event reference: https://platform.openai.com/docs/api-reference/realtime-server-events