### PR TITLE
fix(test): stabilize llm db release fixture

### DIFF
--- a/test/fixtures/llm_db_release/mix.exs
+++ b/test/fixtures/llm_db_release/mix.exs
@@ -23,8 +23,7 @@ defmodule ReqLLM.LLMDBReleaseFixture.MixProject do
 
   defp deps do
     [
-      {:req_llm, path: @req_llm_path},
-      {:llm_db, path: Path.join(@req_llm_path, "deps/llm_db"), override: true}
+      {:req_llm, path: @req_llm_path}
     ]
   end
 end

--- a/test/release/llm_db_dependency_test.exs
+++ b/test/release/llm_db_dependency_test.exs
@@ -24,17 +24,9 @@ defmodule ReqLLM.Release.LLMDBDependencyTest do
     environment = [
       {"HEX_OFFLINE", "1"},
       {"MIX_ENV", "prod"},
+      {"MIX_DEPS_PATH", Path.join(@project_root, "deps")},
       {"REQ_LLM_PATH", @project_root}
     ]
-
-    {deps_output, deps_status} =
-      System.cmd(mix_executable(), ["deps.get", "--only", "prod"],
-        cd: fixture_path,
-        env: environment,
-        stderr_to_stdout: true
-      )
-
-    assert deps_status == 0, deps_output
 
     {build_output, build_status} =
       System.cmd(mix_executable(), ["release", "--path", release_path],


### PR DESCRIPTION
## Summary

- remove the fixture-only llm_db path override so the release test uses ReqLLM's normal locked dependency
- reuse dependencies already fetched for the root project during the offline release build
- avoid a second offline dependency resolution that depended on runner-specific Hex registry and tarball caches

## Validation

- `mix test test/release/llm_db_dependency_test.exs --trace`
- `mix test`
- `mix quality`