### PR TITLE
feat(openai): support explicit cache breakpoints

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1028,19 +1028,22 @@ defmodule ReqLLM.Provider.Defaults do
 
   defp encode_openai_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
-         file_id: file_id
+         file_id: file_id,
+         metadata: metadata
        })
        when is_binary(file_id) and file_id != "" do
     %{
       type: "file",
       file: %{file_id: file_id}
     }
+    |> merge_content_metadata(metadata)
   end
 
   defp encode_openai_content_part(%ReqLLM.Message.ContentPart{
          type: :file,
          data: data,
-         media_type: media_type
+         media_type: media_type,
+         metadata: metadata
        })
        when is_binary(data) do
     # Encode file as image_url data URI (OpenAI format supports various media types this way)
@@ -1052,6 +1055,7 @@ defmodule ReqLLM.Provider.Defaults do
         url: "data:#{media_type};base64,#{base64}"
       }
     }
+    |> merge_content_metadata(metadata)
   end
 
   # Thinking content is extracted to the top-level reasoning_content field
@@ -1068,7 +1072,12 @@ defmodule ReqLLM.Provider.Defaults do
 
   defp maybe_put_image_detail(image_url, _metadata), do: image_url
 
-  @passthrough_metadata_keys [:cache_control, "cache_control"]
+  @passthrough_metadata_keys [
+    :cache_control,
+    "cache_control",
+    :prompt_cache_breakpoint,
+    "prompt_cache_breakpoint"
+  ]
 
   defp merge_content_metadata(base, metadata) when is_map(metadata) and map_size(metadata) > 0 do
     passthrough =
@@ -1076,6 +1085,7 @@ defmodule ReqLLM.Provider.Defaults do
       |> Map.take(@passthrough_metadata_keys)
       |> Map.new(fn
         {"cache_control", v} -> {:cache_control, v}
+        {"prompt_cache_breakpoint", v} -> {:prompt_cache_breakpoint, v}
         {k, v} -> {k, v}
       end)
 
@@ -1587,6 +1597,7 @@ defmodule ReqLLM.Provider.Defaults do
       end
 
     cached_tokens = get_in(usage, ["prompt_tokens_details", "cached_tokens"]) || 0
+    cache_creation_tokens = get_in(usage, ["prompt_tokens_details", "cache_write_tokens"])
 
     base = %{
       input_tokens: input,
@@ -1595,6 +1606,8 @@ defmodule ReqLLM.Provider.Defaults do
       cached_tokens: cached_tokens,
       reasoning_tokens: reasoning_tokens
     }
+
+    base = maybe_put_cache_creation_tokens(base, cache_creation_tokens)
 
     extra =
       Map.drop(usage, [
@@ -1616,6 +1629,11 @@ defmodule ReqLLM.Provider.Defaults do
       cached_tokens: 0,
       reasoning_tokens: 0
     }
+
+  defp maybe_put_cache_creation_tokens(usage, nil), do: usage
+
+  defp maybe_put_cache_creation_tokens(usage, tokens),
+    do: Map.put(usage, :cache_creation_tokens, tokens)
 
   # DeepSeek R1 models return reasoning in "reasoning_content" field
   # When present, we use completion_tokens as reasoning_tokens

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -47,6 +47,26 @@ defmodule ReqLLM.Providers.OpenAI do
   - Returns images as `ReqLLM.Message.ContentPart` with `:image` or `:image_url` type
   - Streaming not supported
 
+  ## Explicit Prompt Caching
+
+  GPT-5.6 and later models support explicit cache breakpoints. Add
+  `prompt_cache_breakpoint` to content-part metadata and configure the request-wide
+  policy through provider options:
+
+      cached_part =
+        ReqLLM.Message.ContentPart.text("Stable instructions", %{
+          prompt_cache_breakpoint: %{mode: "explicit"}
+        })
+
+      ReqLLM.generate_text(model, ReqLLM.Context.user([cached_part]),
+        provider_options: [
+          prompt_cache_key: "tenant:acme:instructions-v1",
+          prompt_cache_options: %{mode: "explicit", ttl: "30m"}
+        ]
+      )
+
+  Both the Chat Completions API and Responses API support these options.
+
   ## Usage Normalization
 
   Chat and Responses drivers normalize usage metrics to provide consistent field names:
@@ -200,6 +220,15 @@ defmodule ReqLLM.Providers.OpenAI do
       doc:
         "Whether to store responses for multi-turn chaining via previous_response_id. " <>
           "Set to false for Zero Data Retention (ZDR) organizations."
+    ],
+    prompt_cache_key: [
+      type: :string,
+      doc: "Stable key for OpenAI prompt-cache matching"
+    ],
+    prompt_cache_options: [
+      type: {:or, [:map, :keyword_list]},
+      doc:
+        "OpenAI prompt-cache policy for GPT-5.6 and later models, such as %{mode: \"explicit\", ttl: \"30m\"}"
     ],
     openai_stream_transport: [
       type: {:in, [:sse, :websocket]},

--- a/lib/req_llm/providers/openai/chat_api/request.ex
+++ b/lib/req_llm/providers/openai/chat_api/request.ex
@@ -29,6 +29,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI.Request do
         |> add_stream_options(request_options)
         |> add_reasoning_effort(request_options)
         |> add_service_tier(request_options)
+        |> add_prompt_cache_options(request_options)
         |> add_verbosity(request_options)
         |> add_response_format(request_options)
         |> add_parallel_tool_calls(request_options)
@@ -91,6 +92,14 @@ defmodule ReqLLM.Providers.OpenAI.ChatAPI.Request do
     provider_options = provider_options(request_options)
     service_tier = request_options[:service_tier] || provider_options[:service_tier]
     maybe_put(body, :service_tier, service_tier)
+  end
+
+  defp add_prompt_cache_options(body, request_options) do
+    provider_options = provider_options(request_options)
+
+    body
+    |> maybe_put(:prompt_cache_key, provider_options[:prompt_cache_key])
+    |> maybe_put(:prompt_cache_options, provider_options[:prompt_cache_options])
   end
 
   defp add_verbosity(body, request_options) do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -770,6 +770,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("tool_choice", tool_choice)
       |> maybe_put_string("parallel_tool_calls", opts_map[:parallel_tool_calls])
       |> maybe_put_string("service_tier", service_tier)
+      |> maybe_put_string("prompt_cache_key", provider_opts[:prompt_cache_key])
+      |> maybe_put_string("prompt_cache_options", provider_opts[:prompt_cache_options])
       |> maybe_put_string("include", include)
       |> maybe_put_string("text", text_format)
 
@@ -910,25 +912,53 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp has_image_content?(_), do: false
 
-  defp encode_input_content_part(%ReqLLM.Message.ContentPart{type: :text, text: text}, type) do
-    [%{"type" => type, "text" => text}]
+  defp encode_input_content_part(
+         %ReqLLM.Message.ContentPart{type: :text, text: text, metadata: metadata},
+         type
+       ) do
+    block =
+      %{"type" => type, "text" => text}
+      |> maybe_put_prompt_cache_breakpoint(metadata)
+
+    [block]
   end
 
   defp encode_input_content_part(
-         %ReqLLM.Message.ContentPart{type: :image, data: data, media_type: media_type},
+         %ReqLLM.Message.ContentPart{
+           type: :image,
+           data: data,
+           media_type: media_type,
+           metadata: metadata
+         },
          _type
        ) do
     base64 = Base.encode64(data)
-    [%{"type" => "input_image", "image_url" => "data:#{media_type};base64,#{base64}"}]
-  end
 
-  defp encode_input_content_part(%ReqLLM.Message.ContentPart{type: :image_url, url: url}, _type) do
-    [%{"type" => "input_image", "image_url" => url}]
+    block =
+      %{"type" => "input_image", "image_url" => "data:#{media_type};base64,#{base64}"}
+      |> maybe_put_prompt_cache_breakpoint(metadata)
+
+    [block]
   end
 
   defp encode_input_content_part(
-         %ReqLLM.Message.ContentPart{type: :file, file_id: legacy_file_id, filename: filename} =
-           part,
+         %ReqLLM.Message.ContentPart{type: :image_url, url: url, metadata: metadata},
+         _type
+       ) do
+    block =
+      %{"type" => "input_image", "image_url" => url}
+      |> maybe_put_prompt_cache_breakpoint(metadata)
+
+    [block]
+  end
+
+  defp encode_input_content_part(
+         %ReqLLM.Message.ContentPart{
+           type: :file,
+           file_id: legacy_file_id,
+           filename: filename,
+           metadata: metadata
+         } = part,
          _type
        )
        when is_binary(legacy_file_id) and legacy_file_id != "" do
@@ -937,6 +967,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     file =
       %{"type" => "input_file", "file_id" => file_id}
       |> maybe_put_string("filename", filename)
+      |> maybe_put_prompt_cache_breakpoint(metadata)
 
     [file]
   end
@@ -946,7 +977,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
            type: :file,
            data: data,
            media_type: media_type,
-           filename: filename
+           filename: filename,
+           metadata: metadata
          },
          _type
        )
@@ -956,11 +988,25 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     file =
       %{"type" => "input_file", "file_data" => "data:#{media_type};base64,#{base64}"}
       |> maybe_put_string("filename", filename)
+      |> maybe_put_prompt_cache_breakpoint(metadata)
 
     [file]
   end
 
   defp encode_input_content_part(_, _type), do: []
+
+  @prompt_cache_block_types ~w(input_text input_image input_file)
+
+  defp maybe_put_prompt_cache_breakpoint(%{"type" => type} = block, metadata)
+       when type in @prompt_cache_block_types and is_map(metadata) do
+    breakpoint =
+      Map.get(metadata, :prompt_cache_breakpoint) ||
+        Map.get(metadata, "prompt_cache_breakpoint")
+
+    maybe_put_string(block, "prompt_cache_breakpoint", breakpoint)
+  end
+
+  defp maybe_put_prompt_cache_breakpoint(block, _metadata), do: block
 
   defp provider_file_id(part, provider, legacy_file_id) do
     case ReqLLM.ProviderFileReference.reference_id(part, provider) do
@@ -2239,10 +2285,15 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       get_in(response_data, ["usage", "input_tokens_details", "cached_tokens"]) ||
         get_in(response_data, ["usage", "prompt_tokens_details", "cached_tokens"]) || 0
 
+    cache_creation_tokens =
+      get_in(response_data, ["usage", "input_tokens_details", "cache_write_tokens"]) ||
+        get_in(response_data, ["usage", "prompt_tokens_details", "cache_write_tokens"])
+
     usage =
       usage
       |> Map.put(:cached_tokens, cached_tokens)
       |> Map.put(:reasoning_tokens, reasoning_tokens)
+      |> maybe_put_cache_creation_tokens(cache_creation_tokens)
 
     tool_call_counts = extract_tool_call_counts(response_data)
 
@@ -2252,6 +2303,11 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       usage
     end
   end
+
+  defp maybe_put_cache_creation_tokens(usage, nil), do: usage
+
+  defp maybe_put_cache_creation_tokens(usage, tokens),
+    do: Map.put(usage, :cache_creation_tokens, tokens)
 
   # The Responses API returns "completed" status even when tool calls are present.
   # We need to check for tool calls and return :tool_calls in that case.

--- a/lib/req_llm/usage/normalize.ex
+++ b/lib/req_llm/usage/normalize.ex
@@ -196,14 +196,21 @@ defmodule ReqLLM.Usage.Normalize do
 
   defp get_cache_creation_tokens(usage, input, input_includes_cached) do
     creation =
-      MapAccess.get(usage, :cache_creation_input_tokens) ||
+      MapAccess.get(usage, :cache_creation_tokens) ||
+        MapAccess.get(usage, :cache_creation) ||
+        MapAccess.get(usage, :cache_write_tokens) ||
+        MapAccess.get(usage, :cache_creation_input_tokens) ||
         MapAccess.get(usage, "cache_creation_input_tokens") ||
         MapAccess.get(usage, :cacheWriteInputTokens) ||
         MapAccess.get(usage, "cacheWriteInputTokens") ||
         MapAccess.get(usage, :cacheWriteInputTokenCount) ||
         MapAccess.get(usage, "cacheWriteInputTokenCount") ||
         MapAccess.get(usage, :cache_write_input_tokens) ||
-        MapAccess.get(usage, "cache_write_input_tokens")
+        MapAccess.get(usage, "cache_write_input_tokens") ||
+        get_in(usage, ["prompt_tokens_details", "cache_write_tokens"]) ||
+        get_in(usage, [:prompt_tokens_details, :cache_write_tokens]) ||
+        get_in(usage, ["input_tokens_details", "cache_write_tokens"]) ||
+        get_in(usage, [:input_tokens_details, :cache_write_tokens])
 
     if input_includes_cached do
       clamp_tokens(creation, input)

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -62,6 +62,44 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert body["stream"] == true
     end
 
+    test "encodes explicit prompt cache controls" do
+      breakpoint = %{mode: "explicit"}
+
+      context =
+        ReqLLM.Context.new([
+          ReqLLM.Context.user([
+            ReqLLM.Message.ContentPart.text("Stable text", %{
+              prompt_cache_breakpoint: breakpoint
+            }),
+            ReqLLM.Message.ContentPart.image_url("https://example.com/image.png", %{
+              "prompt_cache_breakpoint" => breakpoint
+            }),
+            ReqLLM.Message.ContentPart.file_id("file_123", %{
+              prompt_cache_breakpoint: breakpoint
+            })
+          ])
+        ])
+
+      request =
+        build_request(
+          context: context,
+          provider_options: [
+            prompt_cache_key: "tenant:acme:knowledge-v1",
+            prompt_cache_options: %{mode: "explicit", ttl: "30m"}
+          ]
+        )
+
+      body = request |> ResponsesAPI.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+      assert body["prompt_cache_key"] == "tenant:acme:knowledge-v1"
+      assert body["prompt_cache_options"] == %{"mode" => "explicit", "ttl" => "30m"}
+
+      assert [%{"content" => [text_block, image_block, file_block]}] = body["input"]
+      assert text_block["prompt_cache_breakpoint"] == %{"mode" => "explicit"}
+      assert image_block["prompt_cache_breakpoint"] == %{"mode" => "explicit"}
+      assert file_block["prompt_cache_breakpoint"] == %{"mode" => "explicit"}
+    end
+
     test "encodes tools when present" do
       tool =
         ReqLLM.Tool.new!(
@@ -1764,6 +1802,10 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
           "usage" => %{
             "input_tokens" => 10,
             "output_tokens" => 20,
+            "input_tokens_details" => %{
+              "cached_tokens" => 4,
+              "cache_write_tokens" => 6
+            },
             "output_tokens_details" => %{
               "reasoning_tokens" => 5
             }
@@ -1775,7 +1817,8 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert chunk.metadata.usage.input_tokens == 10
       assert chunk.metadata.usage.output_tokens == 20
       assert chunk.metadata.usage.total_tokens == 30
-      assert chunk.metadata.usage.cached_tokens == 0
+      assert chunk.metadata.usage.cached_tokens == 4
+      assert chunk.metadata.usage.cache_creation_tokens == 6
       assert chunk.metadata.usage.reasoning_tokens == 5
     end
 

--- a/test/providers/openai_chat_request_test.exs
+++ b/test/providers/openai_chat_request_test.exs
@@ -2,6 +2,7 @@ defmodule ReqLLM.Providers.OpenAI.ChatRequestTest do
   use ExUnit.Case, async: true
 
   alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
   alias ReqLLM.Providers.OpenAI.ChatAPI
   alias ReqLLM.Providers.OpenAI.ChatAPI.Request
   alias ReqLLM.Tool
@@ -88,5 +89,37 @@ defmodule ReqLLM.Providers.OpenAI.ChatRequestTest do
     finch_body = ReqLLM.Test.Helpers.json_body(finch_request)
 
     assert req_body == finch_body
+  end
+
+  test "encodes explicit prompt cache controls" do
+    breakpoint = %{mode: "explicit"}
+
+    context =
+      Context.new([
+        Context.system([
+          ContentPart.text("Stable instructions", %{prompt_cache_breakpoint: breakpoint})
+        ]),
+        Context.user("Dynamic request")
+      ])
+
+    body =
+      Request.build_body(
+        context,
+        "gpt-5.6",
+        [
+          provider_options: [
+            prompt_cache_key: "tenant:acme:instructions-v1",
+            prompt_cache_options: %{mode: "explicit", ttl: "30m"}
+          ]
+        ],
+        :chat
+      )
+
+    assert body.prompt_cache_key == "tenant:acme:instructions-v1"
+    assert body.prompt_cache_options == %{mode: "explicit", ttl: "30m"}
+
+    [system_message, _user_message] = body.messages
+    assert [system_block] = system_message.content
+    assert system_block.prompt_cache_breakpoint == breakpoint
   end
 end

--- a/test/providers/openai_chat_streaming_usage_test.exs
+++ b/test/providers/openai_chat_streaming_usage_test.exs
@@ -112,7 +112,12 @@ defmodule ReqLLM.Providers.OpenAI.ChatStreamingUsageTest do
 
     send_sse(server, %{
       "choices" => [%{"index" => 0, "delta" => %{}}],
-      "usage" => %{"prompt_tokens" => 12, "completion_tokens" => 8, "total_tokens" => 20}
+      "usage" => %{
+        "prompt_tokens" => 12,
+        "completion_tokens" => 8,
+        "total_tokens" => 20,
+        "prompt_tokens_details" => %{"cached_tokens" => 5, "cache_write_tokens" => 7}
+      }
     })
 
     send_done(server)
@@ -126,6 +131,8 @@ defmodule ReqLLM.Providers.OpenAI.ChatStreamingUsageTest do
     assert usage.input_tokens == 12
     assert usage.output_tokens == 8
     assert usage.total_tokens == 20
+    assert usage.cached_tokens == 5
+    assert usage.cache_creation_tokens == 7
   end
 
   defp stream_response_for(server) do

--- a/test/req_llm/generation_test.exs
+++ b/test/req_llm/generation_test.exs
@@ -99,6 +99,9 @@ defmodule ReqLLM.GenerationTest do
   defmodule SlowHTTP do
   end
 
+  defmodule CacheWriteHTTP do
+  end
+
   setup do
     # Stub HTTP responses for testing
     Req.Test.stub(ReqLLM.GenerationTest, fn conn ->
@@ -131,6 +134,54 @@ defmodule ReqLLM.GenerationTest do
       assert response.model =~ "gpt-4-turbo"
       assert is_binary(Response.text(response))
       assert String.length(Response.text(response)) > 0
+    end
+
+    test "preserves OpenAI cache writes in response usage and billing" do
+      model = %LLMDB.Model{
+        provider: :openai,
+        id: "gpt-cache-write-test",
+        pricing:
+          ReqLLM.Test.Helpers.pricing_from_cost(%{
+            input: 1.0,
+            output: 2.0,
+            cache_read: 0.1,
+            cache_write: 0.2
+          })
+      }
+
+      Req.Test.stub(CacheWriteHTTP, fn conn ->
+        Req.Test.json(conn, %{
+          "id" => "chatcmpl-cache-write",
+          "model" => model.id,
+          "choices" => [
+            %{
+              "message" => %{"role" => "assistant", "content" => "Cached"},
+              "finish_reason" => "stop"
+            }
+          ],
+          "usage" => %{
+            "prompt_tokens" => 2_000,
+            "completion_tokens" => 10,
+            "total_tokens" => 2_010,
+            "prompt_tokens_details" => %{
+              "cached_tokens" => 1_200,
+              "cache_write_tokens" => 800
+            }
+          }
+        })
+      end)
+
+      assert {:ok, response} =
+               Generation.generate_text(model, "Hello",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, CacheWriteHTTP}]
+               )
+
+      assert response.usage.cached_tokens == 1_200
+      assert response.usage.cache_creation_tokens == 800
+      assert response.usage.input_cost == 0.00028
+      assert response.usage.output_cost == 0.00002
+      assert response.usage.total_cost == 0.0003
     end
 
     test "accepts Context input format" do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -108,6 +108,31 @@ defmodule ReqLLM.Provider.DefaultsTest do
              ]
     end
 
+    test "preserves explicit prompt cache breakpoints on supported content blocks" do
+      breakpoint = %{mode: "explicit"}
+
+      message = %Message{
+        role: :user,
+        content: [
+          ContentPart.text("Stable text", %{prompt_cache_breakpoint: breakpoint}),
+          ContentPart.image_url("https://example.com/image.png", %{
+            "prompt_cache_breakpoint" => breakpoint
+          }),
+          ContentPart.file_id("file_123", %{prompt_cache_breakpoint: breakpoint})
+        ]
+      }
+
+      context = %Context{messages: [message]}
+      result = Defaults.encode_context_to_openai_format(context, "gpt-5.6")
+
+      [encoded_message] = result.messages
+
+      assert [text_block, image_block, file_block] = encoded_message.content
+      assert text_block.prompt_cache_breakpoint == breakpoint
+      assert image_block.prompt_cache_breakpoint == breakpoint
+      assert file_block.prompt_cache_breakpoint == breakpoint
+    end
+
     test "ignores non-passthrough metadata keys" do
       content_with_extra_meta = %ContentPart{
         type: :text,
@@ -551,6 +576,25 @@ defmodule ReqLLM.Provider.DefaultsTest do
         {:ok, result} = Defaults.decode_response_body_openai_format(response_data, model)
         assertion_fn.(result)
       end
+    end
+
+    test "decodes prompt cache write usage", %{model: model} do
+      response_data = %{
+        "choices" => [%{"message" => %{"content" => "Cached"}, "finish_reason" => "stop"}],
+        "usage" => %{
+          "prompt_tokens" => 2_000,
+          "completion_tokens" => 10,
+          "total_tokens" => 2_010,
+          "prompt_tokens_details" => %{
+            "cached_tokens" => 1_200,
+            "cache_write_tokens" => 800
+          }
+        }
+      }
+
+      assert {:ok, response} = Defaults.decode_response_body_openai_format(response_data, model)
+      assert response.usage.cached_tokens == 1_200
+      assert response.usage.cache_creation_tokens == 800
     end
 
     test "decodes reasoning_details to normalized structs", %{model: model} do

--- a/test/req_llm/usage_helpers_test.exs
+++ b/test/req_llm/usage_helpers_test.exs
@@ -56,6 +56,36 @@ defmodule ReqLLM.UsageHelpersTest do
       assert usage.output == 6
     end
 
+    test "preserves OpenAI cache writes across normalization" do
+      usage_maps = [
+        %{
+          input_tokens: 2_000,
+          output_tokens: 10,
+          cache_creation_tokens: 800
+        },
+        %{
+          "prompt_tokens" => 2_000,
+          "completion_tokens" => 10,
+          "prompt_tokens_details" => %{"cache_write_tokens" => 800}
+        },
+        %{
+          "input_tokens" => 2_000,
+          "output_tokens" => 10,
+          "input_tokens_details" => %{"cache_write_tokens" => 800}
+        }
+      ]
+
+      for usage_map <- usage_maps do
+        normalized = ReqLLM.Usage.normalize(usage_map)
+        renormalized = ReqLLM.Usage.normalize(normalized)
+
+        assert normalized.cache_creation == 800
+        assert normalized.cache_creation_tokens == 800
+        assert renormalized.cache_creation == 800
+        assert renormalized.cache_creation_tokens == 800
+      end
+    end
+
     test "returns zeroed canonical and alias keys for non-map values" do
       usage = ReqLLM.Usage.normalize(nil)
 


### PR DESCRIPTION
## Summary

- pass `prompt_cache_breakpoint` metadata through supported text, image, and file content blocks
- add `prompt_cache_key` and `prompt_cache_options` provider options
- support both Chat Completions and Responses request formats
- normalize OpenAI `cache_write_tokens` as `cache_creation_tokens`
- document the GPT-5.6+ usage pattern

## Impact

Applications with stable prompt prefixes can select explicit OpenAI cache boundaries and inspect both cache reads and cache writes. The new request fields are intended for GPT-5.6 and later models; older models reject explicit cache controls.

The implementation stays OpenAI-specific because provider cache policies use different request semantics.

## Validation

- focused OpenAI/default encoder suites: 211 passed
- end-to-end provider option and request encoding check
- `mix quality`
- `mix test` (4,044 of 4,046 passed; two unrelated transient failures passed with `mix test --failed`)

## Reference

- [OpenAI prompt cache breakpoints](https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints)

Closes #937