### PR TITLE
test: isolate namespace warning capture

### DIFF
--- a/test/req_llm/provider/options/namespace_test.exs
+++ b/test/req_llm/provider/options/namespace_test.exs
@@ -1,5 +1,5 @@
 defmodule ReqLLM.Provider.Options.NamespaceTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 


### PR DESCRIPTION
## Summary

- run the namespace warning-policy test module synchronously
- prevent its exact empty-log assertion from capturing unrelated Azure logs emitted by concurrent async modules
- preserve every production path and test assertion unchanged

## Evidence

Post-merge main CI run 29608111528 failed twice in Elixir 1.19/OTP 28 at the same namespace assertion while capturing different unrelated Azure logs. That proves a cross-test logger race rather than a ReqLLM behavior regression.

## Validation

- namespace plus Azure suites at max-cases 8 under three seeds, including failing CI seed 601262: 645 tests passed
- complete suite at seed 601262 and max-cases 8: 3,991 tests passed
- mix quality
- git diff --check

This is a test-only scheduling change with no API or runtime compatibility impact.