### PR TITLE
feat(google_vertex): support multi-region (us/eu) endpoints

### DIFF
--- a/guides/google_vertex.md
+++ b/guides/google_vertex.md
@@ -104,6 +104,7 @@ Passed via `:provider_options` keyword:
 - **Fallback**: `config :req_llm, :google_vertex`, then `GOOGLE_CLOUD_REGION` env var
 - **Example**: `provider_options: [region: "us-central1"]`
 - **Note**: Use `"global"` for newest models, specific regions for regional deployment
+- **Multi-region**: `"us"` or `"eu"` select Agent Platform (fka Vertex AI) multi-region endpoints, served from the `aiplatform.{us,eu}.rep.googleapis.com` (see [AI Platform - locations](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations))
 
 ### `additional_model_request_fields`
 

--- a/lib/req_llm/providers/google_vertex.ex
+++ b/lib/req_llm/providers/google_vertex.ex
@@ -206,6 +206,11 @@ defmodule ReqLLM.Providers.GoogleVertex do
   @vertex_base_url_global "https://aiplatform.googleapis.com"
   @vertex_base_url_regional "https://{region}-aiplatform.googleapis.com"
 
+  # Vertex AI multi-region endpoints use host to match jurisdictional boundaries
+  # https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations
+  @vertex_base_url_multi_region "https://aiplatform.{region}.rep.googleapis.com"
+  @multi_region_locations ~w(us eu)
+
   # Model family to formatter module mapping
   @model_families %{
     "claude" => ReqLLM.Providers.GoogleVertex.Anthropic,
@@ -652,13 +657,19 @@ defmodule ReqLLM.Providers.GoogleVertex do
     raise ArgumentError, "No model path builder for Vertex AI model family: #{family}"
   end
 
-  # Build base URL based on region
+  # Build base URL based on region/location.
+  #
+  #   * "global"        -> the global endpoint
+  #   * "us" / "eu"     -> the multi-region endpoints
+  #   * any other value -> a specific regional endpoint (e.g. "us-east5")
+  defp build_base_url("global"), do: @vertex_base_url_global
+
+  defp build_base_url(region) when region in @multi_region_locations do
+    String.replace(@vertex_base_url_multi_region, "{region}", region)
+  end
+
   defp build_base_url(region) do
-    if region == "global" do
-      @vertex_base_url_global
-    else
-      String.replace(@vertex_base_url_regional, "{region}", region)
-    end
+    String.replace(@vertex_base_url_regional, "{region}", region)
   end
 
   # Process and validate options (shared between do_prepare_request and attach_stream)

--- a/test/providers/google_vertex_config_test.exs
+++ b/test/providers/google_vertex_config_test.exs
@@ -176,6 +176,68 @@ defmodule ReqLLM.Providers.GoogleVertex.ConfigTest do
     end
   end
 
+  describe "endpoint host selection by region" do
+    test "global region uses the global endpoint host" do
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(:chat, model, context_fixture(),
+          project_id: "config-project",
+          region: "global"
+        )
+
+      url = URI.to_string(request.url)
+
+      assert url =~ "https://aiplatform.googleapis.com"
+      assert url =~ "locations/global"
+    end
+
+    test "us multi-region uses the REP host" do
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(:chat, model, context_fixture(),
+          project_id: "config-project",
+          region: "us"
+        )
+
+      url = URI.to_string(request.url)
+
+      assert url =~ "https://aiplatform.us.rep.googleapis.com"
+      assert url =~ "locations/us/"
+    end
+
+    test "eu multi-region uses the REP host" do
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(:chat, model, context_fixture(),
+          project_id: "config-project",
+          region: "eu"
+        )
+
+      url = URI.to_string(request.url)
+
+      assert url =~ "https://aiplatform.eu.rep.googleapis.com"
+      assert url =~ "locations/eu/"
+    end
+
+    test "a specific region still uses the regional host" do
+      {:ok, model} = ReqLLM.model("google_vertex:gemini-2.5-pro")
+
+      {:ok, request} =
+        GoogleVertex.prepare_request(:chat, model, context_fixture(),
+          project_id: "config-project",
+          region: "us-east5"
+        )
+
+      url = URI.to_string(request.url)
+
+      assert url =~ "https://us-east5-aiplatform.googleapis.com"
+      assert url =~ "locations/us-east5/"
+    end
+  end
+
   defp context_fixture do
     Context.new([Context.user("Hello")])
   end


### PR DESCRIPTION
## Summary

Adds support for Vertex AI **multi-region endpoints** to the `google_vertex` provider.

Vertex AI offers three endpoint types: `global`, specific regional (e.g. `us-east5`), and **multi-region** (`us` / `eu`). The multi-region endpoints are served from a distinct **REP** host — `aiplatform.us.rep.googleapis.com` / `aiplatform.eu.rep.googleapis.com` — which does **not** follow the existing `{region}-aiplatform.googleapis.com` pattern, so today passing `region: "us"` builds an invalid host (`us-aiplatform.googleapis.com`).

This recognises the `us` and `eu` location values and builds the REP host for them. `global` and specific regional endpoints are unchanged, and the `locations/{region}` path segment the provider already builds is correct for all three.

Docs: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations

## Changes

- `build_base_url/1`: route `us` / `eu` to `aiplatform.{region}.rep.googleapis.com`; `global` and specific regions unchanged.
- Tests: added coverage for `global`, `us` (REP), `eu` (REP), and a specific region in `google_vertex_config_test.exs`.
- Docs: documented the multi-region option in `guides/google_vertex.md`.

## Usage

```elixir
ReqLLM.generate_text("google_vertex:gemini-2.5-pro", ctx, provider_options: [region: "us"])
ReqLLM.generate_text("google_vertex:claude-opus-4-6", ctx, provider_options: [region: "eu"])
```

## Checks (per CONTRIBUTING.md)

- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean
- `mix credo --strict` — no issues (8347 mods/funs)
- `mix dialyzer` — no warnings from `google_vertex`; the 2 warnings in `lib/req_llm/compatibility/provider_drift.ex` pre-exist on `main` (untouched here)
- `mix test test/providers/google_vertex_config_test.exs` — 13 tests, 0 failures
- **CHANGELOG.md** — not edited (auto-generated by `git_ops` from the Conventional Commit at release).
- `mix mc "google_vertex:*"` — not recorded: model-compatibility fixtures require live GCP credentials, and this change only affects base-URL host selection (not model behaviour), so existing compatibility is unchanged.