### PR TITLE
feat(openrouter): forward Google safety settings to Gemini models

### DIFF
--- a/guides/openrouter.md
+++ b/guides/openrouter.md
@@ -124,6 +124,32 @@ ReqLLM.generate_text("openrouter:anthropic/claude-sonnet-4-20250514", context,
 
 Without `file-parser`, ReqLLM uses the same file encoding and lets OpenRouter select the PDF processing engine.
 
+### Safety Settings (Google Models)
+
+#### `openrouter_safety_settings`
+- **Type**: List of maps
+- **Purpose**: Set Google's per-category content filters on Gemini models routed through OpenRouter
+- **Example**: `provider_options: [openrouter_safety_settings: [%{category: "HARM_CATEGORY_HARASSMENT", threshold: "OFF"}]]`
+
+OpenRouter forwards the top-level `safety_settings` body field to Google, so the
+same categories and thresholds accepted by the Gemini API apply here. This works
+on both of OpenRouter's Google upstreams (`google-ai-studio` and `google-vertex`).
+
+```elixir
+safety_settings =
+  Enum.map(
+    ~w(HARM_CATEGORY_HARASSMENT HARM_CATEGORY_HATE_SPEECH
+       HARM_CATEGORY_SEXUALLY_EXPLICIT HARM_CATEGORY_DANGEROUS_CONTENT),
+    &%{category: &1, threshold: "BLOCK_ONLY_HIGH"}
+  )
+
+ReqLLM.generate_text("openrouter:google/gemini-2.5-flash", "Write a battle scene.",
+  provider_options: [openrouter_safety_settings: safety_settings]
+)
+```
+
+The option is ignored by non-Google models.
+
 ### App Attribution
 
 #### `app_referer`

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -22,6 +22,7 @@ defmodule ReqLLM.Providers.OpenRouter do
   - `openrouter_usage` - Usage options (e.g., `%{include: true}`)
   - `openrouter_plugins` - Array of plugins (e.g., `[%{id: "web"}]`)
   - `openrouter_session_id` - Session ID for grouping related requests in OpenRouter
+  - `openrouter_safety_settings` - Google safety filter settings, forwarded to Gemini models
   - `app_referer` - HTTP-Referer header for app identification
   - `app_title` - X-Title header for app title in rankings
 
@@ -116,6 +117,11 @@ defmodule ReqLLM.Providers.OpenRouter do
     openrouter_session_id: [
       type: :string,
       doc: "OpenRouter session ID for grouping related LLM calls"
+    ],
+    openrouter_safety_settings: [
+      type: {:list, :map},
+      doc:
+        "Google safety filter settings, forwarded to Gemini models as the top-level `safety_settings` body field"
     ],
     dimensions: [
       type: :pos_integer,
@@ -401,6 +407,7 @@ defmodule ReqLLM.Providers.OpenRouter do
     |> maybe_put(:usage, request.options[:openrouter_usage])
     |> maybe_put(:plugins, request.options[:openrouter_plugins])
     |> maybe_put(:session_id, request.options[:openrouter_session_id])
+    |> maybe_put(:safety_settings, request.options[:openrouter_safety_settings])
     |> add_openrouter_specific_options(request.options)
     |> add_stream_options(request.options)
   end

--- a/test/providers/openrouter_test.exs
+++ b/test/providers/openrouter_test.exs
@@ -361,6 +361,45 @@ defmodule ReqLLM.Providers.OpenRouterTest do
       assert decoded["plugins"] == [%{"id" => "web"}, %{"id" => "code"}]
     end
 
+    test "encode_body with openrouter_safety_settings option" do
+      {:ok, model} = ReqLLM.model("openrouter:google/gemini-2.5-flash")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [
+          context: context,
+          model: model.model,
+          stream: false,
+          openrouter_safety_settings: [
+            %{category: "HARM_CATEGORY_HARASSMENT", threshold: "OFF"},
+            %{category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH"}
+          ]
+        ]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      assert decoded["safety_settings"] == [
+               %{"category" => "HARM_CATEGORY_HARASSMENT", "threshold" => "OFF"},
+               %{"category" => "HARM_CATEGORY_HATE_SPEECH", "threshold" => "BLOCK_ONLY_HIGH"}
+             ]
+    end
+
+    test "encode_body omits safety_settings when openrouter_safety_settings is absent" do
+      {:ok, model} = ReqLLM.model("openrouter:google/gemini-2.5-flash")
+      context = context_fixture()
+
+      mock_request = %Req.Request{
+        options: [context: context, model: model.model, stream: false]
+      }
+
+      updated_request = OpenRouter.encode_body(mock_request)
+      decoded = ReqLLM.Test.Helpers.json_body(updated_request)
+
+      refute Map.has_key?(decoded, "safety_settings")
+    end
+
     test "encode_body with file-parser plugin encodes PDF files in OpenRouter format" do
       {:ok, model} = ReqLLM.model("openrouter:openai/gpt-4")
       pdf_data = "%PDF test"


### PR DESCRIPTION
## Description

Adds an `openrouter_safety_settings` provider option that encodes to OpenRouter's top-level `safety_settings` body field, letting Gemini models routed through OpenRouter configure Google's content filters the same way `google_safety_settings` does on the Google provider.

Without it there is no way to reach that field — the OpenRouter provider has no safety option and no generic body passthrough — so these models always run with Google's defaults.

Implementation follows the existing `openrouter_*` passthrough pattern exactly: one schema entry, one `maybe_put/3` in `build_body/1`.

Closes #946

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. The option is optional and omitted from the body when unset (covered by a test).

## Testing

- [x] Tests pass (`mix test`) — `4052 passed, 11 skipped, 150 excluded`
- [x] Quality checks pass (`mix quality`) — format, `--warnings-as-errors`, dialyzer `Total errors: 0`, credo --strict

### Live verification

Verified end-to-end through the patched library against the live OpenRouter API, since a passthrough option that is silently dropped would still pass every mocked test. `google/gemini-3-flash-preview`, routing pinned to `google-ai-studio`, heavy-profanity creative-writing prompt, n=3 per arm:

```
===== arm: absent =====
  run1: finish=:stop chars=831
  run2: finish=:stop chars=950
  run3: finish=:stop chars=927
===== arm: STRICT (BLOCK_LOW_AND_ABOVE) =====
  run1: finish=:error chars=0
  run2: finish=:error chars=0
  run3: finish=:error chars=0
===== arm: OFF =====
  run1: finish=:stop chars=921
  run2: finish=:stop chars=930
  run3: finish=:stop chars=809
```

The strict arm blocks where the other two generate, so the field is genuinely reaching Google. Also confirmed the nested forms (`provider.google.safety_settings`, `extra_body.safety_settings`) are silently dropped by OpenRouter — only the top-level field works — and that both `google-ai-studio` and `google-vertex` upstreams honour it.

### `mix mc "openrouter:*"`

```
Summary: 0/375 active models tested (0.0% coverage)
Overall Coverage: 0/375 active models passing (0.0%) in 181.8s
```

Every model reports `** (RuntimeError) Fixture not found: test/support/fixtures/openrouter/...`. This is pre-existing and not caused by this change — I ran the identical command on unpatched `upstream/main` in a separate worktree and got the same result:

```
Summary: 0/375 active models tested (0.0% coverage)
Overall Coverage: 0/375 active models passing (0.0%) in 211.7s
```

The OpenRouter fixtures aren't in the repo, so I can't produce a passing local run. Happy to record fixtures if you'd like them, though this option doesn't change the response shape — it only adds an optional request-body field — so the existing mocked provider tests are where the behaviour is actually pinned.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

### Provider Feature Extension checklist

- [x] Feature implemented in provider module
- [ ] Fixtures generated for new feature — see the `mix mc` note above
- [x] Tests added covering new functionality (encodes when set, omitted when absent)
- [x] Model compatibility unchanged for the affected provider (identical to `main`)
- [x] Quality checks pass (`mix quality`)
- [x] Documentation updated — `guides/openrouter.md` and the provider `@moduledoc`
- [x] Example usage added to the OpenRouter guide

## Related Issues

Closes #946

---

One observation, out of scope here: when Google blocks via OpenRouter the response surfaces as `finish_reason: :error` rather than `:content_filter`, unlike the Google provider after #939. Happy to open a separate issue/PR for that mapping if you'd want it.
