### PR TITLE
fix(streaming): surface empty-body HTTP failures

### DIFF
--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -873,6 +873,18 @@ defmodule ReqLLM.StreamServer do
     end
   end
 
+  defp process_http_event(:done, %{http_status: status} = state)
+       when is_integer(status) and status >= 400 do
+    error = build_http_error(status, nil, state.headers)
+
+    new_state =
+      state
+      |> finalize_failed_stream(error)
+      |> reply_to_waiting_callers()
+
+    {:reply, :ok, new_state}
+  end
+
   defp process_http_event(:done, state) do
     new_state = finalize_stream_with_fixture(state) |> reply_to_waiting_callers()
     {:reply, :ok, new_state}

--- a/test/req_llm/stream_server/error_handling_test.exs
+++ b/test/req_llm/stream_server/error_handling_test.exs
@@ -108,6 +108,40 @@ defmodule ReqLLM.StreamServer.ErrorHandlingTest do
       StreamServer.cancel(server)
     end
 
+    test "preserves an HTTP error after the response completes" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      assert :ok = GenServer.call(server, {:http_event, {:status, 500}})
+
+      error_json = Jason.encode!(%{"error" => %{"message" => "Internal server error"}})
+      assert :ok = GenServer.call(server, {:http_event, {:data, error_json}})
+      assert :ok = GenServer.call(server, {:http_event, :done})
+
+      assert {:error, %ReqLLM.Error.API.Request{} = error} = StreamServer.next(server, 100)
+      assert error.status == 500
+      assert error.reason == "Internal server error"
+      assert error.response_body["message"] == "Internal server error"
+
+      StreamServer.cancel(server)
+    end
+
+    test "returns an HTTP error when a failed response has no body" do
+      server = start_server()
+      _task = mock_http_task(server)
+
+      assert :ok = GenServer.call(server, {:http_event, {:status, 503}})
+      assert :ok = GenServer.call(server, {:http_event, :done})
+
+      assert {:error, %ReqLLM.Error.API.Request{} = error} = StreamServer.next(server, 100)
+      assert error.status == 503
+      assert error.reason == "HTTP 503"
+      assert error.response_body == nil
+      assert error.retryable == true
+
+      StreamServer.cancel(server)
+    end
+
     test "handles non-JSON error responses" do
       server = start_server()
       _task = mock_http_task(server)


### PR DESCRIPTION
## Summary

- preserve structured streaming HTTP errors after the response completes
- convert empty-body HTTP 4xx/5xx responses into structured API errors
- add regression coverage for completed error responses and empty-body failures

## Root cause

The stream recorded an HTTP failure only when it received response data. A failed response with no body reached the normal `:done` path and appeared as a successful empty stream.

## Impact

Callers now receive a `ReqLLM.Error.API.Request` for failed streaming responses even when the provider sends no error body.

## Validation

- `mix test test/req_llm/stream_server/error_handling_test.exs` (8 passed)
- `mix quality`
- `mix test` (4,042 of 4,044 passed; two unrelated transient failures passed with `mix test --failed`)

Closes #940