### PR TITLE
fix(openrouter): retain generated chat images

### DIFF
--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -5,9 +5,10 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   `ReqLLM.Provider.Defaults.ResponseBuilder` (batch, full chunk list at
   end-of-stream).
 
-  Maintains running iodata buffers for text/thinking, complete content parts,
-  a running tool-call list, and per-index argument-fragment buffers. Reasoning
-  details and logprobs are also collected from `:meta` chunks.
+  Maintains running iodata buffers for text/thinking, ordered content events,
+  complete content parts, a running tool-call list, and per-index
+  argument-fragment buffers. Reasoning details and logprobs are also collected
+  from `:meta` chunks.
 
   ## Finalizers
 
@@ -77,9 +78,13 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
           optional(:metadata) => map()
         }
 
+  @type content_event ::
+          {:text, String.t()} | {:thinking, String.t()} | {:content_part, ContentPart.t()}
+
   @type t :: %__MODULE__{
           text_content: iodata(),
           thinking_content: iodata(),
+          content_events: [content_event()],
           content_parts: [ContentPart.t()],
           tool_calls: [tool_call_record()],
           arg_fragments: %{optional(non_neg_integer()) => iodata()},
@@ -91,6 +96,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
 
   defstruct text_content: [],
             thinking_content: [],
+            content_events: [],
             content_parts: [],
             tool_calls: [],
             arg_fragments: %{},
@@ -118,19 +124,31 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   @spec push(t(), StreamChunk.t()) :: t()
   def push(%__MODULE__{} = acc, %StreamChunk{type: :content, text: text})
       when is_binary(text) and text != "" do
-    %{acc | text_content: [acc.text_content, text]}
+    %{
+      acc
+      | text_content: [acc.text_content, text],
+        content_events: [{:text, text} | acc.content_events]
+    }
   end
 
   def push(%__MODULE__{} = acc, %StreamChunk{type: :thinking, text: text})
       when is_binary(text) and text != "" do
-    %{acc | thinking_content: [acc.thinking_content, text]}
+    %{
+      acc
+      | thinking_content: [acc.thinking_content, text],
+        content_events: [{:thinking, text} | acc.content_events]
+    }
   end
 
   def push(
         %__MODULE__{} = acc,
         %StreamChunk{type: :content_part, content_part: %ContentPart{} = content_part}
       ) do
-    %{acc | content_parts: [content_part | acc.content_parts]}
+    %{
+      acc
+      | content_events: [{:content_part, content_part} | acc.content_events],
+        content_parts: [content_part | acc.content_parts]
+    }
   end
 
   def push(%__MODULE__{} = acc, %StreamChunk{type: :tool_call} = chunk) do
@@ -287,6 +305,50 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   def finalize_content_parts(%__MODULE__{content_parts: content_parts}),
     do: Enum.reverse(content_parts)
 
+  @doc """
+  Returns text, thinking, and complete content parts in arrival order.
+
+  Adjacent text or thinking chunks become one content part. Set
+  `:include_thinking?` to `false` to omit thinking content.
+  """
+  @spec finalize_ordered_content(t(), keyword()) :: [ContentPart.t()]
+  def finalize_ordered_content(%__MODULE__{content_events: content_events}, opts \\ []) do
+    include_thinking? = Keyword.get(opts, :include_thinking?, true)
+
+    content_events
+    |> Enum.reduce([], &prepend_content_event(&1, &2, include_thinking?))
+    |> Enum.map(&materialize_content_event/1)
+  end
+
+  defp prepend_content_event({:text, text}, [{:text, content} | rest], _include_thinking?),
+    do: [{:text, [text, content]} | rest]
+
+  defp prepend_content_event({:text, text}, content, _include_thinking?),
+    do: [{:text, text} | content]
+
+  defp prepend_content_event(
+         {:thinking, thinking},
+         [{:thinking, content} | rest],
+         true
+       ),
+       do: [{:thinking, [thinking, content]} | rest]
+
+  defp prepend_content_event({:thinking, thinking}, content, true),
+    do: [{:thinking, thinking} | content]
+
+  defp prepend_content_event({:thinking, _thinking}, content, false), do: content
+
+  defp prepend_content_event({:content_part, content_part}, content, _include_thinking?),
+    do: [{:content_part, content_part} | content]
+
+  defp materialize_content_event({:text, content}),
+    do: ContentPart.text(IO.iodata_to_binary(content))
+
+  defp materialize_content_event({:thinking, content}),
+    do: ContentPart.thinking(IO.iodata_to_binary(content))
+
+  defp materialize_content_event({:content_part, content_part}), do: content_part
+
   @doc "Returns reasoning details in arrival order."
   @spec finalize_reasoning_details(t()) :: [term()]
   def finalize_reasoning_details(%__MODULE__{reasoning_details: details}),
@@ -400,13 +462,8 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   """
   @spec finalize_message(t()) :: Message.t() | nil
   def finalize_message(%__MODULE__{} = acc) do
-    text = finalize_text(acc)
     tool_calls = finalize_message_tool_calls(acc)
-
-    content_parts =
-      if text == "", do: [], else: [%ContentPart{type: :text, text: text, metadata: %{}}]
-
-    content_parts = content_parts ++ finalize_content_parts(acc)
+    content_parts = finalize_ordered_content(acc, include_thinking?: false)
 
     if content_parts == [] and tool_calls == [] do
       nil

--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -5,9 +5,9 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   `ReqLLM.Provider.Defaults.ResponseBuilder` (batch, full chunk list at
   end-of-stream).
 
-  Maintains running iodata buffers for text/thinking, a running tool-call
-  list, and per-index argument-fragment buffers. Reasoning details and
-  logprobs are also collected from `:meta` chunks.
+  Maintains running iodata buffers for text/thinking, complete content parts,
+  a running tool-call list, and per-index argument-fragment buffers. Reasoning
+  details and logprobs are also collected from `:meta` chunks.
 
   ## Finalizers
 
@@ -23,8 +23,9 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
     * `finalize_message/1` — preserves the historical `StreamServer`
       contract: returns either `nil` (empty acc) or an assistant
       `%ReqLLM.Message{}` ready to attach to OTel content-capture metadata.
-      Text content becomes a single `:text` `ContentPart`; tool calls
-      become `%ReqLLM.ToolCall{}` structs (with builtin flag preserved).
+      Text content becomes a single `:text` `ContentPart`; complete content
+      parts are retained; tool calls become `%ReqLLM.ToolCall{}` structs
+      (with builtin flag preserved).
 
   Reasoning text is intentionally not surfaced through `finalize_message/1`
   — OTel content capture redacts it anyway and the canonical response

--- a/lib/req_llm/provider/chunk_accumulator.ex
+++ b/lib/req_llm/provider/chunk_accumulator.ex
@@ -79,6 +79,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   @type t :: %__MODULE__{
           text_content: iodata(),
           thinking_content: iodata(),
+          content_parts: [ContentPart.t()],
           tool_calls: [tool_call_record()],
           arg_fragments: %{optional(non_neg_integer()) => iodata()},
           reasoning_details: [term()],
@@ -89,6 +90,7 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
 
   defstruct text_content: [],
             thinking_content: [],
+            content_parts: [],
             tool_calls: [],
             arg_fragments: %{},
             reasoning_details: [],
@@ -121,6 +123,13 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   def push(%__MODULE__{} = acc, %StreamChunk{type: :thinking, text: text})
       when is_binary(text) and text != "" do
     %{acc | thinking_content: [acc.thinking_content, text]}
+  end
+
+  def push(
+        %__MODULE__{} = acc,
+        %StreamChunk{type: :content_part, content_part: %ContentPart{} = content_part}
+      ) do
+    %{acc | content_parts: [content_part | acc.content_parts]}
   end
 
   def push(%__MODULE__{} = acc, %StreamChunk{type: :tool_call} = chunk) do
@@ -272,6 +281,11 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
   @spec finalize_thinking(t()) :: String.t()
   def finalize_thinking(%__MODULE__{thinking_content: iodata}), do: IO.iodata_to_binary(iodata)
 
+  @doc "Returns complete content parts in arrival order."
+  @spec finalize_content_parts(t()) :: [ContentPart.t()]
+  def finalize_content_parts(%__MODULE__{content_parts: content_parts}),
+    do: Enum.reverse(content_parts)
+
   @doc "Returns reasoning details in arrival order."
   @spec finalize_reasoning_details(t()) :: [term()]
   def finalize_reasoning_details(%__MODULE__{reasoning_details: details}),
@@ -389,11 +403,9 @@ defmodule ReqLLM.Provider.ChunkAccumulator do
     tool_calls = finalize_message_tool_calls(acc)
 
     content_parts =
-      if text == "" do
-        []
-      else
-        [%ContentPart{type: :text, text: text, metadata: %{}}]
-      end
+      if text == "", do: [], else: [%ContentPart{type: :text, text: text, metadata: %{}}]
+
+    content_parts = content_parts ++ finalize_content_parts(acc)
 
     if content_parts == [] and tool_calls == [] do
       nil

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1266,8 +1266,9 @@ defmodule ReqLLM.Provider.Defaults do
   defp decode_openai_message(message) when is_map(message) do
     content_chunks = decode_openai_content(message)
     reasoning_chunks = decode_openai_reasoning(message)
+    image_chunks = decode_openai_images(message)
     tool_call_chunks = decode_openai_tool_calls(message)
-    content_chunks ++ reasoning_chunks ++ tool_call_chunks
+    content_chunks ++ reasoning_chunks ++ image_chunks ++ tool_call_chunks
   end
 
   defp decode_openai_message(_), do: []
@@ -1310,6 +1311,12 @@ defmodule ReqLLM.Provider.Defaults do
 
   defp decode_openai_tool_calls(_), do: []
 
+  defp decode_openai_images(%{"images" => images}) when is_list(images) do
+    Enum.flat_map(images, &decode_openai_content_part/1)
+  end
+
+  defp decode_openai_images(_), do: []
+
   defp openai_reasoning_details_chunks(%{"reasoning_details" => details}, provider)
        when is_list(details) and details != [] do
     case decode_openai_reasoning_details(details, provider) do
@@ -1348,7 +1355,58 @@ defmodule ReqLLM.Provider.Defaults do
     decode_openai_thinking_content(thinking)
   end
 
+  defp decode_openai_content_part(%{
+         "type" => "image_url",
+         "image_url" => %{"url" => url} = image_url
+       })
+       when is_binary(url) do
+    metadata = Map.delete(image_url, "url")
+    decode_openai_image_url(url, metadata)
+  end
+
+  defp decode_openai_content_part(%{"type" => "image_url", "image_url" => url})
+       when is_binary(url) do
+    decode_openai_image_url(url, %{})
+  end
+
   defp decode_openai_content_part(_), do: []
+
+  defp decode_openai_image_url("data:" <> data_uri = url, metadata) do
+    case String.split(data_uri, ";base64,", parts: 2) do
+      [media_type, encoded] when media_type != "" ->
+        case decode_base64_image(encoded) do
+          {:ok, data} ->
+            [
+              ReqLLM.StreamChunk.content_part(
+                ReqLLM.Message.ContentPart.image(data, media_type, metadata)
+              )
+            ]
+
+          :error ->
+            decode_openai_remote_image_url(url, metadata)
+        end
+
+      _ ->
+        decode_openai_remote_image_url(url, metadata)
+    end
+  end
+
+  defp decode_openai_image_url(url, metadata) do
+    decode_openai_remote_image_url(url, metadata)
+  end
+
+  defp decode_openai_remote_image_url(url, metadata) do
+    [
+      ReqLLM.StreamChunk.content_part(ReqLLM.Message.ContentPart.image_url(url, metadata))
+    ]
+  end
+
+  defp decode_base64_image(encoded) do
+    case Base.decode64(encoded, ignore: :whitespace) do
+      :error -> Base.decode64(encoded, padding: false, ignore: :whitespace)
+      decoded -> decoded
+    end
+  end
 
   defp decode_openai_thinking_content(thinking) when is_binary(thinking) do
     [ReqLLM.StreamChunk.thinking(thinking)]
@@ -1394,33 +1452,24 @@ defmodule ReqLLM.Provider.Defaults do
 
   defp decode_openai_tool_call(_), do: nil
 
-  defp decode_openai_delta(%{"content" => content}) when is_binary(content) and content != "" do
-    [ReqLLM.StreamChunk.text(content)]
+  defp decode_openai_delta(delta) when is_map(delta) do
+    content_chunks = decode_openai_content(delta)
+    reasoning_chunks = decode_openai_reasoning(delta)
+    image_chunks = decode_openai_images(delta)
+    tool_call_chunks = decode_openai_tool_call_deltas(delta)
+
+    content_chunks ++ reasoning_chunks ++ image_chunks ++ tool_call_chunks
   end
 
-  defp decode_openai_delta(%{"content" => parts}) when is_list(parts) do
-    parts
-    |> Enum.flat_map(&decode_openai_content_part/1)
-    |> Enum.reject(&is_nil/1)
-  end
+  defp decode_openai_delta(_), do: []
 
-  defp decode_openai_delta(%{"reasoning_content" => reasoning})
-       when is_binary(reasoning) and reasoning != "" do
-    [ReqLLM.StreamChunk.thinking(reasoning)]
-  end
-
-  defp decode_openai_delta(%{"reasoning" => reasoning})
-       when is_binary(reasoning) and reasoning != "" do
-    [ReqLLM.StreamChunk.thinking(reasoning)]
-  end
-
-  defp decode_openai_delta(%{"tool_calls" => tool_calls}) when is_list(tool_calls) do
+  defp decode_openai_tool_call_deltas(%{"tool_calls" => tool_calls}) when is_list(tool_calls) do
     tool_calls
     |> Enum.map(&decode_openai_tool_call_delta/1)
     |> Enum.reject(&is_nil/1)
   end
 
-  defp decode_openai_delta(_), do: []
+  defp decode_openai_tool_call_deltas(_), do: []
 
   # Handle complete tool call delta with all fields
   defp decode_openai_tool_call_delta(%{

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1371,35 +1371,30 @@ defmodule ReqLLM.Provider.Defaults do
 
   defp decode_openai_content_part(_), do: []
 
-  defp decode_openai_image_url("data:" <> data_uri = url, metadata) do
-    case String.split(data_uri, ";base64,", parts: 2) do
-      [media_type, encoded] when media_type != "" ->
-        case decode_base64_image(encoded) do
-          {:ok, data} ->
-            [
-              ReqLLM.StreamChunk.content_part(
-                ReqLLM.Message.ContentPart.image(data, media_type, metadata)
-              )
-            ]
+  defp decode_openai_image_url(url, metadata) do
+    content_part =
+      case decode_image_data_uri(url) do
+        {:ok, data, media_type} ->
+          ReqLLM.Message.ContentPart.image(data, media_type, metadata)
 
-          :error ->
-            decode_openai_remote_image_url(url, metadata)
-        end
+        :error ->
+          ReqLLM.Message.ContentPart.image_url(url, metadata)
+      end
 
-      _ ->
-        decode_openai_remote_image_url(url, metadata)
+    [ReqLLM.StreamChunk.content_part(content_part)]
+  end
+
+  defp decode_image_data_uri("data:" <> data_uri) do
+    with [media_type, encoded] when media_type != "" <-
+           String.split(data_uri, ";base64,", parts: 2),
+         {:ok, data} <- decode_base64_image(encoded) do
+      {:ok, data, media_type}
+    else
+      _ -> :error
     end
   end
 
-  defp decode_openai_image_url(url, metadata) do
-    decode_openai_remote_image_url(url, metadata)
-  end
-
-  defp decode_openai_remote_image_url(url, metadata) do
-    [
-      ReqLLM.StreamChunk.content_part(ReqLLM.Message.ContentPart.image_url(url, metadata))
-    ]
-  end
+  defp decode_image_data_uri(_url), do: :error
 
   defp decode_base64_image(encoded) do
     case Base.decode64(encoded, ignore: :whitespace) do

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -313,12 +313,20 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     Enum.flat_map(chunks, fn
       %StreamChunk{type: :content, text: text} -> [%ContentPart{type: :text, text: text}]
       %StreamChunk{type: :thinking, text: text} -> [%ContentPart{type: :thinking, text: text}]
+      %StreamChunk{type: :content_part, content_part: %ContentPart{} = part} -> [part]
       _chunk -> []
     end)
   end
 
-  defp materialize_content_parts(_profile, _chunks, text, thinking, tool_calls) do
-    build_content_parts(text, thinking, tool_calls)
+  defp materialize_content_parts(_profile, chunks, text, thinking, tool_calls) do
+    build_content_parts(text, thinking, tool_calls) ++ streamed_content_parts(chunks)
+  end
+
+  defp streamed_content_parts(chunks) do
+    Enum.flat_map(chunks, fn
+      %StreamChunk{type: :content_part, content_part: %ContentPart{} = part} -> [part]
+      _chunk -> []
+    end)
   end
 
   defp materialize_reasoning_details(:buffered, _chunks, acc, _provider) do

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -320,8 +320,10 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
   end
 
   defp materialize_content_parts(_profile, _chunks, acc, text, thinking, tool_calls) do
-    build_content_parts(text, thinking, tool_calls) ++
-      ChunkAccumulator.finalize_content_parts(acc)
+    case ChunkAccumulator.finalize_content_parts(acc) do
+      [] -> build_content_parts(text, thinking, tool_calls)
+      _content_parts -> ChunkAccumulator.finalize_ordered_content(acc)
+    end
   end
 
   defp materialize_reasoning_details(:buffered, _chunks, acc, _provider) do

--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -72,6 +72,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
       materialize_content_parts(
         profile,
         chunks,
+        acc,
         text_content,
         thinking_content,
         normalized_tool_calls
@@ -309,7 +310,7 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     ])
   end
 
-  defp materialize_content_parts(:buffered, chunks, _text, _thinking, _tool_calls) do
+  defp materialize_content_parts(:buffered, chunks, _acc, _text, _thinking, _tool_calls) do
     Enum.flat_map(chunks, fn
       %StreamChunk{type: :content, text: text} -> [%ContentPart{type: :text, text: text}]
       %StreamChunk{type: :thinking, text: text} -> [%ContentPart{type: :thinking, text: text}]
@@ -318,15 +319,9 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     end)
   end
 
-  defp materialize_content_parts(_profile, chunks, text, thinking, tool_calls) do
-    build_content_parts(text, thinking, tool_calls) ++ streamed_content_parts(chunks)
-  end
-
-  defp streamed_content_parts(chunks) do
-    Enum.flat_map(chunks, fn
-      %StreamChunk{type: :content_part, content_part: %ContentPart{} = part} -> [part]
-      _chunk -> []
-    end)
+  defp materialize_content_parts(_profile, _chunks, acc, text, thinking, tool_calls) do
+    build_content_parts(text, thinking, tool_calls) ++
+      ChunkAccumulator.finalize_content_parts(acc)
   end
 
   defp materialize_reasoning_details(:buffered, _chunks, acc, _provider) do

--- a/lib/req_llm/response/stream.ex
+++ b/lib/req_llm/response/stream.ex
@@ -106,11 +106,9 @@ defmodule ReqLLM.Response.Stream do
   """
   @spec join(Enumerable.t(), Response.t()) :: {:ok, Response.t()} | {:error, term()}
   def join(stream, %Response{} = response) do
-    chunks = Enum.to_list(stream)
-
-    content_text = build_content_text(chunks)
-    content_parts = [%{type: :text, text: content_text}] ++ build_content_parts(chunks)
-    final_usage = merge_usage_from_chunks(chunks, response.usage)
+    summary = summarize(stream)
+    content_parts = [%{type: :text, text: summary.text}] ++ summary.content_parts
+    final_usage = merge_usage(response.usage, summary.usage)
 
     message = %Message{
       role: :assistant,
@@ -136,26 +134,8 @@ defmodule ReqLLM.Response.Stream do
        }}
   end
 
-  defp build_content_text(chunks) do
-    chunks
-    |> Enum.filter(&(&1.type == :content))
-    |> Enum.map_join("", & &1.text)
-  end
+  defp merge_usage(existing_usage, nil), do: existing_usage
 
-  defp build_content_parts(chunks) do
-    chunks
-    |> Enum.filter(&(&1.type == :content_part))
-    |> Enum.map(& &1.content_part)
-  end
-
-  defp merge_usage_from_chunks(chunks, existing_usage) do
-    chunks
-    |> Enum.filter(&(&1.type == :meta))
-    |> Enum.reduce(existing_usage, fn chunk, acc ->
-      usage =
-        Map.get(chunk.metadata || %{}, :usage, %{})
-
-      ReqLLM.Usage.merge(acc || %{}, usage)
-    end)
-  end
+  defp merge_usage(existing_usage, streamed_usage),
+    do: ReqLLM.Usage.merge(existing_usage || %{}, streamed_usage)
 end

--- a/lib/req_llm/response/stream.ex
+++ b/lib/req_llm/response/stream.ex
@@ -7,6 +7,7 @@ defmodule ReqLLM.Response.Stream do
   """
 
   alias ReqLLM.{Message, Response}
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.Provider.ChunkAccumulator
 
   @typedoc """
@@ -18,6 +19,7 @@ defmodule ReqLLM.Response.Stream do
   @type summary :: %{
           text: String.t(),
           thinking: String.t(),
+          content_parts: [ContentPart.t()],
           tool_calls: [map()],
           finish_reason: atom() | nil,
           usage: map() | nil
@@ -29,6 +31,7 @@ defmodule ReqLLM.Response.Stream do
   Processes all chunks and returns a map with:
   - `text` - Accumulated text content
   - `thinking` - Accumulated thinking/reasoning content
+  - `content_parts` - Complete multimodal content parts
   - `tool_calls` - List of reconstructed tool calls with merged argument fragments
   - `finish_reason` - The finish reason from metadata chunks (normalized to atom)
   - `usage` - Token usage statistics from metadata chunks
@@ -53,6 +56,7 @@ defmodule ReqLLM.Response.Stream do
     %{
       text: ChunkAccumulator.finalize_text(acc),
       thinking: ChunkAccumulator.finalize_thinking(acc),
+      content_parts: ChunkAccumulator.finalize_content_parts(acc),
       tool_calls: ChunkAccumulator.finalize_tool_calls_for_response(acc),
       finish_reason: normalize_finish_reason(ChunkAccumulator.finalize_finish_reason(acc)),
       usage: ChunkAccumulator.finalize_usage(acc)
@@ -105,11 +109,12 @@ defmodule ReqLLM.Response.Stream do
     chunks = Enum.to_list(stream)
 
     content_text = build_content_text(chunks)
+    content_parts = [%{type: :text, text: content_text}] ++ build_content_parts(chunks)
     final_usage = merge_usage_from_chunks(chunks, response.usage)
 
     message = %Message{
       role: :assistant,
-      content: [%{type: :text, text: content_text}],
+      content: content_parts,
       metadata: %{}
     }
 
@@ -135,6 +140,12 @@ defmodule ReqLLM.Response.Stream do
     chunks
     |> Enum.filter(&(&1.type == :content))
     |> Enum.map_join("", & &1.text)
+  end
+
+  defp build_content_parts(chunks) do
+    chunks
+    |> Enum.filter(&(&1.type == :content_part))
+    |> Enum.map(& &1.content_part)
   end
 
   defp merge_usage_from_chunks(chunks, existing_usage) do

--- a/lib/req_llm/response/stream.ex
+++ b/lib/req_llm/response/stream.ex
@@ -50,10 +50,15 @@ defmodule ReqLLM.Response.Stream do
   """
   @spec summarize(Enumerable.t()) :: summary()
   def summarize(chunks) do
+    {summary, _acc} = summarize_with_acc(chunks)
+    summary
+  end
+
+  defp summarize_with_acc(chunks) do
     chunks_list = if is_list(chunks), do: chunks, else: Enum.to_list(chunks)
     acc = ChunkAccumulator.reduce(ChunkAccumulator.new(), chunks_list)
 
-    %{
+    summary = %{
       text: ChunkAccumulator.finalize_text(acc),
       thinking: ChunkAccumulator.finalize_thinking(acc),
       content_parts: ChunkAccumulator.finalize_content_parts(acc),
@@ -61,6 +66,8 @@ defmodule ReqLLM.Response.Stream do
       finish_reason: normalize_finish_reason(ChunkAccumulator.finalize_finish_reason(acc)),
       usage: ChunkAccumulator.finalize_usage(acc)
     }
+
+    {summary, acc}
   end
 
   defp normalize_finish_reason(nil), do: nil
@@ -106,8 +113,8 @@ defmodule ReqLLM.Response.Stream do
   """
   @spec join(Enumerable.t(), Response.t()) :: {:ok, Response.t()} | {:error, term()}
   def join(stream, %Response{} = response) do
-    summary = summarize(stream)
-    content_parts = [%{type: :text, text: summary.text}] ++ summary.content_parts
+    {summary, acc} = summarize_with_acc(stream)
+    content_parts = joined_content_parts(summary, acc)
     final_usage = merge_usage(response.usage, summary.usage)
 
     message = %Message{
@@ -133,6 +140,12 @@ defmodule ReqLLM.Response.Stream do
          cause: error
        }}
   end
+
+  defp joined_content_parts(%{content_parts: []} = summary, _acc),
+    do: [%{type: :text, text: summary.text}]
+
+  defp joined_content_parts(_summary, acc),
+    do: ChunkAccumulator.finalize_ordered_content(acc, include_thinking?: false)
 
   defp merge_usage(existing_usage, nil), do: existing_usage
 

--- a/lib/req_llm/stream_chunk.ex
+++ b/lib/req_llm/stream_chunk.ex
@@ -21,6 +21,12 @@ defmodule ReqLLM.StreamChunk do
       chunk.type   #=> :content
       chunk.text   #=> "Hello world"
 
+      # Complete multimodal content
+      part = ReqLLM.Message.ContentPart.image_url("https://example.com/image.png")
+      chunk = ReqLLM.StreamChunk.content_part(part)
+      chunk.type         #=> :content_part
+      chunk.content_part #=> #ContentPart<:image_url ...>
+
       # Thinking/reasoning content
       chunk = ReqLLM.StreamChunk.thinking("Let me think about this...")
       chunk.type   #=> :thinking

--- a/lib/req_llm/stream_chunk.ex
+++ b/lib/req_llm/stream_chunk.ex
@@ -3,12 +3,13 @@ defmodule ReqLLM.StreamChunk do
   Represents a single chunk in a streaming response.
 
   StreamChunk provides a unified format for streaming responses across different providers,
-  supporting text content, tool calls, thinking tokens, and metadata. This structure enables
+  supporting text content, content parts, tool calls, thinking tokens, and metadata. This structure enables
   consistent handling of streaming data regardless of the underlying provider's format.
 
   ## Chunk Types
 
   - `:content` - Text content chunks (the main response text)
+  - `:content_part` - Complete multimodal content parts, such as generated images
   - `:thinking` - Reasoning/thinking tokens (e.g., Claude's `<thinking>` tags)
   - `:tool_call` - Function/tool call chunks with name and arguments
   - `:meta` - Metadata chunks (usage, finish reasons, etc.)
@@ -72,13 +73,14 @@ defmodule ReqLLM.StreamChunk do
   @typedoc """
   Chunk type indicating the kind of content in this chunk.
   """
-  @type chunk_type :: :content | :thinking | :tool_call | :meta
+  @type chunk_type :: :content | :content_part | :thinking | :tool_call | :meta
 
   @typedoc "A single chunk of streaming response data"
 
   @schema Zoi.struct(__MODULE__, %{
             type: Zoi.any(),
             text: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
+            content_part: Zoi.any() |> Zoi.nullable() |> Zoi.default(nil),
             name: Zoi.string() |> Zoi.nullable() |> Zoi.default(nil),
             arguments: Zoi.map() |> Zoi.nullable() |> Zoi.default(nil),
             metadata: Zoi.map() |> Zoi.default(%{})
@@ -116,6 +118,22 @@ defmodule ReqLLM.StreamChunk do
     %__MODULE__{
       type: :content,
       text: content,
+      metadata: metadata
+    }
+  end
+
+  @doc """
+  Creates a chunk containing a complete multimodal content part.
+
+  This constructor carries non-text output, such as generated images, through
+  streaming response assembly without converting it to provider metadata.
+  """
+  @spec content_part(ReqLLM.Message.ContentPart.t(), map()) :: t()
+  def content_part(%ReqLLM.Message.ContentPart{} = content_part, metadata \\ %{})
+      when is_map(metadata) do
+    %__MODULE__{
+      type: :content_part,
+      content_part: content_part,
       metadata: metadata
     }
   end
@@ -292,6 +310,15 @@ defmodule ReqLLM.StreamChunk do
   defp validate_by_type(%{type: :content, text: text}) when is_binary(text), do: :ok
   defp validate_by_type(%{type: :content}), do: {:error, "Content chunks must have non-nil text"}
 
+  defp validate_by_type(%{
+         type: :content_part,
+         content_part: %ReqLLM.Message.ContentPart{}
+       }),
+       do: :ok
+
+  defp validate_by_type(%{type: :content_part}),
+    do: {:error, "Content part chunks must contain a ContentPart"}
+
   defp validate_by_type(%{type: :thinking, text: text}) when is_binary(text), do: :ok
 
   defp validate_by_type(%{type: :thinking}),
@@ -317,6 +344,9 @@ defmodule ReqLLM.StreamChunk do
         case type do
           :content ->
             inspect_text(chunk.text, 20)
+
+          :content_part ->
+            Inspect.Algebra.to_doc(chunk.content_part, opts)
 
           :thinking ->
             text_preview = inspect_text(chunk.text, 20)

--- a/lib/req_llm/stream_response/event_projector.ex
+++ b/lib/req_llm/stream_response/event_projector.ex
@@ -1,6 +1,7 @@
 defmodule ReqLLM.StreamResponse.EventProjector do
   @moduledoc false
 
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.Provider.ChunkAccumulator
   alias ReqLLM.Response.OutputItem
   alias ReqLLM.Response.Projection
@@ -161,6 +162,20 @@ defmodule ReqLLM.StreamResponse.EventProjector do
        when is_binary(text) do
     event = StreamEvent.new(:reasoning_delta, text, safe_map(metadata))
     output_item_events([event], metadata, state)
+  end
+
+  defp chunk_events(
+         %StreamChunk{
+           type: :content_part,
+           content_part: %ContentPart{type: type} = part,
+           metadata: metadata
+         },
+         state
+       )
+       when type in [:image, :image_url, :video_url, :file] do
+    item_metadata = Map.merge(safe_map(part.metadata), safe_map(metadata))
+    item = %OutputItem{type: type, data: part, metadata: item_metadata}
+    unique_output_item_events([item], state)
   end
 
   defp chunk_events(%StreamChunk{type: :tool_call, name: name} = chunk, state)

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -1504,7 +1504,7 @@ defmodule ReqLLM.StreamServer do
   end
 
   defp semantic_progress_chunk?(%StreamChunk{type: type})
-       when type in [:content, :thinking, :tool_call],
+       when type in [:content, :content_part, :thinking, :tool_call],
        do: true
 
   defp semantic_progress_chunk?(%StreamChunk{type: :meta, metadata: metadata})

--- a/test/req_llm/provider/chunk_accumulator_test.exs
+++ b/test/req_llm/provider/chunk_accumulator_test.exs
@@ -369,6 +369,22 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
              } = ChunkAccumulator.finalize_message(acc)
     end
 
+    test "builds an assistant message with generated image content" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(StreamChunk.content_part(image))
+
+      assert ChunkAccumulator.finalize_content_parts(acc) == [image]
+
+      assert %Message{
+               role: :assistant,
+               content: [^image],
+               tool_calls: nil
+             } = ChunkAccumulator.finalize_message(acc)
+    end
+
     test "builds assistant message with tool calls as ToolCall structs" do
       acc =
         ChunkAccumulator.new()

--- a/test/req_llm/provider/chunk_accumulator_test.exs
+++ b/test/req_llm/provider/chunk_accumulator_test.exs
@@ -38,6 +38,28 @@ defmodule ReqLLM.Provider.ChunkAccumulatorTest do
     end
   end
 
+  describe "finalize_ordered_content/2" do
+    test "keeps images before and between merged text parts" do
+      first_image = ContentPart.image(<<1>>, "image/png")
+      second_image = ContentPart.image(<<2>>, "image/png")
+
+      acc =
+        ChunkAccumulator.new()
+        |> ChunkAccumulator.push(StreamChunk.content_part(first_image))
+        |> ChunkAccumulator.push(StreamChunk.text("First "))
+        |> ChunkAccumulator.push(StreamChunk.text("caption"))
+        |> ChunkAccumulator.push(StreamChunk.content_part(second_image))
+        |> ChunkAccumulator.push(StreamChunk.text("Second caption"))
+
+      assert ChunkAccumulator.finalize_ordered_content(acc) == [
+               first_image,
+               ContentPart.text("First caption"),
+               second_image,
+               ContentPart.text("Second caption")
+             ]
+    end
+  end
+
   describe "push/2 - tool calls" do
     test "captures tool call with provider-supplied id" do
       acc =

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -660,6 +660,38 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert ReqLLM.Response.thinking(result) == "Okay, let me plan this."
       assert ReqLLM.Response.text(result) == "Build a broad foundation first."
     end
+
+    test "decodes generated images from OpenRouter responses" do
+      model = %LLMDB.Model{provider: :openrouter, id: "google/gemini-3-pro-image"}
+      image_data = <<255, 216, 255, 224>>
+      data_uri = "data:image/jpeg;base64,#{Base.encode64(image_data)}"
+
+      response_data = %{
+        "choices" => [
+          %{
+            "message" => %{
+              "role" => "assistant",
+              "content" => "",
+              "images" => [
+                %{"type" => "image_url", "image_url" => %{"url" => data_uri}},
+                %{
+                  "type" => "image_url",
+                  "image_url" => %{"url" => "https://example.com/generated.png"}
+                }
+              ]
+            },
+            "finish_reason" => "stop"
+          }
+        ]
+      }
+
+      {:ok, result} = Defaults.decode_response_body_openai_format(response_data, model)
+
+      assert ReqLLM.Response.images(result) == [
+               ContentPart.image(image_data, "image/jpeg"),
+               ContentPart.image_url("https://example.com/generated.png")
+             ]
+    end
   end
 
   describe "default_decode_stream_event/2" do
@@ -825,6 +857,53 @@ defmodule ReqLLM.Provider.DefaultsTest do
                %StreamChunk{type: :thinking, text: ", streaming thoughts."},
                %StreamChunk{type: :content, text: "Then answer."}
              ] = chunks
+    end
+
+    test "retains generated images from OpenRouter streaming deltas" do
+      model = %LLMDB.Model{provider: :openrouter, id: "google/gemini-3-pro-image"}
+      image_data = <<255, 216, 255, 224>>
+      data_uri = "data:image/jpeg;base64,#{Base.encode64(image_data)}"
+
+      event = %{
+        data: %{
+          "choices" => [
+            %{
+              "index" => 0,
+              "finish_reason" => nil,
+              "delta" => %{
+                "role" => "assistant",
+                "content" => "",
+                "images" => [
+                  %{"type" => "image_url", "image_url" => %{"url" => data_uri}}
+                ]
+              }
+            }
+          ]
+        }
+      }
+
+      chunks = Defaults.default_decode_stream_event(event, model)
+
+      assert [
+               %{
+                 type: :content_part,
+                 content_part: %ContentPart{
+                   type: :image,
+                   data: ^image_data,
+                   media_type: "image/jpeg"
+                 }
+               }
+             ] = chunks
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{},
+          context: Context.new([]),
+          model: model
+        )
+
+      assert ReqLLM.Response.images(response) == [
+               ContentPart.image(image_data, "image/jpeg")
+             ]
     end
 
     test "handles nil tool names in streaming deltas", %{model: model} do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -940,6 +940,33 @@ defmodule ReqLLM.Provider.DefaultsTest do
              ] = Defaults.default_decode_stream_event(event, model)
     end
 
+    test "preserves image and text order in streaming responses" do
+      model = %LLMDB.Model{provider: :openrouter, id: "google/gemini-3-pro-image"}
+      first_image = ContentPart.image(<<1>>, "image/png")
+      second_image = ContentPart.image(<<2>>, "image/png")
+
+      chunks = [
+        StreamChunk.content_part(first_image),
+        StreamChunk.text("First caption"),
+        StreamChunk.content_part(second_image),
+        StreamChunk.text("Second "),
+        StreamChunk.text("caption")
+      ]
+
+      {:ok, response} =
+        ResponseBuilder.build_response(chunks, %{},
+          context: Context.new([]),
+          model: model
+        )
+
+      assert response.message.content == [
+               first_image,
+               ContentPart.text("First caption"),
+               second_image,
+               ContentPart.text("Second caption")
+             ]
+    end
+
     test "handles nil tool names in streaming deltas", %{model: model} do
       nil_name_event = %{
         data: %{

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -665,6 +665,7 @@ defmodule ReqLLM.Provider.DefaultsTest do
       model = %LLMDB.Model{provider: :openrouter, id: "google/gemini-3-pro-image"}
       image_data = <<255, 216, 255, 224>>
       data_uri = "data:image/jpeg;base64,#{Base.encode64(image_data)}"
+      invalid_data_uri = "data:image/png;base64,not-valid-base64!"
 
       response_data = %{
         "choices" => [
@@ -676,8 +677,12 @@ defmodule ReqLLM.Provider.DefaultsTest do
                 %{"type" => "image_url", "image_url" => %{"url" => data_uri}},
                 %{
                   "type" => "image_url",
-                  "image_url" => %{"url" => "https://example.com/generated.png"}
-                }
+                  "image_url" => %{
+                    "url" => "https://example.com/generated.png",
+                    "detail" => "high"
+                  }
+                },
+                %{"type" => "image_url", "image_url" => %{"url" => invalid_data_uri}}
               ]
             },
             "finish_reason" => "stop"
@@ -689,7 +694,8 @@ defmodule ReqLLM.Provider.DefaultsTest do
 
       assert ReqLLM.Response.images(result) == [
                ContentPart.image(image_data, "image/jpeg"),
-               ContentPart.image_url("https://example.com/generated.png")
+               ContentPart.image_url("https://example.com/generated.png", %{"detail" => "high"}),
+               ContentPart.image_url(invalid_data_uri)
              ]
     end
   end
@@ -904,6 +910,34 @@ defmodule ReqLLM.Provider.DefaultsTest do
       assert ReqLLM.Response.images(response) == [
                ContentPart.image(image_data, "image/jpeg")
              ]
+    end
+
+    test "emits text and images from the same streaming delta" do
+      model = %LLMDB.Model{provider: :openrouter, id: "google/gemini-3-pro-image"}
+      image_url = "https://example.com/generated.png"
+
+      event = %{
+        data: %{
+          "choices" => [
+            %{
+              "delta" => %{
+                "content" => "Generated image:",
+                "images" => [
+                  %{"type" => "image_url", "image_url" => %{"url" => image_url}}
+                ]
+              }
+            }
+          ]
+        }
+      }
+
+      assert [
+               %StreamChunk{type: :content, text: "Generated image:"},
+               %StreamChunk{
+                 type: :content_part,
+                 content_part: %ContentPart{type: :image_url, url: ^image_url}
+               }
+             ] = Defaults.default_decode_stream_event(event, model)
     end
 
     test "handles nil tool names in streaming deltas", %{model: model} do

--- a/test/req_llm/response/stream_test.exs
+++ b/test/req_llm/response/stream_test.exs
@@ -3,6 +3,7 @@ defmodule ReqLLM.Response.StreamTest do
 
   @moduletag contract: :public_api
 
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.Response.Stream, as: ResponseStream
   alias ReqLLM.StreamChunk
 
@@ -30,6 +31,13 @@ defmodule ReqLLM.Response.StreamTest do
 
       assert summary.thinking == "Let me think... about this."
       assert summary.text == "Here's my answer."
+    end
+
+    test "accumulates complete multimodal content parts" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+      summary = ResponseStream.summarize([StreamChunk.content_part(image)])
+
+      assert summary.content_parts == [image]
     end
 
     test "reconstructs tool calls from fragments" do

--- a/test/req_llm/response_test.exs
+++ b/test/req_llm/response_test.exs
@@ -355,6 +355,20 @@ defmodule ReqLLM.ResponseTest do
       assert materialized.message.content == [%{type: :text, text: ""}]
     end
 
+    test "materializes generated images from streaming responses" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+
+      response =
+        create_response(
+          message: nil,
+          stream?: true,
+          stream: [StreamChunk.content_part(image)]
+        )
+
+      assert {:ok, materialized} = Response.join_stream(response)
+      assert Response.images(materialized) == [image]
+    end
+
     test "returns error when stream consumption fails" do
       error_stream = Stream.repeatedly(fn -> raise "Stream error" end)
       response = create_response(message: nil, stream?: true, stream: error_stream)

--- a/test/req_llm/response_test.exs
+++ b/test/req_llm/response_test.exs
@@ -369,6 +369,33 @@ defmodule ReqLLM.ResponseTest do
       assert Response.images(materialized) == [image]
     end
 
+    test "preserves image and text order in joined streaming responses" do
+      first_image = ContentPart.image(<<1>>, "image/png")
+      second_image = ContentPart.image(<<2>>, "image/png")
+
+      response =
+        create_response(
+          message: nil,
+          stream?: true,
+          stream: [
+            StreamChunk.content_part(first_image),
+            StreamChunk.text("First caption"),
+            StreamChunk.content_part(second_image),
+            StreamChunk.text("Second "),
+            StreamChunk.text("caption")
+          ]
+        )
+
+      assert {:ok, materialized} = Response.join_stream(response)
+
+      assert materialized.message.content == [
+               first_image,
+               ContentPart.text("First caption"),
+               second_image,
+               ContentPart.text("Second caption")
+             ]
+    end
+
     test "returns error when stream consumption fails" do
       error_stream = Stream.repeatedly(fn -> raise "Stream error" end)
       response = create_response(message: nil, stream?: true, stream: error_stream)

--- a/test/req_llm/stream_chunk_test.exs
+++ b/test/req_llm/stream_chunk_test.exs
@@ -3,6 +3,7 @@ defmodule ReqLLM.StreamChunkTest do
 
   @moduletag contract: :public_api
 
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.StreamChunk
 
   # Shared test helpers
@@ -37,6 +38,19 @@ defmodule ReqLLM.StreamChunkTest do
       assert_nil_fields(basic_chunk, [:name, :arguments])
 
       assert_chunk_fields(with_meta, type: :thinking, text: "Step 1...", metadata: %{step: 1})
+    end
+
+    test "content_part/2 creates multimodal content chunks" do
+      part = ContentPart.image(<<1, 2, 3>>, "image/png")
+      chunk = StreamChunk.content_part(part, %{index: 0})
+
+      assert_chunk_fields(chunk,
+        type: :content_part,
+        content_part: part,
+        metadata: %{index: 0}
+      )
+
+      assert_nil_fields(chunk, [:text, :name, :arguments])
     end
 
     test "tool_call/3 creates tool call chunks" do
@@ -76,6 +90,8 @@ defmodule ReqLLM.StreamChunkTest do
   describe "validation" do
     @valid_cases [
       {:content, StreamChunk.text("valid")},
+      {:content_part,
+       StreamChunk.content_part(ContentPart.image_url("https://example.com/a.png"))},
       {:thinking, StreamChunk.thinking("valid reasoning")},
       {:tool_call, StreamChunk.tool_call("func", %{arg: "value"})},
       {:meta, StreamChunk.meta(%{key: "value"})},
@@ -88,6 +104,8 @@ defmodule ReqLLM.StreamChunkTest do
     @invalid_cases [
       {:content_nil_text, %StreamChunk{type: :content, text: nil},
        "Content chunks must have non-nil text"},
+      {:content_part_nil, %StreamChunk{type: :content_part, content_part: nil},
+       "Content part chunks must contain a ContentPart"},
       {:thinking_nil_text, %StreamChunk{type: :thinking, text: nil},
        "Thinking chunks must have non-nil text"},
       {:tool_call_nil_name, %StreamChunk{type: :tool_call, name: nil, arguments: %{}},

--- a/test/req_llm/stream_event_projection_test.exs
+++ b/test/req_llm/stream_event_projection_test.exs
@@ -4,6 +4,7 @@ defmodule ReqLLM.StreamEventProjectionTest do
   @moduletag contract: :public_api
 
   alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.Provider.Defaults
   alias ReqLLM.Providers.Anthropic
   alias ReqLLM.Response.OutputItem
@@ -402,6 +403,23 @@ defmodule ReqLLM.StreamEventProjectionTest do
 
       legacy_response = stream_response(chunks, %{finish_reason: :stop})
       assert Enum.to_list(legacy_response.stream) == chunks
+    end
+
+    test "projects generated image chunks as output items" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+      chunks = [StreamChunk.content_part(image, %{sequence: 2})]
+      response = stream_response(chunks, %{finish_reason: :stop})
+
+      events = Enum.to_list(StreamResponse.events(response))
+
+      assert %StreamEvent{
+               type: :output_item,
+               data: %OutputItem{
+                 type: :image,
+                 data: ^image,
+                 metadata: %{sequence: 2}
+               }
+             } = Enum.find(events, &(&1.type == :output_item))
     end
 
     test "keeps the StreamResponse struct and legacy projections unchanged" do


### PR DESCRIPTION
## Summary

- decode OpenRouter-generated images from both buffered `message.images` and streaming `delta.images` payloads
- represent complete multimodal output as canonical `StreamChunk.content_part/2` chunks
- retain image parts through response assembly, legacy stream joining, telemetry accumulation, and stream-event projection
- preserve the arrival order of text, thinking, and generated media in streamed responses
- preserve text and image output when both fields arrive in one delta

## Root cause

The shared OpenAI-compatible delta decoder selected one field per clause and did not recognize OpenRouter's `images` extension. An empty `content` placeholder therefore caused an image-only delta to return no chunks. The buffered decoder also ignored `message.images`.

## Validation

- reproduced the bug on current `main` with the exact OpenRouter delta shape from issue #933
- covered image-only, mixed text-and-image, ordered multimodal, remote URL, metadata, and malformed data-URI cases
- `mix test` (4,037 passed, 11 skipped, 150 excluded)
- `mix quality`

Closes #933