### PR TITLE
fix(streaming): fall back after oversized websocket messages

### DIFF
--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -805,7 +805,7 @@ defmodule ReqLLM.Providers.OpenAI do
   defp websocket_session_fell_back?(session) when is_pid(session) do
     ReqLLM.Streaming.WebSocketSession.http_fallback?(session)
   catch
-    :exit, _reason -> true
+    :exit, _reason -> false
   end
 
   defp websocket_session_fell_back?(_session), do: false

--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -791,13 +791,24 @@ defmodule ReqLLM.Providers.OpenAI do
 
   def stream_transport(_model, opts) do
     provider_opts = Keyword.get(opts, :provider_options, [])
+    session = Keyword.get(provider_opts, :openai_websocket_session)
 
     case Keyword.get(provider_opts, :openai_stream_transport, :sse) do
-      :websocket -> :websocket
-      "websocket" -> :websocket
-      _ -> :http
+      transport when transport in [:websocket, "websocket"] ->
+        if websocket_session_fell_back?(session), do: :http, else: :websocket
+
+      _ ->
+        :http
     end
   end
+
+  defp websocket_session_fell_back?(session) when is_pid(session) do
+    ReqLLM.Streaming.WebSocketSession.http_fallback?(session)
+  catch
+    :exit, _reason -> true
+  end
+
+  defp websocket_session_fell_back?(_session), do: false
 
   @doc false
   def resolve_request_credential!(%LLMDB.Model{} = model, opts) do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1145,7 +1145,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
        headers: headers,
        initial_messages: [Jason.encode!(create_event)],
        http_context: ReqLLM.Providers.OpenAI.WebSocket.http_context(url, headers),
-       canonical_json: body
+       canonical_json: body,
+       fallback_transport: :http
      }}
   rescue
     error ->

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -410,7 +410,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
   defp websocket_session_fell_back?(session) when is_pid(session) do
     ReqLLM.Streaming.WebSocketSession.http_fallback?(session)
   catch
-    :exit, _reason -> true
+    :exit, _reason -> false
   end
 
   defp websocket_session_fell_back?(_session), do: false

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -268,10 +268,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
   def stream_transport(_model, opts) do
     provider_opts = Keyword.get(opts, :provider_options, [])
+    session = Keyword.get(provider_opts, :openai_websocket_session)
 
     case Keyword.get(provider_opts, :openai_stream_transport, :sse) do
-      transport when transport in [:websocket, "websocket"] -> :websocket
-      _ -> :http
+      transport when transport in [:websocket, "websocket"] ->
+        if websocket_session_fell_back?(session), do: :http, else: :websocket
+
+      _ ->
+        :http
     end
   end
 
@@ -378,7 +382,8 @@ defmodule ReqLLM.Providers.OpenAICodex do
        headers: headers,
        initial_messages: [Jason.encode!(create_event)],
        http_context: ReqLLM.Providers.OpenAI.WebSocket.http_context(url, headers),
-       canonical_json: body
+       canonical_json: body,
+       fallback_transport: :http
      }}
   rescue
     error ->
@@ -401,6 +406,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
       connect_timeout: Keyword.get(opts, :connect_timeout, 10_000)
     )
   end
+
+  defp websocket_session_fell_back?(session) when is_pid(session) do
+    ReqLLM.Streaming.WebSocketSession.http_fallback?(session)
+  catch
+    :exit, _reason -> true
+  end
+
+  defp websocket_session_fell_back?(_session), do: false
 
   defp build_codex_body(context, %LLMDB.Model{} = model, opts, request) do
     opts = opts |> ensure_provider_options() |> force_store_false()

--- a/lib/req_llm/stream_server.ex
+++ b/lib/req_llm/stream_server.ex
@@ -838,6 +838,27 @@ defmodule ReqLLM.StreamServer do
     {:reply, :ok, state}
   end
 
+  defp process_http_event(
+         {:transport_fallback, :http, _reason, http_context, canonical_json},
+         state
+       ) do
+    protocol_parser = http_protocol_parser(state.provider_mod)
+    provider_state = reset_provider_state(state.provider_mod, state.model)
+
+    new_state = %{
+      state
+      | protocol_parser: protocol_parser,
+        protocol_state: nil,
+        provider_state: provider_state,
+        http_context: http_context,
+        canonical_json: canonical_json,
+        http_status: nil,
+        headers: []
+    }
+
+    {:reply, :ok, new_state}
+  end
+
   defp process_http_event({:status, status}, state) do
     new_state = %{state | http_status: status}
     {:reply, :ok, new_state}
@@ -949,6 +970,20 @@ defmodule ReqLLM.StreamServer do
 
   defp process_http_task_exit(state, reason) do
     finalize_failed_stream(state, {:http_task_failed, reason})
+  end
+
+  defp http_protocol_parser(provider_mod) do
+    if function_exported?(provider_mod, :parse_stream_protocol, 2) do
+      fn chunk, buffer -> provider_mod.parse_stream_protocol(chunk, buffer) end
+    else
+      &ReqLLM.Provider.parse_stream_protocol/2
+    end
+  end
+
+  defp reset_provider_state(provider_mod, model) do
+    if function_exported?(provider_mod, :init_stream_state, 1) do
+      provider_mod.init_stream_state(model)
+    end
   end
 
   defp parse_protocol_events(chunk, state) do

--- a/lib/req_llm/streaming/finch_client.ex
+++ b/lib/req_llm/streaming/finch_client.ex
@@ -98,8 +98,8 @@ defmodule ReqLLM.Streaming.FinchClient do
     end
   end
 
-  # Build Finch.Request using provider callback
-  defp build_stream_request(provider_mod, model, context, opts, finch_name) do
+  @doc false
+  def build_stream_request(provider_mod, model, context, opts, finch_name) do
     alias ReqLLM.Streaming.Fixtures
 
     with {:ok, finch_request} <- provider_mod.attach_stream(model, context, opts, finch_name),
@@ -166,45 +166,7 @@ defmodule ReqLLM.Streaming.FinchClient do
 
     task_pid =
       Task.Supervisor.async(ReqLLM.TaskSupervisor, fn ->
-        finch_stream_callback = fn
-          {:status, status}, acc ->
-            safe_http_event(stream_server_pid, {:status, status})
-            acc
-
-          {:headers, headers}, acc ->
-            safe_http_event(stream_server_pid, {:headers, headers})
-            acc
-
-          {:data, chunk}, acc ->
-            safe_http_event(stream_server_pid, {:data, chunk})
-            acc
-
-          :done, acc ->
-            safe_http_event(stream_server_pid, :done)
-            acc
-        end
-
-        try do
-          case Retry.stream(
-                 finch_request,
-                 finch_name,
-                 :ok,
-                 finch_stream_callback,
-                 stream_opts
-               ) do
-            {:ok, _} ->
-              :ok
-
-            {:error, reason, _callback_acc} ->
-              forward_stream_failure(stream_server_pid, reason)
-          end
-        catch
-          :exit, reason ->
-            forward_stream_failure(stream_server_pid, {:exit, reason})
-
-          kind, reason ->
-            forward_stream_failure(stream_server_pid, {kind, reason})
-        end
+        run_stream_with_options(finch_request, stream_server_pid, finch_name, stream_opts)
       end)
 
     {:ok, task_pid.pid}
@@ -212,6 +174,47 @@ defmodule ReqLLM.Streaming.FinchClient do
     error ->
       Logger.error("Failed to start streaming task: #{inspect(error)}")
       {:error, {:task_start_failed, error}}
+  end
+
+  @doc false
+  def run_stream(finch_request, stream_server_pid, finch_name, opts) do
+    stream_opts =
+      finch_request
+      |> Fixtures.canonical_json_from_finch_request()
+      |> stream_options(opts)
+      |> Keyword.put(:on_retry, fn retry -> StreamServer.retry_event(stream_server_pid, retry) end)
+
+    run_stream_with_options(finch_request, stream_server_pid, finch_name, stream_opts)
+  end
+
+  defp run_stream_with_options(finch_request, stream_server_pid, finch_name, stream_opts) do
+    finch_stream_callback = fn
+      {:status, status}, acc ->
+        safe_http_event(stream_server_pid, {:status, status})
+        acc
+
+      {:headers, headers}, acc ->
+        safe_http_event(stream_server_pid, {:headers, headers})
+        acc
+
+      {:data, chunk}, acc ->
+        safe_http_event(stream_server_pid, {:data, chunk})
+        acc
+
+      :done, acc ->
+        safe_http_event(stream_server_pid, :done)
+        acc
+    end
+
+    try do
+      case Retry.stream(finch_request, finch_name, :ok, finch_stream_callback, stream_opts) do
+        {:ok, _} -> :ok
+        {:error, reason, _callback_acc} -> forward_stream_failure(stream_server_pid, reason)
+      end
+    catch
+      :exit, reason -> forward_stream_failure(stream_server_pid, {:exit, reason})
+      kind, reason -> forward_stream_failure(stream_server_pid, {kind, reason})
+    end
   end
 
   defp forward_stream_failure(stream_server_pid, reason) do

--- a/lib/req_llm/streaming/web_socket_client.ex
+++ b/lib/req_llm/streaming/web_socket_client.ex
@@ -33,7 +33,8 @@ defmodule ReqLLM.Streaming.WebSocketClient do
 
       :no_fixture ->
         with {:ok, config} <- build_stream_request(provider_mod, model, context, opts),
-             {:ok, task_pid} <- start_streaming_task(config, stream_server_pid, opts) do
+             {:ok, task_pid} <-
+               start_streaming_task(config, stream_server_pid, provider_mod, model, context, opts) do
           {:ok, task_pid, config.http_context, config.canonical_json}
         end
     end
@@ -53,7 +54,8 @@ defmodule ReqLLM.Streaming.WebSocketClient do
          headers: config.headers || [],
          initial_messages: config.initial_messages || [],
          http_context: http_context,
-         canonical_json: config.canonical_json || %{}
+         canonical_json: config.canonical_json || %{},
+         fallback_transport: Map.get(config, :fallback_transport)
        }}
     else
       false ->
@@ -102,19 +104,33 @@ defmodule ReqLLM.Streaming.WebSocketClient do
     end
   end
 
-  defp start_streaming_task(config, stream_server_pid, opts) do
+  defp start_streaming_task(config, stream_server_pid, provider_mod, model, context, opts) do
     task_pid =
       Task.Supervisor.async(ReqLLM.TaskSupervisor, fn ->
-        case reusable_session(opts) do
-          nil ->
-            start_owned_session(config, stream_server_pid, opts)
+        session = reusable_session(opts)
 
-          session_pid when is_pid(session_pid) ->
-            await_connect_and_stream(session_pid, stream_server_pid, opts,
-              initial_messages: config.initial_messages,
-              close_on_terminal?: false
-            )
-        end
+        result =
+          case session do
+            nil ->
+              start_owned_session(config, stream_server_pid, opts)
+
+            session_pid when is_pid(session_pid) ->
+              await_connect_and_stream(session_pid, stream_server_pid, opts,
+                initial_messages: config.initial_messages,
+                close_on_terminal?: false
+              )
+          end
+
+        maybe_fallback_to_http(
+          result,
+          config,
+          stream_server_pid,
+          provider_mod,
+          model,
+          context,
+          opts,
+          session
+        )
       end)
 
     {:ok, task_pid.pid}
@@ -150,8 +166,12 @@ defmodule ReqLLM.Streaming.WebSocketClient do
 
         case send_initial_messages(session_pid, Keyword.get(session_opts, :initial_messages, [])) do
           :ok ->
-            relay_messages(session_pid, stream_server_pid, opts,
-              close_on_terminal?: Keyword.get(session_opts, :close_on_terminal?, true)
+            relay_messages(
+              session_pid,
+              stream_server_pid,
+              opts,
+              [close_on_terminal?: Keyword.get(session_opts, :close_on_terminal?, true)],
+              false
             )
 
           {:error, reason} ->
@@ -165,7 +185,7 @@ defmodule ReqLLM.Streaming.WebSocketClient do
     end
   end
 
-  defp relay_messages(session_pid, stream_server_pid, opts, relay_opts) do
+  defp relay_messages(session_pid, stream_server_pid, opts, relay_opts, output_observed?) do
     case WebSocketSession.next_message(session_pid, receive_timeout(opts)) do
       {:ok, message} ->
         case WebSocketProtocol.decode_message(message) do
@@ -182,7 +202,7 @@ defmodule ReqLLM.Streaming.WebSocketClient do
                   Keyword.get(relay_opts, :close_on_terminal?, true)
                 )
               else
-                relay_messages(session_pid, stream_server_pid, opts, relay_opts)
+                relay_messages(session_pid, stream_server_pid, opts, relay_opts, true)
               end
             end
 
@@ -198,10 +218,100 @@ defmodule ReqLLM.Streaming.WebSocketClient do
         :ok
 
       {:error, reason} ->
-        safe_http_event(stream_server_pid, {:error, reason})
-        {:error, reason}
+        if message_too_big?(reason) do
+          {:websocket_error, reason, output_observed?}
+        else
+          safe_http_event(stream_server_pid, {:error, reason})
+          {:error, reason}
+        end
     end
   end
+
+  defp maybe_fallback_to_http(
+         {:websocket_error, reason, false},
+         %{fallback_transport: :http},
+         stream_server_pid,
+         provider_mod,
+         model,
+         context,
+         opts,
+         session
+       ) do
+    mark_session_http_fallback(session)
+
+    http_opts =
+      opts
+      |> Keyword.delete(:stream_transport)
+      |> Keyword.update(:provider_options, [], fn provider_opts ->
+        provider_opts
+        |> Keyword.put(:openai_stream_transport, :sse)
+        |> Keyword.delete(:openai_websocket_session)
+      end)
+
+    finch_name = Keyword.get(opts, :finch_name, ReqLLM.Finch)
+
+    case ReqLLM.Streaming.FinchClient.build_stream_request(
+           provider_mod,
+           model,
+           context,
+           http_opts,
+           finch_name
+         ) do
+      {:ok, finch_request, http_context, canonical_json} ->
+        safe_http_event(
+          stream_server_pid,
+          {:transport_fallback, :http, reason, http_context, canonical_json}
+        )
+
+        ReqLLM.Streaming.FinchClient.run_stream(
+          finch_request,
+          stream_server_pid,
+          finch_name,
+          http_opts
+        )
+
+      {:error, fallback_reason} ->
+        safe_http_event(stream_server_pid, {:error, fallback_reason})
+        {:error, fallback_reason}
+    end
+  end
+
+  defp maybe_fallback_to_http(
+         {:websocket_error, reason, true},
+         _config,
+         stream_server_pid,
+         _provider_mod,
+         _model,
+         _context,
+         _opts,
+         _session
+       ) do
+    safe_http_event(stream_server_pid, {:error, reason})
+    {:error, reason}
+  end
+
+  defp maybe_fallback_to_http(
+         result,
+         _config,
+         _stream_server_pid,
+         _provider_mod,
+         _model,
+         _context,
+         _opts,
+         _session
+       ),
+       do: result
+
+  defp message_too_big?({side, 1009, _detail}) when side in [:local, :remote], do: true
+  defp message_too_big?(_reason), do: false
+
+  defp mark_session_http_fallback(session) when is_pid(session) do
+    WebSocketSession.mark_http_fallback(session)
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp mark_session_http_fallback(_session), do: :ok
 
   defp reusable_session(opts) do
     opts

--- a/lib/req_llm/streaming/web_socket_client.ex
+++ b/lib/req_llm/streaming/web_socket_client.ex
@@ -150,7 +150,11 @@ defmodule ReqLLM.Streaming.WebSocketClient do
            connect_timeout: connect_timeout
          ) do
       {:ok, session_pid} ->
-        await_connect_and_stream(session_pid, stream_server_pid, opts, close_on_terminal?: true)
+        result =
+          await_connect_and_stream(session_pid, stream_server_pid, opts, close_on_terminal?: true)
+
+        close_owned_session(session_pid)
+        result
 
       {:error, reason} ->
         safe_http_event(stream_server_pid, {:error, reason})
@@ -277,7 +281,7 @@ defmodule ReqLLM.Streaming.WebSocketClient do
   end
 
   defp maybe_fallback_to_http(
-         {:websocket_error, reason, true},
+         {:websocket_error, reason, _output_observed?},
          _config,
          stream_server_pid,
          _provider_mod,
@@ -312,6 +316,12 @@ defmodule ReqLLM.Streaming.WebSocketClient do
   end
 
   defp mark_session_http_fallback(_session), do: :ok
+
+  defp close_owned_session(session) do
+    WebSocketSession.close(session)
+  catch
+    :exit, _reason -> :ok
+  end
 
   defp reusable_session(opts) do
     opts

--- a/lib/req_llm/streaming/web_socket_session.ex
+++ b/lib/req_llm/streaming/web_socket_session.ex
@@ -15,7 +15,8 @@ defmodule ReqLLM.Streaming.WebSocketSession do
     queue: :queue.new(),
     initial_messages: [],
     waiting_callers: [],
-    waiting_connect_callers: []
+    waiting_connect_callers: [],
+    http_fallback?: false
   ]
 
   @type t :: pid()
@@ -50,6 +51,16 @@ defmodule ReqLLM.Streaming.WebSocketSession do
   @spec close(t()) :: :ok
   def close(server) do
     GenServer.call(server, :close)
+  end
+
+  @spec mark_http_fallback(t()) :: :ok
+  def mark_http_fallback(server) do
+    GenServer.call(server, :mark_http_fallback)
+  end
+
+  @spec http_fallback?(t()) :: boolean()
+  def http_fallback?(server) do
+    GenServer.call(server, :http_fallback?)
   end
 
   @impl GenServer
@@ -131,6 +142,14 @@ defmodule ReqLLM.Streaming.WebSocketSession do
     {:reply, :ok, state}
   end
 
+  def handle_call(:mark_http_fallback, _from, state) do
+    {:reply, :ok, %{state | http_fallback?: true}}
+  end
+
+  def handle_call(:http_fallback?, _from, state) do
+    {:reply, state.http_fallback?, state}
+  end
+
   def handle_call(:close, _from, state) do
     if is_pid(state.client_pid) and Process.alive?(state.client_pid) do
       :ok = Client.close(state.client_pid)
@@ -172,6 +191,13 @@ defmodule ReqLLM.Streaming.WebSocketSession do
       |> reply_to_waiting_callers()
 
     {:noreply, state}
+  end
+
+  def handle_info(
+        {:DOWN, ref, :process, _pid, _down_reason},
+        %{client_ref: ref, status: {:error, _status_reason}} = state
+      ) do
+    {:noreply, %{state | client_pid: nil, client_ref: nil}}
   end
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{client_ref: ref} = state) do

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -249,6 +249,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
         )
 
       assert config.url == "wss://chatgpt.com/backend-api/codex/responses"
+      assert config.fallback_transport == :http
       assert {"openai-beta", "responses_websockets=2026-02-06"} in config.headers
       assert {"session_id", "req_ws"} in config.headers
       assert {"x-client-request-id", "req_ws"} in config.headers

--- a/test/req_llm/openai_websocket_test.exs
+++ b/test/req_llm/openai_websocket_test.exs
@@ -12,12 +12,45 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     plug(:dispatch)
 
     get "/v1/responses" do
+      socket =
+        Application.get_env(
+          :req_llm,
+          :openai_websocket_responses_socket,
+          ReqLLM.OpenAIWebSocketTest.ResponsesSocket
+        )
+
       WebSockAdapter.upgrade(
         conn,
-        ReqLLM.OpenAIWebSocketTest.ResponsesSocket,
+        socket,
         Application.fetch_env!(:req_llm, :openai_websocket_test_pid),
         []
       )
+    end
+
+    post "/v1/responses" do
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+      send(
+        Application.fetch_env!(:req_llm, :openai_websocket_test_pid),
+        {:responses_http_request, Jason.decode!(body)}
+      )
+
+      events = [
+        %{"type" => "response.output_text.delta", "delta" => "HTTP fallback"},
+        %{
+          "type" => "response.completed",
+          "response" => %{
+            "id" => "resp_http_123",
+            "usage" => %{"input_tokens" => 12, "output_tokens" => 3}
+          }
+        }
+      ]
+
+      payload = Enum.map_join(events, "", &("data: " <> Jason.encode!(&1) <> "\n\n"))
+
+      conn
+      |> Plug.Conn.put_resp_content_type("text/event-stream")
+      |> Plug.Conn.send_resp(200, payload)
     end
 
     get "/v1/realtime" do
@@ -66,6 +99,38 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     def handle_info(_message, test_pid) do
       {:ok, test_pid}
     end
+  end
+
+  defmodule MessageTooBigSocket do
+    @behaviour WebSock
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_in({message, opts}, test_pid) when is_binary(message) and is_list(opts) do
+      send(test_pid, {:responses_oversized_socket_message, Jason.decode!(message)})
+      {:stop, :normal, {1009, "message too big"}, test_pid}
+    end
+
+    @impl true
+    def handle_info(_message, test_pid), do: {:ok, test_pid}
+  end
+
+  defmodule PartialThenMessageTooBigSocket do
+    @behaviour WebSock
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_in({_message, opts}, test_pid) when is_list(opts) do
+      message = Jason.encode!(%{"type" => "response.output_text.delta", "delta" => "partial"})
+      {:stop, :normal, {1009, "message too big"}, [{:text, message}], test_pid}
+    end
+
+    @impl true
+    def handle_info(_message, test_pid), do: {:ok, test_pid}
   end
 
   defmodule RealtimeSocket do
@@ -124,6 +189,7 @@ defmodule ReqLLM.OpenAIWebSocketTest do
       end
 
       Application.delete_env(:req_llm, :openai_websocket_test_pid)
+      Application.delete_env(:req_llm, :openai_websocket_responses_socket)
     end)
 
     websocket_url = String.replace_prefix(base_url, "http://", "ws://") <> "/realtime"
@@ -153,6 +219,88 @@ defmodule ReqLLM.OpenAIWebSocketTest do
 
     assert request["model"] == "gpt-5"
     assert Enum.any?(request["input"], fn item -> item["role"] == "user" end)
+  end
+
+  test "falls back from pre-output websocket close 1009 to HTTP/SSE", %{base_url: base_url} do
+    Application.put_env(
+      :req_llm,
+      :openai_websocket_responses_socket,
+      MessageTooBigSocket
+    )
+
+    {:ok, stream_response} =
+      ReqLLM.stream_text(
+        "openai:gpt-5",
+        "Say hello",
+        base_url: base_url,
+        receive_timeout: 5_000,
+        provider_options: [openai_stream_transport: :websocket]
+      )
+
+    assert ReqLLM.StreamResponse.text(stream_response) == "HTTP fallback"
+    assert ReqLLM.StreamResponse.finish_reason(stream_response) == :stop
+    assert_received {:responses_oversized_socket_message, %{"type" => "response.create"}}
+    assert_received {:responses_http_request, %{"model" => "gpt-5"}}
+  end
+
+  test "does not replay over HTTP after websocket output", %{base_url: base_url} do
+    Application.put_env(
+      :req_llm,
+      :openai_websocket_responses_socket,
+      PartialThenMessageTooBigSocket
+    )
+
+    {:ok, stream_response} =
+      ReqLLM.stream_text(
+        "openai:gpt-5",
+        "Say hello",
+        base_url: base_url,
+        receive_timeout: 5_000,
+        provider_options: [openai_stream_transport: :websocket]
+      )
+
+    assert_raise ReqLLM.Error.API.Stream, ~r/1009/, fn ->
+      Enum.to_list(stream_response.stream)
+    end
+
+    refute_received {:responses_http_request, _request}
+  end
+
+  test "a reusable session keeps HTTP fallback sticky across turns", %{base_url: base_url} do
+    Application.put_env(
+      :req_llm,
+      :openai_websocket_responses_socket,
+      MessageTooBigSocket
+    )
+
+    {:ok, model} = ReqLLM.model("openai:gpt-5")
+
+    {:ok, session} =
+      ReqLLM.Providers.OpenAI.WebSocket.start_responses_session(model,
+        base_url: base_url,
+        api_key: "test-key-12345"
+      )
+
+    for prompt <- ["first", "second"] do
+      {:ok, stream_response} =
+        ReqLLM.stream_text(
+          model,
+          prompt,
+          base_url: base_url,
+          receive_timeout: 5_000,
+          provider_options: [
+            openai_stream_transport: :websocket,
+            openai_websocket_session: session
+          ]
+        )
+
+      assert ReqLLM.StreamResponse.text(stream_response) == "HTTP fallback"
+    end
+
+    assert_received {:responses_oversized_socket_message, %{"type" => "response.create"}}
+    refute_received {:responses_oversized_socket_message, %{"type" => "response.create"}}
+    assert_received {:responses_http_request, _request}
+    assert_received {:responses_http_request, _request}
   end
 
   test "stream_text can reuse caller-owned OpenAI responses websocket sessions", %{

--- a/test/req_llm/openai_websocket_test.exs
+++ b/test/req_llm/openai_websocket_test.exs
@@ -117,6 +117,24 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     def handle_info(_message, test_pid), do: {:ok, test_pid}
   end
 
+  defmodule MessageTooBigWithoutFallbackProvider do
+    def stream_transport(_model, _opts), do: :websocket
+
+    def attach_websocket_stream(model, _context, opts) do
+      base_url = Keyword.fetch!(opts, :base_url)
+      headers = [{"Authorization", "Bearer test-key-12345"}]
+      url = ReqLLM.Providers.OpenAI.WebSocket.responses_url(model, base_url: base_url)
+
+      {:ok,
+       %{
+         url: url,
+         headers: headers,
+         initial_messages: [Jason.encode!(%{"type" => "response.create"})],
+         canonical_json: %{"type" => "response.create"}
+       }}
+    end
+  end
+
   defmodule PartialThenMessageTooBigSocket do
     @behaviour WebSock
 
@@ -243,6 +261,55 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     assert_received {:responses_http_request, %{"model" => "gpt-5"}}
   end
 
+  test "owned websocket sessions stop after HTTP fallback", %{base_url: base_url} do
+    Application.put_env(
+      :req_llm,
+      :openai_websocket_responses_socket,
+      MessageTooBigSocket
+    )
+
+    before_pids = websocket_session_pids()
+
+    {:ok, stream_response} =
+      ReqLLM.stream_text(
+        "openai:gpt-5",
+        "Say hello",
+        base_url: base_url,
+        receive_timeout: 5_000,
+        provider_options: [openai_stream_transport: :websocket]
+      )
+
+    assert ReqLLM.StreamResponse.text(stream_response) == "HTTP fallback"
+    assert wait_until(fn -> websocket_session_pids() == before_pids end)
+  end
+
+  test "preserves close 1009 when HTTP fallback is not enabled", %{base_url: base_url} do
+    Application.put_env(
+      :req_llm,
+      :openai_websocket_responses_socket,
+      MessageTooBigSocket
+    )
+
+    {:ok, context} = ReqLLM.Context.normalize("Say hello")
+    model = %LLMDB.Model{provider: :test, id: "test", base_url: base_url}
+
+    assert {:ok, stream_response} =
+             ReqLLM.Streaming.start_stream(
+               MessageTooBigWithoutFallbackProvider,
+               model,
+               context,
+               base_url: base_url,
+               connect_timeout: 5_000,
+               receive_timeout: 5_000
+             )
+
+    assert_raise ReqLLM.Error.API.Stream, ~r/1009/, fn ->
+      Enum.to_list(stream_response.stream)
+    end
+
+    refute_received {:responses_http_request, _request}
+  end
+
   test "does not replay over HTTP after websocket output", %{base_url: base_url} do
     Application.put_env(
       :req_llm,
@@ -301,6 +368,23 @@ defmodule ReqLLM.OpenAIWebSocketTest do
     refute_received {:responses_oversized_socket_message, %{"type" => "response.create"}}
     assert_received {:responses_http_request, _request}
     assert_received {:responses_http_request, _request}
+  end
+
+  test "a dead reusable session does not silently select HTTP" do
+    session = spawn(fn -> :ok end)
+    monitor = Process.monitor(session)
+    assert_receive {:DOWN, ^monitor, :process, ^session, reason}
+    assert reason in [:normal, :noproc]
+
+    opts = [
+      provider_options: [
+        openai_stream_transport: :websocket,
+        openai_websocket_session: session
+      ]
+    ]
+
+    assert ReqLLM.Providers.OpenAI.stream_transport(nil, opts) == :websocket
+    assert ReqLLM.Providers.OpenAICodex.stream_transport(nil, opts) == :websocket
   end
 
   test "stream_text can reuse caller-owned OpenAI responses websocket sessions", %{
@@ -479,6 +563,33 @@ defmodule ReqLLM.OpenAIWebSocketTest do
 
       Process.sleep(5)
       do_await_websocket_waiter(session, receiver_pid, deadline)
+    end
+  end
+
+  defp websocket_session_pids do
+    Process.list()
+    |> Enum.filter(fn pid ->
+      case Process.info(pid, :dictionary) do
+        {:dictionary, dictionary} ->
+          Keyword.get(dictionary, :"$initial_call") ==
+            {ReqLLM.Streaming.WebSocketSession, :init, 1}
+
+        nil ->
+          false
+      end
+    end)
+    |> MapSet.new()
+  end
+
+  defp wait_until(fun, attempts \\ 100)
+  defp wait_until(_fun, 0), do: false
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(5)
+      wait_until(fun, attempts - 1)
     end
   end
 


### PR DESCRIPTION
## Description

OpenAI Responses WebSocket requests are sent as a single `response.create` text message. For large conversations, the upstream endpoint can reject that message with WebSocket close code `1009` (message too big). Retrying the same WebSocket payload cannot succeed and currently leaves callers with a transport error, even though the same request can be streamed through HTTP/SSE.

This PR adds a narrow, provider-declared fallback:

- recognize close code `1009` before any provider output has been emitted;
- replay the request once through the provider's existing HTTP/SSE streaming path;
- never replay after observable output, avoiding duplicate output or side effects;
- mark caller-owned reusable Responses WebSocket sessions as HTTP-only after fallback, so later turns do not repeat the known-failing transport;
- reset `StreamServer` protocol and provider state when switching from WebSocket events to SSE;
- reuse the existing Finch request construction, retry, telemetry, backpressure, and error handling paths.

Both OpenAI Responses and OpenAI Codex opt into the generic fallback through WebSocket request metadata. Other WebSocket providers retain their existing behavior.

This follows the transport strategy used by the official Codex client:

- [Responses WebSocket endpoint](https://github.com/openai/codex/blob/4ef836f883c38ba6d39e6920f335ce6452b7de33/codex-rs/codex-api/src/endpoint/responses_websocket.rs) sends `response.create` over WebSocket and enables `permessage-deflate`.
- [Responses retry orchestration](https://github.com/openai/codex/blob/4ef836f883c38ba6d39e6920f335ce6452b7de33/codex-rs/core/src/responses_retry.rs) switches transports after the WebSocket retry budget is exhausted.
- [Client transport state](https://github.com/openai/codex/blob/4ef836f883c38ba6d39e6920f335ce6452b7de33/codex-rs/core/src/client.rs) keeps fallback state at session scope.
- [Fallback integration tests](https://github.com/openai/codex/blob/4ef836f883c38ba6d39e6920f335ce6452b7de33/codex-rs/core/tests/suite/websocket_fallback.rs) verify HTTP fallback and that it remains sticky across turns.

ReqLLM intentionally implements the smallest corrective subset here: pre-output `1009` fallback and sticky routing. WebSocket compression and incremental `previous_response_id` reuse remain separate concerns.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Added integration coverage for:

- pre-output close `1009` replaying successfully over HTTP/SSE;
- close `1009` after provider output remaining an error without replay;
- reusable session fallback remaining sticky across subsequent turns;
- OpenAI Codex WebSocket requests declaring HTTP fallback support.

Validation performed:

- full suite: 4,136 passed, 11 skipped, 151 excluded;
- `mix quality`: formatting, warnings-as-errors compilation, Credo, and Dialyzer passed;
- real `openai_codex:gpt-5.6-sol` normal WebSocket stream succeeded;
- locally forced pre-output close `1009` then replayed successfully against the real Codex HTTP/SSE endpoint;
- the same smoke test verified sticky HTTP routing for the reusable session.

The real smoke test refreshed OAuth credentials in memory only and did not persist or log them.

## Checklist

- [x] My code follows the project's style guidelines
- [x] Documentation is unchanged because this is automatic transport recovery with no new public option
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

No linked issue.
