### PR TITLE
fix(google): map Gemini policy stops to content_filter

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1906,6 +1906,35 @@ defmodule ReqLLM.Providers.Google do
   defp normalize_google_finish_reason("MAX_TOKENS"), do: "length"
   defp normalize_google_finish_reason("SAFETY"), do: "content_filter"
   defp normalize_google_finish_reason("RECITATION"), do: "content_filter"
+
+  # Gemini flags generated content under several names beyond SAFETY. The proto
+  # describes this whole group in the same words — "the response candidate
+  # content was flagged for ..." — so they are one outcome wearing different
+  # labels and normalize the same way. Collapsing them into "error" instead
+  # makes a deterministic, non-retryable stop look like a transient provider
+  # fault, which callers then retry pointlessly.
+  #
+  # Source of truth is the FinishReason enum in googleapis/googleapis
+  # (google/ai/generativelanguage/v1beta/generative_service.proto). Cross-check
+  # both generated clients before adding names: the public REST reference omits
+  # the IMAGE_* values, and google-genai's Python types omit
+  # TOO_MANY_TOOL_CALLS, so neither is complete on its own.
+  #
+  # Deliberately NOT mapped here, because they are not content flags and want
+  # different handling than "the model refused": UNEXPECTED_TOOL_CALL (a tool
+  # call with no tools enabled in the request — a request-construction fault),
+  # TOO_MANY_TOOL_CALLS (the system aborted a tool-call runaway), NO_IMAGE /
+  # IMAGE_OTHER, and OTHER. Retrying most of these is equally futile, but they
+  # need a non-retryable non-refusal classification that does not exist yet, so
+  # they keep the existing "error" behaviour rather than borrow the wrong one.
+  defp normalize_google_finish_reason("BLOCKLIST"), do: "content_filter"
+  defp normalize_google_finish_reason("PROHIBITED_CONTENT"), do: "content_filter"
+  defp normalize_google_finish_reason("SPII"), do: "content_filter"
+  defp normalize_google_finish_reason("LANGUAGE"), do: "content_filter"
+  defp normalize_google_finish_reason("IMAGE_SAFETY"), do: "content_filter"
+  defp normalize_google_finish_reason("IMAGE_PROHIBITED_CONTENT"), do: "content_filter"
+  defp normalize_google_finish_reason("IMAGE_RECITATION"), do: "content_filter"
+
   defp normalize_google_finish_reason("OTHER"), do: "error"
   defp normalize_google_finish_reason(_), do: "error"
 

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1644,6 +1644,46 @@ defmodule ReqLLM.Providers.GoogleTest do
       assert meta_chunk.metadata[:terminal?] == true
     end
 
+    test "policy stops normalize to content_filter like SAFETY", %{model: model} do
+      for reason <- [
+            "BLOCKLIST",
+            "PROHIBITED_CONTENT",
+            "SPII",
+            "LANGUAGE",
+            "IMAGE_SAFETY",
+            "IMAGE_PROHIBITED_CONTENT",
+            "IMAGE_RECITATION"
+          ] do
+        event = %{data: %{"candidates" => [%{"finishReason" => reason, "index" => 0}]}}
+
+        [meta_chunk] = Google.decode_stream_event(event, model)
+
+        assert meta_chunk.metadata[:finish_reason] == "content_filter",
+               "#{reason} should be a content filter stop, got #{inspect(meta_chunk.metadata[:finish_reason])}"
+      end
+    end
+
+    # These are stops, but not content flags, and they want handling the
+    # content_filter path cannot give them ("the model refused" would be wrong).
+    # Pinning them keeps a later pass from sweeping the whole enum into
+    # content_filter for tidiness.
+    test "non-content-flag stops stay error", %{model: model} do
+      for reason <- [
+            "UNEXPECTED_TOOL_CALL",
+            "TOO_MANY_TOOL_CALLS",
+            "NO_IMAGE",
+            "IMAGE_OTHER",
+            "OTHER"
+          ] do
+        event = %{data: %{"candidates" => [%{"finishReason" => reason, "index" => 0}]}}
+
+        [meta_chunk] = Google.decode_stream_event(event, model)
+
+        assert meta_chunk.metadata[:finish_reason] == "error",
+               "#{reason} is not a content flag and should stay error, got #{inspect(meta_chunk.metadata[:finish_reason])}"
+      end
+    end
+
     test "usageMetadata alone still has no finish_reason (unchanged)", %{model: model} do
       event = %{
         data: %{


### PR DESCRIPTION
## Description

`normalize_google_finish_reason/1` maps `SAFETY` and `RECITATION` to `"content_filter"`, but the sibling finish reasons for the same outcome — `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `LANGUAGE`, `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `IMAGE_RECITATION` — fall through the catch-all and become `"error"`. The `FinishReason` proto describes the whole group in the same words ("the response candidate content was flagged for ..."), so they are one outcome wearing different labels.

Reporting them as `"error"` makes a deterministic, non-retryable stop look like a transient provider fault, so callers retry a request that can never succeed.

This is the Google sibling of #749 (Anthropic stop_reasons collapsed to `:error`).

**Deliberately not mapped**, and pinned by a test so a later tidy-up pass doesn't sweep the whole enum in: `UNEXPECTED_TOOL_CALL` (tool call with no tools enabled — a request-construction fault), `TOO_MANY_TOOL_CALLS` (system-aborted runaway), `NO_IMAGE`, `IMAGE_OTHER`, `OTHER`. Retrying most of these is equally futile, but they need a non-retryable non-refusal classification that doesn't exist yet, and "the model refused" would be the wrong story for them.

A note on sourcing the names, since no single reference is complete: the values were taken from the `FinishReason` enum in `googleapis/googleapis` (`google/ai/generativelanguage/v1beta/generative_service.proto`) and cross-checked against both generated clients — the public REST reference omits the `IMAGE_*` values, and google-genai's Python types omit `TOO_MANY_TOOL_CALLS`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None in the API surface. Behaviour does change for the seven listed finish reasons: `finish_reason` becomes `"content_filter"` where it was previously `"error"` — which is the point of the fix, and matches how `SAFETY`/`RECITATION` already behave. Unmapped values are untouched.

## Testing

- [x] Tests pass (`mix test`, 4039 passed, 11 skipped)
- [x] Quality checks pass (`mix quality`, dialyzer clean, credo --strict clean)

Two new decode tests: one asserting all seven content-flag reasons normalize to `"content_filter"`, one pinning the five non-content-flag stops as `"error"`. Both fail without the lib change.

`mix mc "google:*"` is byte-identical before and after the change (verified by running it on unpatched `main` and on this branch):

```
Summary: 2/31 active models tested (6.5% coverage)
Overall Coverage: 2/31 active models passing (6.5%) in 23s
```

The low coverage is local fixture availability, not a regression — most Google fixtures aren't in the repo. Happy to re-run any specific model if you can point me at the fixtures.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #938

Independent of #936 (raw finishReason preservation) — they touch the same function but neither depends on the other, and they can merge in either order.