### PR TITLE
fix: use current Req Finch options

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -407,10 +407,9 @@ defmodule ReqLLM.Provider.Defaults do
             method: :post,
             base_url: Keyword.get(opts, :base_url, provider_mod.default_base_url()),
             receive_timeout: timeout,
-            pool_timeout: timeout,
             form_multipart: form_parts,
             auth: {:bearer, api_key}
-          ] ++ http_opts
+          ] ++ default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
         |> ReqLLM.Step.Retry.attach(opts)
@@ -495,12 +494,11 @@ defmodule ReqLLM.Provider.Defaults do
             method: :post,
             base_url: Keyword.get(opts, :base_url, provider_mod.default_base_url()),
             receive_timeout: timeout,
-            pool_timeout: timeout,
             body: Jason.encode!(body),
             auth: {:bearer, api_key},
             # Disable Req's automatic JSON decoding — response is raw audio binary
             decode_body: false
-          ] ++ http_opts
+          ] ++ default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
@@ -593,9 +591,21 @@ defmodule ReqLLM.Provider.Defaults do
     |> ReqLLM.Step.Fixture.maybe_attach(model, user_opts)
   end
 
-  @spec finch_option(Req.Request.t()) :: keyword()
-  def finch_option(%Req.Request{} = request) do
-    [finch: request.options[:finch] || ReqLLM.Application.finch_name()]
+  @spec default_finch_option(keyword()) :: keyword()
+  def default_finch_option(options \\ []) do
+    [finch: Keyword.put_new(options, :name, ReqLLM.Application.finch_name())]
+  end
+
+  @spec finch_option(Req.Request.t(), keyword()) :: keyword()
+  def finch_option(%Req.Request{} = request, options \\ []) do
+    current_options =
+      case request.options[:finch] do
+        nil -> [name: ReqLLM.Application.finch_name()]
+        name when is_atom(name) -> [name: name]
+        options when is_list(options) -> options
+      end
+
+    [finch: Keyword.merge(current_options, options)]
   end
 
   @doc """

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -409,7 +409,7 @@ defmodule ReqLLM.Provider.Defaults do
             receive_timeout: timeout,
             form_multipart: form_parts,
             auth: {:bearer, api_key}
-          ] ++ default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
         |> ReqLLM.Step.Retry.attach(opts)
@@ -498,7 +498,7 @@ defmodule ReqLLM.Provider.Defaults do
             auth: {:bearer, api_key},
             # Disable Req's automatic JSON decoding — response is raw audio binary
             decode_body: false
-          ] ++ default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")
@@ -591,22 +591,25 @@ defmodule ReqLLM.Provider.Defaults do
     |> ReqLLM.Step.Fixture.maybe_attach(model, user_opts)
   end
 
-  @spec default_finch_option(keyword()) :: keyword()
-  def default_finch_option(options \\ []) do
-    [finch: Keyword.put_new(options, :name, ReqLLM.Application.finch_name())]
+  @spec merge_finch_options(keyword(), keyword()) :: keyword()
+  def merge_finch_options(request_options, defaults \\ []) do
+    {finch, request_options} = Keyword.pop(request_options, :finch)
+    finch_options = Keyword.merge(defaults, normalize_finch_options(finch))
+
+    Keyword.put(request_options, :finch, finch_options)
   end
 
   @spec finch_option(Req.Request.t(), keyword()) :: keyword()
   def finch_option(%Req.Request{} = request, options \\ []) do
     current_options =
-      case request.options[:finch] do
-        nil -> [name: ReqLLM.Application.finch_name()]
-        name when is_atom(name) -> [name: name]
-        options when is_list(options) -> options
-      end
+      normalize_finch_options(request.options[:finch])
 
     [finch: Keyword.merge(current_options, options)]
   end
+
+  defp normalize_finch_options(nil), do: [name: ReqLLM.Application.finch_name()]
+  defp normalize_finch_options(name) when is_atom(name), do: [name: name]
+  defp normalize_finch_options(options) when is_list(options), do: options
 
   @doc """
   Fetches API key and extra common option keys.

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -215,9 +215,8 @@ defmodule ReqLLM.Providers.Anthropic do
             base_url: base_url,
             url: request_path(plan),
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ http_opts
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/anthropic.ex
+++ b/lib/req_llm/providers/anthropic.ex
@@ -216,7 +216,7 @@ defmodule ReqLLM.Providers.Anthropic do
             url: request_path(plan),
             method: :post,
             receive_timeout: timeout
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/elevenlabs.ex
+++ b/lib/req_llm/providers/elevenlabs.ex
@@ -112,7 +112,7 @@ defmodule ReqLLM.Providers.ElevenLabs do
             receive_timeout: timeout,
             body: Jason.encode!(body),
             decode_body: false
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("xi-api-key", api_key)
@@ -162,7 +162,7 @@ defmodule ReqLLM.Providers.ElevenLabs do
             params: transcription_query_params(provider_options),
             receive_timeout: timeout,
             form_multipart: form_parts
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.put_header("xi-api-key", api_key)
         |> ReqLLM.Step.Retry.attach(opts)

--- a/lib/req_llm/providers/elevenlabs.ex
+++ b/lib/req_llm/providers/elevenlabs.ex
@@ -110,10 +110,9 @@ defmodule ReqLLM.Providers.ElevenLabs do
             base_url: Keyword.get(opts, :base_url, default_base_url()),
             params: [output_format: format_string],
             receive_timeout: timeout,
-            pool_timeout: timeout,
             body: Jason.encode!(body),
             decode_body: false
-          ] ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("xi-api-key", api_key)
@@ -162,9 +161,8 @@ defmodule ReqLLM.Providers.ElevenLabs do
             base_url: Keyword.get(opts, :base_url, default_base_url()),
             params: transcription_query_params(provider_options),
             receive_timeout: timeout,
-            pool_timeout: timeout,
             form_multipart: form_parts
-          ] ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.put_header("xi-api-key", api_key)
         |> ReqLLM.Step.Retry.attach(opts)

--- a/lib/req_llm/providers/google_vertex/auth.ex
+++ b/lib/req_llm/providers/google_vertex/auth.ex
@@ -201,7 +201,7 @@ defmodule ReqLLM.Providers.GoogleVertex.Auth do
 
     request =
       Req.new(
-        finch: ReqLLM.Application.finch_name(),
+        finch: [name: ReqLLM.Application.finch_name()],
         url: @token_uri,
         method: :post,
         body: body,

--- a/lib/req_llm/providers/meta.ex
+++ b/lib/req_llm/providers/meta.ex
@@ -226,8 +226,10 @@ defmodule ReqLLM.Providers.Meta do
             method: :post,
             receive_timeout: timeout
           ] ++
-            ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++
-            Keyword.get(opts, :req_http_options, [])
+            ReqLLM.Provider.Defaults.merge_finch_options(
+              Keyword.get(opts, :req_http_options, []),
+              pool_timeout: timeout
+            )
         )
         |> Req.Request.register_options(request_option_keys())
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/meta.ex
+++ b/lib/req_llm/providers/meta.ex
@@ -224,9 +224,10 @@ defmodule ReqLLM.Providers.Meta do
           [
             url: ResponsesAPI.path(),
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ Keyword.get(opts, :req_http_options, [])
+            receive_timeout: timeout
+          ] ++
+            ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++
+            Keyword.get(opts, :req_http_options, [])
         )
         |> Req.Request.register_options(request_option_keys())
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -110,9 +110,8 @@ defmodule ReqLLM.Providers.Minimax do
           [
             url: path,
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ http_opts
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -111,7 +111,7 @@ defmodule ReqLLM.Providers.Minimax do
             url: path,
             method: :post,
             receive_timeout: timeout
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -417,8 +417,8 @@ defmodule ReqLLM.Providers.OpenAI do
             method: :post,
             receive_timeout: timeout
           ] ++
-            ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++
-            form_multipart_options ++ http_opts
+            form_multipart_options ++
+            ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(image_options)
@@ -466,7 +466,7 @@ defmodule ReqLLM.Providers.OpenAI do
             url: path,
             method: :post,
             receive_timeout: timeout
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(
@@ -532,8 +532,8 @@ defmodule ReqLLM.Providers.OpenAI do
             receive_timeout: timeout,
             form_multipart: form_parts
           ] ++
-            ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++
-            auth_req_options(credential) ++ http_opts
+            auth_req_options(credential) ++
+            ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> maybe_put_authorization_header(credential)
         |> ReqLLM.Step.Retry.attach(opts)

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -415,9 +415,10 @@ defmodule ReqLLM.Providers.OpenAI do
           [
             url: path,
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ form_multipart_options ++ http_opts
+            receive_timeout: timeout
+          ] ++
+            ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++
+            form_multipart_options ++ http_opts
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(image_options)
@@ -464,9 +465,8 @@ defmodule ReqLLM.Providers.OpenAI do
           [
             url: path,
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ http_opts
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(
@@ -530,9 +530,10 @@ defmodule ReqLLM.Providers.OpenAI do
             method: :post,
             base_url: Keyword.get(opts, :base_url, base_url()),
             receive_timeout: timeout,
-            pool_timeout: timeout,
             form_multipart: form_parts
-          ] ++ auth_req_options(credential) ++ http_opts
+          ] ++
+            ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++
+            auth_req_options(credential) ++ http_opts
         )
         |> maybe_put_authorization_header(credential)
         |> ReqLLM.Step.Retry.attach(opts)

--- a/lib/req_llm/providers/openai/files.ex
+++ b/lib/req_llm/providers/openai/files.ex
@@ -344,9 +344,11 @@ defmodule ReqLLM.Providers.OpenAI.Files do
           base_url: Keyword.get(opts, :base_url, OpenAI.base_url()),
           receive_timeout: receive_timeout
         ] ++
-          ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: receive_timeout) ++
           Keyword.take(request_opts, [:form_multipart, :params]) ++
-          OpenAI.auth_req_options(credential) ++ http_opts
+          OpenAI.auth_req_options(credential) ++
+          ReqLLM.Provider.Defaults.merge_finch_options(http_opts,
+            pool_timeout: receive_timeout
+          )
 
       request =
         Req.new(request_options)

--- a/lib/req_llm/providers/openai/files.ex
+++ b/lib/req_llm/providers/openai/files.ex
@@ -342,9 +342,9 @@ defmodule ReqLLM.Providers.OpenAI.Files do
           method: method,
           url: path,
           base_url: Keyword.get(opts, :base_url, OpenAI.base_url()),
-          receive_timeout: receive_timeout,
-          pool_timeout: receive_timeout
+          receive_timeout: receive_timeout
         ] ++
+          ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: receive_timeout) ++
           Keyword.take(request_opts, [:form_multipart, :params]) ++
           OpenAI.auth_req_options(credential) ++ http_opts
 

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -158,9 +158,8 @@ defmodule ReqLLM.Providers.OpenAICodex do
           [
             url: codex_path(),
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ http_opts
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -159,7 +159,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
             url: codex_path(),
             method: :post,
             receive_timeout: timeout
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -244,10 +244,9 @@ defmodule ReqLLM.Providers.OpenRouter do
             method: :post,
             base_url: Keyword.get(opts, :base_url, base_url()),
             receive_timeout: timeout,
-            pool_timeout: timeout,
             json: body,
             auth: {:bearer, api_key}
-          ] ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")

--- a/lib/req_llm/providers/openrouter.ex
+++ b/lib/req_llm/providers/openrouter.ex
@@ -246,7 +246,7 @@ defmodule ReqLLM.Providers.OpenRouter do
             receive_timeout: timeout,
             json: body,
             auth: {:bearer, api_key}
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.put_header("content-type", "application/json")
         |> Req.Request.put_header("authorization", "Bearer #{api_key}")

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -243,9 +243,8 @@ defmodule ReqLLM.Providers.XAI do
           [
             url: path,
             method: :post,
-            receive_timeout: timeout,
-            pool_timeout: timeout
-          ] ++ http_opts
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -244,7 +244,7 @@ defmodule ReqLLM.Providers.XAI do
             url: path,
             method: :post,
             receive_timeout: timeout
-          ] ++ ReqLLM.Provider.Defaults.default_finch_option(pool_timeout: timeout) ++ http_opts
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
         )
         |> Req.Request.register_options(req_keys)
         |> Req.Request.merge_options(

--- a/lib/req_llm/providers/zai/shared.ex
+++ b/lib/req_llm/providers/zai/shared.ex
@@ -41,7 +41,9 @@ defmodule ReqLLM.Providers.Zai.Shared do
       |> Map.update!(:options, fn opts ->
         opts
         |> Map.put(:receive_timeout, timeout)
-        |> Map.put(:pool_timeout, timeout)
+        |> Map.merge(
+          Map.new(ReqLLM.Provider.Defaults.finch_option(request, pool_timeout: timeout))
+        )
       end)
 
     ReqLLM.Provider.Defaults.default_attach(

--- a/lib/req_llm/providers/zai_coding_plan.ex
+++ b/lib/req_llm/providers/zai_coding_plan.ex
@@ -77,7 +77,9 @@ defmodule ReqLLM.Providers.ZaiCodingPlan do
       |> Map.update!(:options, fn opts ->
         opts
         |> Map.put(:receive_timeout, timeout)
-        |> Map.put(:pool_timeout, timeout)
+        |> Map.merge(
+          Map.new(ReqLLM.Provider.Defaults.finch_option(request, pool_timeout: timeout))
+        )
       end)
 
     ReqLLM.Provider.Defaults.default_attach(__MODULE__, updated_request, model_input, user_opts)

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -91,7 +91,7 @@ defmodule ReqLLM.Providers.AzureTest do
           req_http_options: [finch: :custom_finch]
         )
 
-      assert request.options[:finch] == :custom_finch
+      assert request.options[:finch] == [name: :custom_finch]
     end
 
     test "embedding operation uses correct endpoint" do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -82,7 +82,7 @@ defmodule ReqLLM.Providers.OpenAITest do
       {:ok, request} =
         OpenAI.prepare_request(:chat, model, context, req_http_options: [finch: :custom_finch])
 
-      assert request.options[:finch] == :custom_finch
+      assert request.options[:finch] == [name: :custom_finch]
     end
 
     test "prepare_request honors caller retry limits in chat and object pipelines" do

--- a/test/providers/openai_test.exs
+++ b/test/providers/openai_test.exs
@@ -75,14 +75,19 @@ defmodule ReqLLM.Providers.OpenAITest do
       assert request.method == :post
     end
 
-    test "prepare_request preserves custom finch from req_http_options" do
+    test "prepare_request merges custom Finch options with the request timeout" do
       {:ok, model} = ReqLLM.model("openai:gpt-4-turbo")
       context = context_fixture()
 
       {:ok, request} =
-        OpenAI.prepare_request(:chat, model, context, req_http_options: [finch: :custom_finch])
+        OpenAI.prepare_request(:chat, model, context,
+          receive_timeout: 45_000,
+          req_http_options: [finch: [name: :custom_finch, pool_tag: :bulk]]
+        )
 
-      assert request.options[:finch] == [name: :custom_finch]
+      assert request.options[:finch][:name] == :custom_finch
+      assert request.options[:finch][:pool_tag] == :bulk
+      assert request.options[:finch][:pool_timeout] == 45_000
     end
 
     test "prepare_request honors caller retry limits in chat and object pipelines" do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -11,8 +11,39 @@ defmodule ReqLLM.Provider.DefaultsTest do
 
   describe "Finch options" do
     test "builds current Req options for the application pool and timeout" do
-      assert Defaults.default_finch_option(pool_timeout: 30_000) ==
-               [finch: [name: ReqLLM.Application.finch_name(), pool_timeout: 30_000]]
+      merged = Defaults.merge_finch_options([], pool_timeout: 30_000)
+
+      assert merged[:finch][:name] == ReqLLM.Application.finch_name()
+      assert merged[:finch][:pool_timeout] == 30_000
+    end
+
+    test "merges caller Finch options with request defaults" do
+      request_options = [finch: [name: MyApp.CustomFinch, pool_tag: :bulk], retry: false]
+
+      merged = Defaults.merge_finch_options(request_options, pool_timeout: 30_000)
+
+      assert merged[:finch][:name] == MyApp.CustomFinch
+      assert merged[:finch][:pool_tag] == :bulk
+      assert merged[:finch][:pool_timeout] == 30_000
+      assert merged[:retry] == false
+    end
+
+    test "lets caller Finch options override request defaults" do
+      request_options = [finch: [name: MyApp.CustomFinch, pool_timeout: 60_000]]
+
+      merged = Defaults.merge_finch_options(request_options, pool_timeout: 30_000)
+
+      assert merged[:finch][:pool_timeout] == 60_000
+    end
+
+    test "does not add a pool name to dynamic Finch pool options" do
+      request_options = [finch: [conn_max_idle_time: 10_000]]
+
+      merged = Defaults.merge_finch_options(request_options, pool_timeout: 30_000)
+
+      refute Keyword.has_key?(merged[:finch], :name)
+      assert merged[:finch][:conn_max_idle_time] == 10_000
+      assert merged[:finch][:pool_timeout] == 30_000
     end
 
     test "normalizes a legacy pool name" do

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -9,6 +9,34 @@ defmodule ReqLLM.Provider.DefaultsTest do
   alias ReqLLM.Provider.Defaults.ResponseBuilder
   alias ReqLLM.StreamChunk
 
+  describe "Finch options" do
+    test "builds current Req options for the application pool and timeout" do
+      assert Defaults.default_finch_option(pool_timeout: 30_000) ==
+               [finch: [name: ReqLLM.Application.finch_name(), pool_timeout: 30_000]]
+    end
+
+    test "normalizes a legacy pool name" do
+      request = Req.new() |> Req.Request.merge_options(finch: MyApp.CustomFinch)
+
+      assert Defaults.finch_option(request) == [finch: [name: MyApp.CustomFinch]]
+    end
+
+    test "preserves current Finch options and merges overrides" do
+      request =
+        Req.new()
+        |> Req.Request.merge_options(finch: [name: MyApp.CustomFinch, pool_tag: :bulk])
+
+      assert Defaults.finch_option(request, pool_timeout: 30_000) ==
+               [
+                 finch: [
+                   name: MyApp.CustomFinch,
+                   pool_tag: :bulk,
+                   pool_timeout: 30_000
+                 ]
+               ]
+    end
+  end
+
   describe "encode_context_to_openai_format/2" do
     test "encodes text content correctly" do
       test_cases = [

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -479,7 +479,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
-      assert request.options[:finch] == ReqLLM.Application.finch_name()
+      assert request.options[:finch] == [name: ReqLLM.Application.finch_name()]
     end
   end
 
@@ -712,7 +712,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
       attached = AmazonBedrock.attach_embedding(request, model, opts)
 
-      assert attached.options[:finch] == ReqLLM.Application.finch_name()
+      assert attached.options[:finch] == [name: ReqLLM.Application.finch_name()]
     end
 
     test "sets content-type header", %{model: model, opts: opts} do

--- a/test/req_llm/providers/google_finch_test.exs
+++ b/test/req_llm/providers/google_finch_test.exs
@@ -7,7 +7,7 @@ defmodule ReqLLM.Providers.GoogleFinchTest do
     test "routes the request to the configured Finch pool" do
       request = Google.attach(Req.new(), "google:gemini-2.5-flash", api_key: "test")
 
-      assert request.options[:finch] == ReqLLM.Application.finch_name()
+      assert request.options[:finch] == [name: ReqLLM.Application.finch_name()]
     end
 
     test "keeps a Finch pool already set on the request" do
@@ -16,7 +16,7 @@ defmodule ReqLLM.Providers.GoogleFinchTest do
         |> Req.Request.merge_options(finch: MyApp.CustomFinch)
         |> Google.attach("google:gemini-2.5-flash", api_key: "test")
 
-      assert request.options[:finch] == MyApp.CustomFinch
+      assert request.options[:finch] == [name: MyApp.CustomFinch]
     end
   end
 end

--- a/test/req_llm/step/retry_test.exs
+++ b/test/req_llm/step/retry_test.exs
@@ -248,7 +248,7 @@ defmodule ReqLLM.Step.RetryTest do
           api_key: "test-key"
         )
 
-      assert request.options[:finch] == :custom_finch
+      assert request.options[:finch] == [name: :custom_finch]
     end
 
     test "default_attach preserves caller max_retries" do


### PR DESCRIPTION
## Summary

- nest Finch pool timeouts under Req's current `finch` option
- normalize configured Finch pool names to `finch: [name: ...]`
- merge caller Finch settings with operation defaults without losing either configuration
- preserve explicit caller timeouts and valid dynamic pool settings
- cover option normalization, merge precedence, dynamic pools, and provider integration with regression tests

## Root cause

ReqLLM passed `pool_timeout` as a top-level Req option and passed custom Finch pool names as bare atoms. Req 0.7.2 deprecates both forms and emits warnings while it builds requests.

## Impact

Non-streaming requests now use the supported Req 0.7.2 Finch option structure. Custom pools retain the operation checkout timeout, explicit caller values take precedence, and dynamic pool options remain valid.

## Validation

- `mix test` — 4,064 passed, 11 skipped, 150 excluded
- `mix quality` — format, warnings-as-errors compile, Credo, and Dialyzer passed

Closes #951