### PR TITLE
feat(minimax): add video generation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ req_llm-*.tar
 
 # playground config
 playground_config.json
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ That breadth extends well beyond chat: ReqLLM tracks **92 non-text operation mod
 | [Google Vertex AI](https://llmcatalog.dev/?providers=google_vertex) | `google_vertex` | 40 | text | 11 | [Guide](guides/google_vertex.md) |
 | [Groq](https://llmcatalog.dev/?providers=groq) | `groq` | 18 | text, speech 2, transcription 2 | 11 | [Guide](guides/groq.md) |
 | [Meta Model API](https://llmcatalog.dev/?providers=meta) | `meta` | 1 | text | 1 | [Guide](guides/meta.md) |
-| [MiniMax](https://llmcatalog.dev/?providers=minimax) | `minimax` | 6 | text | 6 | — |
+| [MiniMax](https://llmcatalog.dev/?providers=minimax) | `minimax` | 6 | text, video 2 | 6 | — |
 | [Moonshot AI](https://llmcatalog.dev/?providers=moonshotai) | `moonshotai` | 1 | text | 1 | [Guide](guides/moonshot_ai.md) |
 | [OpenAI](https://llmcatalog.dev/?providers=openai) | `openai` | 86 | text, embedding 3, image 5, speech 6, transcription 7 | 64 | [Guide](guides/openai.md) |
 | [OpenRouter](https://llmcatalog.dev/?providers=openrouter) | `openrouter` | 364 | text, embedding 25, image 5 | 234 | [Guide](guides/openrouter.md) |
@@ -135,6 +135,41 @@ File.write!("red_square.png", image_bytes)
 ```
 
 Note: Google image models gemini-2.5-flash-image and gemini-3-pro-image-preview reject :n; specify the image count in the prompt.
+
+```elixir
+{:ok, task} =
+  ReqLLM.generate_video("minimax:MiniMax-H3",
+    [prompt: "A boy playing basketball by the sea", first_frame_image: "https://example.com/frame.png"],
+    duration: 5,
+    resolution: "2K"
+  )
+
+{:ok, completed} = ReqLLM.wait_video("minimax:MiniMax-H3", task.task_id)
+# completed.url is the video download URL
+
+# Hailuo series (V1 API) returns a file_id instead of a url:
+{:ok, task} =
+  ReqLLM.generate_video("minimax:MiniMax-Hailuo-2.3",
+    [prompt: "A cat", first_frame_image: "https://example.com/cat.png"],
+    duration: 6,
+    resolution: "768P"
+  )
+
+{:ok, completed} = ReqLLM.wait_video("minimax:MiniMax-Hailuo-2.3", task.task_id)
+{:ok, file} = ReqLLM.retrieve_video_file("minimax:MiniMax-Hailuo-2.3", completed.file_id)
+# file.url is the time-limited download URL
+
+# Sensitive images: no public URL exposure. Auto-upload with {:upload, binary, media_type}:
+# - H3 (V2 API): uploads to the platform and references mm_file://{file_id}
+# - Hailuo (V1 API): inlines the image as a base64 data URL
+{:ok, task} =
+  ReqLLM.generate_video("minimax:MiniMax-Hailuo-2.3",
+    [prompt: "The cat turns its head",
+     first_frame_image: {:upload, image_bytes, "image/jpeg"}],
+    duration: 6,
+    resolution: "768P"
+  )
+```
 
 ```elixir
 {:ok, response} = ReqLLM.generate_text(

--- a/guides/model-support.md
+++ b/guides/model-support.md
@@ -163,9 +163,9 @@ provider-native feature and are not consulted by request routing.
 | `veo-2.0-generate-001` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
 | `veo-3.0-fast-generate-001` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
 | `veo-3.0-generate-001` | `text` | `google.unrecorded_text` | text → text | Experimental | 0/5 | 2026-05-30T01:01:43Z | surface declaration unknown |
-| `veo-3.1-fast-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
-| `veo-3.1-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
-| `veo-3.1-lite-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | basic failed at provider_drift |
+| `veo-3.1-fast-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | operation not declared |
+| `veo-3.1-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | operation not declared |
+| `veo-3.1-lite-generate-preview` | `text` | `google.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:01:43Z | operation not declared |
 
 ## groq
 
@@ -629,7 +629,7 @@ provider-native feature and are not consulted by request routing.
 | `grok-imagine-image` | `image` | `xai.image` | text → image | First-class | 1/1 | 2026-05-30T01:06:56Z | complete current baseline |
 | `grok-imagine-image-pro` | `image` | `xai.image` | text → image | First-class | 1/1 | 2026-05-30T01:06:56Z | complete current baseline |
 | `grok-imagine-image-quality` | `image` | `xai.image` | text → image | First-class | 1/1 | 2026-05-30T01:06:56Z | complete current baseline |
-| `grok-imagine-video` | `text` | `xai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:06:18Z | basic failed at provider_drift |
+| `grok-imagine-video` | `text` | `xai.unrecorded_text` | text → text | Unsupported | 0/5 | 2026-05-30T01:06:18Z | operation not declared |
 
 ## zai
 

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -1263,7 +1263,7 @@ defmodule ReqLLM do
   @doc """
   Resolves a video `file_id` to a time-limited download URL (V1 providers).
   """
-  @spec retrieve_video_file(ReqLLM.model_input(), String.t(), keyword()) ::
+  @spec retrieve_video_file(ReqLLM.model_input(), String.t() | integer(), keyword()) ::
           {:ok, ReqLLM.Video.File.t()} | {:error, term()}
   defdelegate retrieve_video_file(model_spec, file_id, opts \\ []), to: Video, as: :retrieve_file
 

--- a/lib/req_llm.ex
+++ b/lib/req_llm.ex
@@ -92,7 +92,8 @@ defmodule ReqLLM do
     Schema,
     Speech,
     Tool,
-    Transcription
+    Transcription,
+    Video
   }
 
   @typedoc """
@@ -1231,6 +1232,47 @@ defmodule ReqLLM do
       {:error, error} -> raise error
     end
   end
+
+  # ===========================================================================
+  # Video Generation API - Delegated to ReqLLM.Video
+  # ===========================================================================
+
+  @doc """
+  Submits a video generation task and returns a `ReqLLM.Video.Task` with the
+  provider `task_id`. The task runs asynchronously; poll with `query_video/3`
+  or block until completion with `wait_video/3`.
+  """
+  @spec generate_video(ReqLLM.model_input(), keyword(), keyword()) ::
+          {:ok, ReqLLM.Video.Task.t()} | {:error, term()}
+  defdelegate generate_video(model_spec, content, opts \\ []), to: Video
+
+  @doc """
+  Queries the status of a video generation task by `task_id`.
+  """
+  @spec query_video(ReqLLM.model_input(), String.t(), keyword()) ::
+          {:ok, ReqLLM.Video.Task.t()} | {:error, term()}
+  defdelegate query_video(model_spec, task_id, opts \\ []), to: Video
+
+  @doc """
+  Polls a video generation task until it reaches a terminal state.
+  """
+  @spec wait_video(ReqLLM.model_input(), String.t(), keyword()) ::
+          {:ok, ReqLLM.Video.Task.t()} | {:error, term()}
+  defdelegate wait_video(model_spec, task_id, opts \\ []), to: Video
+
+  @doc """
+  Resolves a video `file_id` to a time-limited download URL (V1 providers).
+  """
+  @spec retrieve_video_file(ReqLLM.model_input(), String.t(), keyword()) ::
+          {:ok, ReqLLM.Video.File.t()} | {:error, term()}
+  defdelegate retrieve_video_file(model_spec, file_id, opts \\ []), to: Video, as: :retrieve_file
+
+  @doc """
+  Uploads a file to the provider platform for use as video generation input.
+  """
+  @spec upload_video_file(ReqLLM.model_input(), binary(), keyword()) ::
+          {:ok, ReqLLM.Video.File.t()} | {:error, term()}
+  defdelegate upload_video_file(model_spec, file_binary, opts \\ []), to: Video, as: :upload_file
 
   @doc """
   Streams structured data generation using an AI model with schema validation.

--- a/lib/req_llm/compatibility/scenario_catalog.ex
+++ b/lib/req_llm/compatibility/scenario_catalog.ex
@@ -41,6 +41,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
     %{id: :transcription, test_file: "transcription_test.exs"},
     %{id: :rerank, test_file: "rerank_test.exs"},
     %{id: :ocr, test_file: "ocr_test.exs"},
+    %{id: :video, test_file: "video_generation_test.exs"},
     %{id: :all, test_file: :provider_directory}
   ]
 
@@ -57,6 +58,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
     %{id: "transcription", operation: :transcription},
     %{id: "rerank", operation: :rerank},
     %{id: "ocr", operation: :ocr},
+    %{id: "video", operation: :video},
     %{id: "grounding", operation: :text},
     %{id: "grounding_legacy", operation: :text},
     %{id: "multimodal_tool_result", operation: :text},
@@ -135,6 +137,10 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog do
                        output_modalities: [:ranked_documents], requirements: [:reranking]},
                       {"ocr_basic", "ocr",
                        input_modalities: [:document], requirements: [:ocr], proof: :declared},
+                      {"video_basic", "video",
+                       output_modalities: [:video],
+                       requirements: [:video_generation],
+                       proof: :declared},
                       {"grounding_basic", "grounding",
                        requirements: [:grounding], applicability: :focused, providers: [:google]},
                       {"grounding_with_context", "grounding",

--- a/lib/req_llm/compatibility/scenario_catalog/validator.ex
+++ b/lib/req_llm/compatibility/scenario_catalog/validator.ex
@@ -29,7 +29,8 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
     :token_logprobs,
     :tool_call,
     :tool_result,
-    :usage
+    :usage,
+    :video
   ]
   @requirements [
     :cross_provider_tool_ids,
@@ -47,6 +48,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalog.Validator do
     :reasoning,
     :tool_calling,
     :transcription,
+    :video_generation,
     :web_fetch,
     :web_search
   ]

--- a/lib/req_llm/model_input.ex
+++ b/lib/req_llm/model_input.ex
@@ -76,6 +76,7 @@ defmodule ReqLLM.ModelInput do
   defp option_schema(:speech), do: ReqLLM.Speech.schema()
   defp option_schema(:rerank), do: ReqLLM.Rerank.schema()
   defp option_schema(:ocr), do: ReqLLM.OCR.schema()
+  defp option_schema(:video), do: ReqLLM.Video.schema()
 
   defp merge_defaults(defaults, call_opts) do
     Keyword.merge(defaults, call_opts)

--- a/lib/req_llm/model_operation.ex
+++ b/lib/req_llm/model_operation.ex
@@ -1,11 +1,12 @@
 defmodule ReqLLM.ModelOperation do
   @moduledoc false
 
-  @operations ~w(text embedding image speech transcription rerank ocr all)a
+  @operations ~w(text embedding image speech transcription rerank ocr video all)a
   @image_providers ~w(openai google xai minimax azure)a
   @speech_providers ~w(openai elevenlabs)a
   @transcription_providers ~w(openai groq elevenlabs openrouter)a
   @rerank_providers ~w(cohere)a
+  @video_providers ~w(minimax)a
   @operation_map for operation <- @operations,
                      into: %{},
                      do: {Atom.to_string(operation), operation}
@@ -36,6 +37,7 @@ defmodule ReqLLM.ModelOperation do
   def supported?(model, :transcription), do: transcription?(model)
   def supported?(model, :rerank), do: rerank?(model)
   def supported?(model, :ocr), do: ocr?(model)
+  def supported?(model, :video), do: video?(model)
   def supported?(model, :text), do: text?(model)
   def supported?(_model, _operation), do: false
 
@@ -46,6 +48,7 @@ defmodule ReqLLM.ModelOperation do
   def category(:transcription), do: "transcription"
   def category(:rerank), do: "rerank"
   def category(:ocr), do: "ocr"
+  def category(:video), do: "video"
   def category(_operation), do: "core"
 
   @spec config_key(atom()) :: atom()
@@ -61,6 +64,7 @@ defmodule ReqLLM.ModelOperation do
       transcription_model?(model) -> "transcription"
       rerank_model?(model) -> "rerank"
       ocr_model?(model) -> "ocr"
+      video_model?(model) -> "video"
       true -> "text"
     end
   end
@@ -72,7 +76,8 @@ defmodule ReqLLM.ModelOperation do
       not speech_model?(model) and
       not transcription_model?(model) and
       not rerank_model?(model) and
-      not ocr_model?(model)
+      not ocr_model?(model) and
+      not video_model?(model)
   end
 
   defp chat_enabled?(model) do
@@ -108,6 +113,10 @@ defmodule ReqLLM.ModelOperation do
     field(model, :provider) == :google_vertex and ocr_model?(model)
   end
 
+  defp video?(model) do
+    provider?(model, @video_providers) and video_model?(model)
+  end
+
   defp image_model?(model) do
     capability_truthy?(model, [:images]) or
       id_contains?(model, ["image", "imagen", "dall-e"]) or
@@ -134,6 +143,12 @@ defmodule ReqLLM.ModelOperation do
     capability_truthy?(model, [:ocr]) or
       field(model, :family) == "mistral-ocr" or
       id_contains?(model, ["ocr"])
+  end
+
+  defp video_model?(model) do
+    capability_truthy?(model, [:video]) or
+      id_contains?(model, ["hailuo", "h3", "video"]) or
+      (modality?(model, :output, :video) and not modality?(model, :output, :text))
   end
 
   defp capability_present?(model, path) do

--- a/lib/req_llm/provider/options.ex
+++ b/lib/req_llm/provider/options.ex
@@ -501,6 +501,7 @@ defmodule ReqLLM.Provider.Options do
   end
 
   defp base_schema_for_operation(:image), do: ReqLLM.Images.schema()
+  defp base_schema_for_operation(:video), do: ReqLLM.Video.schema()
 
   defp base_schema_for_operation(:embedding) do
     embedding_schema = ReqLLM.Embedding.schema()
@@ -793,6 +794,7 @@ defmodule ReqLLM.Provider.Options do
   defp maybe_extract_model_options(:image, _model, opts), do: opts
   defp maybe_extract_model_options(:embedding, _model, opts), do: opts
   defp maybe_extract_model_options(:rerank, _model, opts), do: opts
+  defp maybe_extract_model_options(:video, _model, opts), do: opts
 
   defp maybe_extract_model_options(_operation, model, opts),
     do: extract_model_options(model, opts)

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -49,6 +49,10 @@ defmodule ReqLLM.Providers.Minimax do
       default: false,
       doc: "Enable automatic prompt optimization for MiniMax image generation."
     ],
+    fast_pretreatment: [
+      type: :boolean,
+      doc: "Reduce MiniMax video prompt optimization time when prompt optimization is enabled."
+    ],
     subject_reference: [
       type: :any,
       doc:
@@ -353,6 +357,17 @@ defmodule ReqLLM.Providers.Minimax do
     {opts, Enum.reverse(warnings)}
   end
 
+  def pre_validate_options(:video, _model, opts) do
+    provider_options =
+      opts
+      |> Keyword.get(:provider_options, [])
+      |> Keyword.put_new(:prompt_optimizer, true)
+
+    Keyword.put(opts, :provider_options, provider_options)
+  end
+
+  def pre_validate_options(_operation, _model, opts), do: opts
+
   @impl ReqLLM.Provider
   def encode_body(%{options: %{api_mod: api_mod}} = request) when is_atom(api_mod) do
     api_mod.encode_body(request)
@@ -471,6 +486,16 @@ defmodule ReqLLM.Providers.Minimax do
   end
 
   defp video_content(content) when is_list(content) do
+    if Keyword.keyword?(content) do
+      validate_video_prompt(content)
+    else
+      invalid_video_content()
+    end
+  end
+
+  defp video_content(_content), do: invalid_video_content()
+
+  defp validate_video_prompt(content) do
     prompt = Keyword.get(content, :prompt)
 
     if is_binary(prompt) and String.trim(prompt) != "" do
@@ -483,7 +508,7 @@ defmodule ReqLLM.Providers.Minimax do
     end
   end
 
-  defp video_content(_content) do
+  defp invalid_video_content do
     {:error,
      ReqLLM.Error.Invalid.Parameter.exception(
        parameter: "video content must be a keyword list with a :prompt"

--- a/lib/req_llm/providers/minimax.ex
+++ b/lib/req_llm/providers/minimax.ex
@@ -131,12 +131,196 @@ defmodule ReqLLM.Providers.Minimax do
     end
   end
 
+  def prepare_request(:video, model_spec, content, opts) do
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, content} <- video_content(content),
+         http_opts = Keyword.get(opts, :req_http_options, []),
+         api_mod = video_api_mod(model),
+         opts = Keyword.put_new(opts, :base_url, api_mod.base_url()),
+         {:ok, processed_opts} <-
+           ReqLLM.Provider.Options.process(__MODULE__, :video, model, opts) do
+      path = api_mod.path()
+
+      req_keys =
+        supported_provider_options() ++
+          [
+            :operation,
+            :model,
+            :content,
+            :duration,
+            :resolution,
+            :ratio,
+            :callback_url,
+            :prompt_optimizer,
+            :fast_pretreatment,
+            :provider_options,
+            :req_http_options,
+            :api_mod,
+            :base_url
+          ]
+
+      timeout =
+        Keyword.get(
+          processed_opts,
+          :receive_timeout,
+          Application.get_env(:req_llm, :video_receive_timeout, 60_000)
+        )
+
+      request =
+        Req.new(
+          [
+            url: path,
+            method: :post,
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
+        )
+        |> Req.Request.register_options(req_keys)
+        |> Req.Request.merge_options(
+          Keyword.take(processed_opts, req_keys) ++
+            [
+              operation: :video,
+              model: model.provider_model_id || model.id,
+              content: content,
+              base_url: Keyword.get(opts, :base_url, api_mod.base_url()),
+              api_mod: api_mod
+            ]
+        )
+        |> attach(model, processed_opts)
+
+      {:ok, request}
+    end
+  end
+
+  def prepare_request(:video_query, model_spec, task_id, opts) do
+    with {:ok, model} <- ReqLLM.model(model_spec) do
+      api_mod = video_api_mod(model)
+      path = api_mod.query_path(task_id)
+      http_opts = Keyword.get(opts, :req_http_options, [])
+      timeout = Keyword.get(opts, :receive_timeout, 30_000)
+
+      request =
+        Req.new(
+          [
+            url: path,
+            method: :get,
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
+        )
+        |> Req.Request.register_options([
+          :operation,
+          :model,
+          :task_id,
+          :api_mod,
+          :base_url,
+          :req_http_options
+        ])
+        |> Req.Request.merge_options(
+          operation: :video_query,
+          model: model.provider_model_id || model.id,
+          task_id: task_id,
+          base_url: Keyword.get(opts, :base_url, api_mod.base_url()),
+          api_mod: api_mod
+        )
+        |> attach(model, opts)
+
+      {:ok, request}
+    end
+  end
+
+  def prepare_request(:video_retrieve, model_spec, file_id, opts) do
+    with {:ok, model} <- ReqLLM.model(model_spec) do
+      api_mod = ReqLLM.Providers.Minimax.VideoAPIV1
+      path = api_mod.retrieve_path(file_id)
+      http_opts = Keyword.get(opts, :req_http_options, [])
+      timeout = Keyword.get(opts, :receive_timeout, 30_000)
+
+      request =
+        Req.new(
+          [
+            url: path,
+            method: :get,
+            receive_timeout: timeout
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
+        )
+        |> Req.Request.register_options([
+          :operation,
+          :model,
+          :file_id,
+          :api_mod,
+          :base_url,
+          :req_http_options
+        ])
+        |> Req.Request.merge_options(
+          operation: :video_retrieve,
+          model: model.provider_model_id || model.id,
+          file_id: file_id,
+          base_url: Keyword.get(opts, :base_url, api_mod.base_url()),
+          api_mod: api_mod
+        )
+        |> attach(model, opts)
+
+      {:ok, request}
+    end
+  end
+
+  def prepare_request(:video_upload, model_spec, file_binary, opts) do
+    with {:ok, model} <- ReqLLM.model(model_spec) do
+      api_mod = ReqLLM.Providers.Minimax.VideoAPIV1
+      path = api_mod.upload_path()
+      http_opts = Keyword.get(opts, :req_http_options, [])
+      timeout = Keyword.get(opts, :receive_timeout, 60_000)
+      purpose = Keyword.get(opts, :purpose, "video_generation_input")
+      media_type = Keyword.get(opts, :media_type, "application/octet-stream")
+      filename = Keyword.get(opts, :filename) || upload_filename(media_type)
+
+      request =
+        Req.new(
+          [
+            url: path,
+            method: :post,
+            receive_timeout: timeout,
+            form_multipart: [
+              {"purpose", purpose},
+              {"file", {file_binary, [filename: filename, content_type: media_type]}}
+            ]
+          ] ++ ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: timeout)
+        )
+        |> Req.Request.register_options([
+          :operation,
+          :model,
+          :api_mod,
+          :base_url,
+          :req_http_options,
+          :purpose,
+          :filename,
+          :media_type
+        ])
+        |> Req.Request.merge_options(
+          operation: :video_upload,
+          model: model.provider_model_id || model.id,
+          base_url: Keyword.get(opts, :base_url, api_mod.base_url()),
+          api_mod: api_mod
+        )
+        |> attach(model, opts)
+
+      {:ok, request}
+    end
+  end
+
   def prepare_request(operation, model_spec, input, opts) do
     ReqLLM.Provider.Defaults.prepare_request(__MODULE__, operation, model_spec, input, opts)
   end
 
   @impl ReqLLM.Provider
   def translate_options(:image, _model, opts), do: {opts, []}
+
+  def translate_options(:video, _model, opts), do: {opts, []}
+
+  def translate_options(:video_query, _model, opts), do: {opts, []}
+
+  def translate_options(:video_retrieve, _model, opts), do: {opts, []}
+
+  def translate_options(:video_upload, _model, opts), do: {opts, []}
 
   def translate_options(_operation, _model, opts) do
     warnings = []
@@ -249,6 +433,61 @@ defmodule ReqLLM.Providers.Minimax do
     event
     |> ReqLLM.Provider.Defaults.default_decode_stream_event(model)
     |> Enum.map(&normalize_stream_chunk/1)
+  end
+
+  @media_type_extensions %{
+    "image/jpeg" => "jpg",
+    "image/png" => "png",
+    "image/webp" => "webp",
+    "image/heic" => "heic",
+    "image/heif" => "heif",
+    "video/mp4" => "mp4",
+    "video/quicktime" => "mov",
+    "audio/wav" => "wav",
+    "audio/mpeg" => "mp3"
+  }
+
+  defp upload_filename(media_type) do
+    ext = Map.get(@media_type_extensions, media_type, "bin")
+    "input.#{ext}"
+  end
+
+  @doc """
+  Returns the API driver module for the given model's video operations.
+
+  `MiniMax-H3*` models use the V2 API (`ReqLLM.Providers.Minimax.VideoAPI`);
+  all other video models (Hailuo series, I2V-01*, T2V-01*) use the V1 API
+  (`ReqLLM.Providers.Minimax.VideoAPIV1`).
+  """
+  @spec video_api_mod(LLMDB.Model.t()) :: module()
+  def video_api_mod(model) do
+    model_id = model.provider_model_id || model.id || ""
+
+    if String.starts_with?(model_id, "MiniMax-H3") do
+      ReqLLM.Providers.Minimax.VideoAPI
+    else
+      ReqLLM.Providers.Minimax.VideoAPIV1
+    end
+  end
+
+  defp video_content(content) when is_list(content) do
+    prompt = Keyword.get(content, :prompt)
+
+    if is_binary(prompt) and String.trim(prompt) != "" do
+      {:ok, content}
+    else
+      {:error,
+       ReqLLM.Error.Invalid.Parameter.exception(
+         parameter: "video generation requires a non-empty :prompt in content"
+       )}
+    end
+  end
+
+  defp video_content(_content) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(
+       parameter: "video content must be a keyword list with a :prompt"
+     )}
   end
 
   defp image_context(prompt_or_messages, opts) do

--- a/lib/req_llm/providers/minimax/video_api.ex
+++ b/lib/req_llm/providers/minimax/video_api.ex
@@ -1,0 +1,271 @@
+defmodule ReqLLM.Providers.Minimax.VideoAPI do
+  @moduledoc """
+  MiniMax Video API driver.
+
+  Implements request/response handling for MiniMax video generation via the
+  native async endpoints:
+
+    * `POST /v2/video_generation` - create a generation task, returns `task_id`
+    * `GET /v2/query/video_generation/{task_id}` - poll task status, returns
+      the video download URL on success
+
+  The request body uses the multimodal `content[]` shape (`text` /
+  `image_url` / `video_url` / `audio_url` with optional `role`), which is
+  encoded from the structured keyword list passed to `ReqLLM.Video`.
+  """
+
+  @behaviour ReqLLM.Providers.OpenAI.API
+
+  import ReqLLM.Provider.Utils, only: [ensure_parsed_body: 1]
+
+  alias ReqLLM.Video.Task
+
+  @status_map %{
+    "queued" => :queued,
+    "running" => :running,
+    "succeeded" => :succeeded,
+    "failed" => :failed,
+    "cancelled" => :cancelled
+  }
+
+  @impl true
+  def path, do: "/v2/video_generation"
+
+  @doc """
+  Base URL for the MiniMax V2 video endpoints (the V1 base URL does not apply).
+  """
+  @spec base_url() :: String.t()
+  def base_url, do: "https://api.minimax.io"
+
+  @doc """
+  Path of the task query endpoint for the given `task_id`.
+  """
+  @spec query_path(String.t()) :: String.t()
+  def query_path(task_id) do
+    "/v2/query/video_generation/#{task_id}"
+  end
+
+  @impl true
+  def encode_body(request) do
+    case request.options[:operation] do
+      :video -> encode_create_body(request)
+      :video_query -> request
+    end
+  end
+
+  defp encode_create_body(request) do
+    opts = request.options
+
+    body =
+      %{
+        "model" => opts[:model],
+        "content" => encode_content(opts[:content])
+      }
+      |> maybe_put_string("resolution", opts[:resolution])
+      |> maybe_put_integer("duration", opts[:duration])
+      |> maybe_put_string("ratio", opts[:ratio])
+      |> maybe_put_string("callback_url", opts[:callback_url])
+
+    put_in(request.options[:json], body)
+  end
+
+  @impl true
+  def decode_response({req, resp}) do
+    body = ensure_parsed_body(resp.body)
+
+    case minimax_error?(body) do
+      {:error, error} ->
+        {req, error}
+
+      :ok ->
+        case resp.status do
+          200 ->
+            case req.options[:operation] do
+              :video -> decode_create_response(req, resp, body)
+              :video_query -> decode_query_response(req, resp, body)
+            end
+
+          status ->
+            err =
+              ReqLLM.Error.API.Response.exception(
+                reason: "MiniMax Video API error",
+                status: status,
+                response_body: resp.body
+              )
+
+            {req, err}
+        end
+    end
+  end
+
+  @impl true
+  def decode_stream_event(_event, _model), do: []
+
+  @impl true
+  def attach_stream(_model, _context, _opts, _finch_name) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(parameter: "streaming not supported for :video")}
+  end
+
+  defp decode_create_response(req, resp, %{"task_id" => task_id} = body) do
+    task = %Task{
+      task_id: task_id,
+      status: :queued,
+      model: req.options[:model],
+      provider: :minimax,
+      provider_meta: %{"minimax" => Map.delete(body, "task_id")}
+    }
+
+    {req, %{resp | body: task}}
+  end
+
+  defp decode_create_response(req, resp, body) do
+    err =
+      ReqLLM.Error.API.Response.exception(
+        reason: "MiniMax Video API error: missing task_id in response",
+        status: resp.status,
+        response_body: body
+      )
+
+    {req, err}
+  end
+
+  defp decode_query_response(req, resp, %{"task" => task}) when is_map(task) do
+    status = Map.get(task, "status", "queued") |> decode_status()
+
+    task_struct = %Task{
+      task_id: Map.get(task, "id", req.options[:task_id]),
+      status: status,
+      url: get_in(task, ["content", "url"]),
+      error: decode_error(get_in(task, ["error"])),
+      model: Map.get(task, "model", req.options[:model]),
+      provider: :minimax,
+      provider_meta: %{
+        "minimax" =>
+          Map.take(task, ["created_at", "updated_at", "resolution", "duration", "ratio"])
+      }
+    }
+
+    {req, %{resp | body: task_struct}}
+  end
+
+  defp decode_query_response(req, resp, body) do
+    err =
+      ReqLLM.Error.API.Response.exception(
+        reason: "MiniMax Video API error: missing task in response",
+        status: resp.status,
+        response_body: body
+      )
+
+    {req, err}
+  end
+
+  defp decode_status(status) when is_binary(status), do: Map.get(@status_map, status, :queued)
+  defp decode_status(_status), do: :queued
+
+  defp decode_error(nil), do: nil
+
+  defp decode_error(%{"message" => message} = error) do
+    code = Map.get(error, "code")
+
+    if code do
+      "#{code}: #{message}"
+    else
+      message
+    end
+  end
+
+  defp decode_error(_), do: nil
+
+  defp encode_content(content) when is_list(content) do
+    prompt = Keyword.get(content, :prompt)
+
+    text_item = %{"type" => "text", "text" => prompt}
+
+    image_items =
+      encode_media_items(content, :first_frame_image, "image_url", "first_frame") ++
+        encode_media_items(content, :last_frame_image, "image_url", "last_frame") ++
+        encode_media_items(content, :reference_images, "image_url", "reference_image")
+
+    video_items =
+      encode_media_items(content, :reference_videos, "video_url", "reference_video")
+
+    audio_items =
+      encode_media_items(content, :reference_audio, "audio_url", "reference_audio")
+
+    [text_item | image_items ++ video_items ++ audio_items]
+  end
+
+  defp encode_content(_content), do: []
+
+  defp encode_media_items(content, key, type, role) do
+    case Keyword.get(content, key) do
+      nil ->
+        []
+
+      value when is_binary(value) ->
+        [media_item(type, role, value)]
+
+      values when is_list(values) ->
+        Enum.map(values, &media_item(type, role, &1)) |> Enum.reject(&is_nil/1)
+
+      _ ->
+        []
+    end
+  end
+
+  defp media_item(type, role, url) when is_binary(url) do
+    %{"type" => type, type => %{"url" => url}, "role" => role}
+  end
+
+  defp media_item(_type, _role, _url), do: nil
+
+  defp minimax_error?(body) when is_map(body) do
+    case get_in(body, ["base_resp", "status_code"]) do
+      code when is_integer(code) and code != 0 ->
+        status_msg =
+          get_in(body, ["base_resp", "status_msg"]) || "MiniMax video generation failed"
+
+        {:error,
+         ReqLLM.Error.API.Response.exception(
+           reason: "MiniMax error #{code}: #{status_msg}",
+           status: code,
+           response_body: body
+         )}
+
+      _ ->
+        case Map.get(body, "type") do
+          "error" ->
+            message = get_in(body, ["error", "message"]) || "MiniMax video generation failed"
+
+            {:error,
+             ReqLLM.Error.API.Response.exception(
+               reason: "MiniMax error: #{message}",
+               status: 400,
+               response_body: body
+             )}
+
+          _ ->
+            :ok
+        end
+    end
+  end
+
+  defp minimax_error?(_body), do: :ok
+
+  defp maybe_put_string(body, _key, nil), do: body
+
+  defp maybe_put_string(body, key, value) when is_atom(value) do
+    Map.put(body, key, Atom.to_string(value))
+  end
+
+  defp maybe_put_string(body, key, value) when is_binary(value) do
+    Map.put(body, key, value)
+  end
+
+  defp maybe_put_string(body, _key, _), do: body
+
+  defp maybe_put_integer(body, _key, nil), do: body
+  defp maybe_put_integer(body, key, value) when is_integer(value), do: Map.put(body, key, value)
+  defp maybe_put_integer(body, _key, _), do: body
+end

--- a/lib/req_llm/providers/minimax/video_api_v1.ex
+++ b/lib/req_llm/providers/minimax/video_api_v1.ex
@@ -1,0 +1,262 @@
+defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
+  @moduledoc """
+  MiniMax Video API V1 driver (Hailuo series).
+
+  Implements request/response handling for the legacy MiniMax video generation
+  endpoints used by the `MiniMax-Hailuo-*`, `I2V-01*`, and `T2V-01*` models:
+
+    * `POST /v1/video_generation` - create a generation task, returns `task_id`
+    * `GET /v1/query/video_generation?task_id=...` - poll task status, returns
+      a `file_id` on success
+    * `GET /v1/files/retrieve?file_id=...` - resolve the `file_id` to a
+      time-limited download URL
+
+  Unlike the V2 API (MiniMax-H3), the request body is flat (`prompt`,
+  `first_frame_image`, ...) and the query endpoint takes `task_id` as a query
+  parameter. Task statuses are `Preparing` / `Queueing` / `Processing` /
+  `Success` / `Fail`.
+  """
+
+  @behaviour ReqLLM.Providers.OpenAI.API
+
+  import ReqLLM.Provider.Utils, only: [ensure_parsed_body: 1]
+
+  alias ReqLLM.Video.Task
+
+  @status_map %{
+    "Preparing" => :queued,
+    "Queueing" => :queued,
+    "Processing" => :running,
+    "Success" => :succeeded,
+    "Fail" => :failed
+  }
+
+  @impl true
+  def path, do: "/video_generation"
+
+  @doc """
+  Path of the task query endpoint for the given `task_id`.
+  """
+  @spec query_path(String.t()) :: String.t()
+  def query_path(task_id) do
+    "/query/video_generation?task_id=#{task_id}"
+  end
+
+  @doc """
+  Path of the file retrieval endpoint for the given `file_id`.
+  """
+  @spec retrieve_path(String.t()) :: String.t()
+  def retrieve_path(file_id) do
+    "/files/retrieve?file_id=#{file_id}"
+  end
+
+  @doc """
+  Path of the file upload endpoint.
+  """
+  @spec upload_path() :: String.t()
+  def upload_path, do: "/files/upload"
+
+  @doc """
+  Base URL for the MiniMax V1 video endpoints.
+  """
+  @spec base_url() :: String.t()
+  def base_url, do: "https://api.minimax.io/v1"
+
+  @impl true
+  def encode_body(request) do
+    case request.options[:operation] do
+      :video -> encode_create_body(request)
+      :video_query -> request
+      :video_retrieve -> request
+      :video_upload -> request
+    end
+  end
+
+  defp encode_create_body(request) do
+    opts = request.options
+    content = opts[:content] || []
+
+    body =
+      %{"model" => opts[:model]}
+      |> maybe_put_string("prompt", Keyword.get(content, :prompt))
+      |> maybe_put_string("first_frame_image", Keyword.get(content, :first_frame_image))
+      |> maybe_put_boolean("prompt_optimizer", opts[:prompt_optimizer])
+      |> maybe_put_boolean("fast_pretreatment", opts[:fast_pretreatment])
+      |> maybe_put_integer("duration", opts[:duration])
+      |> maybe_put_string("resolution", opts[:resolution])
+      |> maybe_put_string("callback_url", opts[:callback_url])
+
+    put_in(request.options[:json], body)
+  end
+
+  @impl true
+  def decode_response({req, resp}) do
+    body = ensure_parsed_body(resp.body)
+
+    case req.options[:operation] do
+      :video ->
+        case minimax_error?(body) do
+          {:error, error} ->
+            {req, error}
+
+          :ok ->
+            decode_create_response(req, resp, body)
+        end
+
+      :video_query ->
+        decode_query_response(req, resp, body)
+
+      :video_retrieve ->
+        case minimax_error?(body) do
+          {:error, error} -> {req, error}
+          :ok -> decode_retrieve_response(req, resp, body)
+        end
+
+      :video_upload ->
+        case minimax_error?(body) do
+          {:error, error} -> {req, error}
+          :ok -> decode_upload_response(req, resp, body)
+        end
+    end
+  end
+
+  @impl true
+  def decode_stream_event(_event, _model), do: []
+
+  @impl true
+  def attach_stream(_model, _context, _opts, _finch_name) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(parameter: "streaming not supported for :video")}
+  end
+
+  defp decode_create_response(req, resp, %{"task_id" => task_id} = body) do
+    task = %Task{
+      task_id: task_id,
+      status: :queued,
+      model: req.options[:model],
+      provider: :minimax,
+      provider_meta: %{"minimax" => Map.delete(body, "task_id")}
+    }
+
+    {req, %{resp | body: task}}
+  end
+
+  defp decode_create_response(req, resp, body) do
+    err =
+      ReqLLM.Error.API.Response.exception(
+        reason: "MiniMax Video API error: missing task_id in response",
+        status: resp.status,
+        response_body: body
+      )
+
+    {req, err}
+  end
+
+  defp decode_query_response(req, resp, body) do
+    status = Map.get(body, "status")
+
+    case get_in(body, ["base_resp", "status_code"]) do
+      code when is_integer(code) and code != 0 and status != "Fail" ->
+        status_msg =
+          get_in(body, ["base_resp", "status_msg"]) || "MiniMax video query failed"
+
+        err =
+          ReqLLM.Error.API.Response.exception(
+            reason: "MiniMax error #{code}: #{status_msg}",
+            status: code,
+            response_body: body
+          )
+
+        {req, err}
+
+      _ ->
+        task = %Task{
+          task_id: Map.get(body, "task_id", req.options[:task_id]),
+          status: decode_status(Map.get(body, "status")),
+          file_id: Map.get(body, "file_id"),
+          error: decode_error(body),
+          model: req.options[:model],
+          provider: :minimax,
+          provider_meta: %{
+            "minimax" => Map.take(body, ["video_width", "video_height", "base_resp"])
+          }
+        }
+
+        {req, %{resp | body: task}}
+    end
+  end
+
+  defp decode_upload_response(req, resp, body) do
+    file = %ReqLLM.Video.File{
+      file_id: get_in(body, ["file", "file_id"]),
+      filename: get_in(body, ["file", "filename"]),
+      bytes: get_in(body, ["file", "bytes"]),
+      purpose: get_in(body, ["file", "purpose"]),
+      provider_meta: %{"minimax" => Map.take(body, ["base_resp"])}
+    }
+
+    {req, %{resp | body: file}}
+  end
+
+  defp decode_retrieve_response(req, resp, body) do
+    file = %ReqLLM.Video.File{
+      file_id: get_in(body, ["file", "file_id"]),
+      url: get_in(body, ["file", "download_url"]),
+      filename: get_in(body, ["file", "filename"]),
+      bytes: get_in(body, ["file", "bytes"]),
+      purpose: get_in(body, ["file", "purpose"]),
+      provider_meta: %{"minimax" => Map.take(body, ["base_resp"])}
+    }
+
+    {req, %{resp | body: file}}
+  end
+
+  defp decode_status(status) when is_binary(status), do: Map.get(@status_map, status, :queued)
+  defp decode_status(_status), do: :queued
+
+  defp decode_error(%{"status" => "Fail"} = body) do
+    get_in(body, ["base_resp", "status_msg"]) || "MiniMax video generation failed"
+  end
+
+  defp decode_error(_body), do: nil
+
+  defp minimax_error?(body) when is_map(body) do
+    case get_in(body, ["base_resp", "status_code"]) do
+      code when is_integer(code) and code != 0 ->
+        status_msg =
+          get_in(body, ["base_resp", "status_msg"]) || "MiniMax video generation failed"
+
+        {:error,
+         ReqLLM.Error.API.Response.exception(
+           reason: "MiniMax error #{code}: #{status_msg}",
+           status: code,
+           response_body: body
+         )}
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp minimax_error?(_body), do: :ok
+
+  defp maybe_put_string(body, _key, nil), do: body
+
+  defp maybe_put_string(body, key, value) when is_atom(value) do
+    Map.put(body, key, Atom.to_string(value))
+  end
+
+  defp maybe_put_string(body, key, value) when is_binary(value) do
+    Map.put(body, key, value)
+  end
+
+  defp maybe_put_string(body, _key, _), do: body
+
+  defp maybe_put_integer(body, _key, nil), do: body
+  defp maybe_put_integer(body, key, value) when is_integer(value), do: Map.put(body, key, value)
+  defp maybe_put_integer(body, _key, _), do: body
+
+  defp maybe_put_boolean(body, _key, nil), do: body
+  defp maybe_put_boolean(body, key, value) when is_boolean(value), do: Map.put(body, key, value)
+  defp maybe_put_boolean(body, _key, _), do: body
+end

--- a/lib/req_llm/providers/minimax/video_api_v1.ex
+++ b/lib/req_llm/providers/minimax/video_api_v1.ex
@@ -91,6 +91,19 @@ defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
   end
 
   @impl true
+  def decode_response({req, %Req.Response{status: status} = resp}) when status not in 200..299 do
+    body = ensure_parsed_body(resp.body)
+
+    error =
+      ReqLLM.Error.API.Response.exception(
+        reason: http_error_reason(body),
+        status: status,
+        response_body: body
+      )
+
+    {req, error}
+  end
+
   def decode_response({req, resp}) do
     body = ensure_parsed_body(resp.body)
 
@@ -153,9 +166,8 @@ defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
     {req, err}
   end
 
-  defp decode_query_response(req, resp, body) do
-    status = Map.get(body, "status")
-
+  defp decode_query_response(req, resp, %{"status" => status} = body)
+       when is_binary(status) do
     case get_in(body, ["base_resp", "status_code"]) do
       code when is_integer(code) and code != 0 and status != "Fail" ->
         status_msg =
@@ -187,12 +199,46 @@ defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
     end
   end
 
-  defp decode_upload_response(req, resp, body) do
+  defp decode_query_response(req, resp, body) do
+    malformed_response(req, resp, body, "missing status in query response")
+  end
+
+  defp decode_upload_response(
+         req,
+         resp,
+         %{"file" => %{"file_id" => file_id} = file_body} = body
+       )
+       when is_binary(file_id) or is_integer(file_id) do
     file = %ReqLLM.Video.File{
-      file_id: get_in(body, ["file", "file_id"]),
-      filename: get_in(body, ["file", "filename"]),
-      bytes: get_in(body, ["file", "bytes"]),
-      purpose: get_in(body, ["file", "purpose"]),
+      file_id: file_id,
+      filename: Map.get(file_body, "filename"),
+      bytes: Map.get(file_body, "bytes"),
+      purpose: Map.get(file_body, "purpose"),
+      provider_meta: %{"minimax" => Map.take(body, ["base_resp"])}
+    }
+
+    {req, %{resp | body: file}}
+  end
+
+  defp decode_upload_response(req, resp, body) do
+    malformed_response(req, resp, body, "missing file_id in upload response")
+  end
+
+  defp decode_retrieve_response(
+         req,
+         resp,
+         %{
+           "file" => %{"file_id" => file_id, "download_url" => download_url} = file_body
+         } = body
+       )
+       when (is_binary(file_id) or is_integer(file_id)) and is_binary(download_url) and
+              download_url != "" do
+    file = %ReqLLM.Video.File{
+      file_id: file_id,
+      url: download_url,
+      filename: Map.get(file_body, "filename"),
+      bytes: Map.get(file_body, "bytes"),
+      purpose: Map.get(file_body, "purpose"),
       provider_meta: %{"minimax" => Map.take(body, ["base_resp"])}
     }
 
@@ -200,16 +246,7 @@ defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
   end
 
   defp decode_retrieve_response(req, resp, body) do
-    file = %ReqLLM.Video.File{
-      file_id: get_in(body, ["file", "file_id"]),
-      url: get_in(body, ["file", "download_url"]),
-      filename: get_in(body, ["file", "filename"]),
-      bytes: get_in(body, ["file", "bytes"]),
-      purpose: get_in(body, ["file", "purpose"]),
-      provider_meta: %{"minimax" => Map.take(body, ["base_resp"])}
-    }
-
-    {req, %{resp | body: file}}
+    malformed_response(req, resp, body, "missing file_id or download_url in retrieve response")
   end
 
   defp decode_status(status) when is_binary(status), do: Map.get(@status_map, status, :queued)
@@ -240,6 +277,28 @@ defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
   end
 
   defp minimax_error?(_body), do: :ok
+
+  defp http_error_reason(body) do
+    case get_in(body, ["base_resp", "status_code"]) do
+      code when is_integer(code) and code != 0 ->
+        status_msg = get_in(body, ["base_resp", "status_msg"]) || "request failed"
+        "MiniMax error #{code}: #{status_msg}"
+
+      _ ->
+        "MiniMax Video API error"
+    end
+  end
+
+  defp malformed_response(req, resp, body, detail) do
+    error =
+      ReqLLM.Error.API.Response.exception(
+        reason: "MiniMax Video API error: #{detail}",
+        status: resp.status,
+        response_body: body
+      )
+
+    {req, error}
+  end
 
   defp maybe_put_string(body, _key, nil), do: body
 

--- a/lib/req_llm/providers/minimax/video_api_v1.ex
+++ b/lib/req_llm/providers/minimax/video_api_v1.ex
@@ -80,6 +80,7 @@ defmodule ReqLLM.Providers.Minimax.VideoAPIV1 do
       %{"model" => opts[:model]}
       |> maybe_put_string("prompt", Keyword.get(content, :prompt))
       |> maybe_put_string("first_frame_image", Keyword.get(content, :first_frame_image))
+      |> maybe_put_string("last_frame_image", Keyword.get(content, :last_frame_image))
       |> maybe_put_boolean("prompt_optimizer", opts[:prompt_optimizer])
       |> maybe_put_boolean("fast_pretreatment", opts[:fast_pretreatment])
       |> maybe_put_integer("duration", opts[:duration])

--- a/lib/req_llm/video.ex
+++ b/lib/req_llm/video.ex
@@ -34,6 +34,13 @@ defmodule ReqLLM.Video do
   alias LLMDB.Model
 
   @terminal_statuses [:succeeded, :failed, :cancelled]
+  @type file_id :: String.t() | integer()
+
+  @wait_schema NimbleOptions.new!(
+                 poll_interval: [type: :non_neg_integer, default: 10_000],
+                 timeout: [type: :pos_integer, default: 600_000],
+                 max_transient_retries: [type: :non_neg_integer, default: 3]
+               )
 
   @base_schema NimbleOptions.new!(
                  duration: [
@@ -124,7 +131,7 @@ defmodule ReqLLM.Video do
             task_id: String.t(),
             status: :queued | :running | :succeeded | :failed | :cancelled,
             url: String.t() | nil,
-            file_id: String.t() | nil,
+            file_id: ReqLLM.Video.file_id() | nil,
             error: String.t() | nil,
             model: String.t() | nil,
             provider: atom() | nil,
@@ -171,7 +178,7 @@ defmodule ReqLLM.Video do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
     deadline = ReqLLM.TimeoutBudget.deadline(opts)
 
-    with {:ok, model} <- ReqLLM.model(model_spec),
+    with {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, opts} <-
            ReqLLM.Provider.Options.normalize_namespaced_provider_options(
@@ -180,7 +187,8 @@ defmodule ReqLLM.Video do
              model,
              opts
            ),
-         {:ok, content} <- maybe_upload_content(model, content, opts),
+         {:ok, content} <- validate_content(content),
+         {:ok, content} <- maybe_upload_content(model, content, opts, deadline),
          {:ok, request} <- provider_module.prepare_request(:video, model, content, opts),
          {:ok, %Req.Response{status: status, body: %Task{} = task}} when status in 200..299 <-
            ReqLLM.TimeoutBudget.request(request, deadline) do
@@ -211,7 +219,7 @@ defmodule ReqLLM.Video do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
     deadline = ReqLLM.TimeoutBudget.deadline(opts)
 
-    with {:ok, model} <- ReqLLM.model(model_spec),
+    with {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, request} <- provider_module.prepare_request(:video_query, model, task_id, opts),
          {:ok, %Req.Response{status: status, body: %Task{} = task}} when status in 200..299 <-
@@ -252,44 +260,49 @@ defmodule ReqLLM.Video do
   @spec wait_video(ReqLLM.model_input(), String.t(), keyword()) ::
           {:ok, Task.t()} | {:error, term()}
   def wait_video(model_spec, task_id, opts \\ []) do
-    {poll_interval, opts} = Keyword.pop(opts, :poll_interval, 10_000)
-    {timeout, opts} = Keyword.pop(opts, :timeout, 600_000)
-    {max_transient_retries, opts} = Keyword.pop(opts, :max_transient_retries, 3)
-    deadline = System.monotonic_time(:millisecond) + timeout
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
 
-    with {:ok, model} <- ReqLLM.model(model_spec),
+    with {:ok, wait_opts, request_opts} <- validate_wait_options(opts),
+         {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
-         {:ok, request} <- provider_module.prepare_request(:video_query, model, task_id, opts) do
-      do_wait(request, poll_interval, deadline, max_transient_retries, timeout, opts)
+         {:ok, request} <-
+           provider_module.prepare_request(:video_query, model, task_id, request_opts) do
+      wait_deadline = ReqLLM.TimeoutBudget.deadline(total_timeout: wait_opts[:timeout])
+
+      do_wait(
+        request,
+        wait_opts[:poll_interval],
+        wait_deadline,
+        wait_opts[:max_transient_retries],
+        request_opts
+      )
     end
   end
 
-  defp do_wait(request, poll_interval, deadline, retries_left, timeout, opts) do
-    case query_request(request, opts) do
-      {:ok, %Task{status: status} = task} when status in @terminal_statuses ->
-        {:ok, task}
+  defp do_wait(request, poll_interval, wait_deadline, retries_left, opts) do
+    if ReqLLM.TimeoutBudget.remaining(wait_deadline) == 0 do
+      wait_timeout(wait_deadline)
+    else
+      request_deadline = earliest_deadline(wait_deadline, ReqLLM.TimeoutBudget.deadline(opts))
 
-      {:ok, %Task{}} ->
-        if System.monotonic_time(:millisecond) >= deadline do
-          {:error, ReqLLM.Error.API.Timeout.exception(kind: :total, timeout: timeout)}
-        else
-          Process.sleep(poll_interval)
-          do_wait(request, poll_interval, deadline, retries_left, timeout, opts)
-        end
+      case query_request(request, request_deadline) do
+        {:ok, %Task{status: status} = task} when status in @terminal_statuses ->
+          {:ok, task}
 
-      {:error, error} ->
-        if retries_left > 0 and transient_error?(error) do
-          Process.sleep(poll_interval)
-          do_wait(request, poll_interval, deadline, retries_left - 1, timeout, opts)
-        else
-          {:error, error}
-        end
+        {:ok, %Task{}} ->
+          continue_wait(request, poll_interval, wait_deadline, retries_left, opts)
+
+        {:error, error} ->
+          if retries_left > 0 and transient_error?(error) do
+            continue_wait(request, poll_interval, wait_deadline, retries_left - 1, opts)
+          else
+            {:error, error}
+          end
+      end
     end
   end
 
-  defp query_request(request, opts) do
-    deadline = ReqLLM.TimeoutBudget.deadline(opts)
-
+  defp query_request(request, deadline) do
     case ReqLLM.TimeoutBudget.request(request, deadline) do
       {:ok, %Req.Response{status: status, body: %Task{} = task}} when status in 200..299 ->
         {:ok, task}
@@ -304,6 +317,40 @@ defmodule ReqLLM.Video do
 
       {:error, error} ->
         {:error, error}
+    end
+  end
+
+  defp continue_wait(request, poll_interval, wait_deadline, retries_left, opts) do
+    remaining = ReqLLM.TimeoutBudget.remaining(wait_deadline)
+
+    if remaining == 0 do
+      wait_timeout(wait_deadline)
+    else
+      Process.sleep(min(poll_interval, remaining))
+      do_wait(request, poll_interval, wait_deadline, retries_left, opts)
+    end
+  end
+
+  defp earliest_deadline(:infinity, deadline), do: deadline
+  defp earliest_deadline(deadline, :infinity), do: deadline
+
+  defp earliest_deadline(%{expires_at: left} = first, %{expires_at: right})
+       when left <= right,
+       do: first
+
+  defp earliest_deadline(_first, second), do: second
+
+  defp wait_timeout(%{timeout: timeout}) do
+    {:error, ReqLLM.Error.API.Timeout.exception(kind: :total, timeout: timeout)}
+  end
+
+  defp validate_wait_options(opts) do
+    {wait_opts, request_opts} =
+      Keyword.split(opts, [:poll_interval, :timeout, :max_transient_retries])
+
+    case NimbleOptions.validate(wait_opts, @wait_schema) do
+      {:ok, validated} -> {:ok, validated, request_opts}
+      {:error, error} -> {:error, error}
     end
   end
 
@@ -326,13 +373,13 @@ defmodule ReqLLM.Video do
 
   Returns `{:ok, %ReqLLM.Video.File{}}` with the `url` populated.
   """
-  @spec retrieve_file(ReqLLM.model_input(), String.t(), keyword()) ::
+  @spec retrieve_file(ReqLLM.model_input(), file_id(), keyword()) ::
           {:ok, File.t()} | {:error, term()}
   def retrieve_file(model_spec, file_id, opts \\ []) do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
     deadline = ReqLLM.TimeoutBudget.deadline(opts)
 
-    with {:ok, model} <- ReqLLM.model(model_spec),
+    with {:ok, model} <- validate_model(model_spec),
          {:ok, provider_module} <- ReqLLM.provider(model.provider),
          {:ok, request} <- provider_module.prepare_request(:video_retrieve, model, file_id, opts),
          {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
@@ -375,24 +422,9 @@ defmodule ReqLLM.Video do
     opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
     deadline = ReqLLM.TimeoutBudget.deadline(opts)
 
-    with {:ok, model} <- ReqLLM.model(model_spec),
-         {:ok, provider_module} <- ReqLLM.provider(model.provider),
-         {:ok, request} <-
-           provider_module.prepare_request(:video_upload, model, file_binary, opts),
-         {:ok, %Req.Response{status: status, body: %File{} = file}} when status in 200..299 <-
-           ReqLLM.TimeoutBudget.request(request, deadline) do
-      {:ok, file}
-    else
-      {:ok, %Req.Response{status: status, body: body}} ->
-        {:error,
-         ReqLLM.Error.API.Request.exception(
-           reason: "HTTP #{status}: Request failed",
-           status: status,
-           response_body: body
-         )}
-
-      {:error, error} ->
-        {:error, error}
+    with {:ok, model} <- validate_model(model_spec),
+         :ok <- validate_file_binary(file_binary) do
+      upload_file_with_deadline(model, file_binary, opts, deadline)
     end
   end
 
@@ -418,55 +450,135 @@ defmodule ReqLLM.Video do
     :req_http_options
   ]
 
-  defp maybe_upload_content(model, content, opts) when is_list(content) do
+  defp maybe_upload_content(model, content, opts, deadline) do
     upload_opts = Keyword.take(opts, @upload_opts)
     v2? = ReqLLM.Providers.Minimax.video_api_mod(model) == ReqLLM.Providers.Minimax.VideoAPI
 
     Enum.reduce_while(@media_keys, {:ok, content}, fn key, {:ok, acc} ->
-      case Keyword.get(acc, key) do
-        {:upload, binary, media_type} when is_binary(media_type) ->
-          case upload_reference(model, v2?, binary, media_type, upload_opts) do
-            {:ok, ref} -> {:cont, {:ok, Keyword.put(acc, key, ref)}}
+      case Keyword.fetch(acc, key) do
+        {:ok, input} ->
+          case resolve_media_value(model, v2?, input, upload_opts, deadline) do
+            {:ok, value} -> {:cont, {:ok, Keyword.put(acc, key, value)}}
             {:error, error} -> {:halt, {:error, error}}
           end
 
-        {:upload, _binary, _media_type} ->
-          {:halt,
-           {:error,
-            ReqLLM.Error.Invalid.Parameter.exception(
-              parameter:
-                "media_type must be a binary, e.g. {:upload, image_bytes, \"image/jpeg\"}"
-            )}}
-
-        {:file, path} ->
-          case :file.read_file(path) do
-            {:ok, binary} ->
-              case upload_reference(model, v2?, binary, media_type_from_path(path), upload_opts) do
-                {:ok, ref} -> {:cont, {:ok, Keyword.put(acc, key, ref)}}
-                {:error, error} -> {:halt, {:error, error}}
-              end
-
-            {:error, error} ->
-              {:halt, {:error, error}}
-          end
-
-        _ ->
+        :error ->
           {:cont, {:ok, acc}}
       end
     end)
   end
 
-  defp maybe_upload_content(_model, content, _opts), do: {:ok, content}
+  defp resolve_media_value(model, v2?, values, upload_opts, deadline) when is_list(values) do
+    Enum.reduce_while(values, {:ok, []}, fn value, {:ok, resolved} ->
+      case resolve_media_value(model, v2?, value, upload_opts, deadline) do
+        {:ok, result} -> {:cont, {:ok, [result | resolved]}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, resolved} -> {:ok, Enum.reverse(resolved)}
+      {:error, error} -> {:error, error}
+    end
+  end
 
-  defp upload_reference(model, true, binary, media_type, upload_opts) do
+  defp resolve_media_value(model, v2?, {:upload, binary, media_type}, upload_opts, deadline)
+       when is_binary(binary) and is_binary(media_type) do
+    upload_reference(model, v2?, binary, media_type, upload_opts, deadline)
+  end
+
+  defp resolve_media_value(_model, _v2?, {:upload, _binary, _media_type}, _opts, _deadline) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(
+       parameter:
+         "upload media and media_type must be binaries, e.g. {:upload, image_bytes, \"image/jpeg\"}"
+     )}
+  end
+
+  defp resolve_media_value(model, v2?, {:file, path}, upload_opts, deadline)
+       when is_binary(path) do
+    case Elixir.File.read(path) do
+      {:ok, binary} ->
+        upload_reference(
+          model,
+          v2?,
+          binary,
+          media_type_from_path(path),
+          upload_opts,
+          deadline
+        )
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp resolve_media_value(_model, _v2?, {:file, _path}, _opts, _deadline) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(parameter: "media file path must be a binary")}
+  end
+
+  defp resolve_media_value(_model, _v2?, value, _upload_opts, _deadline), do: {:ok, value}
+
+  defp upload_reference(model, true, binary, media_type, upload_opts, deadline) do
     with {:ok, file} <-
-           upload_file(model, binary, Keyword.put(upload_opts, :media_type, media_type)) do
+           upload_file_with_deadline(
+             model,
+             binary,
+             Keyword.put(upload_opts, :media_type, media_type),
+             deadline
+           ) do
       {:ok, "mm_file://#{file.file_id}"}
     end
   end
 
-  defp upload_reference(_model, false, binary, media_type, _upload_opts) do
+  defp upload_reference(_model, false, binary, media_type, _upload_opts, _deadline) do
     {:ok, "data:#{media_type};base64,#{Base.encode64(binary)}"}
+  end
+
+  defp upload_file_with_deadline(model, file_binary, opts, deadline) do
+    with {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, request} <-
+           provider_module.prepare_request(:video_upload, model, file_binary, opts),
+         {:ok, %Req.Response{status: status, body: %File{} = file}} when status in 200..299 <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, file}
+    else
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         ReqLLM.Error.API.Request.exception(
+           reason: "HTTP #{status}: Request failed",
+           status: status,
+           response_body: body
+         )}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp validate_content(content) when is_list(content) do
+    if Keyword.keyword?(content) do
+      {:ok, content}
+    else
+      {:error,
+       ReqLLM.Error.Invalid.Parameter.exception(
+         parameter: "video content must be a keyword list with a :prompt"
+       )}
+    end
+  end
+
+  defp validate_content(_content) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(
+       parameter: "video content must be a keyword list with a :prompt"
+     )}
+  end
+
+  defp validate_file_binary(file_binary) when is_binary(file_binary), do: :ok
+
+  defp validate_file_binary(_file_binary) do
+    {:error,
+     ReqLLM.Error.Invalid.Parameter.exception(parameter: "uploaded file must be a binary")}
   end
 
   defp media_type_from_path(path) do

--- a/lib/req_llm/video.ex
+++ b/lib/req_llm/video.ex
@@ -1,0 +1,524 @@
+defmodule ReqLLM.Video do
+  @moduledoc """
+  Video generation functionality for ReqLLM.
+
+  Video generation is asynchronous: `generate_video/3` submits a task and
+  returns a `ReqLLM.Video.Task` with a `task_id`, `query_video/3` polls the
+  task status, and `wait_video/3` polls until the task reaches a terminal
+  state (`:succeeded`, `:failed`, or `:cancelled`).
+
+  ## Content input
+
+  The `content` argument is a keyword list describing the multimodal input:
+
+    * `:prompt` - required text prompt describing the video
+    * `:first_frame_image` - URL of the first-frame image (image-to-video)
+    * `:last_frame_image` - URL of the last-frame image (image-to-video)
+    * `:reference_images` - list of reference image URLs (reference-to-video)
+    * `:reference_videos` - list of reference video URLs (reference-to-video)
+    * `:reference_audio` - list of reference audio URLs (reference-to-video)
+
+  ## Examples
+
+      {:ok, task} =
+        ReqLLM.Video.generate_video("minimax:MiniMax-H3",
+          [prompt: "A boy playing basketball by the sea",
+           first_frame_image: "https://example.com/frame.png"],
+          duration: 5,
+          resolution: "2K"
+        )
+
+      {:ok, task} = ReqLLM.Video.wait_video("minimax:MiniMax-H3", task.task_id)
+  """
+
+  alias LLMDB.Model
+
+  @terminal_statuses [:succeeded, :failed, :cancelled]
+
+  @base_schema NimbleOptions.new!(
+                 duration: [
+                   type: :pos_integer,
+                   doc:
+                     "Duration of the generated video in seconds (provider dependent, e.g. 4-15)"
+                 ],
+                 resolution: [
+                   type: :string,
+                   doc: ~s(Output resolution, e.g. "768P" or "2K")
+                 ],
+                 ratio: [
+                   type: :string,
+                   doc:
+                     ~s(Aspect ratio, e.g. "16:9" or "adaptive". Required for text-to-video; defaults to "adaptive" otherwise.)
+                 ],
+                 callback_url: [
+                   type: :string,
+                   doc: "Optional callback URL for task status changes (provider dependent)"
+                 ],
+                 provider_options: [
+                   type: {:or, [:map, {:list, :any}]},
+                   doc: "Provider-specific options (keyword list or map)",
+                   default: []
+                 ],
+                 req_http_options: [
+                   type: {:or, [:map, {:list, :any}]},
+                   doc: "Req-specific options (keyword list or map)",
+                   default: []
+                 ],
+                 telemetry: [
+                   type: {:or, [:map, {:list, :any}]},
+                   doc: "ReqLLM telemetry options (for example, [payloads: :raw])",
+                   default: []
+                 ],
+                 receive_timeout: [
+                   type: :pos_integer,
+                   doc: "Timeout for receiving HTTP responses in milliseconds"
+                 ],
+                 total_timeout: [
+                   type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                   doc: "Optional total model-call timeout in milliseconds, including retries"
+                 ],
+                 max_retries: [
+                   type: :non_neg_integer,
+                   default: 3,
+                   doc:
+                     "Maximum number of retry attempts for transient network errors. Set to 0 to disable retries."
+                 ],
+                 on_unsupported: [
+                   type: {:in, [:warn, :error, :ignore]},
+                   default: :warn,
+                   doc: "How to handle provider option translation warnings"
+                 ],
+                 fixture: [
+                   type: {:or, [:string, {:tuple, [:atom, :string]}]},
+                   doc: "HTTP fixture for testing (provider inferred from model if string)"
+                 ]
+               )
+
+  @doc """
+  Returns the base video generation options schema.
+  """
+  @spec schema :: NimbleOptions.t()
+  def schema, do: @base_schema
+
+  defmodule Task do
+    @moduledoc """
+    A video generation task.
+
+    Returned by `generate_video/3` and `query_video/3`. `status` is one of
+    `:queued`, `:running`, `:succeeded`, `:failed`, or `:cancelled`. `url` is
+    populated once the task succeeds; `error` carries the provider error message
+    when the task fails.
+    """
+
+    @enforce_keys [:task_id]
+    defstruct task_id: nil,
+              status: :queued,
+              url: nil,
+              file_id: nil,
+              error: nil,
+              model: nil,
+              provider: nil,
+              provider_meta: %{}
+
+    @type t :: %__MODULE__{
+            task_id: String.t(),
+            status: :queued | :running | :succeeded | :failed | :cancelled,
+            url: String.t() | nil,
+            file_id: String.t() | nil,
+            error: String.t() | nil,
+            model: String.t() | nil,
+            provider: atom() | nil,
+            provider_meta: map()
+          }
+  end
+
+  defmodule File do
+    @moduledoc """
+    A resolved video file.
+
+    Returned by `retrieve_file/3` for V1 providers, where a succeeded task
+    carries a `file_id` that must be resolved to a time-limited download URL.
+    """
+
+    @enforce_keys [:file_id]
+    defstruct file_id: nil,
+              url: nil,
+              filename: nil,
+              bytes: nil,
+              purpose: nil,
+              provider_meta: %{}
+
+    @type t :: %__MODULE__{
+            file_id: String.t() | integer(),
+            url: String.t() | nil,
+            filename: String.t() | nil,
+            bytes: integer() | nil,
+            purpose: String.t() | nil,
+            provider_meta: map()
+          }
+  end
+
+  @doc """
+  Submits a video generation task.
+
+  Returns `{:ok, %ReqLLM.Video.Task{}}` with the provider `task_id`, or
+  `{:error, term()}`. The task runs asynchronously; poll with `query_video/3`
+  or block until completion with `wait_video/3`.
+  """
+  @spec generate_video(ReqLLM.model_input(), keyword(), keyword()) ::
+          {:ok, Task.t()} | {:error, term()}
+  def generate_video(model_spec, content, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
+    deadline = ReqLLM.TimeoutBudget.deadline(opts)
+
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, opts} <-
+           ReqLLM.Provider.Options.normalize_namespaced_provider_options(
+             provider_module,
+             :video,
+             model,
+             opts
+           ),
+         {:ok, content} <- maybe_upload_content(model, content, opts),
+         {:ok, request} <- provider_module.prepare_request(:video, model, content, opts),
+         {:ok, %Req.Response{status: status, body: %Task{} = task}} when status in 200..299 <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, task}
+    else
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         ReqLLM.Error.API.Request.exception(
+           reason: "HTTP #{status}: Request failed",
+           status: status,
+           response_body: body
+         )}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Queries the status of a video generation task by `task_id`.
+
+  Returns `{:ok, %ReqLLM.Video.Task{}}` with the current status; `url` is
+  populated once the task succeeds on V2 providers, `file_id` on V1 providers.
+  """
+  @spec query_video(ReqLLM.model_input(), String.t(), keyword()) ::
+          {:ok, Task.t()} | {:error, term()}
+  def query_video(model_spec, task_id, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
+    deadline = ReqLLM.TimeoutBudget.deadline(opts)
+
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, request} <- provider_module.prepare_request(:video_query, model, task_id, opts),
+         {:ok, %Req.Response{status: status, body: %Task{} = task}} when status in 200..299 <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, task}
+    else
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         ReqLLM.Error.API.Request.exception(
+           reason: "HTTP #{status}: Request failed",
+           status: status,
+           response_body: body
+         )}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Polls a video generation task until it reaches a terminal state.
+
+  Polls every `:poll_interval` milliseconds (default 10s) until the task
+  succeeds, fails, or is cancelled, or until `:timeout` milliseconds (default
+  10 minutes) elapse.
+
+  This function blocks the calling process for the duration of the wait. For
+  production use, prefer persisting the `task_id` and polling with
+  `query_video/3` from a background process.
+
+  Transient query errors (network timeouts, connection resets) are retried up
+  to `:max_transient_retries` times (default 3) before giving up; the task
+  itself keeps running server-side and can be polled again later.
+
+  For V1 providers (e.g. `MiniMax-Hailuo-2.3`) the succeeded task carries a
+  `file_id` instead of a `url`; resolve it with `retrieve_file/3`.
+  """
+  @spec wait_video(ReqLLM.model_input(), String.t(), keyword()) ::
+          {:ok, Task.t()} | {:error, term()}
+  def wait_video(model_spec, task_id, opts \\ []) do
+    {poll_interval, opts} = Keyword.pop(opts, :poll_interval, 10_000)
+    {timeout, opts} = Keyword.pop(opts, :timeout, 600_000)
+    {max_transient_retries, opts} = Keyword.pop(opts, :max_transient_retries, 3)
+    deadline = System.monotonic_time(:millisecond) + timeout
+
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, request} <- provider_module.prepare_request(:video_query, model, task_id, opts) do
+      do_wait(request, poll_interval, deadline, max_transient_retries, timeout, opts)
+    end
+  end
+
+  defp do_wait(request, poll_interval, deadline, retries_left, timeout, opts) do
+    case query_request(request, opts) do
+      {:ok, %Task{status: status} = task} when status in @terminal_statuses ->
+        {:ok, task}
+
+      {:ok, %Task{}} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, ReqLLM.Error.API.Timeout.exception(kind: :total, timeout: timeout)}
+        else
+          Process.sleep(poll_interval)
+          do_wait(request, poll_interval, deadline, retries_left, timeout, opts)
+        end
+
+      {:error, error} ->
+        if retries_left > 0 and transient_error?(error) do
+          Process.sleep(poll_interval)
+          do_wait(request, poll_interval, deadline, retries_left - 1, timeout, opts)
+        else
+          {:error, error}
+        end
+    end
+  end
+
+  defp query_request(request, opts) do
+    deadline = ReqLLM.TimeoutBudget.deadline(opts)
+
+    case ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, %Req.Response{status: status, body: %Task{} = task}} when status in 200..299 ->
+        {:ok, task}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         ReqLLM.Error.API.Request.exception(
+           reason: "HTTP #{status}: Request failed",
+           status: status,
+           response_body: body
+         )}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp transient_error?(%Req.TransportError{reason: reason}),
+    do: reason in [:closed, :timeout, :econnrefused]
+
+  defp transient_error?(%ReqLLM.Error.API.Request{cause: %Req.TransportError{reason: reason}}),
+    do: reason in [:closed, :timeout, :econnrefused]
+
+  defp transient_error?(%ReqLLM.Error.API.Timeout{}), do: true
+  defp transient_error?(_error), do: false
+
+  @doc """
+  Resolves a video `file_id` to a time-limited download URL.
+
+  V1 providers (e.g. `MiniMax-Hailuo-2.3`) return a `file_id` on task
+  success instead of a direct URL. Call this with the `file_id` from the
+  succeeded task to obtain the download URL, which is time-limited and should
+  be downloaded promptly.
+
+  Returns `{:ok, %ReqLLM.Video.File{}}` with the `url` populated.
+  """
+  @spec retrieve_file(ReqLLM.model_input(), String.t(), keyword()) ::
+          {:ok, File.t()} | {:error, term()}
+  def retrieve_file(model_spec, file_id, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
+    deadline = ReqLLM.TimeoutBudget.deadline(opts)
+
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, request} <- provider_module.prepare_request(:video_retrieve, model, file_id, opts),
+         {:ok, %Req.Response{status: status, body: body}} when status in 200..299 <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, body}
+    else
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         ReqLLM.Error.API.Request.exception(
+           reason: "HTTP #{status}: Request failed",
+           status: status,
+           response_body: body
+         )}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Uploads a file to the provider platform for use as video generation input.
+
+  Returns `{:ok, %ReqLLM.Video.File{}}` with the `file_id` populated. Use the
+  returned `file_id` as `mm_file://{file_id}` in the `content` media fields of
+  `generate_video/3` to reference the uploaded file without exposing a public
+  URL (important for sensitive data).
+
+  Alternatively, pass `{:upload, binary, media_type}` or `{:file, path}` as a
+  media value in `generate_video/3` content to upload automatically. For V1
+  models (e.g. `MiniMax-Hailuo-2.3`) the media is inlined as a base64 data URL
+  instead, since the V1 API does not support `mm_file://` references.
+
+  Options: `:purpose` (default `"video_generation_input"`), `:filename`
+  (defaults to `"input.<ext>"` derived from `:media_type`), `:media_type`
+  (default `"application/octet-stream"`).
+  """
+  @spec upload_file(ReqLLM.model_input(), binary(), keyword()) ::
+          {:ok, File.t()} | {:error, term()}
+  def upload_file(model_spec, file_binary, opts \\ []) do
+    opts = ReqLLM.ModelInput.merge_tuple_defaults(model_spec, :video, opts)
+    deadline = ReqLLM.TimeoutBudget.deadline(opts)
+
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, provider_module} <- ReqLLM.provider(model.provider),
+         {:ok, request} <-
+           provider_module.prepare_request(:video_upload, model, file_binary, opts),
+         {:ok, %Req.Response{status: status, body: %File{} = file}} when status in 200..299 <-
+           ReqLLM.TimeoutBudget.request(request, deadline) do
+      {:ok, file}
+    else
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         ReqLLM.Error.API.Request.exception(
+           reason: "HTTP #{status}: Request failed",
+           status: status,
+           response_body: body
+         )}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @media_keys [
+    :first_frame_image,
+    :last_frame_image,
+    :reference_images,
+    :reference_videos,
+    :reference_audio
+  ]
+
+  @upload_opts [
+    :api_key,
+    :base_url,
+    :purpose,
+    :filename,
+    :media_type,
+    :receive_timeout,
+    :total_timeout,
+    :max_retries,
+    :telemetry,
+    :fixture,
+    :req_http_options
+  ]
+
+  defp maybe_upload_content(model, content, opts) when is_list(content) do
+    upload_opts = Keyword.take(opts, @upload_opts)
+    v2? = ReqLLM.Providers.Minimax.video_api_mod(model) == ReqLLM.Providers.Minimax.VideoAPI
+
+    Enum.reduce_while(@media_keys, {:ok, content}, fn key, {:ok, acc} ->
+      case Keyword.get(acc, key) do
+        {:upload, binary, media_type} when is_binary(media_type) ->
+          case upload_reference(model, v2?, binary, media_type, upload_opts) do
+            {:ok, ref} -> {:cont, {:ok, Keyword.put(acc, key, ref)}}
+            {:error, error} -> {:halt, {:error, error}}
+          end
+
+        {:upload, _binary, _media_type} ->
+          {:halt,
+           {:error,
+            ReqLLM.Error.Invalid.Parameter.exception(
+              parameter:
+                "media_type must be a binary, e.g. {:upload, image_bytes, \"image/jpeg\"}"
+            )}}
+
+        {:file, path} ->
+          case :file.read_file(path) do
+            {:ok, binary} ->
+              case upload_reference(model, v2?, binary, media_type_from_path(path), upload_opts) do
+                {:ok, ref} -> {:cont, {:ok, Keyword.put(acc, key, ref)}}
+                {:error, error} -> {:halt, {:error, error}}
+              end
+
+            {:error, error} ->
+              {:halt, {:error, error}}
+          end
+
+        _ ->
+          {:cont, {:ok, acc}}
+      end
+    end)
+  end
+
+  defp maybe_upload_content(_model, content, _opts), do: {:ok, content}
+
+  defp upload_reference(model, true, binary, media_type, upload_opts) do
+    with {:ok, file} <-
+           upload_file(model, binary, Keyword.put(upload_opts, :media_type, media_type)) do
+      {:ok, "mm_file://#{file.file_id}"}
+    end
+  end
+
+  defp upload_reference(_model, false, binary, media_type, _upload_opts) do
+    {:ok, "data:#{media_type};base64,#{Base.encode64(binary)}"}
+  end
+
+  defp media_type_from_path(path) do
+    case path |> Path.extname() |> String.downcase() |> String.trim_leading(".") do
+      "jpg" -> "image/jpeg"
+      "jpeg" -> "image/jpeg"
+      "png" -> "image/png"
+      "webp" -> "image/webp"
+      "heic" -> "image/heic"
+      "heif" -> "image/heif"
+      "mp4" -> "video/mp4"
+      "mov" -> "video/quicktime"
+      "wav" -> "audio/wav"
+      "mp3" -> "audio/mpeg"
+      _ -> "application/octet-stream"
+    end
+  end
+
+  @doc """
+  Returns a list of model specs that likely support video generation.
+  """
+  @spec supported_models() :: [String.t()]
+  def supported_models do
+    ReqLLM.Providers.list()
+    |> Enum.flat_map(fn provider ->
+      LLMDB.models(provider)
+      |> Enum.filter(&video_capable_model?/1)
+      |> Enum.map(&LLMDB.Model.spec/1)
+    end)
+  end
+
+  @doc """
+  Validates that a model supports video generation operations.
+  """
+  @spec validate_model(ReqLLM.model_input()) :: {:ok, Model.t()} | {:error, term()}
+  def validate_model(model_spec) do
+    with {:ok, model} <- ReqLLM.model(model_spec),
+         {:ok, _provider_module} <- ReqLLM.provider(model.provider) do
+      model_string = LLMDB.Model.spec(model)
+
+      if video_capable_model?(model) do
+        {:ok, model}
+      else
+        {:error,
+         ReqLLM.Error.Invalid.Parameter.exception(
+           parameter: "model: #{model_string} does not appear to support video generation"
+         )}
+      end
+    end
+  end
+
+  defp video_capable_model?(model) do
+    ReqLLM.ModelOperation.supported?(model, :video)
+  end
+end

--- a/priv/model_compat_scenarios.json
+++ b/priv/model_compat_scenarios.json
@@ -4028,14 +4028,12 @@
     },
     "google:veo-3.1-fast-generate-preview": {
       "catalog_status": "present",
-      "declared_operations": [
-        "text"
-      ],
+      "declared_operations": [],
       "model": "veo-3.1-fast-generate-preview",
       "provider": "google",
       "surfaces": {
         "google.unrecorded_text": {
-          "declaration": "declared",
+          "declaration": "not_declared",
           "operation": "text",
           "provider": "google",
           "scenarios": {
@@ -4060,14 +4058,12 @@
     },
     "google:veo-3.1-generate-preview": {
       "catalog_status": "present",
-      "declared_operations": [
-        "text"
-      ],
+      "declared_operations": [],
       "model": "veo-3.1-generate-preview",
       "provider": "google",
       "surfaces": {
         "google.unrecorded_text": {
-          "declaration": "declared",
+          "declaration": "not_declared",
           "operation": "text",
           "provider": "google",
           "scenarios": {
@@ -4092,14 +4088,12 @@
     },
     "google:veo-3.1-lite-generate-preview": {
       "catalog_status": "present",
-      "declared_operations": [
-        "text"
-      ],
+      "declared_operations": [],
       "model": "veo-3.1-lite-generate-preview",
       "provider": "google",
       "surfaces": {
         "google.unrecorded_text": {
-          "declaration": "declared",
+          "declaration": "not_declared",
           "operation": "text",
           "provider": "google",
           "scenarios": {
@@ -17926,14 +17920,12 @@
     },
     "xai:grok-imagine-video": {
       "catalog_status": "present",
-      "declared_operations": [
-        "text"
-      ],
+      "declared_operations": [],
       "model": "grok-imagine-video",
       "provider": "xai",
       "surfaces": {
         "xai.unrecorded_text": {
-          "declaration": "declared",
+          "declaration": "not_declared",
           "operation": "text",
           "provider": "xai",
           "scenarios": {

--- a/test/req_llm/compatibility/scenario_catalog_test.exs
+++ b/test/req_llm/compatibility/scenario_catalog_test.exs
@@ -11,6 +11,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
     %{id: :transcription, test_file: "transcription_test.exs"},
     %{id: :rerank, test_file: "rerank_test.exs"},
     %{id: :ocr, test_file: "ocr_test.exs"},
+    %{id: :video, test_file: "video_generation_test.exs"},
     %{id: :all, test_file: :provider_directory}
   ]
 
@@ -27,6 +28,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
     "transcription" => ~w(transcription_basic),
     "rerank" => ~w(rerank_basic),
     "ocr" => ~w(ocr_basic),
+    "video" => ~w(video_basic),
     "grounding" => ~w(grounding_basic grounding_with_context grounding_streaming),
     "grounding_legacy" => ~w(grounding_legacy),
     "multimodal_tool_result" => ~w(multimodal_tool_result),
@@ -50,7 +52,7 @@ defmodule ReqLLM.Compatibility.ScenarioCatalogTest do
     test "represents every scenario once" do
       scenario_ids = Enum.map(ScenarioCatalog.scenarios(), & &1.id)
 
-      assert length(scenario_ids) == 39
+      assert length(scenario_ids) == 40
       assert length(scenario_ids) == MapSet.size(MapSet.new(scenario_ids))
     end
 

--- a/test/req_llm/provider/options_test.exs
+++ b/test/req_llm/provider/options_test.exs
@@ -301,6 +301,15 @@ defmodule ReqLLM.Provider.OptionsTest do
       refute Keyword.has_key?(processed, :max_tokens)
     end
 
+    test "does not extract max_tokens for :video operation" do
+      model = %LLMDB.Model{provider: :mock, id: "test-model", limits: %{output: 4}}
+      opts = [duration: 5, resolution: "2K"]
+
+      assert {:ok, processed} = Options.process(MockProvider, :video, model, opts)
+      refute Keyword.has_key?(processed, :max_tokens)
+      assert processed[:duration] == 5
+    end
+
     test "uses provider base_url when model has no base_url" do
       model = %LLMDB.Model{provider: :mock, id: "test-model"}
       opts = []

--- a/test/req_llm/tuple_model_options_test.exs
+++ b/test/req_llm/tuple_model_options_test.exs
@@ -17,6 +17,9 @@ defmodule ReqLLM.TupleModelOptionsTest do
   defmodule ImageHTTP do
   end
 
+  defmodule VideoHTTP do
+  end
+
   defmodule TranscriptionHTTP do
   end
 
@@ -144,7 +147,8 @@ defmodule ReqLLM.TupleModelOptionsTest do
       {:transcription, {:openai, "whisper-1", total_timeout: 1_000}},
       {:speech, {:openai, "tts-1", total_timeout: 1_000}},
       {:rerank, {:cohere, "rerank-v3.5", total_timeout: 1_000}},
-      {:ocr, {:google_vertex, "mistral-ocr-2505", total_timeout: 1_000}}
+      {:ocr, {:google_vertex, "mistral-ocr-2505", total_timeout: 1_000}},
+      {:video, {:minimax, "MiniMax-H3", total_timeout: 1_000}}
     ]
 
     for {operation, model} <- cases do
@@ -299,6 +303,26 @@ defmodule ReqLLM.TupleModelOptionsTest do
              )
 
     assert_body_delta(baseline, receive_body(ImageHTTP), "size", "512x512")
+  end
+
+  test "video tuple defaults change only the corresponding request key" do
+    stub_json(VideoHTTP, %{"task_id" => "task-1"})
+    opts = [api_key: "test-key", req_http_options: [plug: {Req.Test, VideoHTTP}]]
+    content = [prompt: "A square moves across the frame"]
+
+    assert {:ok, _task} =
+             ReqLLM.generate_video({:minimax, id: "MiniMax-H3"}, content, opts)
+
+    baseline = receive_body(VideoHTTP)
+
+    assert {:ok, _task} =
+             ReqLLM.generate_video(
+               {:minimax, "MiniMax-H3", duration: 5},
+               content,
+               opts
+             )
+
+    assert_body_delta(baseline, receive_body(VideoHTTP), "duration", 5)
   end
 
   test "transcription tuple defaults change only the corresponding multipart field" do

--- a/test/req_llm_test.exs
+++ b/test/req_llm_test.exs
@@ -348,6 +348,9 @@ defmodule ReqLLMTest do
       assert {:error, :unknown_provider} = ReqLLM.speak("invalid:model", "Hello")
       assert {:error, :unknown_provider} = ReqLLM.generate_image("invalid:model", "Hello")
       assert {:error, :unknown_provider} = ReqLLM.ocr("invalid:model", <<0, 1, 2>>)
+      assert {:error, :unknown_provider} = ReqLLM.generate_video("invalid:model", prompt: "x")
+      assert {:error, :unknown_provider} = ReqLLM.query_video("invalid:model", "task-1")
+      assert {:error, :unknown_provider} = ReqLLM.wait_video("invalid:model", "task-1")
     end
   end
 

--- a/test/support/provider_test/video.ex
+++ b/test/support/provider_test/video.ex
@@ -1,0 +1,64 @@
+defmodule ReqLLM.ProviderTest.Video do
+  @moduledoc """
+  Video generation provider coverage tests.
+
+  The suite accepts an explicit `:models` option because video generation
+  support currently targets provider-hosted models that may not be listed
+  under the provider's catalog entry yet.
+
+  Video generation is asynchronous: the coverage test submits a task, waits
+  for it to complete, and asserts the returned download URL.
+  """
+
+  defmacro __using__(opts) do
+    provider = Keyword.fetch!(opts, :provider)
+    models = Keyword.get(opts, :models, [])
+
+    quote bind_quoted: [provider: provider, models: models] do
+      use ExUnit.Case, async: false
+
+      import ExUnit.Case
+      import ReqLLM.Test.Helpers
+
+      @moduletag :coverage
+      @moduletag category: :video
+      @moduletag provider: provider
+      @moduletag timeout: 300_000
+
+      @provider provider
+      @models models
+
+      setup_all do
+        LLMDB.load(allow: :all, custom: Application.get_env(:llm_db, :custom, %{}))
+        :ok
+      end
+
+      for model_spec <- @models do
+        @model_spec model_spec
+
+        describe "#{inspect(model_spec)}" do
+          @tag category: :video
+          @tag ReqLLM.Test.CompatibilityScenario.tag!(:video_basic)
+          test "basic video generation" do
+            {:ok, task} =
+              ReqLLM.Video.generate_video(
+                @model_spec,
+                [prompt: "A red ball bouncing on a beach at sunset"],
+                duration: 4,
+                resolution: "768P",
+                ratio: "16:9"
+              )
+
+            assert is_binary(task.task_id)
+
+            {:ok, completed} =
+              ReqLLM.Video.wait_video(@model_spec, task.task_id, timeout: 240_000)
+
+            assert completed.status == :succeeded
+            assert is_binary(completed.url)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/video_generation_test.exs
+++ b/test/video_generation_test.exs
@@ -1,0 +1,1097 @@
+defmodule ReqLLM.VideoGenerationTest do
+  use ReqLLM.ProviderCase, provider: ReqLLM.Providers.Minimax
+
+  alias ReqLLM.Providers.Minimax
+  alias ReqLLM.Providers.Minimax.VideoAPI
+  alias ReqLLM.Video
+  alias ReqLLM.Video.Task
+
+  defp minimax_video_model(model_id \\ "MiniMax-H3") do
+    %LLMDB.Model{
+      id: model_id,
+      model: model_id,
+      provider_model_id: model_id,
+      provider: :minimax,
+      name: model_id,
+      family: "minimax-h3",
+      capabilities: %{video: true},
+      limits: %{},
+      extra: %{}
+    }
+  end
+
+  describe "model operation" do
+    test ":video is a known operation" do
+      assert ReqLLM.ModelOperation.known?(:video)
+      assert :video in ReqLLM.ModelOperation.operations()
+    end
+
+    test "video-capable models are detected" do
+      model = minimax_video_model()
+      assert ReqLLM.ModelOperation.supported?(model, :video)
+      refute ReqLLM.ModelOperation.supported?(model, :text)
+    end
+  end
+
+  describe "prepare_request" do
+    test "prepare_request for :video creates /v2/video_generation request with api_mod" do
+      model = minimax_video_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(:video, model, [prompt: "A boy playing basketball by the sea"],
+          duration: 5,
+          resolution: "2K",
+          ratio: "16:9",
+          api_key: "test-key"
+        )
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/v2/video_generation"
+      assert request.method == :post
+      assert request.options[:base_url] == "https://api.minimax.io"
+      assert request.options[:api_mod] == VideoAPI
+      assert request.options[:operation] == :video
+      assert request.options[:content][:prompt] == "A boy playing basketball by the sea"
+    end
+
+    test "prepare_request for :video rejects empty prompt" do
+      model = minimax_video_model()
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               Minimax.prepare_request(:video, model, [prompt: "  "], api_key: "test-key")
+    end
+
+    test "prepare_request for :video_query creates query request with task_id" do
+      model = minimax_video_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(:video_query, model, "task-123", api_key: "test-key")
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/v2/query/video_generation/task-123"
+      assert request.method == :get
+      assert request.options[:api_mod] == VideoAPI
+      assert request.options[:operation] == :video_query
+      assert request.options[:task_id] == "task-123"
+    end
+  end
+
+  describe "encode_body" do
+    defp video_request(content, opts \\ []) do
+      Req.new(url: VideoAPI.path())
+      |> Req.Request.register_options([
+        :model,
+        :content,
+        :duration,
+        :resolution,
+        :ratio,
+        :callback_url,
+        :operation
+      ])
+      |> Req.Request.merge_options(
+        Keyword.merge(
+          [
+            model: "MiniMax-H3",
+            content: content,
+            operation: :video
+          ],
+          opts
+        )
+      )
+    end
+
+    test "text-to-video content encoding" do
+      encoded =
+        video_request([prompt: "A boy playing basketball by the sea"],
+          duration: 5,
+          resolution: "2K",
+          ratio: "16:9"
+        )
+        |> VideoAPI.encode_body()
+
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["model"] == "MiniMax-H3"
+      assert body["duration"] == 5
+      assert body["resolution"] == "2K"
+      assert body["ratio"] == "16:9"
+
+      assert body["content"] == [
+               %{"type" => "text", "text" => "A boy playing basketball by the sea"}
+             ]
+    end
+
+    test "image-to-video content encoding with first and last frame" do
+      encoded =
+        video_request(
+          [
+            prompt: "A little girl grows up",
+            first_frame_image: "https://example.com/start.png",
+            last_frame_image: "https://example.com/end.png"
+          ],
+          duration: 5,
+          resolution: "2K"
+        )
+        |> VideoAPI.encode_body()
+
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["content"] == [
+               %{"type" => "text", "text" => "A little girl grows up"},
+               %{
+                 "type" => "image_url",
+                 "image_url" => %{"url" => "https://example.com/start.png"},
+                 "role" => "first_frame"
+               },
+               %{
+                 "type" => "image_url",
+                 "image_url" => %{"url" => "https://example.com/end.png"},
+                 "role" => "last_frame"
+               }
+             ]
+    end
+
+    test "reference-to-video content encoding" do
+      encoded =
+        video_request(
+          [
+            prompt: "Character dances following the reference",
+            reference_images: ["https://example.com/char.png"],
+            reference_videos: ["https://example.com/motion.mp4"],
+            reference_audio: ["https://example.com/voice.mp3"]
+          ],
+          duration: 5,
+          resolution: "2K"
+        )
+        |> VideoAPI.encode_body()
+
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["content"] == [
+               %{"type" => "text", "text" => "Character dances following the reference"},
+               %{
+                 "type" => "image_url",
+                 "image_url" => %{"url" => "https://example.com/char.png"},
+                 "role" => "reference_image"
+               },
+               %{
+                 "type" => "video_url",
+                 "video_url" => %{"url" => "https://example.com/motion.mp4"},
+                 "role" => "reference_video"
+               },
+               %{
+                 "type" => "audio_url",
+                 "audio_url" => %{"url" => "https://example.com/voice.mp3"},
+                 "role" => "reference_audio"
+               }
+             ]
+    end
+
+    test "single media value is accepted without a list" do
+      encoded =
+        video_request(
+          [prompt: "A cat", first_frame_image: "https://example.com/cat.png"],
+          duration: 4,
+          resolution: "768P"
+        )
+        |> VideoAPI.encode_body()
+
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert [%{"type" => "text"}, %{"type" => "image_url", "role" => "first_frame"}] =
+               body["content"]
+    end
+  end
+
+  describe "decode_response" do
+    test "create response yields a Task with task_id" do
+      req =
+        Req.new(url: VideoAPI.path())
+        |> Req.Request.register_options([:model, :operation])
+        |> Req.Request.merge_options(model: "MiniMax-H3", operation: :video)
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{"task_id" => "424010985738629"}
+      }
+
+      {_req, updated} = VideoAPI.decode_response({req, resp})
+
+      assert %Task{task_id: "424010985738629", status: :queued, provider: :minimax} =
+               updated.body
+    end
+
+    test "query response yields a Task with url on success" do
+      req =
+        Req.new(url: VideoAPI.query_path("task-1"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-H3",
+          operation: :video_query,
+          task_id: "task-1"
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "task" => %{
+            "id" => "task-1",
+            "model" => "MiniMax-H3",
+            "status" => "succeeded",
+            "content" => %{"url" => "https://cdn.example.com/output.mp4"},
+            "resolution" => "2K",
+            "duration" => 5,
+            "ratio" => "16:9"
+          }
+        }
+      }
+
+      {_req, updated} = VideoAPI.decode_response({req, resp})
+
+      assert %Task{
+               task_id: "task-1",
+               status: :succeeded,
+               url: "https://cdn.example.com/output.mp4",
+               error: nil
+             } = updated.body
+    end
+
+    test "query response yields a Task with error on failure" do
+      req =
+        Req.new(url: VideoAPI.query_path("task-2"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-H3",
+          operation: :video_query,
+          task_id: "task-2"
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "task" => %{
+            "id" => "task-2",
+            "status" => "failed",
+            "error" => %{"code" => "1026", "message" => "sensitive content"}
+          }
+        }
+      }
+
+      {_req, updated} = VideoAPI.decode_response({req, resp})
+
+      assert %Task{task_id: "task-2", status: :failed, error: "1026: sensitive content"} =
+               updated.body
+    end
+
+    test "query response maps running status" do
+      req =
+        Req.new(url: VideoAPI.query_path("task-3"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-H3",
+          operation: :video_query,
+          task_id: "task-3"
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{"task" => %{"id" => "task-3", "status" => "running"}}
+      }
+
+      {_req, updated} = VideoAPI.decode_response({req, resp})
+
+      assert %Task{task_id: "task-3", status: :running, url: nil} = updated.body
+    end
+
+    test "200 response with OpenAI-style error body is surfaced" do
+      req =
+        Req.new(url: VideoAPI.path())
+        |> Req.Request.register_options([:model, :operation])
+        |> Req.Request.merge_options(model: "MiniMax-H3", operation: :video)
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "type" => "error",
+          "error" => %{
+            "type" => "bad_request_error",
+            "message" => "invalid params, content must include a non-empty text item (2013)",
+            "http_code" => "400"
+          }
+        }
+      }
+
+      {_req, updated} = VideoAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Error.API.Response{} = updated
+      assert updated.reason =~ "2013"
+    end
+
+    test "OpenAI-style error body is surfaced" do
+      req =
+        Req.new(url: VideoAPI.path())
+        |> Req.Request.register_options([:model, :operation])
+        |> Req.Request.merge_options(model: "MiniMax-H3", operation: :video)
+
+      resp = %Req.Response{
+        status: 400,
+        body: %{
+          "type" => "error",
+          "error" => %{
+            "type" => "bad_request_error",
+            "message" => "content must include a non-empty text item (2013)",
+            "http_code" => "400"
+          }
+        }
+      }
+
+      {_req, updated} = VideoAPI.decode_response({req, resp})
+
+      assert %ReqLLM.Error.API.Response{} = updated
+    end
+  end
+
+  describe "generate_video" do
+    test "completes a MiniMax public API round trip" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v2/video_generation"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer test-key"]
+
+        {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+        request_json = Jason.decode!(request_body)
+
+        assert request_json["model"] == "MiniMax-H3"
+        assert request_json["duration"] == 5
+        assert request_json["resolution"] == "2K"
+        assert request_json["ratio"] == "16:9"
+
+        assert [%{"type" => "text", "text" => "A boy playing basketball by the sea"}] =
+                 request_json["content"]
+
+        Req.Test.json(conn, %{"task_id" => "424010985738629"})
+      end)
+
+      assert {:ok, %Task{task_id: "424010985738629", status: :queued}} =
+               ReqLLM.Video.generate_video(
+                 minimax_video_model(),
+                 [prompt: "A boy playing basketball by the sea"],
+                 duration: 5,
+                 resolution: "2K",
+                 ratio: "16:9",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+  end
+
+  describe "query_video" do
+    test "completes a MiniMax query round trip" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/v2/query/video_generation/task-1"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer test-key"]
+
+        Req.Test.json(conn, %{
+          "task" => %{
+            "id" => "task-1",
+            "model" => "MiniMax-H3",
+            "status" => "succeeded",
+            "content" => %{"url" => "https://cdn.example.com/output.mp4"}
+          }
+        })
+      end)
+
+      assert {:ok, %Task{status: :succeeded, url: "https://cdn.example.com/output.mp4"}} =
+               ReqLLM.Video.query_video(minimax_video_model(), "task-1",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+  end
+
+  describe "wait_video" do
+    test "polls until the task succeeds" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.request_path == "/v2/query/video_generation/task-1"
+
+        Req.Test.json(conn, %{
+          "task" => %{
+            "id" => "task-1",
+            "status" => "succeeded",
+            "content" => %{"url" => "https://cdn.example.com/output.mp4"}
+          }
+        })
+      end)
+
+      assert {:ok, %Task{status: :succeeded, url: "https://cdn.example.com/output.mp4"}} =
+               ReqLLM.Video.wait_video(minimax_video_model(), "task-1",
+                 api_key: "test-key",
+                 poll_interval: 1,
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "returns the failed task with error" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{
+          "task" => %{
+            "id" => "task-2",
+            "status" => "failed",
+            "error" => %{"code" => "1026", "message" => "sensitive content"}
+          }
+        })
+      end)
+
+      assert {:ok, %Task{status: :failed, error: "1026: sensitive content"}} =
+               ReqLLM.Video.wait_video(minimax_video_model(), "task-2",
+                 api_key: "test-key",
+                 poll_interval: 1,
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "retries transient query errors until the task succeeds" do
+      counter = :counters.new(1, [])
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        if :counters.get(counter, 1) < 4 do
+          :counters.add(counter, 1, 1)
+          Req.Test.transport_error(conn, :closed)
+        else
+          Req.Test.json(conn, %{
+            "task" => %{
+              "id" => "task-1",
+              "status" => "succeeded",
+              "content" => %{"url" => "https://cdn.example.com/output.mp4"}
+            }
+          })
+        end
+      end)
+
+      assert {:ok, %Task{status: :succeeded, url: "https://cdn.example.com/output.mp4"}} =
+               ReqLLM.Video.wait_video(minimax_video_model(), "task-1",
+                 api_key: "test-key",
+                 poll_interval: 1,
+                 max_transient_retries: 3,
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "gives up after max_transient_retries on persistent transient errors" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.transport_error(conn, :closed)
+      end)
+
+      assert {:error, %ReqLLM.Error.API.Request{cause: %Req.TransportError{reason: :closed}}} =
+               ReqLLM.Video.wait_video(minimax_video_model(), "task-1",
+                 api_key: "test-key",
+                 poll_interval: 1,
+                 max_transient_retries: 1,
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "times out when the task never reaches a terminal state" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{
+          "task" => %{"id" => "task-3", "status" => "running"}
+        })
+      end)
+
+      assert {:error, %ReqLLM.Error.API.Timeout{timeout: 5}} =
+               ReqLLM.Video.wait_video(minimax_video_model(), "task-3",
+                 api_key: "test-key",
+                 poll_interval: 1,
+                 timeout: 5,
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+  end
+end
+
+defmodule ReqLLM.VideoGenerationV1Test do
+  use ReqLLM.ProviderCase, provider: ReqLLM.Providers.Minimax
+
+  alias ReqLLM.Providers.Minimax
+  alias ReqLLM.Providers.Minimax.VideoAPIV1
+  alias ReqLLM.Video.Task
+
+  defp minimax_hailuo_model(model_id \\ "MiniMax-Hailuo-2.3") do
+    %LLMDB.Model{
+      id: model_id,
+      model: model_id,
+      provider_model_id: model_id,
+      provider: :minimax,
+      name: model_id,
+      family: "minimax-hailuo",
+      capabilities: %{video: true},
+      limits: %{},
+      extra: %{}
+    }
+  end
+
+  describe "V1 API dispatch" do
+    test "H3 models route to the V2 API driver" do
+      model = %LLMDB.Model{
+        id: "MiniMax-H3",
+        model: "MiniMax-H3",
+        provider_model_id: "MiniMax-H3",
+        provider: :minimax,
+        name: "MiniMax-H3",
+        family: "minimax-h3",
+        capabilities: %{video: true},
+        limits: %{},
+        extra: %{}
+      }
+
+      {:ok, request} =
+        Minimax.prepare_request(:video, model, [prompt: "test"], api_key: "test-key")
+
+      assert request.options[:api_mod] == ReqLLM.Providers.Minimax.VideoAPI
+      assert request.url.path == "/v2/video_generation"
+    end
+
+    test "Hailuo models route to the V1 API driver" do
+      model = minimax_hailuo_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(:video, model, [prompt: "test"], api_key: "test-key")
+
+      assert request.options[:api_mod] == VideoAPIV1
+      assert request.url.path == "/video_generation"
+      assert request.options[:base_url] == "https://api.minimax.io/v1"
+    end
+  end
+
+  describe "V1 prepare_request" do
+    test "creates /video_generation request with api_mod" do
+      model = minimax_hailuo_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(
+          :video,
+          model,
+          [prompt: "A cat", first_frame_image: "https://example.com/cat.png"],
+          duration: 6,
+          resolution: "768P",
+          api_key: "test-key"
+        )
+
+      assert %Req.Request{} = request
+      assert request.url.path == "/video_generation"
+      assert request.method == :post
+      assert request.options[:api_mod] == VideoAPIV1
+      assert request.options[:operation] == :video
+    end
+
+    test "creates query request with task_id as query param" do
+      model = minimax_hailuo_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(:video_query, model, "task-1", api_key: "test-key")
+
+      assert request.url.path == "/query/video_generation"
+      assert request.url.query == "task_id=task-1"
+      assert request.method == :get
+      assert request.options[:api_mod] == VideoAPIV1
+    end
+
+    test "creates file retrieve request" do
+      model = minimax_hailuo_model()
+
+      {:ok, request} =
+        Minimax.prepare_request(:video_retrieve, model, "file-1", api_key: "test-key")
+
+      assert request.url.path == "/files/retrieve"
+      assert request.url.query == "file_id=file-1"
+      assert request.method == :get
+      assert request.options[:api_mod] == VideoAPIV1
+      assert request.options[:operation] == :video_retrieve
+    end
+  end
+
+  describe "V1 encode_body" do
+    test "emits flat MiniMax V1 JSON" do
+      request =
+        Req.new(url: VideoAPIV1.path())
+        |> Req.Request.register_options([
+          :model,
+          :content,
+          :duration,
+          :resolution,
+          :prompt_optimizer,
+          :fast_pretreatment,
+          :operation
+        ])
+        |> Req.Request.merge_options(
+          model: "MiniMax-Hailuo-2.3",
+          content: [
+            prompt: "A cat",
+            first_frame_image: "https://example.com/cat.png"
+          ],
+          duration: 6,
+          resolution: "768P",
+          prompt_optimizer: true,
+          fast_pretreatment: false,
+          operation: :video
+        )
+
+      encoded = VideoAPIV1.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["model"] == "MiniMax-Hailuo-2.3"
+      assert body["prompt"] == "A cat"
+      assert body["first_frame_image"] == "https://example.com/cat.png"
+      assert body["duration"] == 6
+      assert body["resolution"] == "768P"
+      assert body["prompt_optimizer"] == true
+      assert body["fast_pretreatment"] == false
+      refute Map.has_key?(body, "content")
+    end
+
+    test "query and retrieve requests carry no body" do
+      for operation <- [:video_query, :video_retrieve] do
+        request =
+          Req.new(url: VideoAPIV1.path())
+          |> Req.Request.register_options([:model, :operation])
+          |> Req.Request.merge_options(model: "MiniMax-Hailuo-2.3", operation: operation)
+
+        encoded = VideoAPIV1.encode_body(request)
+        refute Map.has_key?(encoded.options, :json)
+      end
+    end
+  end
+
+  describe "V1 decode_response" do
+    test "query response maps statuses and file_id" do
+      req =
+        Req.new(url: VideoAPIV1.query_path("task-1"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-Hailuo-2.3",
+          operation: :video_query,
+          task_id: "task-1"
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "task_id" => "task-1",
+          "status" => "Success",
+          "file_id" => "file-1",
+          "video_width" => 1920,
+          "video_height" => 1080,
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        }
+      }
+
+      {_req, updated} = VideoAPIV1.decode_response({req, resp})
+
+      assert %Task{
+               task_id: "task-1",
+               status: :succeeded,
+               file_id: "file-1",
+               url: nil
+             } = updated.body
+    end
+
+    test "query response maps processing and fail statuses" do
+      req =
+        Req.new(url: VideoAPIV1.query_path("task-2"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-Hailuo-2.3",
+          operation: :video_query,
+          task_id: "task-2"
+        )
+
+      for {wire_status, expected} <- [
+            {"Processing", :running},
+            {"Queueing", :queued},
+            {"Fail", :failed}
+          ] do
+        resp = %Req.Response{
+          status: 200,
+          body: %{"task_id" => "task-2", "status" => wire_status}
+        }
+
+        {_req, updated} = VideoAPIV1.decode_response({req, resp})
+        assert updated.body.status == expected
+      end
+    end
+
+    test "query response with Fail status yields a failed Task with error" do
+      req =
+        Req.new(url: VideoAPIV1.query_path("task-4"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-Hailuo-2.3",
+          operation: :video_query,
+          task_id: "task-4"
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "task_id" => "task-4",
+          "status" => "Fail",
+          "file_id" => "",
+          "video_width" => 0,
+          "video_height" => 0,
+          "base_resp" => %{
+            "status_code" => 2013,
+            "status_msg" => "invalid params, first_frame_image"
+          }
+        }
+      }
+
+      {_req, updated} = VideoAPIV1.decode_response({req, resp})
+
+      assert %Task{
+               task_id: "task-4",
+               status: :failed,
+               error: "invalid params, first_frame_image"
+             } = updated.body
+    end
+
+    test "retrieve response passes through download_url" do
+      req =
+        Req.new(url: VideoAPIV1.retrieve_path("file-1"))
+        |> Req.Request.register_options([:model, :operation, :file_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-Hailuo-2.3",
+          operation: :video_retrieve,
+          file_id: "file-1"
+        )
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"},
+          "file" => %{
+            "file_id" => "file-1",
+            "bytes" => 1024,
+            "download_url" => "https://cdn.example.com/video.mp4",
+            "filename" => "output.mp4",
+            "purpose" => "video_generation"
+          }
+        }
+      }
+
+      {_req, updated} = VideoAPIV1.decode_response({req, resp})
+
+      assert %ReqLLM.Video.File{
+               file_id: "file-1",
+               url: "https://cdn.example.com/video.mp4",
+               filename: "output.mp4",
+               bytes: 1024,
+               purpose: "video_generation"
+             } = updated.body
+    end
+
+    test "base_resp error is surfaced" do
+      req =
+        Req.new(url: VideoAPIV1.path())
+        |> Req.Request.register_options([:model, :operation])
+        |> Req.Request.merge_options(model: "MiniMax-Hailuo-2.3", operation: :video)
+
+      resp = %Req.Response{
+        status: 200,
+        body: %{
+          "base_resp" => %{"status_code" => 1004, "status_msg" => "auth failed"}
+        }
+      }
+
+      {_req, updated} = VideoAPIV1.decode_response({req, resp})
+
+      assert %ReqLLM.Error.API.Response{} = updated
+    end
+  end
+
+  describe "V1 upload" do
+    test "upload_file completes a multipart round trip" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v1/files/upload"
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer test-key"]
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body =~ "video_generation_input"
+        assert body =~ "cat.png"
+        assert body =~ "fake-image-bytes"
+
+        Req.Test.json(conn, %{
+          "file" => %{
+            "file_id" => 42_921_536_529_229,
+            "bytes" => 17,
+            "created_at" => 1_786_341_878,
+            "filename" => "cat.png",
+            "purpose" => "video_generation_input"
+          },
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        })
+      end)
+
+      model = minimax_hailuo_model()
+
+      assert {:ok, %ReqLLM.Video.File{file_id: 42_921_536_529_229, filename: "cat.png"}} =
+               ReqLLM.Video.upload_file(model, "fake-image-bytes",
+                 filename: "cat.png",
+                 media_type: "image/png",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "upload filename derives extension from media_type" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body =~ ~s(filename="input.jpg")
+
+        Req.Test.json(conn, %{
+          "file" => %{
+            "file_id" => 789,
+            "bytes" => 17,
+            "filename" => "input.jpg",
+            "purpose" => "video_generation_input"
+          },
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        })
+      end)
+
+      model = minimax_hailuo_model()
+
+      assert {:ok, %ReqLLM.Video.File{file_id: 789}} =
+               ReqLLM.Video.upload_file(model, "fake-image-bytes",
+                 media_type: "image/jpeg",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "generate_video inlines {:upload, binary, media_type} as a data URL for V1" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v1/video_generation"
+
+        {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+        request_json = Jason.decode!(request_body)
+
+        assert request_json["first_frame_image"] ==
+                 "data:image/png;base64," <> Base.encode64("fake-image-bytes")
+
+        Req.Test.json(conn, %{
+          "task_id" => "task-1",
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        })
+      end)
+
+      model = minimax_hailuo_model()
+
+      assert {:ok, %Task{task_id: "task-1"}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 [
+                   prompt: "A cat",
+                   first_frame_image: {:upload, "fake-image-bytes", "image/png"}
+                 ],
+                 duration: 6,
+                 resolution: "768P",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "generate_video inlines {:file, path} as a data URL for V1" do
+      path = Path.join(System.tmp_dir!(), "req_llm_upload_test.png")
+      File.write!(path, "fake-image-bytes")
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/v1/video_generation"
+
+        {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+        request_json = Jason.decode!(request_body)
+
+        assert request_json["first_frame_image"] ==
+                 "data:image/png;base64," <> Base.encode64("fake-image-bytes")
+
+        Req.Test.json(conn, %{
+          "task_id" => "task-2",
+          "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+        })
+      end)
+
+      model = minimax_hailuo_model()
+
+      assert {:ok, %Task{task_id: "task-2"}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 [prompt: "A cat", first_frame_image: {:file, path}],
+                 duration: 6,
+                 resolution: "768P",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      File.rm!(path)
+    end
+  end
+
+  describe "upload content validation" do
+    test "rejects {:upload, binary, media_type} with non-binary media_type" do
+      model = %LLMDB.Model{
+        id: "MiniMax-H3",
+        model: "MiniMax-H3",
+        provider_model_id: "MiniMax-H3",
+        provider: :minimax,
+        name: "MiniMax-H3",
+        family: "minimax-h3",
+        capabilities: %{video: true},
+        limits: %{},
+        extra: %{}
+      }
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 [prompt: "A cat", first_frame_image: {:upload, "bytes", nil}],
+                 duration: 5,
+                 resolution: "2K",
+                 api_key: "test-key"
+               )
+    end
+  end
+
+  describe "V2 auto-upload" do
+    test "generate_video uploads {:upload, ...} and references mm_file:// for H3" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/v1/files/upload"} ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn)
+            assert body =~ "video_generation_input"
+            assert body =~ "fake-image-bytes"
+
+            Req.Test.json(conn, %{
+              "file" => %{
+                "file_id" => 123,
+                "bytes" => 17,
+                "filename" => "input.jpg",
+                "purpose" => "video_generation_input"
+              },
+              "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+            })
+
+          {"POST", "/v2/video_generation"} ->
+            {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+            request_json = Jason.decode!(request_body)
+
+            assert [%{"type" => "text"}, %{"type" => "image_url"}] =
+                     request_json["content"]
+
+            assert get_in(request_json, ["content", Access.at(1), "image_url", "url"]) ==
+                     "mm_file://123"
+
+            Req.Test.json(conn, %{"task_id" => "task-1"})
+        end
+      end)
+
+      model = %LLMDB.Model{
+        id: "MiniMax-H3",
+        model: "MiniMax-H3",
+        provider_model_id: "MiniMax-H3",
+        provider: :minimax,
+        name: "MiniMax-H3",
+        family: "minimax-h3",
+        capabilities: %{video: true},
+        limits: %{},
+        extra: %{}
+      }
+
+      assert {:ok, %Task{task_id: "task-1"}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 [
+                   prompt: "A cat",
+                   first_frame_image: {:upload, "fake-image-bytes", "image/jpeg"}
+                 ],
+                 duration: 5,
+                 resolution: "2K",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+  end
+
+  describe "V1 round trip" do
+    test "generate, query, and retrieve complete a full flow" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/v1/video_generation"} ->
+            assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer test-key"]
+
+            {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+            request_json = Jason.decode!(request_body)
+
+            assert request_json["model"] == "MiniMax-Hailuo-2.3"
+            assert request_json["prompt"] == "A cat"
+            assert request_json["first_frame_image"] == "https://example.com/cat.png"
+
+            Req.Test.json(conn, %{
+              "task_id" => "task-1",
+              "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+            })
+
+          {"GET", "/v1/query/video_generation"} ->
+            assert conn.query_string == "task_id=task-1"
+
+            Req.Test.json(conn, %{
+              "task_id" => "task-1",
+              "status" => "Success",
+              "file_id" => "file-1",
+              "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+            })
+
+          {"GET", "/v1/files/retrieve"} ->
+            assert conn.query_string == "file_id=file-1"
+
+            Req.Test.json(conn, %{
+              "base_resp" => %{"status_code" => 0, "status_msg" => "success"},
+              "file" => %{
+                "file_id" => "file-1",
+                "bytes" => 1024,
+                "download_url" => "https://cdn.example.com/video.mp4",
+                "filename" => "output.mp4",
+                "purpose" => "video_generation"
+              }
+            })
+        end
+      end)
+
+      model = minimax_hailuo_model()
+
+      assert {:ok, %Task{task_id: "task-1"}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 [prompt: "A cat", first_frame_image: "https://example.com/cat.png"],
+                 duration: 6,
+                 resolution: "768P",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert {:ok, %Task{status: :succeeded, file_id: "file-1"}} =
+               ReqLLM.Video.query_video(model, "task-1",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert {:ok, %ReqLLM.Video.File{url: "https://cdn.example.com/video.mp4"}} =
+               ReqLLM.Video.retrieve_file(model, "file-1",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+  end
+end

--- a/test/video_generation_test.exs
+++ b/test/video_generation_test.exs
@@ -886,6 +886,56 @@ defmodule ReqLLM.VideoGenerationV1Test do
 
       assert %ReqLLM.Error.API.Response{} = updated
     end
+
+    test "non-success HTTP responses are surfaced before operation decoding" do
+      req =
+        Req.new(url: VideoAPIV1.query_path("task-1"))
+        |> Req.Request.register_options([:model, :operation, :task_id])
+        |> Req.Request.merge_options(
+          model: "MiniMax-Hailuo-2.3",
+          operation: :video_query,
+          task_id: "task-1"
+        )
+
+      resp = %Req.Response{
+        status: 503,
+        body: %{
+          "base_resp" => %{"status_code" => 1001, "status_msg" => "service unavailable"}
+        }
+      }
+
+      {_req, updated} = VideoAPIV1.decode_response({req, resp})
+
+      assert %ReqLLM.Error.API.Response{status: 503} = updated
+      assert updated.reason =~ "1001"
+      assert updated.reason =~ "service unavailable"
+    end
+
+    test "malformed successful responses are surfaced" do
+      for {operation, path, body, detail} <- [
+            {:video_query, VideoAPIV1.query_path("task-1"), %{"task_id" => "task-1"},
+             "missing status"},
+            {:video_upload, VideoAPIV1.upload_path(), %{"file" => %{}}, "missing file_id"},
+            {:video_retrieve, VideoAPIV1.retrieve_path("file-1"),
+             %{"file" => %{"file_id" => "file-1"}}, "missing file_id or download_url"}
+          ] do
+        req =
+          Req.new(url: path)
+          |> Req.Request.register_options([:model, :operation, :task_id, :file_id])
+          |> Req.Request.merge_options(
+            model: "MiniMax-Hailuo-2.3",
+            operation: operation,
+            task_id: "task-1",
+            file_id: "file-1"
+          )
+
+        resp = %Req.Response{status: 200, body: body}
+        {_req, updated} = VideoAPIV1.decode_response({req, resp})
+
+        assert %ReqLLM.Error.API.Response{status: 200} = updated
+        assert updated.reason =~ detail
+      end
+    end
   end
 
   describe "V1 upload" do

--- a/test/video_generation_test.exs
+++ b/test/video_generation_test.exs
@@ -383,6 +383,44 @@ defmodule ReqLLM.VideoGenerationTest do
                  req_http_options: [plug: {Req.Test, __MODULE__}]
                )
     end
+
+    test "rejects a model that does not support video generation" do
+      model = %LLMDB.Model{
+        id: "MiniMax-M2.7",
+        model: "MiniMax-M2.7",
+        provider_model_id: "MiniMax-M2.7",
+        provider: :minimax,
+        name: "MiniMax-M2.7",
+        family: "minimax-m2",
+        capabilities: %{chat: true},
+        limits: %{},
+        extra: %{}
+      }
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               ReqLLM.Video.generate_video(model, prompt: "A cat")
+    end
+
+    test "returns validation errors for malformed content and upload tuples" do
+      model = minimax_video_model()
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               ReqLLM.Video.generate_video(model, ["not", "a", "keyword", "list"])
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 prompt: "A cat",
+                 first_frame_image: {:upload, :not_binary, "image/png"}
+               )
+
+      assert {:error, %ReqLLM.Error.Invalid.Parameter{}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 prompt: "A cat",
+                 first_frame_image: {:file, :not_a_path}
+               )
+    end
   end
 
   describe "query_video" do
@@ -507,6 +545,24 @@ defmodule ReqLLM.VideoGenerationTest do
                  req_http_options: [plug: {Req.Test, __MODULE__}]
                )
     end
+
+    test "enforces the wait timeout while a query request is running" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        Process.sleep(50)
+
+        Req.Test.json(conn, %{
+          "task" => %{"id" => "task-4", "status" => "succeeded"}
+        })
+      end)
+
+      assert {:error, %ReqLLM.Error.API.Timeout{timeout: 10}} =
+               ReqLLM.Video.wait_video(minimax_video_model(), "task-4",
+                 api_key: "test-key",
+                 poll_interval: 1,
+                 timeout: 10,
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
   end
 end
 
@@ -585,6 +641,27 @@ defmodule ReqLLM.VideoGenerationV1Test do
       assert request.options[:operation] == :video
     end
 
+    test "accepts fast pretreatment and preserves the video prompt optimizer default" do
+      model = minimax_hailuo_model()
+
+      assert {:ok, request} =
+               Minimax.prepare_request(:video, model, [prompt: "A cat"],
+                 fast_pretreatment: true,
+                 api_key: "test-key"
+               )
+
+      assert request.options[:fast_pretreatment] == true
+      assert request.options[:prompt_optimizer] == true
+
+      assert {:ok, request} =
+               Minimax.prepare_request(:video, model, [prompt: "A cat"],
+                 prompt_optimizer: false,
+                 api_key: "test-key"
+               )
+
+      assert request.options[:prompt_optimizer] == false
+    end
+
     test "creates query request with task_id as query param" do
       model = minimax_hailuo_model()
 
@@ -628,7 +705,8 @@ defmodule ReqLLM.VideoGenerationV1Test do
           model: "MiniMax-Hailuo-2.3",
           content: [
             prompt: "A cat",
-            first_frame_image: "https://example.com/cat.png"
+            first_frame_image: "https://example.com/cat.png",
+            last_frame_image: "https://example.com/adult-cat.png"
           ],
           duration: 6,
           resolution: "768P",
@@ -643,6 +721,7 @@ defmodule ReqLLM.VideoGenerationV1Test do
       assert body["model"] == "MiniMax-Hailuo-2.3"
       assert body["prompt"] == "A cat"
       assert body["first_frame_image"] == "https://example.com/cat.png"
+      assert body["last_frame_image"] == "https://example.com/adult-cat.png"
       assert body["duration"] == 6
       assert body["resolution"] == "768P"
       assert body["prompt_optimizer"] == true
@@ -1018,6 +1097,66 @@ defmodule ReqLLM.VideoGenerationV1Test do
                  ],
                  duration: 5,
                  resolution: "2K",
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+
+    test "uploads private media inside reference lists" do
+      upload_counter = :counters.new(1, [])
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        case {conn.method, conn.request_path} do
+          {"POST", "/v1/files/upload"} ->
+            :counters.add(upload_counter, 1, 1)
+            file_id = :counters.get(upload_counter, 1)
+
+            Req.Test.json(conn, %{
+              "file" => %{
+                "file_id" => file_id,
+                "bytes" => 17,
+                "filename" => "input.jpg",
+                "purpose" => "video_generation_input"
+              },
+              "base_resp" => %{"status_code" => 0, "status_msg" => "success"}
+            })
+
+          {"POST", "/v2/video_generation"} ->
+            {:ok, request_body, conn} = Plug.Conn.read_body(conn)
+            request_json = Jason.decode!(request_body)
+
+            assert [
+                     %{"type" => "text"},
+                     %{"image_url" => %{"url" => "mm_file://1"}},
+                     %{"image_url" => %{"url" => "mm_file://2"}}
+                   ] = request_json["content"]
+
+            Req.Test.json(conn, %{"task_id" => "task-list"})
+        end
+      end)
+
+      model = %LLMDB.Model{
+        id: "MiniMax-H3",
+        model: "MiniMax-H3",
+        provider_model_id: "MiniMax-H3",
+        provider: :minimax,
+        name: "MiniMax-H3",
+        family: "minimax-h3",
+        capabilities: %{video: true},
+        limits: %{},
+        extra: %{}
+      }
+
+      assert {:ok, %Task{task_id: "task-list"}} =
+               ReqLLM.Video.generate_video(
+                 model,
+                 [
+                   prompt: "A cat",
+                   reference_images: [
+                     {:upload, "first-image", "image/jpeg"},
+                     {:upload, "second-image", "image/jpeg"}
+                   ]
+                 ],
                  api_key: "test-key",
                  req_http_options: [plug: {Req.Test, __MODULE__}]
                )


### PR DESCRIPTION
## Description

Adds video generation to the MiniMax provider via a new `:video` operation. Video generation is async (task_id + polling), so `ReqLLM.Video` exposes `generate_video/3`, `query_video/3`, `wait_video/3`, plus `retrieve_file/3` and `upload_file/3` for the V1 file flow.

Two API generations, dispatched by model:

- `MiniMax-H3*` → V2 API (`/v2/video_generation`, content[] body, direct download URL)
- Hailuo series (`MiniMax-Hailuo-2.3` etc.) → V1 API (flat body, `file_id` + `/v1/files/retrieve`)

`generate_video` content accepts `{:upload, binary, media_type}` / `{:file, path}` for private media: uploaded and referenced as `mm_file://{file_id}` on V2, inlined as base64 data URLs on V1.

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Testing

- [x] Tests pass (`mix test`) — 4183 passed
- [x] Quality checks pass (`mix quality`)