### PR TITLE
Add warn_unverified_models config to disable the unverified-model warning

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -34,6 +34,9 @@ config :req_llm,
   # Privacy
   redact_context: false,             # Hide message contents in inspect output
 
+  # Warnings
+  warn_unverified_models: true,      # Warn when a model spec is not in the LLMDB catalog
+
   # Debugging
   debug: false                       # Enable verbose logging
 ```
@@ -267,6 +270,7 @@ config :req_llm, thinking_timeout: 600_000  # 10 minutes
 ```
 
 **Automatic detection:** ReqLLM automatically applies `thinking_timeout` when:
+
 - Extended thinking is enabled on Anthropic models
 - Using OpenAI o1/o3 reasoning models
 - Z.AI or Z.AI Coder thinking mode is enabled
@@ -552,6 +556,22 @@ When disabled (the default), the full message preview is shown as normal:
 inspect(context)
 #=> "#Context<2 msgs: system:\"You are a helpful assistant\", user:\"Hello\">"
 ```
+
+## Unverified Model Warnings
+
+When a `"provider:model"` spec resolves to a model that is not in the LLMDB catalog, ReqLLM emits a one-off warning (pricing, token counting, and capability detection may be unavailable for such models). For a fixed set of models, the preferred fix is an inline model spec:
+
+```elixir
+ReqLLM.model(%{provider: :openai, id: "my-custom-model"})
+```
+
+When model ids are dynamic — user-configured, stored in a database, or pointing at self-hosted OpenAI-compatible servers — uncataloged ids are expected, and the warning can be disabled globally:
+
+```elixir
+config :req_llm, warn_unverified_models: false
+```
+
+The default is `true`.
 
 ## Example: Production Configuration
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -559,7 +559,7 @@ inspect(context)
 
 ## Unverified Model Warnings
 
-When a `"provider:model"` spec resolves to a model that is not in the LLMDB catalog, ReqLLM emits a one-off warning (pricing, token counting, and capability detection may be unavailable for such models). For a fixed set of models, the preferred fix is an inline model spec:
+When a `"provider:model"` spec resolves to a model that is not in the LLMDB catalog, ReqLLM emits a warning (pricing, token counting, and capability detection may be unavailable for such models). For a fixed set of models, the preferred fix is an inline model spec:
 
 ```elixir
 ReqLLM.model(%{provider: :openai, id: "my-custom-model"})

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -745,17 +745,26 @@ defmodule ReqLLM do
   end
 
   defp warn_unverified_model(provider, model_id) do
-    IO.warn("""
-    Using unverified model: #{provider}:#{model_id}
+    if Application.get_env(:req_llm, :warn_unverified_models, true) do
+      IO.warn("""
+      Using unverified model: #{provider}:#{model_id}
 
-    This model is not in the LLMDB catalog. While it will work if the provider \
-    supports this model ID, some features like pricing, token counting, and \
-    capability detection may be unavailable.
+      This model is not in the LLMDB catalog. While it will work if the provider \
+      supports this model ID, some features like pricing, token counting, and \
+      capability detection may be unavailable.
 
-    To suppress this warning, use an inline model spec:
+      To suppress this warning, use an inline model spec:
 
-        ReqLLM.model(%{provider: :#{provider}, id: "#{model_id}"})
-    """)
+          ReqLLM.model(%{provider: :#{provider}, id: "#{model_id}"})
+
+      or, when model ids are dynamic (user- or database-configured), disable it \
+      globally:
+
+          config :req_llm, warn_unverified_models: false
+      """)
+    end
+
+    :ok
   end
 
   defp provider_atom_from_string(provider_name) when is_binary(provider_name) do

--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -85,6 +85,23 @@ defmodule ReqLLMTest do
       assert output =~ "To suppress this warning, use an inline model spec"
     end
 
+    test "warn_unverified_models: false suppresses the unverified-model warning" do
+      Application.put_env(:req_llm, :warn_unverified_models, false)
+      on_exit(fn -> Application.delete_env(:req_llm, :warn_unverified_models) end)
+
+      output =
+        capture_io(:stderr, fn ->
+          assert {:ok,
+                  %LLMDB.Model{
+                    provider: :openai,
+                    id: "quiet-unverified-model",
+                    provider_model_id: "quiet-unverified-model"
+                  }} = ReqLLM.model("openai:quiet-unverified-model")
+        end)
+
+      assert output == ""
+    end
+
     test "resolves unknown registered provider tuple specs with a warning" do
       output =
         capture_io(:stderr, fn ->


### PR DESCRIPTION
## Motivation

The unverified-model `IO.warn` fires on every call whose `provider:model` string is not in the LLMDB catalog. The documented suppression (an inline model spec) works well when an application has a fixed set of models, but not when model ids are dynamic: user-configured, stored in a database, or pointing at self-hosted OpenAI-compatible servers (llama.cpp, vLLM, Ollama). In those setups uncataloged ids are the normal case, not a mistake, and every request emits a multi-line warning with a stacktrace, e.g.:

```
warning: Using unverified model: openai:unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Q8_0
```

Callers can pre-parse the string and build an inline spec themselves, but that means re-implementing pieces of `ReqLLM.model/1`'s string resolution (provider atom normalization, the provider-specific fallbacks) just to keep logs clean.

## Change

- Gate `warn_unverified_model/2` on a new application config, **on by default** so existing behavior is unchanged:

  ```elixir
  config :req_llm, warn_unverified_models: false
  ```

- The warning text now mentions the global switch alongside the existing inline-spec suggestion.
- Documented in `guides/configuration.md` (quick reference + a section).
- Test: with the config set to `false`, resolving an uncataloged `provider:model` string emits nothing on stderr (added next to the existing warning assertions in `test/req_llm_test.exs`; the existing tests cover the default-on behavior).

`mix test test/req_llm_test.exs` and `mix format --check-formatted` pass.