### PR TITLE
fix(minimax): preserve normalized streaming reasoning details

### DIFF
--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -514,6 +514,9 @@ defmodule ReqLLM.Providers.Minimax do
     |> Enum.map(&normalize_reasoning_detail/1)
   end
 
+  defp normalize_reasoning_detail({%ReqLLM.Message.ReasoningDetails{} = detail, _fallback_index}),
+    do: detail
+
   defp normalize_reasoning_detail({raw, fallback_index}) when is_map(raw) do
     %ReqLLM.Message.ReasoningDetails{
       text: raw["text"],

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -514,8 +514,19 @@ defmodule ReqLLM.Providers.Minimax do
     |> Enum.map(&normalize_reasoning_detail/1)
   end
 
-  defp normalize_reasoning_detail({%ReqLLM.Message.ReasoningDetails{} = detail, _fallback_index}),
-    do: detail
+  defp normalize_reasoning_detail({%ReqLLM.Message.ReasoningDetails{} = detail, fallback_index}) do
+    provider_data = normalize_provider_data(detail.provider_data)
+
+    %ReqLLM.Message.ReasoningDetails{
+      text: detail.text,
+      signature: detail.signature || provider_data["id"],
+      encrypted?: false,
+      provider: :minimax,
+      format: detail.format || "minimax-response-v1",
+      index: detail.index || fallback_index,
+      provider_data: Map.drop(provider_data, ["text", "id", "format", "index"])
+    }
+  end
 
   defp normalize_reasoning_detail({raw, fallback_index}) when is_map(raw) do
     %ReqLLM.Message.ReasoningDetails{

--- a/test/providers/minimax_test.exs
+++ b/test/providers/minimax_test.exs
@@ -362,6 +362,47 @@ defmodule ReqLLM.Providers.MinimaxTest do
       assert List.last(response.context.messages).reasoning_details ==
                response.message.reasoning_details
     end
+
+    test "stream decoding preserves reasoning details already normalized by the default decoder" do
+      event = %{
+        data: %{
+          "choices" => [
+            %{
+              "index" => 0,
+              "delta" => %{
+                "reasoning_content" => "Think",
+                "reasoning_details" => [
+                  %{
+                    "type" => "reasoning.text",
+                    "id" => "reasoning-text-1",
+                    "format" => "MiniMax-response-v1",
+                    "index" => 0,
+                    "text" => "Think"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+
+      assert [%StreamChunk{type: :thinking}, %StreamChunk{type: :meta} = metadata_chunk] =
+               Minimax.decode_stream_event(event, minimax_model())
+
+      assert [
+               %ReasoningDetails{
+                 text: "Think",
+                 signature: nil,
+                 provider: :minimax,
+                 format: "MiniMax-response-v1",
+                 index: 0,
+                 provider_data: %{
+                   "id" => "reasoning-text-1",
+                   "type" => "reasoning.text"
+                 }
+               }
+             ] = metadata_chunk.metadata.reasoning_details
+    end
   end
 
   describe "image generation" do

--- a/test/providers/minimax_test.exs
+++ b/test/providers/minimax_test.exs
@@ -363,7 +363,15 @@ defmodule ReqLLM.Providers.MinimaxTest do
                response.message.reasoning_details
     end
 
-    test "stream decoding preserves reasoning details already normalized by the default decoder" do
+    test "stream decoding matches non-streaming reasoning details" do
+      reasoning_detail = %{
+        "type" => "reasoning.text",
+        "id" => "reasoning-text-1",
+        "format" => "MiniMax-response-v1",
+        "index" => 0,
+        "text" => "Think"
+      }
+
       event = %{
         data: %{
           "choices" => [
@@ -371,15 +379,7 @@ defmodule ReqLLM.Providers.MinimaxTest do
               "index" => 0,
               "delta" => %{
                 "reasoning_content" => "Think",
-                "reasoning_details" => [
-                  %{
-                    "type" => "reasoning.text",
-                    "id" => "reasoning-text-1",
-                    "format" => "MiniMax-response-v1",
-                    "index" => 0,
-                    "text" => "Think"
-                  }
-                ]
+                "reasoning_details" => [reasoning_detail]
               }
             }
           ]
@@ -389,17 +389,35 @@ defmodule ReqLLM.Providers.MinimaxTest do
       assert [%StreamChunk{type: :thinking}, %StreamChunk{type: :meta} = metadata_chunk] =
                Minimax.decode_stream_event(event, minimax_model())
 
+      body =
+        openai_format_json_fixture(model: "MiniMax-M2.7", content: "Done")
+        |> put_in(
+          ["choices", Access.at(0), "message", "reasoning_details"],
+          [reasoning_detail]
+        )
+
+      request = %Req.Request{
+        options: [
+          context: context_fixture(),
+          model: "MiniMax-M2.7",
+          operation: :chat
+        ]
+      }
+
+      {_request, response} =
+        Minimax.decode_response({request, %Req.Response{status: 200, body: body}})
+
+      assert metadata_chunk.metadata.reasoning_details ==
+               response.body.message.reasoning_details
+
       assert [
                %ReasoningDetails{
                  text: "Think",
-                 signature: nil,
+                 signature: "reasoning-text-1",
                  provider: :minimax,
                  format: "MiniMax-response-v1",
                  index: 0,
-                 provider_data: %{
-                   "id" => "reasoning-text-1",
-                   "type" => "reasoning.text"
-                 }
+                 provider_data: %{"type" => "reasoning.text"}
                }
              ] = metadata_chunk.metadata.reasoning_details
     end


### PR DESCRIPTION
MiniMax streaming passes `reasoning_details` through the shared OpenAI-compatible decoder before the provider-specific normalization step. Those entries can therefore already be `%ReqLLM.Message.ReasoningDetails{}` structs. Since structs satisfy `is_map/1`, the existing string-key access raises `UndefinedFunctionError` during real reasoning streams.

This change preserves already-normalized entries and adds a regression test that exercises the public `decode_stream_event/2` path with the provider's actual reasoning-detail shape.

Verification:
- `mix test test/providers/minimax_test.exs` — 28 passed
- targeted formatter check — passed
- strict Credo reports only the pre-existing 121-character line in `test/support/provider_test/comprehensive.ex:366`