### PR TITLE
feat(ollama): forward reasoning_effort to disable thinking on reasoning models

### DIFF
--- a/lib/req_llm/providers/ollama.ex
+++ b/lib/req_llm/providers/ollama.ex
@@ -25,10 +25,22 @@ defmodule ReqLLM.Providers.Ollama do
   - `num_ctx` — context window size in tokens (Ollama `options.num_ctx`)
   - `keep_alive` — how long to keep model loaded, e.g. `"30m"` or `0` to unload immediately
 
+  ## Reasoning models
+
+  `reasoning_effort` is a **core** ReqLLM option. ReqLLM's default body
+  builder accepts it but does not emit it, so this provider forwards it
+  `"none"` disables thinking entirely for reasoning models. Ollama honors
+  this on the `/v1` endpoint; the native `think` flag does not apply there.
+
   ## Examples
 
       ReqLLM.generate_text("ollama:gemma4:27b", "Hello",
         provider_options: [num_ctx: 16_384, keep_alive: "30m"]
+      )
+
+      # Disable thinking on a reasoning model:
+      ReqLLM.generate_object("ollama:qwen3:14b", "Extract entities…", schema,
+        reasoning_effort: :none
       )
   """
 
@@ -37,6 +49,9 @@ defmodule ReqLLM.Providers.Ollama do
     default_base_url: "http://localhost:11434/v1"
 
   use ReqLLM.Provider.Defaults
+
+  @reasoning_efforts [:none, :low, :medium, :high, :max]
+  @reasoning_effort_strings Enum.map(@reasoning_efforts, &Atom.to_string/1)
 
   @provider_schema [
     num_ctx: [
@@ -52,6 +67,31 @@ defmodule ReqLLM.Providers.Ollama do
       doc: "Response format configuration for Ollama's OpenAI-compatible API"
     ]
   ]
+
+  @impl ReqLLM.Provider
+  def translate_options(_operation, _model, opts) do
+    {reasoning_effort, opts} = Keyword.pop(opts, :reasoning_effort)
+
+    case normalize_reasoning_effort(reasoning_effort) do
+      {:ok, nil} ->
+        {opts, []}
+
+      {:ok, normalized} ->
+        {Keyword.put(opts, :reasoning_effort, normalized), []}
+
+      {:clamped, normalized} ->
+        warning =
+          "Ollama reasoning_effort #{inspect(reasoning_effort)} was clamped to #{inspect(normalized)}"
+
+        {Keyword.put(opts, :reasoning_effort, normalized), [warning]}
+
+      :unsupported ->
+        warning =
+          "Ollama supports reasoning_effort values :none, :low, :medium, :high, and :max; #{inspect(reasoning_effort)} will be ignored"
+
+        {opts, [warning]}
+    end
+  end
 
   @impl ReqLLM.Provider
   def prepare_request(:object, model_spec, prompt, opts) do
@@ -147,15 +187,19 @@ defmodule ReqLLM.Providers.Ollama do
   @doc """
   Builds the Ollama request body.
 
-  Extends the standard OpenAI-compat body with two Ollama-specific fields:
+  Extends the standard OpenAI-compat body with Ollama-specific fields:
   - `options.num_ctx` — nested under the `options` map (Ollama model parameter)
   - `keep_alive` — top-level field controlling how long the model stays loaded
+  - `reasoning_effort` — top-level field controlling thinking (`"none"` disables it).
+    `default_build_body/1` recognizes `reasoning_effort` as an option but does not
+    emit it, so the Ollama provider forwards it here.
   """
   @impl ReqLLM.Provider
   def build_body(request) do
     ReqLLM.Provider.Defaults.default_build_body(request)
     |> maybe_add_num_ctx(request.options[:num_ctx])
     |> maybe_add_keep_alive(request.options[:keep_alive])
+    |> maybe_add_reasoning_effort(request.options[:reasoning_effort])
   end
 
   defp maybe_add_num_ctx(body, nil), do: body
@@ -163,6 +207,30 @@ defmodule ReqLLM.Providers.Ollama do
 
   defp maybe_add_keep_alive(body, nil), do: body
   defp maybe_add_keep_alive(body, keep_alive), do: Map.put(body, :keep_alive, keep_alive)
+
+  defp maybe_add_reasoning_effort(body, nil), do: body
+
+  defp maybe_add_reasoning_effort(body, effort),
+    do: Map.put(body, :reasoning_effort, to_string(effort))
+
+  defp normalize_reasoning_effort(nil), do: {:ok, nil}
+  defp normalize_reasoning_effort(:default), do: {:ok, nil}
+  defp normalize_reasoning_effort("default"), do: {:ok, nil}
+  defp normalize_reasoning_effort(:minimal), do: {:clamped, "low"}
+  defp normalize_reasoning_effort("minimal"), do: {:clamped, "low"}
+  defp normalize_reasoning_effort(:xhigh), do: {:clamped, "max"}
+  defp normalize_reasoning_effort("xhigh"), do: {:clamped, "max"}
+
+  defp normalize_reasoning_effort(effort) when effort in @reasoning_efforts,
+    do: {:ok, Atom.to_string(effort)}
+
+  defp normalize_reasoning_effort(effort) when is_binary(effort) do
+    if effort in @reasoning_effort_strings,
+      do: {:ok, effort},
+      else: :unsupported
+  end
+
+  defp normalize_reasoning_effort(_effort), do: :unsupported
 
   defp encode_stream_body(model, context, opts) do
     req_opts =

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -61,6 +61,56 @@ defmodule ReqLLM.Providers.OllamaTest do
       body = Ollama.build_body(request)
       assert body.keep_alive == "30m"
     end
+
+    test "omits :reasoning_effort key when not given" do
+      request = req_with_opts(model: "llama3", context: simple_context())
+      body = Ollama.build_body(request)
+      refute Map.has_key?(body, :reasoning_effort)
+    end
+
+    test "injects reasoning_effort at body top-level, atom coerced to string (:none disables thinking)" do
+      request =
+        req_with_opts(model: "qwen3:14b", context: simple_context(), reasoning_effort: :none)
+
+      body = Ollama.build_body(request)
+      assert body.reasoning_effort == "none"
+    end
+  end
+
+  describe "translate_options/3" do
+    test "normalizes every Ollama-supported reasoning effort" do
+      for effort <- [:none, :low, :medium, :high, :max] do
+        assert {translated, []} =
+                 Ollama.translate_options(:chat, ollama_model(), reasoning_effort: effort)
+
+        assert translated[:reasoning_effort] == Atom.to_string(effort)
+      end
+    end
+
+    test "omits the provider default reasoning effort" do
+      assert {translated, []} =
+               Ollama.translate_options(:chat, ollama_model(), reasoning_effort: :default)
+
+      refute Keyword.has_key?(translated, :reasoning_effort)
+    end
+
+    test "clamps unsupported canonical levels to Ollama equivalents" do
+      for {effort, expected} <- [minimal: "low", xhigh: "max"] do
+        assert {translated, [warning]} =
+                 Ollama.translate_options(:chat, ollama_model(), reasoning_effort: effort)
+
+        assert translated[:reasoning_effort] == expected
+        assert warning =~ "was clamped"
+      end
+    end
+
+    test "drops unknown direct-callback values with a warning" do
+      assert {translated, [warning]} =
+               Ollama.translate_options(:chat, ollama_model(), reasoning_effort: :extreme)
+
+      refute Keyword.has_key?(translated, :reasoning_effort)
+      assert warning =~ "will be ignored"
+    end
   end
 
   describe "attach/3" do
@@ -105,6 +155,16 @@ defmodule ReqLLM.Providers.OllamaTest do
 
       refute Map.has_key?(body, "tools")
       refute Map.has_key?(body, "tool_choice")
+    end
+
+    test "request processing translates reasoning effort before encoding" do
+      {:ok, request} =
+        Ollama.prepare_request(:chat, ollama_model(), "ping", reasoning_effort: :minimal)
+
+      encoded = Ollama.encode_body(request)
+      body = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert body["reasoning_effort"] == "low"
     end
   end
 
@@ -171,6 +231,20 @@ defmodule ReqLLM.Providers.OllamaTest do
       assert decoded["stream"] == true
       assert is_list(decoded["messages"])
       assert decoded["messages"] != []
+    end
+
+    test "translates reasoning effort in streaming request bodies" do
+      assert {:ok, request} =
+               Ollama.attach_stream(
+                 ollama_model(),
+                 simple_context(),
+                 [reasoning_effort: :xhigh],
+                 ReqLLM.Finch
+               )
+
+      decoded = request.body |> IO.iodata_to_binary() |> Jason.decode!()
+
+      assert decoded["reasoning_effort"] == "max"
     end
   end
 end


### PR DESCRIPTION
Ollama's /v1 OpenAI-compatible endpoint honors `reasoning_effort` (`:none` fully disables thinking on Qwen3/Gemma-style reasoning models), but ReqLLM's default body builder recognizes :reasoning_effort as a core option without emitting it — so it was silently dropped for Ollama.

Forward reasoning_effort as a top-level Ollama body field in build_body/1 (mirroring num_ctx/keep_alive). The core option validates to an atom; coerce to the string form Ollama's body expects.

Note: the native `think` flag applies only to Ollama's /api/chat endpoint, not /v1, so reasoning_effort is the correct lever for the OpenAI-compat path ReqLLM uses.

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [X] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

## Testing

- [X] Tests pass (`mix test`)
- [X] Quality checks pass (`mix quality`)

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have updated the documentation accordingly
- [X] I have added tests that prove my fix/feature works
- [X] All new and existing tests pass
- [X] My commits follow conventional commit format
- [X] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
