### PR TITLE
fix(google,bedrock): route non-streaming requests to the configured Finch pool

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -425,13 +425,16 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         :tools
       ])
       |> Req.Request.merge_options(
-        base_url: base_url,
-        model: model_id,
-        model_family: model_family,
-        context: opts[:context],
-        use_converse: use_converse,
-        operation: opts[:operation],
-        tools: opts[:tools]
+        ReqLLM.Provider.Defaults.finch_option(request) ++
+          [
+            base_url: base_url,
+            model: model_id,
+            model_family: model_family,
+            context: opts[:context],
+            use_converse: use_converse,
+            operation: opts[:operation],
+            tools: opts[:tools]
+          ]
       )
 
     model_body =
@@ -501,10 +504,13 @@ defmodule ReqLLM.Providers.AmazonBedrock do
           |> Map.put(:url, URI.parse(base_url <> "/model/#{model_id}/invoke"))
           |> Req.Request.register_options([:model, :text, :operation, :model_family])
           |> Req.Request.merge_options(
-            base_url: base_url,
-            model: model_id,
-            operation: :embedding,
-            model_family: model_family
+            ReqLLM.Provider.Defaults.finch_option(request) ++
+              [
+                base_url: base_url,
+                model: model_id,
+                operation: :embedding,
+                model_family: model_family
+              ]
           )
           |> Req.Request.put_header("content-type", "application/json")
           |> Req.Request.put_private(:req_llm_model, model)

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -587,7 +587,10 @@ defmodule ReqLLM.Providers.Google do
     request
     # Google uses query parameter for API key, not Authorization header
     |> Req.Request.register_options(extra_option_keys)
-    |> Req.Request.merge_options([model: model.id, params: [key: api_key]] ++ req_opts)
+    |> Req.Request.merge_options(
+      ReqLLM.Provider.Defaults.finch_option(request) ++
+        [model: model.id, params: [key: api_key]] ++ req_opts
+    )
     |> ReqLLM.Step.Error.attach()
     |> ReqLLM.Step.Retry.attach(user_opts)
     |> Req.Request.prepend_request_steps(llm_encode_body: &__MODULE__.encode_body/1)

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -466,6 +466,23 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
     end
   end
 
+  describe "attach/3 Finch pool routing" do
+    test "routes chat requests to the configured Finch pool" do
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "us-east-1"
+      ]
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.options[:finch] == ReqLLM.Application.finch_name()
+    end
+  end
+
   describe "attach_stream/4" do
     setup do
       {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
@@ -688,6 +705,14 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       attached = AmazonBedrock.attach_embedding(request, model, opts)
 
       assert attached.request_steps[:aws_sigv4] != nil
+    end
+
+    test "routes the request to the configured Finch pool", %{model: model, opts: opts} do
+      request = Req.new(url: "/model/cohere.embed-english-v3/invoke", method: :post)
+
+      attached = AmazonBedrock.attach_embedding(request, model, opts)
+
+      assert attached.options[:finch] == ReqLLM.Application.finch_name()
     end
 
     test "sets content-type header", %{model: model, opts: opts} do

--- a/test/req_llm/providers/google_finch_test.exs
+++ b/test/req_llm/providers/google_finch_test.exs
@@ -1,0 +1,22 @@
+defmodule ReqLLM.Providers.GoogleFinchTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.Google
+
+  describe "attach/3 Finch pool routing" do
+    test "routes the request to the configured Finch pool" do
+      request = Google.attach(Req.new(), "google:gemini-2.5-flash", api_key: "test")
+
+      assert request.options[:finch] == ReqLLM.Application.finch_name()
+    end
+
+    test "keeps a Finch pool already set on the request" do
+      request =
+        Req.new()
+        |> Req.Request.merge_options(finch: MyApp.CustomFinch)
+        |> Google.attach("google:gemini-2.5-flash", api_key: "test")
+
+      assert request.options[:finch] == MyApp.CustomFinch
+    end
+  end
+end


### PR DESCRIPTION
## Description

The Google and Amazon Bedrock providers implement custom `attach/3` (plus `attach_embedding/3` for Bedrock) that never sets `:finch`, so their non-streaming requests ignore the configured Finch pool and run on Req's implicit default pool (50 connections per host). Under concurrent load this exhausts the default pool and crashes callers with "Finch was unable to provide a connection".

This prepends `ReqLLM.Provider.Defaults.finch_option(request)` to the `merge_options` call in the three affected functions, matching `default_attach/4` semantics: a pool already set on the request (e.g. via `req_http_options`) still wins.

All other providers with a custom `attach/3` already apply `finch_option/1` or delegate to `default_attach/4`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`, 4026 passed)
- [x] Quality checks pass (`mix quality`, dialyzer clean)

Added regression tests for both providers; all three fail without the lib change. `mix mc google` and `mix mc amazon_bedrock` results are identical before and after the change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #931
