### PR TITLE
fix(openai): send null content for tool-only assistant messages

### DIFF
--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -868,9 +868,19 @@ defmodule ReqLLM.Provider.Defaults do
        ) do
     {reasoning_content, content_without_thinking} = extract_reasoning_content(c)
 
+    # DeepSeek / xAI / Groq / Mistral reject tool-only assistant messages
+    # whose content is an empty string: the OpenAI spec says content is
+    # nullable when tool_calls is present, so send null instead of "".
+    content =
+      if tc not in [nil, []] and empty_content?(content_without_thinking) do
+        nil
+      else
+        encode_openai_content(content_without_thinking)
+      end
+
     base_message = %{
       role: to_string(r),
-      content: encode_openai_content(content_without_thinking)
+      content: content
     }
 
     base_message
@@ -965,6 +975,25 @@ defmodule ReqLLM.Provider.Defaults do
     |> Enum.map(&encode_openai_content_part/1)
     |> normalize_encoded_content()
   end
+
+  # True when a message has no visible text (only empty text parts or
+  # thinking), so a tool-call-only assistant message can send content: null.
+  defp empty_content?(nil), do: true
+  defp empty_content?(""), do: true
+
+  defp empty_content?(content) when is_list(content) do
+    content
+    |> Enum.reject(fn
+      %ReqLLM.Message.ContentPart{type: :thinking} -> true
+      _ -> false
+    end)
+    |> Enum.all?(fn
+      %ReqLLM.Message.ContentPart{type: :text, text: text} -> text in [nil, ""]
+      _ -> false
+    end)
+  end
+
+  defp empty_content?(_), do: false
 
   # Normalize encoded content parts: reject nils, flatten single text blocks,
   # and collapse empty arrays to "" (vLLM/strict OpenAI rejects "content": []).

--- a/test/providers/openai_chat_request_test.exs
+++ b/test/providers/openai_chat_request_test.exs
@@ -180,4 +180,52 @@ defmodule ReqLLM.Providers.OpenAI.ChatRequestTest do
       Request.build_body(context, "gpt-4o-mini-search-preview", opts, :chat)
     end
   end
+
+  describe "tool-only assistant messages" do
+    test "send content: null when tool_calls are present and there is no text" do
+      tool_call = ReqLLM.ToolCall.new("call_1", "get_weather", ~s({"location":"SF"}))
+
+      context =
+        Context.new([
+          Context.user("What's the weather?"),
+          Context.assistant("", tool_calls: [tool_call]),
+          Context.tool_result("call_1", "24°C")
+        ])
+
+      body = Request.build_body(context, "gpt-4o-mini", [], :chat)
+
+      [user_msg, assistant_msg, tool_msg] = body.messages
+      assert user_msg[:role] == "user"
+      # DeepSeek / xAI / Groq / Mistral reject "" here; must be null
+      assert assistant_msg[:content] == nil
+      assert [%{id: "call_1", type: "function"}] = assistant_msg[:tool_calls]
+      assert tool_msg[:role] == "tool"
+      assert tool_msg[:tool_call_id] == "call_1"
+    end
+
+    test "keep text content when the assistant message has both text and tool_calls" do
+      tool_call = ReqLLM.ToolCall.new("call_1", "get_weather", ~s({"location":"SF"}))
+
+      context =
+        Context.new([
+          Context.user("What's the weather?"),
+          Context.assistant("Let me check", tool_calls: [tool_call]),
+          Context.tool_result("call_1", "24°C")
+        ])
+
+      body = Request.build_body(context, "gpt-4o-mini", [], :chat)
+
+      [_user_msg, assistant_msg, _tool_msg] = body.messages
+      assert assistant_msg[:content] == "Let me check"
+      assert [%{id: "call_1"}] = assistant_msg[:tool_calls]
+    end
+
+    test "plain assistant messages keep their content" do
+      context = Context.new([Context.user("hi"), Context.assistant("hello")])
+      body = Request.build_body(context, "gpt-4o-mini", [], :chat)
+
+      [_user_msg, assistant_msg] = body.messages
+      assert assistant_msg[:content] == "hello"
+    end
+  end
 end

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -370,7 +370,8 @@ defmodule ReqLLM.Provider.DefaultsTest do
         messages: [
           %{
             role: "assistant",
-            content: "",
+            # tool-only assistant messages send null content (OpenAI spec)
+            content: nil,
             tool_calls: [
               %{
                 id: "call_123",
@@ -534,8 +535,8 @@ defmodule ReqLLM.Provider.DefaultsTest do
       result = Defaults.encode_context_to_openai_format(context, "gpt-4")
 
       [encoded_message] = result.messages
-      # All parts filtered → empty array collapsed to ""
-      assert encoded_message.content == ""
+      # Thinking-only content with tool_calls → null content (OpenAI spec)
+      assert encoded_message.content == nil
       # Tool calls still present
       assert length(encoded_message.tool_calls) == 1
       # reasoning_content emitted for assistant


### PR DESCRIPTION
## Description

DeepSeek, xAI, Groq and Mistral reject assistant messages that carry `tool_calls` but an empty-string `content` with `400: Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`. The OpenAI spec says `content` is nullable when `tool_calls` is present, so the OpenAI-compatible encoder now sends `null` instead of `""` for messages that have `tool_calls` and no visible text (empty text parts or thinking-only content are treated as empty).

Adds `empty_content?/1` and updates the existing encoder tests that asserted the old `""` behavior.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] Tests pass (`mix test`) — 4220 passed
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
