### PR TITLE
feat(minimax): add image generation support

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -328,6 +328,7 @@ config :req_llm, :sample_embedding_models, ~w(
 config :req_llm, :sample_image_models, ~w(
     openai:gpt-image-1.5
     google:gemini-2.5-flash-image
+    minimax:image-01
   )
 config :req_llm, :sample_speech_models, ~w(
     openai:tts-1

--- a/config/test.exs
+++ b/config/test.exs
@@ -328,7 +328,6 @@ config :req_llm, :sample_embedding_models, ~w(
 config :req_llm, :sample_image_models, ~w(
     openai:gpt-image-1.5
     google:gemini-2.5-flash-image
-    minimax:image-01
   )
 config :req_llm, :sample_speech_models, ~w(
     openai:tts-1

--- a/lib/req_llm/model_operation.ex
+++ b/lib/req_llm/model_operation.ex
@@ -2,7 +2,7 @@ defmodule ReqLLM.ModelOperation do
   @moduledoc false
 
   @operations ~w(text embedding image speech transcription rerank ocr all)a
-  @image_providers ~w(openai google xai)a
+  @image_providers ~w(openai google xai minimax)a
   @speech_providers ~w(openai elevenlabs)a
   @transcription_providers ~w(openai groq elevenlabs openrouter)a
   @rerank_providers ~w(cohere)a

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -52,9 +52,7 @@ defmodule ReqLLM.Providers.Minimax do
     subject_reference: [
       type: :any,
       doc:
-        "Image-to-image character reference for MiniMax image generation. " <>
-          "A keyword list or map (or list thereof) with :type/\"type\" (\"character\") " <>
-          "and :image_file/\"image_file\" (public URL or base64 data URL)."
+        ~s|Image-to-image character reference for MiniMax image generation. A keyword list or map (or list thereof) with :type/"type" ("character") and :image_file/"image_file" (public URL or base64 data URL).|
     ]
   ]
 

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -42,7 +42,19 @@ defmodule ReqLLM.Providers.Minimax do
     reasoning_split: [
       type: :boolean,
       default: true,
-      doc: "Return thinking content in reasoning_details instead of inline <think> tags."
+      doc: "Return thinking content in reasoning_details instead of inline <thinking> tags."
+    ],
+    prompt_optimizer: [
+      type: :boolean,
+      default: false,
+      doc: "Enable automatic prompt optimization for MiniMax image generation."
+    ],
+    subject_reference: [
+      type: :any,
+      doc:
+        "Image-to-image character reference for MiniMax image generation. " <>
+          "A keyword list or map (or list thereof) with :type/\"type\" (\"character\") " <>
+          "and :image_file/\"image_file\" (public URL or base64 data URL)."
     ]
   ]
 
@@ -59,11 +71,76 @@ defmodule ReqLLM.Providers.Minimax do
     unsupported_operation(:speech)
   end
 
+  def prepare_request(:image, model_spec, prompt_or_messages, opts) do
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, context, prompt} <- image_context(prompt_or_messages, opts),
+         opts_with_context = Keyword.put(opts, :context, context),
+         http_opts = Keyword.get(opts, :req_http_options, []),
+         {:ok, processed_opts} <-
+           ReqLLM.Provider.Options.process(__MODULE__, :image, model, opts_with_context) do
+      api_mod = ReqLLM.Providers.Minimax.ImagesAPI
+      path = api_mod.path()
+
+      req_keys =
+        supported_provider_options() ++
+          [
+            :context,
+            :operation,
+            :model,
+            :prompt,
+            :n,
+            :size,
+            :aspect_ratio,
+            :output_format,
+            :response_format,
+            :seed,
+            :provider_options,
+            :req_http_options,
+            :api_mod,
+            :base_url
+          ]
+
+      timeout =
+        Keyword.get(
+          processed_opts,
+          :receive_timeout,
+          Application.get_env(:req_llm, :image_receive_timeout, 120_000)
+        )
+
+      request =
+        Req.new(
+          [
+            url: path,
+            method: :post,
+            receive_timeout: timeout,
+            pool_timeout: timeout
+          ] ++ http_opts
+        )
+        |> Req.Request.register_options(req_keys)
+        |> Req.Request.merge_options(
+          Keyword.take(processed_opts, req_keys) ++
+            [
+              operation: :image,
+              model: model.provider_model_id || model.id,
+              prompt: prompt,
+              context: context,
+              base_url: Keyword.get(processed_opts, :base_url, default_base_url()),
+              api_mod: api_mod
+            ]
+        )
+        |> attach(model, processed_opts)
+
+      {:ok, request}
+    end
+  end
+
   def prepare_request(operation, model_spec, input, opts) do
     ReqLLM.Provider.Defaults.prepare_request(__MODULE__, operation, model_spec, input, opts)
   end
 
   @impl ReqLLM.Provider
+  def translate_options(:image, _model, opts), do: {opts, []}
+
   def translate_options(_operation, _model, opts) do
     warnings = []
 
@@ -96,6 +173,16 @@ defmodule ReqLLM.Providers.Minimax do
   end
 
   @impl ReqLLM.Provider
+  def encode_body(%{options: %{api_mod: api_mod}} = request) when is_atom(api_mod) do
+    api_mod.encode_body(request)
+  end
+
+  def encode_body(request) do
+    body = build_body(request)
+    ReqLLM.Provider.Defaults.encode_body_from_map(request, body)
+  end
+
+  @impl ReqLLM.Provider
   def build_body(request) do
     reasoning_split = option_value(request.options, :reasoning_split, true)
     original_context = request.options[:context]
@@ -111,7 +198,17 @@ defmodule ReqLLM.Providers.Minimax do
   end
 
   @impl ReqLLM.Provider
-  def decode_response({req, resp} = args) do
+  def decode_response({req, resp} = _args) do
+    case req.options[:api_mod] do
+      api_mod when is_atom(api_mod) and not is_nil(api_mod) ->
+        api_mod.decode_response({req, resp})
+
+      _ ->
+        decode_chat_response({req, resp})
+    end
+  end
+
+  defp decode_chat_response({req, resp} = args) do
     case resp.status do
       200 ->
         body = ensure_parsed_body(resp.body)
@@ -155,6 +252,53 @@ defmodule ReqLLM.Providers.Minimax do
     event
     |> ReqLLM.Provider.Defaults.default_decode_stream_event(model)
     |> Enum.map(&normalize_stream_chunk/1)
+  end
+
+  defp image_context(prompt_or_messages, opts) do
+    context_result =
+      case Keyword.get(opts, :context) do
+        %ReqLLM.Context{} = context -> {:ok, context}
+        _ -> ReqLLM.Context.normalize(prompt_or_messages, opts)
+      end
+
+    with {:ok, context} <- context_result,
+         {:ok, prompt} <- extract_image_prompt(context) do
+      {:ok, context, prompt}
+    end
+  end
+
+  defp extract_image_prompt(%ReqLLM.Context{messages: messages}) do
+    last_user =
+      messages
+      |> Enum.reverse()
+      |> Enum.find(&(&1.role == :user))
+
+    prompt =
+      case last_user do
+        nil ->
+          ""
+
+        %ReqLLM.Message{content: content} when is_list(content) ->
+          content
+          |> Enum.filter(&(&1.type == :text))
+          |> Enum.map_join("", & &1.text)
+
+        %ReqLLM.Message{content: content} when is_binary(content) ->
+          content
+
+        _ ->
+          ""
+      end
+      |> String.trim()
+
+    if prompt == "" do
+      {:error,
+       ReqLLM.Error.Invalid.Parameter.exception(
+         parameter: "image generation requires a non-empty user text prompt"
+       )}
+    else
+      {:ok, prompt}
+    end
   end
 
   defp unsupported_operation(operation) do

--- a/lib/req_llm/providers/minimax/images_api.ex
+++ b/lib/req_llm/providers/minimax/images_api.ex
@@ -19,11 +19,9 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
 
   @known_size_to_aspect_ratio %{
     "1024x1024" => "1:1",
-    "1792x1024" => "16:9",
-    "1024x1792" => "9:16",
-    "1536x1024" => "3:2",
+    "1280x720" => "16:9",
+    "720x1280" => "9:16",
     "1248x832" => "3:2",
-    "1024x1536" => "2:3",
     "832x1248" => "2:3",
     "1152x864" => "4:3",
     "864x1152" => "3:4",
@@ -44,7 +42,7 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
         _ -> []
       end
 
-    aspect_ratio = resolve_aspect_ratio(opts[:aspect_ratio], opts[:size])
+    {aspect_ratio, width, height} = resolve_dimensions(opts[:aspect_ratio], opts[:size])
 
     body =
       %{
@@ -53,6 +51,8 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
       }
       |> maybe_put_integer("n", opts[:n])
       |> maybe_put_string("aspect_ratio", aspect_ratio)
+      |> maybe_put_integer("width", width)
+      |> maybe_put_integer("height", height)
       |> maybe_put_integer("seed", opts[:seed])
       |> maybe_put_string("response_format", minimax_response_format(opts[:response_format]))
       |> maybe_put_boolean("prompt_optimizer", provider_opts[:prompt_optimizer])
@@ -99,16 +99,18 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
   end
 
   defp decode_images_response(req, %{} = body) do
-    data = Map.get(body, "data", %{})
+    data = Map.get(body, "data") || %{}
 
     url_parts =
       data
-      |> Map.get("image_urls", [])
+      |> Map.get("image_urls")
+      |> Kernel.||([])
       |> Enum.map(&decode_url_item/1)
 
     b64_parts =
       data
-      |> Map.get("image_base64", [])
+      |> Map.get("image_base64")
+      |> Kernel.||([])
       |> Enum.map(&decode_b64_item/1)
 
     parts = Enum.reject(url_parts ++ b64_parts, &is_nil/1)
@@ -122,7 +124,7 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
       end
 
     base_response = %Response{
-      id: image_response_id(),
+      id: Map.get(body, "id") || image_response_id(),
       model: req.options[:model] || "unknown",
       context: req.options[:context] || %Context{messages: []},
       message: message,
@@ -176,15 +178,29 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
 
   defp minimax_error?(_body), do: :ok
 
-  defp resolve_aspect_ratio(nil, size) when is_binary(size) do
-    Map.get(@known_size_to_aspect_ratio, size)
+  defp resolve_dimensions(nil, size) when is_binary(size) do
+    case Map.fetch(@known_size_to_aspect_ratio, size) do
+      {:ok, aspect_ratio} -> {aspect_ratio, nil, nil}
+      :error -> parse_dimensions(size)
+    end
   end
 
-  defp resolve_aspect_ratio(nil, {w, h}) when is_integer(w) and is_integer(h) do
-    Map.get(@known_size_to_aspect_ratio, "#{w}x#{h}")
+  defp resolve_dimensions(nil, {width, height})
+       when is_integer(width) and is_integer(height) do
+    resolve_dimensions(nil, "#{width}x#{height}")
   end
 
-  defp resolve_aspect_ratio(aspect_ratio, _size), do: aspect_ratio
+  defp resolve_dimensions(aspect_ratio, _size), do: {aspect_ratio, nil, nil}
+
+  defp parse_dimensions(size) do
+    with [width, height] <- String.split(size, "x", parts: 2),
+         {width, ""} <- Integer.parse(width),
+         {height, ""} <- Integer.parse(height) do
+      {nil, width, height}
+    else
+      _ -> {nil, nil, nil}
+    end
+  end
 
   defp minimax_response_format(:url), do: "url"
   defp minimax_response_format(:binary), do: "base64"

--- a/lib/req_llm/providers/minimax/images_api.ex
+++ b/lib/req_llm/providers/minimax/images_api.ex
@@ -100,7 +100,6 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
 
   defp decode_images_response(req, %{} = body) do
     data = Map.get(body, "data", %{})
-    media_type = output_media_type(req.options[:output_format])
 
     url_parts =
       data
@@ -110,7 +109,7 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
     b64_parts =
       data
       |> Map.get("image_base64", [])
-      |> Enum.map(&decode_b64_item(&1, media_type))
+      |> Enum.map(&decode_b64_item/1)
 
     parts = Enum.reject(url_parts ++ b64_parts, &is_nil/1)
 
@@ -139,15 +138,17 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
     Context.merge_response(base_response.context, base_response)
   end
 
-  defp decode_b64_item(b64, media_type) when is_binary(b64) do
+  defp decode_b64_item(b64) when is_binary(b64) do
+    data = Base.decode64!(b64)
+
     %ContentPart{
       type: :image,
-      data: Base.decode64!(b64),
-      media_type: media_type
+      data: data,
+      media_type: image_media_type(data)
     }
   end
 
-  defp decode_b64_item(_b64, _media_type), do: nil
+  defp decode_b64_item(_b64), do: nil
 
   defp decode_url_item(url) when is_binary(url) do
     %ContentPart{type: :image_url, url: url}
@@ -190,9 +191,15 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
   defp minimax_response_format(other) when is_binary(other), do: other
   defp minimax_response_format(_), do: "base64"
 
-  defp output_media_type(:jpeg), do: "image/jpeg"
-  defp output_media_type(:webp), do: "image/webp"
-  defp output_media_type(_), do: "image/png"
+  defp image_media_type(<<0xFF, 0xD8, 0xFF, _::binary>>), do: "image/jpeg"
+
+  defp image_media_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _::binary>>),
+    do: "image/png"
+
+  defp image_media_type(<<"RIFF", _size::binary-size(4), "WEBP", _::binary>>), do: "image/webp"
+  defp image_media_type(<<"GIF87a", _::binary>>), do: "image/gif"
+  defp image_media_type(<<"GIF89a", _::binary>>), do: "image/gif"
+  defp image_media_type(_data), do: "application/octet-stream"
 
   defp maybe_put_string(body, _key, nil), do: body
 
@@ -215,6 +222,10 @@ defmodule ReqLLM.Providers.Minimax.ImagesAPI do
   defp maybe_put_boolean(body, _key, _), do: body
 
   defp maybe_put_subject_reference(body, nil), do: body
+
+  defp maybe_put_subject_reference(body, reference) when is_map(reference) do
+    Map.put(body, "subject_reference", [reference_to_wire(reference)])
+  end
 
   defp maybe_put_subject_reference(body, references) when is_list(references) do
     wire_refs =

--- a/lib/req_llm/providers/minimax/images_api.ex
+++ b/lib/req_llm/providers/minimax/images_api.ex
@@ -1,0 +1,249 @@
+defmodule ReqLLM.Providers.Minimax.ImagesAPI do
+  @moduledoc """
+  MiniMax Images API driver.
+
+  Implements request/response handling for MiniMax image generation via the
+  native `POST /v1/image_generation` endpoint. MiniMax is not OpenAI-compatible
+  for images: the response is a flat `data.image_urls[]` / `data.image_base64[]`
+  shape and the request uses `response_format: "url" | "base64"`.
+  """
+
+  @behaviour ReqLLM.Providers.OpenAI.API
+
+  import ReqLLM.Provider.Utils, only: [ensure_parsed_body: 1]
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message
+  alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Response
+
+  @known_size_to_aspect_ratio %{
+    "1024x1024" => "1:1",
+    "1792x1024" => "16:9",
+    "1024x1792" => "9:16",
+    "1536x1024" => "3:2",
+    "1248x832" => "3:2",
+    "1024x1536" => "2:3",
+    "832x1248" => "2:3",
+    "1152x864" => "4:3",
+    "864x1152" => "3:4",
+    "1344x576" => "21:9"
+  }
+
+  @impl true
+  def path, do: "/image_generation"
+
+  @impl true
+  def encode_body(request) do
+    opts = if is_map(request.options), do: request.options, else: Map.new(request.options)
+
+    provider_opts =
+      case Map.get(opts, :provider_options, []) do
+        opts when is_list(opts) -> opts
+        opts when is_map(opts) -> opts
+        _ -> []
+      end
+
+    aspect_ratio = resolve_aspect_ratio(opts[:aspect_ratio], opts[:size])
+
+    body =
+      %{
+        "model" => opts[:model],
+        "prompt" => opts[:prompt]
+      }
+      |> maybe_put_integer("n", opts[:n])
+      |> maybe_put_string("aspect_ratio", aspect_ratio)
+      |> maybe_put_integer("seed", opts[:seed])
+      |> maybe_put_string("response_format", minimax_response_format(opts[:response_format]))
+      |> maybe_put_boolean("prompt_optimizer", provider_opts[:prompt_optimizer])
+      |> maybe_put_subject_reference(provider_opts[:subject_reference])
+
+    request
+    |> put_in([Access.key!(:options), :json], body)
+  end
+
+  @impl true
+  def decode_response({req, resp}) do
+    body = ensure_parsed_body(resp.body)
+
+    case minimax_error?(body) do
+      {:error, error} ->
+        {req, error}
+
+      :ok ->
+        case resp.status do
+          200 ->
+            merged_response = decode_images_response(req, body)
+            {req, %{resp | body: merged_response}}
+
+          status ->
+            err =
+              ReqLLM.Error.API.Response.exception(
+                reason: "MiniMax Images API error",
+                status: status,
+                response_body: resp.body
+              )
+
+            {req, err}
+        end
+    end
+  end
+
+  @impl true
+  def decode_stream_event(_event, _model), do: []
+
+  @impl true
+  def attach_stream(_model, _context, _opts, _finch_name) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(parameter: "streaming not supported for :image")}
+  end
+
+  defp decode_images_response(req, %{} = body) do
+    data = Map.get(body, "data", %{})
+    media_type = output_media_type(req.options[:output_format])
+
+    url_parts =
+      data
+      |> Map.get("image_urls", [])
+      |> Enum.map(&decode_url_item/1)
+
+    b64_parts =
+      data
+      |> Map.get("image_base64", [])
+      |> Enum.map(&decode_b64_item(&1, media_type))
+
+    parts = Enum.reject(url_parts ++ b64_parts, &is_nil/1)
+
+    message = %Message{role: :assistant, content: parts}
+    image_usage = ReqLLM.Usage.Image.build_generated(length(parts))
+
+    usage =
+      if map_size(image_usage) > 0 do
+        %{image_usage: image_usage}
+      end
+
+    base_response = %Response{
+      id: image_response_id(),
+      model: req.options[:model] || "unknown",
+      context: req.options[:context] || %Context{messages: []},
+      message: message,
+      object: nil,
+      stream?: false,
+      stream: nil,
+      usage: usage,
+      finish_reason: :stop,
+      provider_meta: %{"minimax" => Map.delete(body, "data")},
+      error: nil
+    }
+
+    Context.merge_response(base_response.context, base_response)
+  end
+
+  defp decode_b64_item(b64, media_type) when is_binary(b64) do
+    %ContentPart{
+      type: :image,
+      data: Base.decode64!(b64),
+      media_type: media_type
+    }
+  end
+
+  defp decode_b64_item(_b64, _media_type), do: nil
+
+  defp decode_url_item(url) when is_binary(url) do
+    %ContentPart{type: :image_url, url: url}
+  end
+
+  defp decode_url_item(_url), do: nil
+
+  defp minimax_error?(body) when is_map(body) do
+    case get_in(body, ["base_resp", "status_code"]) do
+      code when is_integer(code) and code != 0 ->
+        status_msg =
+          get_in(body, ["base_resp", "status_msg"]) || "MiniMax image generation failed"
+
+        {:error,
+         ReqLLM.Error.API.Response.exception(
+           reason: "MiniMax error #{code}: #{status_msg}",
+           status: code,
+           response_body: body
+         )}
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp minimax_error?(_body), do: :ok
+
+  defp resolve_aspect_ratio(nil, size) when is_binary(size) do
+    Map.get(@known_size_to_aspect_ratio, size)
+  end
+
+  defp resolve_aspect_ratio(nil, {w, h}) when is_integer(w) and is_integer(h) do
+    Map.get(@known_size_to_aspect_ratio, "#{w}x#{h}")
+  end
+
+  defp resolve_aspect_ratio(aspect_ratio, _size), do: aspect_ratio
+
+  defp minimax_response_format(:url), do: "url"
+  defp minimax_response_format(:binary), do: "base64"
+  defp minimax_response_format(other) when is_binary(other), do: other
+  defp minimax_response_format(_), do: "base64"
+
+  defp output_media_type(:jpeg), do: "image/jpeg"
+  defp output_media_type(:webp), do: "image/webp"
+  defp output_media_type(_), do: "image/png"
+
+  defp maybe_put_string(body, _key, nil), do: body
+
+  defp maybe_put_string(body, key, value) when is_atom(value) do
+    Map.put(body, key, Atom.to_string(value))
+  end
+
+  defp maybe_put_string(body, key, value) when is_binary(value) do
+    Map.put(body, key, value)
+  end
+
+  defp maybe_put_string(body, _key, _), do: body
+
+  defp maybe_put_integer(body, _key, nil), do: body
+  defp maybe_put_integer(body, key, value) when is_integer(value), do: Map.put(body, key, value)
+  defp maybe_put_integer(body, _key, _), do: body
+
+  defp maybe_put_boolean(body, _key, nil), do: body
+  defp maybe_put_boolean(body, key, value) when is_boolean(value), do: Map.put(body, key, value)
+  defp maybe_put_boolean(body, _key, _), do: body
+
+  defp maybe_put_subject_reference(body, nil), do: body
+
+  defp maybe_put_subject_reference(body, references) when is_list(references) do
+    wire_refs =
+      if Keyword.keyword?(references) do
+        [reference_to_wire(references)]
+      else
+        Enum.map(references, &reference_to_wire/1)
+      end
+
+    Map.put(body, "subject_reference", wire_refs)
+  end
+
+  defp maybe_put_subject_reference(body, _), do: body
+
+  defp reference_to_wire(ref) when is_list(ref) do
+    %{
+      "type" => to_string(Keyword.get(ref, :type, "character")),
+      "image_file" => Keyword.get(ref, :image_file)
+    }
+  end
+
+  defp reference_to_wire(ref) when is_map(ref) do
+    %{
+      "type" => Map.get(ref, "type", Map.get(ref, :type, "character")),
+      "image_file" => Map.get(ref, "image_file", Map.get(ref, :image_file))
+    }
+  end
+
+  defp image_response_id do
+    "img_" <> (:crypto.strong_rand_bytes(12) |> Base.url_encode64(padding: false))
+  end
+end

--- a/test/providers/minimax_test.exs
+++ b/test/providers/minimax_test.exs
@@ -49,6 +49,8 @@ defmodule ReqLLM.Providers.MinimaxTest do
 
       assert :max_completion_tokens in schema_keys
       assert :reasoning_split in schema_keys
+      assert :prompt_optimizer in schema_keys
+      assert :subject_reference in schema_keys
     end
 
     test "provider_extended_generation_schema includes all core keys" do
@@ -439,6 +441,30 @@ defmodule ReqLLM.Providers.MinimaxTest do
 
       assert body["aspect_ratio"] == "1:1"
       assert body["response_format"] == "url"
+      refute Map.has_key?(body, "width")
+      refute Map.has_key?(body, "height")
+    end
+
+    test "encode_body preserves string and tuple non-canonical sizes" do
+      for size <- ["1792x1024", {1792, 1024}] do
+        request =
+          Req.new(url: ImagesAPI.path())
+          |> Req.Request.register_options([:model, :prompt, :size, :response_format, :context])
+          |> Req.Request.merge_options(
+            model: "image-01",
+            prompt: "A lighthouse",
+            size: size,
+            response_format: :url,
+            context: %Context{messages: []}
+          )
+
+        encoded = ImagesAPI.encode_body(request)
+        body = ReqLLM.Test.Helpers.json_body(encoded)
+
+        assert body["width"] == 1792
+        assert body["height"] == 1024
+        refute Map.has_key?(body, "aspect_ratio")
+      end
     end
 
     test "encode_body forwards subject_reference for image-to-image" do
@@ -491,6 +517,54 @@ defmodule ReqLLM.Providers.MinimaxTest do
              ]
     end
 
+    test "generate_image completes a MiniMax public API round trip" do
+      image_data = <<0xFF, 0xD8, 0xFF, 0xE0, "generated-image">>
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v1/image_generation"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer test-key"]
+
+        {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+        request_json = Jason.decode!(request_body)
+
+        assert request_json["model"] == "image-01"
+        assert request_json["prompt"] == "A girl by a window"
+        assert request_json["width"] == 1792
+        assert request_json["height"] == 1024
+
+        assert request_json["subject_reference"] == [
+                 %{
+                   "type" => "character",
+                   "image_file" => "https://example.com/face.jpg"
+                 }
+               ]
+
+        Req.Test.json(conn, %{
+          "id" => "trace-public-api",
+          "data" => %{"image_base64" => [Base.encode64(image_data)]},
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        })
+      end)
+
+      assert {:ok, response} =
+               ReqLLM.generate_image(minimax_image_model(), "A girl by a window",
+                 api_key: "test-key",
+                 size: "1792x1024",
+                 provider_options: [
+                   subject_reference: %{
+                     "type" => "character",
+                     "image_file" => "https://example.com/face.jpg"
+                   }
+                 ],
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert response.id == "trace-public-api"
+      assert ReqLLM.Response.image_data(response) == image_data
+      assert [%{type: :image, media_type: "image/jpeg"}] = ReqLLM.Response.images(response)
+    end
+
     test "decode_response detects image media type from decoded bytes" do
       req =
         Req.new(url: ImagesAPI.path())
@@ -520,6 +594,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
         {_req, updated} = ImagesAPI.decode_response({req, resp})
 
         assert %ReqLLM.Response{} = updated.body
+        assert updated.body.id == "trace-123"
         assert ReqLLM.Response.image_data(updated.body) == image_data
 
         [part] = ReqLLM.Response.images(updated.body)
@@ -553,7 +628,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
       assert part.type == :image_url
     end
 
-    test "decode_response raises on base_resp status_code != 0 even with HTTP 200" do
+    test "decode_response returns an error on base_resp status_code != 0 even with HTTP 200" do
       req =
         Req.new(url: ImagesAPI.path())
         |> Req.Request.register_options([:model, :context])

--- a/test/providers/minimax_test.exs
+++ b/test/providers/minimax_test.exs
@@ -5,6 +5,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
   alias ReqLLM.Message.ReasoningDetails
   alias ReqLLM.Provider.ResponseBuilder
   alias ReqLLM.Providers.Minimax
+  alias ReqLLM.Providers.Minimax.ImagesAPI
   alias ReqLLM.StreamChunk
   alias ReqLLM.ToolCall
 
@@ -19,6 +20,20 @@ defmodule ReqLLM.Providers.MinimaxTest do
       capabilities: %{chat: true, tools: %{enabled: true}},
       limits: %{context: 204_800, output: 2048},
       extra: %{wire: %{protocol: "openai_chat"}}
+    }
+  end
+
+  defp minimax_image_model(model_id \\ "image-01") do
+    %LLMDB.Model{
+      id: model_id,
+      model: model_id,
+      provider_model_id: model_id,
+      provider: :minimax,
+      name: model_id,
+      family: "minimax-image",
+      capabilities: %{images: true},
+      limits: %{},
+      extra: %{}
     }
   end
 
@@ -344,6 +359,192 @@ defmodule ReqLLM.Providers.MinimaxTest do
 
       assert List.last(response.context.messages).reasoning_details ==
                response.message.reasoning_details
+    end
+  end
+
+  describe "image generation" do
+    test "prepare_request for :image creates /image_generation request with api_mod" do
+      model = minimax_image_model()
+
+      {:ok, request} = Minimax.prepare_request(:image, model, "A red square", api_key: "test-key")
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/image_generation"
+      assert request.method == :post
+      assert request.options[:base_url] == "https://api.minimax.io/v1"
+      assert request.options[:api_mod] == ImagesAPI
+      assert request.options[:prompt] == "A red square"
+      assert request.options[:operation] == :image
+    end
+
+    test "prepare_request for :image rejects empty prompt" do
+      model = minimax_image_model()
+      context = Context.new([Context.system("you are helpful")])
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Minimax.prepare_request(:image, model, context, api_key: "test-key")
+    end
+
+    test "encode_body emits MiniMax-native JSON with base64 response format" do
+      request =
+        Req.new(url: ImagesAPI.path())
+        |> Req.Request.register_options([
+          :model,
+          :prompt,
+          :n,
+          :aspect_ratio,
+          :response_format,
+          :seed,
+          :provider_options,
+          :context
+        ])
+        |> Req.Request.merge_options(
+          model: "image-01",
+          prompt: "A lighthouse",
+          n: 2,
+          aspect_ratio: "16:9",
+          response_format: :binary,
+          seed: 42,
+          provider_options: [prompt_optimizer: true],
+          context: %Context{messages: []}
+        )
+
+      encoded = ImagesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["model"] == "image-01"
+      assert body["prompt"] == "A lighthouse"
+      assert body["n"] == 2
+      assert body["aspect_ratio"] == "16:9"
+      assert body["response_format"] == "base64"
+      assert body["seed"] == 42
+      assert body["prompt_optimizer"] == true
+      refute Map.has_key?(body, "subject_reference")
+    end
+
+    test "encode_body maps size to aspect_ratio when aspect_ratio is absent" do
+      request =
+        Req.new(url: ImagesAPI.path())
+        |> Req.Request.register_options([:model, :prompt, :size, :response_format, :context])
+        |> Req.Request.merge_options(
+          model: "image-01",
+          prompt: "A lighthouse",
+          size: "1024x1024",
+          response_format: :url,
+          context: %Context{messages: []}
+        )
+
+      encoded = ImagesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["aspect_ratio"] == "1:1"
+      assert body["response_format"] == "url"
+    end
+
+    test "encode_body forwards subject_reference for image-to-image" do
+      request =
+        Req.new(url: ImagesAPI.path())
+        |> Req.Request.register_options([
+          :model,
+          :prompt,
+          :response_format,
+          :provider_options,
+          :context
+        ])
+        |> Req.Request.merge_options(
+          model: "image-01",
+          prompt: "A girl by a window",
+          response_format: :binary,
+          provider_options: [
+            subject_reference: [type: "character", image_file: "https://example.com/face.jpg"]
+          ],
+          context: %Context{messages: []}
+        )
+
+      encoded = ImagesAPI.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["subject_reference"] == [
+               %{"type" => "character", "image_file" => "https://example.com/face.jpg"}
+             ]
+    end
+
+    test "decode_response decodes image_base64 array into image content parts" do
+      req =
+        Req.new(url: ImagesAPI.path())
+        |> Req.Request.register_options([:model, :output_format, :context])
+        |> Req.Request.merge_options(
+          model: "image-01",
+          output_format: :png,
+          context: %Context{messages: []}
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "id" => "trace-123",
+          "data" => %{"image_base64" => [Base.encode64("abc")]},
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        }
+      }
+
+      {_req, updated} = ImagesAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Response{} = updated.body
+      assert ReqLLM.Response.image_data(updated.body) == "abc"
+
+      [part] = ReqLLM.Response.images(updated.body)
+      assert part.type == :image
+      assert part.media_type == "image/png"
+    end
+
+    test "decode_response decodes image_urls array into image_url content parts" do
+      req =
+        Req.new(url: ImagesAPI.path())
+        |> Req.Request.register_options([:model, :context])
+        |> Req.Request.merge_options(
+          model: "image-01",
+          context: %Context{messages: []}
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "data" => %{"image_urls" => ["https://example.com/img1.png"]}
+        }
+      }
+
+      {_req, updated} = ImagesAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Response{} = updated.body
+      assert ReqLLM.Response.image_url(updated.body) == "https://example.com/img1.png"
+
+      [part] = ReqLLM.Response.images(updated.body)
+      assert part.type == :image_url
+    end
+
+    test "decode_response raises on base_resp status_code != 0 even with HTTP 200" do
+      req =
+        Req.new(url: ImagesAPI.path())
+        |> Req.Request.register_options([:model, :context])
+        |> Req.Request.merge_options(
+          model: "image-01",
+          context: %Context{messages: []}
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "data" => %{},
+          "base_resp" => %{"status_code" => 1026, "status_msg" => "Sensitive content"}
+        }
+      }
+
+      {_req, result} = ImagesAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Error.API.Response{} = result
+      assert result.status == 1026
+      assert result.reason =~ "1026"
     end
   end
 end

--- a/test/providers/minimax_test.exs
+++ b/test/providers/minimax_test.exs
@@ -469,7 +469,29 @@ defmodule ReqLLM.Providers.MinimaxTest do
              ]
     end
 
-    test "decode_response decodes image_base64 array into image content parts" do
+    test "prepare_request and encode_body accept a string-keyed subject_reference map" do
+      model = minimax_image_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(:image, model, "A girl by a window",
+          api_key: "test-key",
+          provider_options: [
+            subject_reference: %{
+              "type" => "character",
+              "image_file" => "https://example.com/face.jpg"
+            }
+          ]
+        )
+
+      encoded = Minimax.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["subject_reference"] == [
+               %{"type" => "character", "image_file" => "https://example.com/face.jpg"}
+             ]
+    end
+
+    test "decode_response detects image media type from decoded bytes" do
       req =
         Req.new(url: ImagesAPI.path())
         |> Req.Request.register_options([:model, :output_format, :context])
@@ -479,23 +501,31 @@ defmodule ReqLLM.Providers.MinimaxTest do
           context: %Context{messages: []}
         )
 
-      resp = %Req.Response{
-        status: 200,
-        body: %{
-          "id" => "trace-123",
-          "data" => %{"image_base64" => [Base.encode64("abc")]},
-          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+      images = [
+        {<<0xFF, 0xD8, 0xFF, 0xE0, "jpeg">>, "image/jpeg"},
+        {<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, "png">>, "image/png"},
+        {<<"RIFF", 4::little-32, "WEBP", "webp">>, "image/webp"}
+      ]
+
+      for {image_data, expected_media_type} <- images do
+        resp = %Req.Response{
+          status: 200,
+          body: %{
+            "id" => "trace-123",
+            "data" => %{"image_base64" => [Base.encode64(image_data)]},
+            "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+          }
         }
-      }
 
-      {_req, updated} = ImagesAPI.decode_response({req, resp})
+        {_req, updated} = ImagesAPI.decode_response({req, resp})
 
-      assert %ReqLLM.Response{} = updated.body
-      assert ReqLLM.Response.image_data(updated.body) == "abc"
+        assert %ReqLLM.Response{} = updated.body
+        assert ReqLLM.Response.image_data(updated.body) == image_data
 
-      [part] = ReqLLM.Response.images(updated.body)
-      assert part.type == :image
-      assert part.media_type == "image/png"
+        [part] = ReqLLM.Response.images(updated.body)
+        assert part.type == :image
+        assert part.media_type == expected_media_type
+      end
     end
 
     test "decode_response decodes image_urls array into image_url content parts" do


### PR DESCRIPTION
## Description

Adds image generation to the MiniMax provider: text-to-image and image-to-image (character consistency via `subject_reference`).

MiniMax's image API is not OpenAI-compatible, so it gets its own `ImagesAPI` driver (like xAI has) rather than reusing the OpenAI one:

- endpoint is `POST /v1/image_generation` (not `/images/generations`)
- response is flat `data.image_urls[]` / `data.image_base64[]` arrays
- `response_format` is `"base64"` (not `"b64_json"`)
- `base_resp.status_code != 0` is a provider error even with HTTP 200

Other changes:

- `:minimax` added to `ModelOperation.image_providers` so capability detection works
- canonical MiniMax sizes use `aspect_ratio`; other valid string or tuple sizes preserve exact `width` and `height`
- `subject_reference` accepts a keyword list or string-keyed map
- decoded images derive MIME type from their bytes and retain MiniMax response trace IDs

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

11 new tests in `test/providers/minimax_test.exs`. 35 pass across `minimax_test.exs` + `images_test.exs`.

Full local suite: 4,010 passed, 11 skipped, 150 excluded. GitHub CI and Jido Review pass on the final head.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues
