### PR TITLE
fix: OpenAI cost per image

### DIFF
--- a/lib/req_llm/images/openai_compatible.ex
+++ b/lib/req_llm/images/openai_compatible.ex
@@ -516,7 +516,13 @@ defmodule ReqLLM.Images.OpenAICompatible do
       |> Enum.reject(&is_nil/1)
 
     message = %Message{role: :assistant, content: parts}
-    size_class = image_size_class(req.options[:size], req.options[:quality])
+
+    size_class =
+      image_size_class(
+        echoed_option(body, "size") || req.options[:size],
+        echoed_option(body, "quality") || req.options[:quality]
+      )
+
     image_usage = ReqLLM.Usage.Image.build_generated(length(parts), size_class)
     usage = image_response_usage(body, image_usage)
 
@@ -675,6 +681,26 @@ defmodule ReqLLM.Images.OpenAICompatible do
 
   defp image_size_class(size, quality) do
     "#{normalize_image_size(size)}:#{normalize_image_quality(quality)}"
+  end
+
+  # Image-priced models bill per `image.<size>.<quality>` component, and the
+  # rendered dimensions need not match what was asked for: `size: "auto"` (or no
+  # size at all) resolves server-side. The response echoes what was actually
+  # produced, so bill from that and fall back to the request only when the body
+  # is silent or still says "auto".
+  defp echoed_option(body, key) do
+    case Map.get(body, key) do
+      value when is_binary(value) -> reject_auto(value)
+      _ -> nil
+    end
+  end
+
+  defp reject_auto(value) do
+    case value |> String.trim() |> String.downcase() do
+      "auto" -> nil
+      "" -> nil
+      resolved -> resolved
+    end
   end
 
   defp normalize_image_size(nil), do: "1024x1024"

--- a/test/providers/openai_images_test.exs
+++ b/test/providers/openai_images_test.exs
@@ -387,6 +387,64 @@ defmodule ReqLLM.Providers.OpenAIImagesTest do
     assert %{generated: %{count: 1, size_class: "1024x1024:low"}} = usage.image_usage
   end
 
+  test "decode_response/1 bills the size class the response reports, not the one requested" do
+    req =
+      Req.new(url: ImagesAPI.path())
+      |> Req.Request.register_options([:model, :output_format, :size, :quality, :context])
+      |> Req.Request.merge_options(
+        model: "gpt-image-1.5",
+        output_format: :png,
+        size: "auto",
+        quality: "auto",
+        context: %Context{messages: []}
+      )
+
+    resp = %Req.Response{
+      status: 200,
+      headers: [],
+      body: %{
+        "created" => 1_234,
+        "data" => [%{"b64_json" => Base.encode64("abc")}],
+        "size" => "1536x1024",
+        "quality" => "high",
+        "usage" => %{"input_tokens" => 14, "output_tokens" => 229, "total_tokens" => 243}
+      }
+    }
+
+    {_req, updated} = ImagesAPI.decode_response({req, resp})
+
+    assert %{generated: %{count: 1, size_class: "1536x1024:high"}} =
+             updated.body.usage.image_usage
+  end
+
+  test "decode_response/1 falls back to requested size class when the body omits it" do
+    req =
+      Req.new(url: ImagesAPI.path())
+      |> Req.Request.register_options([:model, :output_format, :size, :quality, :context])
+      |> Req.Request.merge_options(
+        model: "gpt-image-1.5",
+        output_format: :png,
+        size: "1024x1536",
+        quality: "high",
+        context: %Context{messages: []}
+      )
+
+    resp = %Req.Response{
+      status: 200,
+      headers: [],
+      body: %{
+        "created" => 1_234,
+        "data" => [%{"b64_json" => Base.encode64("abc")}],
+        "size" => "auto"
+      }
+    }
+
+    {_req, updated} = ImagesAPI.decode_response({req, resp})
+
+    assert %{generated: %{count: 1, size_class: "1024x1536:high"}} =
+             updated.body.usage.image_usage
+  end
+
   test "prepare_request/4 keeps prompt-only image generation on generations JSON endpoint" do
     model = %LLMDB.Model{id: "gpt-image-1.5", provider: :openai}
 


### PR DESCRIPTION
## Description

A small fix where we could bill the images incorrectly when we selected "auto" sizing or had no size input

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
