### PR TITLE
fix(google): stop reporting non-streaming aborts as a clean stop

### DIFF
--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1761,12 +1761,6 @@ defmodule ReqLLM.Providers.Google do
             "finish_reason" => normalize_google_finish_reason(finish_reason)
           }
 
-        # A candidate can carry a finishReason and no "content" key at all:
-        # Gemini does this when it aborts before producing anything, e.g.
-        # UNEXPECTED_TOOL_CALL or MALFORMED_FUNCTION_CALL on the non-streaming
-        # endpoint. Without this clause it fell through to the catch-all below
-        # and was reported as a clean "stop", so a provider abort was
-        # indistinguishable from an empty but successful answer.
         %{"finishReason" => finish_reason} when is_binary(finish_reason) ->
           %{
             "message" => %{"role" => "assistant", "content" => ""},

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1444,10 +1444,13 @@ defmodule ReqLLM.Providers.Google do
                   }
               end
 
+            response_with_raw_finish =
+              put_raw_finish_provider_meta(response_with_grounding, body)
+
             merged_response =
               ReqLLM.Context.merge_response(
                 req.options[:context] || %ReqLLM.Context{messages: []},
-                response_with_grounding
+                response_with_raw_finish
               )
 
             {req, %{resp | body: merged_response}}
@@ -1758,6 +1761,18 @@ defmodule ReqLLM.Providers.Google do
             "finish_reason" => normalize_google_finish_reason(finish_reason)
           }
 
+        # A candidate can carry a finishReason and no "content" key at all:
+        # Gemini does this when it aborts before producing anything, e.g.
+        # UNEXPECTED_TOOL_CALL or MALFORMED_FUNCTION_CALL on the non-streaming
+        # endpoint. Without this clause it fell through to the catch-all below
+        # and was reported as a clean "stop", so a provider abort was
+        # indistinguishable from an empty but successful answer.
+        %{"finishReason" => finish_reason} when is_binary(finish_reason) ->
+          %{
+            "message" => %{"role" => "assistant", "content" => ""},
+            "finish_reason" => normalize_google_finish_reason(finish_reason)
+          }
+
         _ ->
           %{
             "message" => %{"role" => "assistant", "content" => ""},
@@ -1774,6 +1789,32 @@ defmodule ReqLLM.Providers.Google do
 
   defp convert_google_to_openai_format(body) when is_map(body), do: body
   defp convert_google_to_openai_format(_body), do: %{}
+
+  # Non-streaming counterpart of put_raw_finish_meta/3. Normalization collapses
+  # the abort reasons into "error" (or, before the clause above, into "stop"),
+  # so without this the caller cannot tell UNEXPECTED_TOOL_CALL from any other
+  # failure on this path — the streaming path has carried the raw value since
+  # the finish-reason-preservation commit.
+  defp put_raw_finish_provider_meta(%ReqLLM.Response{} = response, body) when is_map(body) do
+    case body do
+      %{"candidates" => [%{"finishReason" => raw} | _]} when is_binary(raw) ->
+        meta = Map.put(response.provider_meta, "finish_reason_raw", raw)
+
+        meta =
+          case body do
+            %{"candidates" => [%{"finishMessage" => message} | _]} when is_binary(message) ->
+              Map.put(meta, "finish_message", message)
+
+            _ ->
+              meta
+          end
+
+        %{response | provider_meta: meta}
+
+      _ ->
+        response
+    end
+  end
 
   defp convert_google_json_mode_to_openai_format(%{"candidates" => candidates} = body) do
     choice =

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1734,6 +1734,33 @@ defmodule ReqLLM.Providers.GoogleTest do
       end
     end
 
+    # Body captured verbatim from gemini-2.5-pro on the non-streaming endpoint
+    # with no tools declared: the candidate carries only a finishReason and no
+    # "content" key. This used to fall through to the catch-all and report
+    # "stop", making a provider abort look like a successful empty answer.
+    test "non-streaming abort with no content keeps its reason and raw name" do
+      google_response = %{
+        "candidates" => [%{"finishReason" => "UNEXPECTED_TOOL_CALL", "index" => 0}],
+        "usageMetadata" => %{"promptTokenCount" => 22, "totalTokenCount" => 22},
+        "modelVersion" => "gemini-2.5-pro"
+      }
+
+      mock_resp = %Req.Response{status: 200, body: google_response}
+      {:ok, model} = ReqLLM.model("google:gemini-2.5-pro")
+
+      mock_req = %Req.Request{
+        options: [context: context_fixture(), stream: false, model: model.model]
+      }
+
+      {_req, resp} = Google.decode_response({mock_req, mock_resp})
+
+      refute ReqLLM.Response.finish_reason(resp.body) == :stop,
+             "an abort must not be reported as a clean stop"
+
+      assert ReqLLM.Response.finish_reason(resp.body) == :error
+      assert resp.body.provider_meta["finish_reason_raw"] == "UNEXPECTED_TOOL_CALL"
+    end
+
     test "usageMetadata alone still has no finish_reason (unchanged)", %{model: model} do
       event = %{
         data: %{

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1740,7 +1740,13 @@ defmodule ReqLLM.Providers.GoogleTest do
     # "stop", making a provider abort look like a successful empty answer.
     test "non-streaming abort with no content keeps its reason and raw name" do
       google_response = %{
-        "candidates" => [%{"finishReason" => "UNEXPECTED_TOOL_CALL", "index" => 0}],
+        "candidates" => [
+          %{
+            "finishReason" => "UNEXPECTED_TOOL_CALL",
+            "finishMessage" => "Unexpected tool call",
+            "index" => 0
+          }
+        ],
         "usageMetadata" => %{"promptTokenCount" => 22, "totalTokenCount" => 22},
         "modelVersion" => "gemini-2.5-pro"
       }
@@ -1759,6 +1765,7 @@ defmodule ReqLLM.Providers.GoogleTest do
 
       assert ReqLLM.Response.finish_reason(resp.body) == :error
       assert resp.body.provider_meta["finish_reason_raw"] == "UNEXPECTED_TOOL_CALL"
+      assert resp.body.provider_meta["finish_message"] == "Unexpected tool call"
     end
 
     test "usageMetadata alone still has no finish_reason (unchanged)", %{model: model} do


### PR DESCRIPTION
## Description

On the non-streaming endpoint a Gemini candidate can arrive carrying only a `finishReason`, with no `content` key at all — Gemini does this when it aborts before producing anything. `UNEXPECTED_TOOL_CALL` reproduces ~9 times out of 10 against `gemini-2.5-pro` with no tools declared, and `MALFORMED_FUNCTION_CALL` turns up there too.

That shape matched neither content-bearing clause in `convert_google_to_openai_format/1`, so it fell through to the catch-all and was reported as `finish_reason: "stop"`: a provider abort was indistinguishable from an empty but successful answer, and the raw reason was discarded before any caller could see it.

This adds the missing clause so the reason is normalized like every other, and carries `finish_reason_raw` (plus `finish_message` when present) in `provider_meta` — the non-streaming counterpart of `put_raw_finish_meta/3`. The streaming path has preserved the raw value since #936; this closes the same hole on the path tool-less requests actually use.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None in the API surface. Behaviour changes for the specific case that was previously mis-reported: a content-less candidate with a `finishReason` now yields the normalized reason (`"error"`, or `"content_filter"` for the policy stops from #939) instead of `"stop"`. Candidates that carry content are untouched.

## Testing

- [x] Tests pass (`mix test`, 4051 passed, 11 skipped)
- [x] Quality checks pass (`mix quality`, dialyzer clean, credo --strict clean)

New test covers the content-less abort candidate: normalized reason plus `finish_reason_raw`/`finish_message` in `provider_meta`. It fails without the lib change.

`mix mc "google:*"` is unchanged from `main` (2/33 active models locally — fixture availability, not a regression):

```
Summary: 2/33 active models tested (6.1% coverage)
Overall Coverage: 2/33 active models passing (6.1%) in 23s
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #944

Completes the Google finish-reason work from #936 (streaming raw reason) and #939 (policy stop mapping) by covering the non-streaming path.