### PR TITLE
fix: treat llm_db as a regular OTP dependency

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,7 @@
 import Config
 
 config :llm_db,
+  compile_embed: true,
   filter: %{
     allow: %{
       alibaba: ["*"],

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -577,6 +577,8 @@ The default is `true`.
 
 ```elixir
 # config/prod.exs
+config :llm_db, compile_embed: true
+
 config :req_llm,
   receive_timeout: 120_000,
   stream_receive_timeout: 120_000,
@@ -590,6 +592,11 @@ config :req_llm,
   telemetry: [payloads: :none],
   load_dotenv: false  # Use proper secrets management in production
 ```
+
+Set `compile_embed` in the root application before dependencies compile. This
+embeds the LLMDB catalog in BEAM bytecode and removes catalog file access at
+runtime. Recompile the dependency after each `llm_db` update. ReqLLM cannot set
+this compile-time option for applications that install ReqLLM from Hex.
 
 ## Example: Development Configuration
 

--- a/lib/req_llm/application.ex
+++ b/lib/req_llm/application.ex
@@ -26,13 +26,10 @@ defmodule ReqLLM.Application do
   def start(_type, _args) do
     req_llm_load_dotenv = Application.get_env(:req_llm, :load_dotenv, true)
 
-    sync_llm_db_dotenv_config(req_llm_load_dotenv)
-
-    if req_llm_load_dotenv or Application.get_env(:llm_db, :load_dotenv, false) do
+    if req_llm_load_dotenv do
       load_dotenv()
     end
 
-    ensure_llm_db_started()
     initialize_registry()
     initialize_schema_cache()
 
@@ -182,23 +179,6 @@ defmodule ReqLLM.Application do
       :named_table,
       read_concurrency: true
     ])
-  end
-
-  defp sync_llm_db_dotenv_config(req_llm_load_dotenv) do
-    case Application.fetch_env(:llm_db, :load_dotenv) do
-      :error ->
-        Application.put_env(:llm_db, :load_dotenv, req_llm_load_dotenv)
-
-      {:ok, _value} ->
-        :ok
-    end
-  end
-
-  defp ensure_llm_db_started do
-    case Application.ensure_all_started(:llm_db) do
-      {:ok, _} -> :ok
-      {:error, reason} -> raise "failed to start :llm_db: #{inspect(reason)}"
-    end
   end
 
   defp load_dotenv do

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule ReqLLM.MixProject do
       deps: deps(),
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
+      test_ignore_filters: [&String.starts_with?(&1, "test/fixtures/")],
 
       # Test coverage
       test_coverage: [tool: ExCoveralls, export: "cov", exclude: [:coverage]],
@@ -215,7 +216,6 @@ defmodule ReqLLM.MixProject do
   def application do
     [
       extra_applications: [:logger, :crypto],
-      included_applications: [:llm_db],
       mod: {ReqLLM.Application, []}
     ]
   end

--- a/test/fixtures/llm_db_release/config/config.exs
+++ b/test/fixtures/llm_db_release/config/config.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :llm_db, compile_embed: true
+config :req_llm, load_dotenv: false

--- a/test/fixtures/llm_db_release/lib/application.ex
+++ b/test/fixtures/llm_db_release/lib/application.ex
@@ -1,0 +1,12 @@
+defmodule ReqLLM.LLMDBReleaseFixture.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    {:ok, %LLMDB.Model{provider: :openai}} = ReqLLM.model("openai:gpt-4o-mini")
+
+    Supervisor.start_link([], strategy: :one_for_one, name: __MODULE__.Supervisor)
+  end
+end

--- a/test/fixtures/llm_db_release/mix.exs
+++ b/test/fixtures/llm_db_release/mix.exs
@@ -1,0 +1,30 @@
+defmodule ReqLLM.LLMDBReleaseFixture.MixProject do
+  use Mix.Project
+
+  @req_llm_path System.fetch_env!("REQ_LLM_PATH")
+
+  def project do
+    [
+      app: :req_llm_llm_db_release_fixture,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      start_permanent: true,
+      lockfile: Path.join(@req_llm_path, "mix.lock"),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {ReqLLM.LLMDBReleaseFixture.Application, []}
+    ]
+  end
+
+  defp deps do
+    [
+      {:req_llm, path: @req_llm_path},
+      {:llm_db, path: Path.join(@req_llm_path, "deps/llm_db"), override: true}
+    ]
+  end
+end

--- a/test/release/llm_db_dependency_test.exs
+++ b/test/release/llm_db_dependency_test.exs
@@ -1,0 +1,88 @@
+defmodule ReqLLM.Release.LLMDBDependencyTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 180_000
+
+  @project_root Path.expand("../..", __DIR__)
+  @fixture_path Path.join(@project_root, "test/fixtures/llm_db_release")
+  @release_name "req_llm_llm_db_release_fixture"
+
+  test "builds and boots with an embedded LLMDB catalog" do
+    temporary_path =
+      Path.join(
+        System.tmp_dir!(),
+        "req-llm-llm-db-release-#{System.unique_integer([:positive])}"
+      )
+
+    fixture_path = Path.join(temporary_path, "fixture")
+    build_path = Path.join(fixture_path, "_build/prod")
+    release_path = Path.join(temporary_path, "release")
+    File.mkdir_p!(temporary_path)
+    File.cp_r!(@fixture_path, fixture_path)
+    on_exit(fn -> File.rm_rf!(temporary_path) end)
+
+    environment = [
+      {"HEX_OFFLINE", "1"},
+      {"MIX_ENV", "prod"},
+      {"REQ_LLM_PATH", @project_root}
+    ]
+
+    {deps_output, deps_status} =
+      System.cmd(mix_executable(), ["deps.get", "--only", "prod"],
+        cd: fixture_path,
+        env: environment,
+        stderr_to_stdout: true
+      )
+
+    assert deps_status == 0, deps_output
+
+    {build_output, build_status} =
+      System.cmd(mix_executable(), ["release", "--path", release_path],
+        cd: fixture_path,
+        env: environment,
+        stderr_to_stdout: true
+      )
+
+    assert build_status == 0, build_output
+
+    assert_regular_llm_db_dependency(build_path)
+    remove_packaged_catalog(release_path)
+    assert_release_boots(release_path)
+  end
+
+  defp assert_regular_llm_db_dependency(build_path) do
+    app_file = Path.join(build_path, "lib/req_llm/ebin/req_llm.app")
+
+    assert {:ok, [{:application, :req_llm, properties}]} = :file.consult(app_file)
+    assert :llm_db in Keyword.fetch!(properties, :applications)
+    refute :llm_db in Keyword.get(properties, :included_applications, [])
+  end
+
+  defp remove_packaged_catalog(release_path) do
+    snapshots =
+      Path.wildcard(Path.join(release_path, "lib/llm_db-*/priv/llm_db/snapshot.json"))
+
+    assert [snapshot] = snapshots
+    File.rm!(snapshot)
+  end
+
+  defp assert_release_boots(release_path) do
+    executable = Path.join([release_path, "bin", @release_name])
+
+    expression =
+      "{:ok, started} = Application.ensure_all_started(:req_llm_llm_db_release_fixture); " <>
+        "true = Enum.member?(started, :llm_db); " <>
+        "{:ok, model} = ReqLLM.model(\"openai:gpt-4o-mini\"); " <>
+        "IO.puts(Atom.to_string(model.provider) <> \":\" <> model.id)"
+
+    {output, status} =
+      System.cmd(executable, ["eval", expression], stderr_to_stdout: true)
+
+    assert status == 0, output
+    assert output =~ "openai:gpt-4o-mini"
+  end
+
+  defp mix_executable do
+    System.find_executable("mix") || raise "mix executable not found"
+  end
+end

--- a/test/req_llm/application_test.exs
+++ b/test/req_llm/application_test.exs
@@ -21,9 +21,8 @@ defmodule ReqLLM.ApplicationTest do
       restore_app_env(:req_llm, :stream_pool_size, original_stream_pool_size)
       restore_app_env(:req_llm, :stream_pool_count, original_stream_pool_count)
       System.delete_env(@dotenv_key)
-      Application.ensure_all_started(:llm_db)
-      LLMDB.load(custom: Application.get_env(:llm_db, :custom, %{}))
       Application.ensure_all_started(:req_llm)
+      LLMDB.load(custom: Application.get_env(:llm_db, :custom, %{}))
     end)
 
     :ok
@@ -121,7 +120,7 @@ defmodule ReqLLM.ApplicationTest do
       end
     end
 
-    test "load_dotenv false prevents llm_db from loading .env during req_llm startup" do
+    test "load_dotenv false prevents ReqLLM from loading .env during startup" do
       with_apps_stopped(fn ->
         with_temp_dir(fn ->
           File.write!(".env", "#{@dotenv_key}=from_file\n")
@@ -149,7 +148,7 @@ defmodule ReqLLM.ApplicationTest do
       end)
     end
 
-    test "explicit llm_db load_dotenv config overrides req_llm default" do
+    test "llm_db load_dotenv configuration does not control ReqLLM startup" do
       with_apps_stopped(fn ->
         with_temp_dir(fn ->
           File.write!(".env", "#{@dotenv_key}=from_file\n")
@@ -158,8 +157,26 @@ defmodule ReqLLM.ApplicationTest do
           Application.put_env(:llm_db, :load_dotenv, true)
 
           assert {:ok, _} = Application.ensure_all_started(:req_llm)
-          assert System.get_env(@dotenv_key) == "from_file"
+          assert System.get_env(@dotenv_key) == nil
         end)
+      end)
+    end
+  end
+
+  describe "OTP dependencies" do
+    test "declares llm_db as a regular application dependency" do
+      applications = Application.spec(:req_llm, :applications)
+      included_applications = Application.spec(:req_llm, :included_applications) || []
+
+      assert :llm_db in applications
+      refute :llm_db in included_applications
+    end
+
+    test "starts llm_db before req_llm" do
+      with_apps_stopped(fn ->
+        assert {:ok, started_applications} = Application.ensure_all_started(:req_llm)
+        assert :llm_db in started_applications
+        assert started?(:llm_db)
       end)
     end
   end
@@ -182,9 +199,13 @@ defmodule ReqLLM.ApplicationTest do
   end
 
   defp stop_app(app) do
-    if Keyword.has_key?(Application.started_applications(), app) do
+    if started?(app) do
       Application.stop(app)
     end
+  end
+
+  defp started?(app) do
+    Keyword.has_key?(Application.started_applications(), app)
   end
 
   defp restore_app_env(app, key, nil), do: Application.delete_env(app, key)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,12 +1,9 @@
-# Ensure LLMDB is started first (loads model catalog from snapshot)
-Application.ensure_all_started(:llm_db)
+# Ensure ReqLLM and its regular OTP dependencies are started
+Application.ensure_all_started(:req_llm)
 
 # Reload LLMDB with custom test models merged with snapshot
 custom_providers = Application.get_env(:llm_db, :custom, %{})
 LLMDB.load(custom: custom_providers)
-
-# Ensure providers are loaded for testing
-Application.ensure_all_started(:req_llm)
 
 # Install fake API keys for tests when not in LIVE mode
 ReqLLM.TestSupport.FakeKeys.install!()


### PR DESCRIPTION
## Summary

- treat `llm_db` as a regular OTP application dependency
- remove the manual LLMDB start and ReqLLM-to-LLMDB dotenv configuration handoff
- use `compile_embed: true` for ReqLLM source and release builds, with root-application override guidance for Hex consumers
- add OTP metadata, start-order, and release regression coverage

## Root cause

ReqLLM declared `llm_db` as an included application and also started it manually. A consumer that declared `llm_db` as a normal direct dependency then produced an invalid Mix Release graph because the same application was both regular and included.

## Impact

OTP now starts LLMDB before ReqLLM through the generated application dependency list. Releases can include another direct `llm_db` dependency without an included-application conflict. The release test also proves that an embedded catalog works after the packaged snapshot file is removed.

Hex consumers can override embedded mode in their root configuration because `compile_embed` is a compile-time LLMDB option.

## Validation

- `mix test test/req_llm/application_test.exs` — 12 passed
- `mix test test/release/llm_db_dependency_test.exs` — 1 passed
- full test suite — 4,194 passed, 11 skipped, 151 excluded
- `mix quality` — passed
- live `openai:gpt-4o-mini` request with `compile_embed: true` — returned `EMBED OK`

Fixes #962