### PR TITLE
test: isolate exact-empty capture assertions

### DIFF
--- a/test/req_llm/plan_test.exs
+++ b/test/req_llm/plan_test.exs
@@ -1,7 +1,10 @@
 defmodule ReqLLM.PlanTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag contract: :public_api
+
+  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
 
   alias ReqLLM.Providers.{Anthropic, OpenAI}
 
@@ -211,6 +214,34 @@ defmodule ReqLLM.PlanTest do
   end
 
   describe "redaction and no-I/O guarantees" do
+    test "does not resolve credentials, access fixtures, or log translation warnings" do
+      model = %{
+        provider: :openai,
+        id: "chat-latest",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      output =
+        capture_io(:stderr, fn ->
+          log =
+            capture_log(fn ->
+              send(
+                self(),
+                ReqLLM.plan(model, :chat,
+                  max_tokens: 64,
+                  temperature: 0.2
+                )
+              )
+            end)
+
+          send(self(), {:captured_log, log})
+        end)
+
+      assert output == ""
+      assert_received {:captured_log, ""}
+      assert_received {:ok, %{surface: :openai_chat_completions}}
+    end
+
     test "omits credential, payload, header, callback, and option values" do
       callback = fn request -> request end
 
@@ -304,44 +335,5 @@ defmodule ReqLLM.PlanTest do
       id: "chat-latest",
       extra: %{wire: %{protocol: "openai_chat"}}
     })
-  end
-end
-
-defmodule ReqLLM.PlanSilenceTest do
-  use ExUnit.Case, async: false
-
-  @moduletag contract: :public_api
-
-  import ExUnit.CaptureIO
-  import ExUnit.CaptureLog
-
-  describe "redaction and no-I/O guarantees" do
-    test "does not resolve credentials, access fixtures, or log translation warnings" do
-      model = %{
-        provider: :openai,
-        id: "chat-latest",
-        extra: %{wire: %{protocol: "openai_chat"}}
-      }
-
-      output =
-        capture_io(:stderr, fn ->
-          log =
-            capture_log(fn ->
-              send(
-                self(),
-                ReqLLM.plan(model, :chat,
-                  max_tokens: 64,
-                  temperature: 0.2
-                )
-              )
-            end)
-
-          send(self(), {:captured_log, log})
-        end)
-
-      assert output == ""
-      assert_received {:captured_log, ""}
-      assert_received {:ok, %{surface: :openai_chat_completions}}
-    end
   end
 end

--- a/test/req_llm/plan_test.exs
+++ b/test/req_llm/plan_test.exs
@@ -3,9 +3,6 @@ defmodule ReqLLM.PlanTest do
 
   @moduletag contract: :public_api
 
-  import ExUnit.CaptureIO
-  import ExUnit.CaptureLog
-
   alias ReqLLM.Providers.{Anthropic, OpenAI}
 
   @api_key "plan-api-key-secret"
@@ -214,34 +211,6 @@ defmodule ReqLLM.PlanTest do
   end
 
   describe "redaction and no-I/O guarantees" do
-    test "does not resolve credentials, access fixtures, or log translation warnings" do
-      model = %{
-        provider: :openai,
-        id: "chat-latest",
-        extra: %{wire: %{protocol: "openai_chat"}}
-      }
-
-      output =
-        capture_io(:stderr, fn ->
-          log =
-            capture_log(fn ->
-              send(
-                self(),
-                ReqLLM.plan(model, :chat,
-                  max_tokens: 64,
-                  temperature: 0.2
-                )
-              )
-            end)
-
-          send(self(), {:captured_log, log})
-        end)
-
-      assert output == ""
-      assert_received {:captured_log, ""}
-      assert_received {:ok, %{surface: :openai_chat_completions}}
-    end
-
     test "omits credential, payload, header, callback, and option values" do
       callback = fn request -> request end
 
@@ -335,5 +304,44 @@ defmodule ReqLLM.PlanTest do
       id: "chat-latest",
       extra: %{wire: %{protocol: "openai_chat"}}
     })
+  end
+end
+
+defmodule ReqLLM.PlanSilenceTest do
+  use ExUnit.Case, async: false
+
+  @moduletag contract: :public_api
+
+  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
+
+  describe "redaction and no-I/O guarantees" do
+    test "does not resolve credentials, access fixtures, or log translation warnings" do
+      model = %{
+        provider: :openai,
+        id: "chat-latest",
+        extra: %{wire: %{protocol: "openai_chat"}}
+      }
+
+      output =
+        capture_io(:stderr, fn ->
+          log =
+            capture_log(fn ->
+              send(
+                self(),
+                ReqLLM.plan(model, :chat,
+                  max_tokens: 64,
+                  temperature: 0.2
+                )
+              )
+            end)
+
+          send(self(), {:captured_log, log})
+        end)
+
+      assert output == ""
+      assert_received {:captured_log, ""}
+      assert_received {:ok, %{surface: :openai_chat_completions}}
+    end
   end
 end

--- a/test/req_llm/request_plan_test.exs
+++ b/test/req_llm/request_plan_test.exs
@@ -1,8 +1,6 @@
 defmodule ReqLLM.RequestPlanTest do
   use ExUnit.Case, async: true
 
-  import ExUnit.CaptureIO
-
   alias ReqLLM.RequestPlan
 
   describe "build/3" do
@@ -101,28 +99,6 @@ defmodule ReqLLM.RequestPlanTest do
       assert plan.surface == :openai_responses
     end
 
-    test "keeps planning warnings in deterministic source order" do
-      model_input =
-        {:openai, "chat-latest", [stream_transport: :http, unsupported_default: true]}
-
-      assert capture_io(:stderr, fn ->
-               send(
-                 self(),
-                 RequestPlan.build(model_input, :chat,
-                   provider_options: [openai_stream_transport: :websocket]
-                 )
-               )
-             end) == ""
-
-      assert_received {:ok, plan}
-
-      assert plan.warnings == [
-               "Ignoring tuple model defaults for chat: :stream_transport is controlled by the operation boundary, not the model, :unsupported_default is not accepted by this operation. Pass only documented chat options; explicit call options take precedence.",
-               "Defaulted to OpenAI Chat Completions because model wire metadata is absent",
-               "Ignored streaming transport selection for a non-streaming request plan"
-             ]
-    end
-
     test "selects WebSocket only for streaming OpenAI Responses" do
       assert {:ok, plan} =
                RequestPlan.build("openai:gpt-4o-mini", :chat,
@@ -199,6 +175,38 @@ defmodule ReqLLM.RequestPlanTest do
                )
 
       assert Exception.message(transport_error) =~ "unsupported internal stream transport"
+    end
+  end
+end
+
+defmodule ReqLLM.RequestPlanSilenceTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias ReqLLM.RequestPlan
+
+  describe "build/3" do
+    test "keeps planning warnings in deterministic source order" do
+      model_input =
+        {:openai, "chat-latest", [stream_transport: :http, unsupported_default: true]}
+
+      assert capture_io(:stderr, fn ->
+               send(
+                 self(),
+                 RequestPlan.build(model_input, :chat,
+                   provider_options: [openai_stream_transport: :websocket]
+                 )
+               )
+             end) == ""
+
+      assert_received {:ok, plan}
+
+      assert plan.warnings == [
+               "Ignoring tuple model defaults for chat: :stream_transport is controlled by the operation boundary, not the model, :unsupported_default is not accepted by this operation. Pass only documented chat options; explicit call options take precedence.",
+               "Defaulted to OpenAI Chat Completions because model wire metadata is absent",
+               "Ignored streaming transport selection for a non-streaming request plan"
+             ]
     end
   end
 end

--- a/test/req_llm/request_plan_test.exs
+++ b/test/req_llm/request_plan_test.exs
@@ -1,5 +1,7 @@
 defmodule ReqLLM.RequestPlanTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
 
   alias ReqLLM.RequestPlan
 
@@ -99,6 +101,28 @@ defmodule ReqLLM.RequestPlanTest do
       assert plan.surface == :openai_responses
     end
 
+    test "keeps planning warnings in deterministic source order" do
+      model_input =
+        {:openai, "chat-latest", [stream_transport: :http, unsupported_default: true]}
+
+      assert capture_io(:stderr, fn ->
+               send(
+                 self(),
+                 RequestPlan.build(model_input, :chat,
+                   provider_options: [openai_stream_transport: :websocket]
+                 )
+               )
+             end) == ""
+
+      assert_received {:ok, plan}
+
+      assert plan.warnings == [
+               "Ignoring tuple model defaults for chat: :stream_transport is controlled by the operation boundary, not the model, :unsupported_default is not accepted by this operation. Pass only documented chat options; explicit call options take precedence.",
+               "Defaulted to OpenAI Chat Completions because model wire metadata is absent",
+               "Ignored streaming transport selection for a non-streaming request plan"
+             ]
+    end
+
     test "selects WebSocket only for streaming OpenAI Responses" do
       assert {:ok, plan} =
                RequestPlan.build("openai:gpt-4o-mini", :chat,
@@ -175,38 +199,6 @@ defmodule ReqLLM.RequestPlanTest do
                )
 
       assert Exception.message(transport_error) =~ "unsupported internal stream transport"
-    end
-  end
-end
-
-defmodule ReqLLM.RequestPlanSilenceTest do
-  use ExUnit.Case, async: false
-
-  import ExUnit.CaptureIO
-
-  alias ReqLLM.RequestPlan
-
-  describe "build/3" do
-    test "keeps planning warnings in deterministic source order" do
-      model_input =
-        {:openai, "chat-latest", [stream_transport: :http, unsupported_default: true]}
-
-      assert capture_io(:stderr, fn ->
-               send(
-                 self(),
-                 RequestPlan.build(model_input, :chat,
-                   provider_options: [openai_stream_transport: :websocket]
-                 )
-               )
-             end) == ""
-
-      assert_received {:ok, plan}
-
-      assert plan.warnings == [
-               "Ignoring tuple model defaults for chat: :stream_transport is controlled by the operation boundary, not the model, :unsupported_default is not accepted by this operation. Pass only documented chat options; explicit call options take precedence.",
-               "Defaulted to OpenAI Chat Completions because model wire metadata is absent",
-               "Ignored streaming transport selection for a non-streaming request plan"
-             ]
     end
   end
 end


### PR DESCRIPTION
## Summary

- Run `ReqLLM.PlanTest` and `ReqLLM.RequestPlanTest` synchronously.
- Isolate exact-empty log and named-stderr capture assertions from concurrent test output.
- Keep the capture assertions in their owning modules with a two-line cumulative diff.

## Root cause

`capture_log/1` and named `capture_io(:stderr, ...)` use shared capture paths. The affected exact-empty assertions ran in async test modules, so they could receive output from another test.

## Validation

- `mix test test/req_llm/plan_test.exs test/req_llm/request_plan_test.exs --repeat-until-failure 100 --max-failures 1`
- `mix test --seed 360582` — 4,133 passed, 11 skipped
- `mix quality`

Closes #959