### PR TITLE
fix(openrouter): encode PDFs as file inputs

### DIFF
--- a/guides/openrouter.md
+++ b/guides/openrouter.md
@@ -104,7 +104,7 @@ Passed via `:provider_options` keyword:
 
 #### File parser PDFs
 
-When the `file-parser` plugin is enabled, ReqLLM encodes PDF `ContentPart.file/3` inputs in OpenRouter's expected file format:
+ReqLLM encodes PDF `ContentPart.file/3` inputs in OpenRouter's file format. The `file-parser` plugin is optional. Use it to select a PDF processing engine:
 
 ```elixir
 alias ReqLLM.Context
@@ -122,7 +122,7 @@ ReqLLM.generate_text("openrouter:anthropic/claude-sonnet-4-20250514", context,
 )
 ```
 
-Without `file-parser`, PDF parts use the normal OpenAI-compatible file encoding.
+Without `file-parser`, ReqLLM uses the same file encoding and lets OpenRouter select the PDF processing engine.
 
 ### App Attribution
 

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -407,79 +407,65 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   defp encode_openrouter_content_parts(body, request_options) do
     context = request_options[:context]
-    plugins = request_options[:openrouter_plugins]
 
     if match?(%ReqLLM.Context{}, context) do
-      replace_openrouter_content_messages(body, context, file_parser_plugin?(plugins))
+      replace_openrouter_content_messages(body, context)
     else
       body
     end
   end
 
-  defp file_parser_plugin?(plugins) when is_list(plugins) do
-    Enum.any?(plugins, fn
-      %{id: "file-parser"} -> true
-      %{"id" => "file-parser"} -> true
-      _ -> false
-    end)
-  end
-
-  defp file_parser_plugin?(_plugins), do: false
-
   defp replace_openrouter_content_messages(
          %{messages: encoded_messages} = body,
-         context,
-         pdf_files?
+         context
        )
        when is_list(encoded_messages) do
     Map.put(
       body,
       :messages,
-      encode_openrouter_content_messages(encoded_messages, context.messages, pdf_files?)
+      encode_openrouter_content_messages(encoded_messages, context.messages)
     )
   end
 
   defp replace_openrouter_content_messages(
          %{"messages" => encoded_messages} = body,
-         context,
-         pdf_files?
+         context
        )
        when is_list(encoded_messages) do
     Map.put(
       body,
       "messages",
-      encode_openrouter_content_messages(encoded_messages, context.messages, pdf_files?)
+      encode_openrouter_content_messages(encoded_messages, context.messages)
     )
   end
 
-  defp replace_openrouter_content_messages(body, _context, _pdf_files?), do: body
+  defp replace_openrouter_content_messages(body, _context), do: body
 
-  defp encode_openrouter_content_messages(encoded_messages, context_messages, pdf_files?)
+  defp encode_openrouter_content_messages(encoded_messages, context_messages)
        when length(encoded_messages) == length(context_messages) do
     encoded_messages
     |> Enum.zip(context_messages)
     |> Enum.map(fn {encoded_message, context_message} ->
-      encode_openrouter_content_message(encoded_message, context_message, pdf_files?)
+      encode_openrouter_content_message(encoded_message, context_message)
     end)
   end
 
-  defp encode_openrouter_content_messages(encoded_messages, _context_messages, _pdf_files?),
+  defp encode_openrouter_content_messages(encoded_messages, _context_messages),
     do: encoded_messages
 
   defp encode_openrouter_content_message(
          encoded_message,
-         %ReqLLM.Message{content: content},
-         pdf_files?
+         %ReqLLM.Message{content: content}
        )
        when is_list(content) do
-    if Enum.any?(content, &openrouter_reencoded_content_part?(&1, pdf_files?)) do
-      put_message_content(encoded_message, encode_openrouter_content(content, pdf_files?))
+    if Enum.any?(content, &openrouter_reencoded_content_part?/1) do
+      put_message_content(encoded_message, encode_openrouter_content(content))
     else
       encoded_message
     end
   end
 
-  defp encode_openrouter_content_message(encoded_message, _message, _pdf_files?),
+  defp encode_openrouter_content_message(encoded_message, _message),
     do: encoded_message
 
   defp put_message_content(%{content: _} = message, content),
@@ -490,9 +476,9 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   defp put_message_content(message, content), do: Map.put(message, :content, content)
 
-  defp encode_openrouter_content(content, pdf_files?) do
+  defp encode_openrouter_content(content) do
     content
-    |> Enum.map(&encode_openrouter_content_part(&1, pdf_files?))
+    |> Enum.map(&encode_openrouter_content_part/1)
     |> Enum.reject(&is_nil/1)
     |> normalize_openrouter_content()
   end
@@ -505,38 +491,29 @@ defmodule ReqLLM.Providers.OpenRouter do
 
   defp normalize_openrouter_content(content), do: content
 
-  defp encode_openrouter_content_part(
-         %ContentPart{type: :text, text: text, metadata: metadata},
-         _pdf_files?
-       ) do
+  defp encode_openrouter_content_part(%ContentPart{type: :text, text: text, metadata: metadata}) do
     %{type: "text", text: text}
     |> merge_content_metadata(metadata)
   end
 
-  defp encode_openrouter_content_part(
-         %ContentPart{
-           type: :image,
-           data: data,
-           media_type: media_type,
-           metadata: metadata
-         },
-         _pdf_files?
-       )
+  defp encode_openrouter_content_part(%ContentPart{
+         type: :image,
+         data: data,
+         media_type: media_type,
+         metadata: metadata
+       })
        when is_binary(data) do
     data
     |> image_url_content_part(media_type)
     |> merge_content_metadata(metadata)
   end
 
-  defp encode_openrouter_content_part(
-         %ContentPart{
-           type: :image_url,
-           url: url,
-           media_type: media_type,
-           metadata: metadata
-         },
-         _pdf_files?
-       ) do
+  defp encode_openrouter_content_part(%ContentPart{
+         type: :image_url,
+         url: url,
+         media_type: media_type,
+         metadata: metadata
+       }) do
     image_url_map = %{url: url}
 
     image_url_map =
@@ -550,7 +527,7 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> merge_content_metadata(metadata)
   end
 
-  defp encode_openrouter_content_part(%ContentPart{type: :file, data: data} = part, pdf_files?)
+  defp encode_openrouter_content_part(%ContentPart{type: :file, data: data} = part)
        when is_binary(data) do
     cond do
       openrouter_input_audio_part?(part) ->
@@ -564,7 +541,7 @@ defmodule ReqLLM.Providers.OpenRouter do
                   "OpenRouter chat audio input supports only mp3 and wav file parts; got #{inspect(part.media_type)}."
               )
 
-      pdf_files? and openrouter_pdf_file_part?(part) ->
+      openrouter_pdf_file_part?(part) ->
         %{
           type: "file",
           file: %{
@@ -578,16 +555,12 @@ defmodule ReqLLM.Providers.OpenRouter do
     end
   end
 
-  defp encode_openrouter_content_part(%ContentPart{type: :thinking}, _pdf_files?), do: nil
-  defp encode_openrouter_content_part(_part, _pdf_files?), do: nil
+  defp encode_openrouter_content_part(%ContentPart{type: :thinking}), do: nil
+  defp encode_openrouter_content_part(_part), do: nil
 
-  defp openrouter_reencoded_content_part?(part, true) do
+  defp openrouter_reencoded_content_part?(part) do
     openrouter_input_audio_part?(part) or openrouter_audio_file_part?(part) or
       openrouter_pdf_file_part?(part)
-  end
-
-  defp openrouter_reencoded_content_part?(part, _pdf_files?) do
-    openrouter_input_audio_part?(part) or openrouter_audio_file_part?(part)
   end
 
   defp input_audio_content_part(data, format) do

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -459,7 +459,7 @@ defmodule ReqLLM.Providers.OpenRouter do
        )
        when is_list(content) do
     if Enum.any?(content, &openrouter_reencoded_content_part?/1) do
-      put_message_content(encoded_message, encode_openrouter_content(content))
+      rewrite_openrouter_message_content(encoded_message, content)
     else
       encoded_message
     end
@@ -468,66 +468,73 @@ defmodule ReqLLM.Providers.OpenRouter do
   defp encode_openrouter_content_message(encoded_message, _message),
     do: encoded_message
 
-  defp put_message_content(%{content: _} = message, content),
-    do: Map.put(message, :content, content)
-
-  defp put_message_content(%{"content" => _} = message, content),
-    do: Map.put(message, "content", content)
-
-  defp put_message_content(message, content), do: Map.put(message, :content, content)
-
-  defp encode_openrouter_content(content) do
-    content
-    |> Enum.map(&encode_openrouter_content_part/1)
-    |> Enum.reject(&is_nil/1)
-    |> normalize_openrouter_content()
+  defp rewrite_openrouter_message_content(%{content: encoded_content} = message, content)
+       when is_list(encoded_content) do
+    Map.put(message, :content, rewrite_openrouter_content(encoded_content, content))
   end
 
-  defp normalize_openrouter_content([]), do: ""
-
-  defp normalize_openrouter_content([%{type: "text", text: text} = block]) do
-    if map_size(block) == 2, do: text, else: [block]
+  defp rewrite_openrouter_message_content(%{"content" => encoded_content} = message, content)
+       when is_list(encoded_content) do
+    Map.put(message, "content", rewrite_openrouter_content(encoded_content, content))
   end
 
-  defp normalize_openrouter_content(content), do: content
+  defp rewrite_openrouter_message_content(message, _content), do: message
 
-  defp encode_openrouter_content_part(%ContentPart{type: :text, text: text, metadata: metadata}) do
-    %{type: "text", text: text}
-    |> merge_content_metadata(metadata)
+  defp rewrite_openrouter_content(encoded_content, content) do
+    case rewrite_openrouter_content_parts(content, encoded_content, []) do
+      {:ok, rewritten_content} ->
+        rewritten_content
+
+      :error ->
+        raise ReqLLM.Error.Invalid.Message.exception(
+                reason: "OpenRouter could not align encoded message content parts."
+              )
+    end
   end
 
-  defp encode_openrouter_content_part(%ContentPart{
-         type: :image,
-         data: data,
-         media_type: media_type,
-         metadata: metadata
-       })
-       when is_binary(data) do
-    data
-    |> image_url_content_part(media_type)
-    |> merge_content_metadata(metadata)
+  defp rewrite_openrouter_content_parts([], encoded_content, rewritten_content) do
+    {:ok, Enum.reverse(rewritten_content, encoded_content)}
   end
 
-  defp encode_openrouter_content_part(%ContentPart{
-         type: :image_url,
-         url: url,
-         media_type: media_type,
-         metadata: metadata
-       }) do
-    image_url_map = %{url: url}
-
-    image_url_map =
-      if is_binary(media_type) and media_type != "" do
-        Map.put(image_url_map, :media_type, media_type)
-      else
-        image_url_map
-      end
-
-    %{type: "image_url", image_url: image_url_map}
-    |> merge_content_metadata(metadata)
+  defp rewrite_openrouter_content_parts([part | parts], encoded_content, rewritten_content) do
+    if openai_encoded_content_part?(part) do
+      rewrite_openrouter_encoded_content_part(
+        part,
+        parts,
+        encoded_content,
+        rewritten_content
+      )
+    else
+      rewrite_openrouter_content_parts(parts, encoded_content, rewritten_content)
+    end
   end
 
-  defp encode_openrouter_content_part(%ContentPart{type: :file, data: data} = part)
+  defp rewrite_openrouter_encoded_content_part(
+         part,
+         parts,
+         [encoded_part | encoded_content],
+         rewritten_content
+       ) do
+    rewritten_part = rewrite_openrouter_content_part(part, encoded_part)
+
+    rewrite_openrouter_content_parts(
+      parts,
+      encoded_content,
+      [rewritten_part | rewritten_content]
+    )
+  end
+
+  defp rewrite_openrouter_encoded_content_part(_part, _parts, [], _rewritten_content),
+    do: :error
+
+  defp rewrite_openrouter_content_part(
+         %ContentPart{type: :file, file_id: file_id},
+         encoded_part
+       )
+       when is_binary(file_id) and file_id != "",
+       do: encoded_part
+
+  defp rewrite_openrouter_content_part(%ContentPart{data: data} = part, encoded_part)
        when is_binary(data) do
     cond do
       openrouter_input_audio_part?(part) ->
@@ -542,25 +549,42 @@ defmodule ReqLLM.Providers.OpenRouter do
               )
 
       openrouter_pdf_file_part?(part) ->
-        %{
-          type: "file",
-          file: %{
-            filename: openrouter_file_filename(part),
-            file_data: "data:#{openrouter_file_media_type(part)};base64,#{Base.encode64(data)}"
-          }
-        }
+        openrouter_pdf_content_part(part)
 
       true ->
-        image_url_content_part(data, part.media_type)
+        encoded_part
     end
   end
 
-  defp encode_openrouter_content_part(%ContentPart{type: :thinking}), do: nil
-  defp encode_openrouter_content_part(_part), do: nil
+  defp rewrite_openrouter_content_part(_part, encoded_part), do: encoded_part
+
+  defp openai_encoded_content_part?(%ContentPart{type: type})
+       when type in [:text, :image, :image_url],
+       do: true
+
+  defp openai_encoded_content_part?(%ContentPart{type: :file, file_id: file_id})
+       when is_binary(file_id) and file_id != "",
+       do: true
+
+  defp openai_encoded_content_part?(%ContentPart{type: :file, data: data})
+       when is_binary(data),
+       do: true
+
+  defp openai_encoded_content_part?(_part), do: false
 
   defp openrouter_reencoded_content_part?(part) do
     openrouter_input_audio_part?(part) or openrouter_audio_file_part?(part) or
       openrouter_pdf_file_part?(part)
+  end
+
+  defp openrouter_pdf_content_part(%ContentPart{data: data} = part) do
+    %{
+      type: "file",
+      file: %{
+        filename: openrouter_file_filename(part),
+        file_data: "data:#{openrouter_file_media_type(part)};base64,#{Base.encode64(data)}"
+      }
+    }
   end
 
   defp input_audio_content_part(data, format) do
@@ -569,15 +593,6 @@ defmodule ReqLLM.Providers.OpenRouter do
       input_audio: %{
         data: Base.encode64(data),
         format: format
-      }
-    }
-  end
-
-  defp image_url_content_part(data, media_type) do
-    %{
-      type: "image_url",
-      image_url: %{
-        url: "data:#{media_type};base64,#{Base.encode64(data)}"
       }
     }
   end

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -399,7 +399,7 @@ defmodule ReqLLM.Providers.OpenRouterTest do
              }
     end
 
-    test "encode_body without file-parser keeps OpenAI-compatible file encoding" do
+    test "encode_body without file-parser encodes PDF files in OpenRouter format" do
       {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
       pdf_data = "%PDF test"
 
@@ -426,9 +426,10 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       [_, file_part] = message["content"]
 
       assert file_part == %{
-               "type" => "image_url",
-               "image_url" => %{
-                 "url" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               "type" => "file",
+               "file" => %{
+                 "filename" => "document.pdf",
+                 "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
                }
              }
     end
@@ -522,6 +523,36 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       assert decoded["plugins"] == [
                %{"id" => "file-parser", "pdf" => %{"engine" => "mistral-ocr"}}
              ]
+
+      assert file_part == %{
+               "type" => "file",
+               "file" => %{
+                 "filename" => "stream.pdf",
+                 "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               }
+             }
+    end
+
+    test "attach_stream without file-parser encodes PDF files in OpenRouter format" do
+      model = ReqLLM.model!("openrouter:openai/gpt-4")
+      pdf_data = "%PDF stream"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.text("Summarize this PDF"),
+            ContentPart.file(pdf_data, "stream.pdf", "application/pdf")
+          ])
+        ])
+
+      {:ok, finch_request} = OpenRouter.attach_stream(model, context, [], MyApp.Finch)
+
+      decoded = Jason.decode!(finch_request.body)
+      [message] = decoded["messages"]
+      [_, file_part] = message["content"]
+
+      assert decoded["stream"] == true
+      refute Map.has_key?(decoded, "plugins")
 
       assert file_part == %{
                "type" => "file",

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -434,6 +434,127 @@ defmodule ReqLLM.Providers.OpenRouterTest do
              }
     end
 
+    test "encode_body preserves mixed content while encoding PDF files" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      pdf_data = "%PDF mixed"
+      text_file_data = "plain text"
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.image_url("https://example.com/chart.png", %{
+              detail: "high",
+              cache_control: %{type: "ephemeral"}
+            }),
+            ContentPart.file_id("file-existing"),
+            ContentPart.file(text_file_data, "notes.txt", "text/plain"),
+            ContentPart.file(pdf_data, "document.pdf", "application/pdf")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      [message] = decoded["messages"]
+      [image_part, file_reference, text_file_part, pdf_part] = message["content"]
+
+      assert image_part == %{
+               "type" => "image_url",
+               "image_url" => %{
+                 "url" => "https://example.com/chart.png",
+                 "detail" => "high"
+               },
+               "cache_control" => %{"type" => "ephemeral"}
+             }
+
+      assert file_reference == %{
+               "type" => "file",
+               "file" => %{"file_id" => "file-existing"}
+             }
+
+      assert text_file_part == %{
+               "type" => "image_url",
+               "image_url" => %{
+                 "url" => "data:text/plain;base64,#{Base.encode64(text_file_data)}"
+               }
+             }
+
+      assert pdf_part == %{
+               "type" => "file",
+               "file" => %{
+                 "filename" => "document.pdf",
+                 "file_data" => "data:application/pdf;base64,#{Base.encode64(pdf_data)}"
+               }
+             }
+    end
+
+    test "encode_body preserves thinking content while encoding PDF files" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+      pdf_data = "%PDF reasoning"
+
+      context =
+        Context.new([
+          Context.assistant([
+            ContentPart.thinking("Reason about the document"),
+            ContentPart.text("Document summary"),
+            ContentPart.file(pdf_data, "document.pdf", "application/pdf")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      [message] = decoded["messages"]
+      [text_part, pdf_part] = message["content"]
+
+      assert message["reasoning_content"] == "Reason about the document"
+      assert text_part == %{"type" => "text", "text" => "Document summary"}
+      assert pdf_part["type"] == "file"
+      assert pdf_part["file"]["filename"] == "document.pdf"
+    end
+
+    test "encode_body rejects video content in messages that contain PDF files" do
+      {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
+
+      context =
+        Context.new([
+          Context.user([
+            ContentPart.file("%PDF video", "document.pdf", "application/pdf"),
+            ContentPart.video_url("https://example.com/video.mp4")
+          ])
+        ])
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false
+        ]
+      }
+
+      assert_raise ReqLLM.Error.Invalid.Message,
+                   ~r/Video URLs are not supported/,
+                   fn ->
+                     OpenRouter.encode_body(mock_request)
+                   end
+    end
+
     test "encode_body encodes mp3 file parts as OpenRouter input_audio" do
       {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
       audio_data = "audio bytes"


### PR DESCRIPTION
## Summary

- encode OpenRouter PDF content parts as `type: "file"` with `file_data` for all requests
- keep `file-parser` as an optional parser-engine configuration
- rewrite only provider-specific PDF and audio blocks while preserving the default encoding of all other content
- add non-streaming, streaming, mixed-content, reasoning-content, and rejection regression coverage
- update the OpenRouter guide to describe the optional plugin behavior

## Root cause

OpenRouter PDF re-encoding was conditional on an explicit `file-parser` plugin. Without that option, the OpenAI-compatible default encoder represented the PDF as an `image_url` with an `application/pdf` data URL. This format can be rejected by downstream providers as an invalid image type.

The first fix re-encoded complete mixed-content messages. That could discard content types that the OpenRouter-specific encoder did not implement. The hardened implementation keeps the default encoded blocks and replaces only the PDF and audio blocks that need OpenRouter-specific formats.

## User impact

Callers can send PDF `ContentPart.file/3` inputs through OpenRouter without explicitly configuring `file-parser`. OpenRouter receives its documented file content format and can select its default PDF processing engine. Mixed prompts preserve file references, image options and metadata, non-PDF files, and reasoning content.

## Validation

- `mix test test/providers/openrouter_test.exs` — 65 passed
- `mix test` — 4,014 passed, 11 skipped, 150 excluded
- `mix quality` — passed

Fixes #922