### PR TITLE
fix(google): preserve raw Gemini finishReason and finishMessage in stream meta

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1902,6 +1902,25 @@ defmodule ReqLLM.Providers.Google do
 
   defp attach_reasoning_details(response, _details), do: response
 
+  # Preserve the provider's original finishReason (and finishMessage, when
+  # present) alongside the normalized value. Normalization collapses every
+  # unrecognized reason (MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL,
+  # OTHER, ...) into "error", which makes provider failures undiagnosable
+  # downstream.
+  defp put_raw_finish_meta(meta, finish_reason, data) do
+    finish_message =
+      case data do
+        %{"candidates" => [%{"finishMessage" => message} | _]} when is_binary(message) -> message
+        _ -> nil
+      end
+
+    meta
+    |> Map.put(:finish_reason_raw, finish_reason)
+    |> then(fn m ->
+      if finish_message, do: Map.put(m, :finish_message, finish_message), else: m
+    end)
+  end
+
   defp normalize_google_finish_reason("STOP"), do: "stop"
   defp normalize_google_finish_reason("MAX_TOKENS"), do: "length"
   defp normalize_google_finish_reason("SAFETY"), do: "content_filter"
@@ -2779,12 +2798,14 @@ defmodule ReqLLM.Providers.Google do
       when finish_reason != nil ->
         chunks = extract_chunks_from_parts(parts)
 
-        meta = %{
-          usage: convert_google_usage_for_streaming(usage),
-          finish_reason: normalize_google_finish_reason(finish_reason),
-          model: model.id,
-          terminal?: true
-        }
+        meta =
+          %{
+            usage: convert_google_usage_for_streaming(usage),
+            finish_reason: normalize_google_finish_reason(finish_reason),
+            model: model.id,
+            terminal?: true
+          }
+          |> put_raw_finish_meta(finish_reason, data)
 
         meta = if provider_meta, do: Map.put(meta, :provider_meta, provider_meta), else: meta
         chunks ++ [ReqLLM.StreamChunk.meta(meta)]
@@ -2795,10 +2816,12 @@ defmodule ReqLLM.Providers.Google do
       when finish_reason != nil ->
         chunks = extract_chunks_from_parts(parts)
 
-        meta = %{
-          finish_reason: normalize_google_finish_reason(finish_reason),
-          terminal?: true
-        }
+        meta =
+          %{
+            finish_reason: normalize_google_finish_reason(finish_reason),
+            terminal?: true
+          }
+          |> put_raw_finish_meta(finish_reason, data)
 
         meta = if provider_meta, do: Map.put(meta, :provider_meta, provider_meta), else: meta
         chunks ++ [ReqLLM.StreamChunk.meta(meta)]
@@ -2828,22 +2851,26 @@ defmodule ReqLLM.Providers.Google do
         "usageMetadata" => usage
       }
       when finish_reason != nil ->
-        meta = %{
-          usage: convert_google_usage_for_streaming(usage),
-          finish_reason: normalize_google_finish_reason(finish_reason),
-          model: model.id,
-          terminal?: true
-        }
+        meta =
+          %{
+            usage: convert_google_usage_for_streaming(usage),
+            finish_reason: normalize_google_finish_reason(finish_reason),
+            model: model.id,
+            terminal?: true
+          }
+          |> put_raw_finish_meta(finish_reason, data)
 
         meta = if provider_meta, do: Map.put(meta, :provider_meta, provider_meta), else: meta
         [ReqLLM.StreamChunk.meta(meta)]
 
       %{"candidates" => [%{"finishReason" => finish_reason} | _]}
       when finish_reason != nil ->
-        meta = %{
-          finish_reason: normalize_google_finish_reason(finish_reason),
-          terminal?: true
-        }
+        meta =
+          %{
+            finish_reason: normalize_google_finish_reason(finish_reason),
+            terminal?: true
+          }
+          |> put_raw_finish_meta(finish_reason, data)
 
         meta = if provider_meta, do: Map.put(meta, :provider_meta, provider_meta), else: meta
         [ReqLLM.StreamChunk.meta(meta)]

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1644,6 +1644,56 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert meta_chunk.metadata[:terminal?] == true
     end
 
+    test "preserves raw finishReason and finishMessage on abnormal finishes", %{model: model} do
+      event = %{
+        data: %{
+          "candidates" => [
+            %{
+              "content" => %{
+                "parts" => [%{"text" => "", "thoughtSignature" => "sig"}],
+                "role" => "model"
+              },
+              "finishReason" => "MALFORMED_FUNCTION_CALL",
+              "finishMessage" =>
+                "Malformed function call: Failed to parse function call: Function call is empty - no input to parse.",
+              "index" => 0
+            }
+          ],
+          "usageMetadata" => %{
+            "promptTokenCount" => 10,
+            "candidatesTokenCount" => 5,
+            "totalTokenCount" => 15
+          }
+        }
+      }
+
+      chunks = Google.decode_stream_event(event, model)
+      meta_chunk = Enum.find(chunks, &(&1.type == :meta))
+      assert meta_chunk.metadata[:finish_reason] == "error"
+      assert meta_chunk.metadata[:finish_reason_raw] == "MALFORMED_FUNCTION_CALL"
+      assert meta_chunk.metadata[:finish_message] =~ "Function call is empty"
+      assert meta_chunk.metadata[:terminal?] == true
+    end
+
+    test "preserves raw finishReason without finishMessage", %{model: model} do
+      event = %{
+        data: %{"candidates" => [%{"finishReason" => "UNEXPECTED_TOOL_CALL", "index" => 0}]}
+      }
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.metadata[:finish_reason] == "error"
+      assert meta_chunk.metadata[:finish_reason_raw] == "UNEXPECTED_TOOL_CALL"
+      refute Map.has_key?(meta_chunk.metadata, :finish_message)
+    end
+
+    test "normal STOP finishes carry the raw reason too", %{model: model} do
+      event = %{data: %{"candidates" => [%{"finishReason" => "STOP", "index" => 0}]}}
+
+      [meta_chunk] = Google.decode_stream_event(event, model)
+      assert meta_chunk.metadata[:finish_reason] == "stop"
+      assert meta_chunk.metadata[:finish_reason_raw] == "STOP"
+    end
+
     test "usageMetadata alone still has no finish_reason (unchanged)", %{model: model} do
       event = %{
         data: %{


### PR DESCRIPTION
## Description

`normalize_google_finish_reason/1` collapses every unrecognized Gemini `finishReason` (`MALFORMED_FUNCTION_CALL`, `UNEXPECTED_TOOL_CALL`, `BLOCKLIST`, `PROHIBITED_CONTENT`, `OTHER`, …) into `"error"`, and `decode_google_event/2` discards Google's explanatory `finishMessage`. Downstream consumers can only see an opaque error, which makes deterministic provider-side aborts undiagnosable — we hit this in production with `gemini-3.5-flash` aborting on `MALFORMED_FUNCTION_CALL` ("Function call is empty - no input to parse") and could only observe "stream finished with error" while retrying a request that could never succeed.

This is the Google sibling of #749 (Anthropic stop_reasons collapsed to `:error`). Unlike those, most Gemini abort reasons have no good canonical `finish_reason` mapping, so instead of remapping, this change leaves normalization untouched and additionally carries in the terminal meta chunk:

- `finish_reason_raw` — the original `finishReason` string, always;
- `finish_message` — Google's `finishMessage`, when present.

Happy to nest these under `provider_meta` (like grounding metadata) instead of top-level meta keys if that's the preferred shape.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None — existing `finish_reason` values are unchanged; the new keys are additive.

## Testing

- [x] Tests pass (`mix test`, 4040 passed)
- [x] Quality checks pass (`mix quality`, dialyzer clean)

Added three decode tests: abnormal finish with `finishMessage` (the MALFORMED_FUNCTION_CALL case, raw values preserved and normalization still `"error"`), abnormal finish without `finishMessage` (key absent), and STOP (raw carried, normalization unchanged). `mix mc google` unchanged (2/31 models covered locally; decode-only change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #935