### PR TITLE
feat(google): accept base_url, receive_timeout, and req_http_options in CachedContent

### DIFF
--- a/lib/req_llm/providers/google/cached_content.ex
+++ b/lib/req_llm/providers/google/cached_content.ex
@@ -18,6 +18,24 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   - Gemini 2.5 Flash: 1,024 tokens minimum
   - Gemini 2.5 Pro: 4,096 tokens minimum
 
+  ## HTTP Options
+
+  Every function in this module accepts the following options in addition to
+  the ones listed in its documentation:
+
+  - `:base_url` - Override the API base URL (e.g. for proxies or test servers).
+    For Google AI Studio the default is `"https://generativelanguage.googleapis.com/v1beta"`.
+    For Vertex AI the default is `"https://{region}-aiplatform.googleapis.com/v1"` for
+    `create/1` and `list/1`, and `"https://aiplatform.googleapis.com/v1"` for the
+    name-based operations (`get/1`, `update/1`, `delete/1`), whose `:name` is a full
+    resource path.
+  - `:receive_timeout` - Timeout for receiving the response in milliseconds
+    (defaults to `120_000`).
+  - `:req_http_options` - Keyword list of `Req` options merged into the underlying
+    request (e.g. `finch: [name: MyFinch]`, `retry: false`, or
+    `plug: {Req.Test, MyStub}` for testing). Requests run through ReqLLM's Finch
+    pool (`ReqLLM.Finch`) unless a `:finch` option is given.
+
   ## Cost Savings
 
   - Gemini 2.5: 90% discount on cached tokens
@@ -100,6 +118,10 @@ defmodule ReqLLM.Providers.Google.CachedContent do
 
   """
 
+  @google_ai_studio_base_url "https://generativelanguage.googleapis.com/v1beta"
+  @vertex_global_base_url "https://aiplatform.googleapis.com/v1"
+  @default_receive_timeout 120_000
+
   @doc """
   Creates a new cached content resource.
 
@@ -117,6 +139,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   - `:tool_config` - Optional tool configuration
   - `:ttl` - Time-to-live duration (e.g., "3600s", defaults to "3600s")
   - `:display_name` - Optional display name for the cache
+  - `:base_url` - Optional API base URL override (see "HTTP Options" in the moduledoc)
+  - `:receive_timeout` - Optional response timeout in milliseconds (defaults to 120000)
+  - `:req_http_options` - Optional `Req` options for the underlying request
 
   ## Returns
 
@@ -179,6 +204,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   - `:region` - GCP region (for Vertex AI)
   - `:page_size` - Number of results per page (optional)
   - `:page_token` - Token for pagination (optional)
+  - `:base_url` - Optional API base URL override (see "HTTP Options" in the moduledoc)
+  - `:receive_timeout` - Optional response timeout in milliseconds (defaults to 120000)
+  - `:req_http_options` - Optional `Req` options for the underlying request
   """
   def list(opts) do
     provider = Keyword.fetch!(opts, :provider)
@@ -201,6 +229,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   - `:service_account_json` - Service account JSON path (for Vertex AI)
   - `:project_id` - GCP project ID (for Vertex AI)
   - `:region` - GCP region (for Vertex AI)
+  - `:base_url` - Optional API base URL override (see "HTTP Options" in the moduledoc)
+  - `:receive_timeout` - Optional response timeout in milliseconds (defaults to 120000)
+  - `:req_http_options` - Optional `Req` options for the underlying request
   """
   def get(opts) do
     provider = Keyword.fetch!(opts, :provider)
@@ -224,6 +255,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   - `:service_account_json` - Service account JSON path (for Vertex AI)
   - `:project_id` - GCP project ID (for Vertex AI)
   - `:region` - GCP region (for Vertex AI)
+  - `:base_url` - Optional API base URL override (see "HTTP Options" in the moduledoc)
+  - `:receive_timeout` - Optional response timeout in milliseconds (defaults to 120000)
+  - `:req_http_options` - Optional `Req` options for the underlying request
   """
   def update(opts) do
     provider = Keyword.fetch!(opts, :provider)
@@ -246,6 +280,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   - `:service_account_json` - Service account JSON path (for Vertex AI)
   - `:project_id` - GCP project ID (for Vertex AI)
   - `:region` - GCP region (for Vertex AI)
+  - `:base_url` - Optional API base URL override (see "HTTP Options" in the moduledoc)
+  - `:receive_timeout` - Optional response timeout in milliseconds (defaults to 120000)
+  - `:req_http_options` - Optional `Req` options for the underlying request
   """
   def delete(opts) do
     provider = Keyword.fetch!(opts, :provider)
@@ -281,9 +318,10 @@ defmodule ReqLLM.Providers.Google.CachedContent do
       |> maybe_put(:toolConfig, tool_config)
       |> maybe_put(:displayName, display_name)
 
-    url = "https://generativelanguage.googleapis.com/v1beta/cachedContents"
+    request_options =
+      http_options(@google_ai_studio_base_url, [json: body, params: [key: api_key]], opts)
 
-    case Req.post(url, json: body, params: [key: api_key]) do
+    case Req.post("/cachedContents", request_options) do
       {:ok, %{status: 200, body: response}} ->
         {:ok, parse_cache_response(response)}
 
@@ -300,14 +338,14 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     page_size = Keyword.get(opts, :page_size)
     page_token = Keyword.get(opts, :page_token)
 
-    url = "https://generativelanguage.googleapis.com/v1beta/cachedContents"
-
     params =
       [key: api_key]
       |> maybe_put_param(:pageSize, page_size)
       |> maybe_put_param(:pageToken, page_token)
 
-    case Req.get(url, params: params) do
+    request_options = http_options(@google_ai_studio_base_url, [params: params], opts)
+
+    case Req.get("/cachedContents", request_options) do
       {:ok, %{status: 200, body: response}} ->
         {:ok, response}
 
@@ -323,9 +361,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     api_key = Keyword.fetch!(opts, :api_key)
     name = Keyword.fetch!(opts, :name)
 
-    url = "https://generativelanguage.googleapis.com/v1beta/#{name}"
+    request_options = http_options(@google_ai_studio_base_url, [params: [key: api_key]], opts)
 
-    case Req.get(url, params: [key: api_key]) do
+    case Req.get("/#{name}", request_options) do
       {:ok, %{status: 200, body: response}} ->
         {:ok, parse_cache_response(response)}
 
@@ -342,10 +380,16 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     name = Keyword.fetch!(opts, :name)
     ttl = Keyword.fetch!(opts, :ttl)
 
-    url = "https://generativelanguage.googleapis.com/v1beta/#{name}"
     body = %{ttl: ttl}
 
-    case Req.patch(url, json: body, params: [key: api_key, updateMask: "ttl"]) do
+    request_options =
+      http_options(
+        @google_ai_studio_base_url,
+        [json: body, params: [key: api_key, updateMask: "ttl"]],
+        opts
+      )
+
+    case Req.patch("/#{name}", request_options) do
       {:ok, %{status: 200, body: response}} ->
         {:ok, parse_cache_response(response)}
 
@@ -361,9 +405,9 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     api_key = Keyword.fetch!(opts, :api_key)
     name = Keyword.fetch!(opts, :name)
 
-    url = "https://generativelanguage.googleapis.com/v1beta/#{name}"
+    request_options = http_options(@google_ai_studio_base_url, [params: [key: api_key]], opts)
 
-    case Req.delete(url, params: [key: api_key]) do
+    case Req.delete("/#{name}", request_options) do
       {:ok, %{status: 200}} ->
         :ok
 
@@ -419,14 +463,16 @@ defmodule ReqLLM.Providers.Google.CachedContent do
       |> maybe_put(:toolConfig, tool_config)
       |> maybe_put(:displayName, display_name)
 
-    url =
-      "https://#{region}-aiplatform.googleapis.com/v1/projects/#{project_id}/locations/#{region}/cachedContents"
+    url = "/projects/#{project_id}/locations/#{region}/cachedContents"
 
     with {:ok, access_token} <-
            ReqLLM.Providers.GoogleVertex.Auth.get_access_token(service_account_json) do
       headers = [{"authorization", "Bearer #{access_token}"}]
 
-      case Req.post(url, json: body, headers: headers) do
+      request_options =
+        http_options(vertex_regional_base_url(region), [json: body, headers: headers], opts)
+
+      case Req.post(url, request_options) do
         {:ok, %{status: 200, body: response}} ->
           {:ok, parse_cache_response(response)}
 
@@ -452,8 +498,7 @@ defmodule ReqLLM.Providers.Google.CachedContent do
       page_size = Keyword.get(opts, :page_size)
       page_token = Keyword.get(opts, :page_token)
 
-      url =
-        "https://#{region}-aiplatform.googleapis.com/v1/projects/#{project_id}/locations/#{region}/cachedContents"
+      url = "/projects/#{project_id}/locations/#{region}/cachedContents"
 
       params =
         []
@@ -464,7 +509,10 @@ defmodule ReqLLM.Providers.Google.CachedContent do
              ReqLLM.Providers.GoogleVertex.Auth.get_access_token(service_account_json) do
         headers = [{"authorization", "Bearer #{access_token}"}]
 
-        case Req.get(url, params: params, headers: headers) do
+        request_options =
+          http_options(vertex_regional_base_url(region), [params: params, headers: headers], opts)
+
+        case Req.get(url, request_options) do
           {:ok, %{status: 200, body: response}} ->
             {:ok, response}
 
@@ -483,13 +531,12 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     name = Keyword.fetch!(opts, :name)
 
     # Name should be full resource path: projects/{project}/locations/{region}/cachedContents/{id}
-    url = "https://aiplatform.googleapis.com/v1/#{name}"
-
     with {:ok, access_token} <-
            ReqLLM.Providers.GoogleVertex.Auth.get_access_token(service_account_json) do
       headers = [{"authorization", "Bearer #{access_token}"}]
+      request_options = http_options(@vertex_global_base_url, [headers: headers], opts)
 
-      case Req.get(url, headers: headers) do
+      case Req.get("/#{name}", request_options) do
         {:ok, %{status: 200, body: response}} ->
           {:ok, parse_cache_response(response)}
 
@@ -507,14 +554,20 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     name = Keyword.fetch!(opts, :name)
     ttl = Keyword.fetch!(opts, :ttl)
 
-    url = "https://aiplatform.googleapis.com/v1/#{name}"
     body = %{ttl: ttl}
 
     with {:ok, access_token} <-
            ReqLLM.Providers.GoogleVertex.Auth.get_access_token(service_account_json) do
       headers = [{"authorization", "Bearer #{access_token}"}]
 
-      case Req.patch(url, json: body, params: [updateMask: "ttl"], headers: headers) do
+      request_options =
+        http_options(
+          @vertex_global_base_url,
+          [json: body, params: [updateMask: "ttl"], headers: headers],
+          opts
+        )
+
+      case Req.patch("/#{name}", request_options) do
         {:ok, %{status: 200, body: response}} ->
           {:ok, parse_cache_response(response)}
 
@@ -531,13 +584,12 @@ defmodule ReqLLM.Providers.Google.CachedContent do
     service_account_json = Keyword.fetch!(opts, :service_account_json)
     name = Keyword.fetch!(opts, :name)
 
-    url = "https://aiplatform.googleapis.com/v1/#{name}"
-
     with {:ok, access_token} <-
            ReqLLM.Providers.GoogleVertex.Auth.get_access_token(service_account_json) do
       headers = [{"authorization", "Bearer #{access_token}"}]
+      request_options = http_options(@vertex_global_base_url, [headers: headers], opts)
 
-      case Req.delete(url, headers: headers) do
+      case Req.delete("/#{name}", request_options) do
         {:ok, %{status: 200}} ->
           :ok
 
@@ -551,6 +603,20 @@ defmodule ReqLLM.Providers.Google.CachedContent do
   end
 
   # Shared helper functions
+
+  defp vertex_regional_base_url(region), do: "https://#{region}-aiplatform.googleapis.com/v1"
+
+  defp http_options(default_base_url, request_options, opts) do
+    http_opts = Keyword.get(opts, :req_http_options, [])
+    receive_timeout = Keyword.get(opts, :receive_timeout, @default_receive_timeout)
+
+    [
+      base_url: Keyword.get(opts, :base_url, default_base_url),
+      receive_timeout: receive_timeout
+    ] ++
+      request_options ++
+      ReqLLM.Provider.Defaults.merge_finch_options(http_opts, pool_timeout: receive_timeout)
+  end
 
   defp format_system_instruction(nil), do: nil
   defp format_system_instruction(text) when is_binary(text), do: %{parts: [%{text: text}]}

--- a/test/req_llm/providers/google/cached_content_test.exs
+++ b/test/req_llm/providers/google/cached_content_test.exs
@@ -94,6 +94,158 @@ defmodule ReqLLM.Providers.Google.CachedContentTest do
     end
   end
 
+  describe "base_url and req_http_options" do
+    test "create/1 defaults to the Google AI Studio base URL" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.host == "generativelanguage.googleapis.com"
+        assert conn.request_path == "/v1beta/cachedContents"
+
+        Req.Test.json(conn, %{"name" => "cachedContents/test-cache"})
+      end)
+
+      assert {:ok, cache} =
+               CachedContent.create(
+                 provider: :google,
+                 model: "gemini-2.5-flash",
+                 api_key: "test-key",
+                 contents: [%{role: "user", parts: [%{text: "Content to cache"}]}],
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert cache.name == "cachedContents/test-cache"
+    end
+
+    test "create/1 sends the request to a custom base URL" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "POST"
+        assert conn.host == "localhost"
+        assert conn.port == 9999
+        assert conn.request_path == "/custom/v1beta/cachedContents"
+        assert %{"key" => "test-key"} = URI.decode_query(conn.query_string)
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        assert payload["model"] == "models/gemini-2.5-flash"
+        assert [%{"role" => "user"}] = payload["contents"]
+
+        Req.Test.json(conn, %{
+          "name" => "cachedContents/test-cache",
+          "createTime" => "2025-01-01T00:00:00Z",
+          "expireTime" => "2025-01-01T01:00:00Z"
+        })
+      end)
+
+      assert {:ok, cache} =
+               CachedContent.create(
+                 provider: :google,
+                 model: "gemini-2.5-flash",
+                 api_key: "test-key",
+                 contents: [%{role: "user", parts: [%{text: "Content to cache"}]}],
+                 base_url: "http://localhost:9999/custom/v1beta/",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert cache.name == "cachedContents/test-cache"
+      assert cache.create_time == "2025-01-01T00:00:00Z"
+      assert cache.expire_time == "2025-01-01T01:00:00Z"
+    end
+
+    test "get/1 sends the request to a custom base URL" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.host == "localhost"
+        assert conn.request_path == "/custom/v1beta/cachedContents/abc123"
+        assert %{"key" => "test-key"} = URI.decode_query(conn.query_string)
+
+        Req.Test.json(conn, %{"name" => "cachedContents/abc123"})
+      end)
+
+      assert {:ok, cache} =
+               CachedContent.get(
+                 provider: :google,
+                 name: "cachedContents/abc123",
+                 api_key: "test-key",
+                 base_url: "http://localhost/custom/v1beta",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert cache.name == "cachedContents/abc123"
+    end
+
+    test "list/1 sends the request to a custom base URL" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "GET"
+        assert conn.host == "localhost"
+        assert conn.request_path == "/custom/v1beta/cachedContents"
+
+        assert %{"key" => "test-key", "pageSize" => "5"} =
+                 URI.decode_query(conn.query_string)
+
+        Req.Test.json(conn, %{"cachedContents" => [%{"name" => "cachedContents/abc123"}]})
+      end)
+
+      assert {:ok, %{"cachedContents" => [cache]}} =
+               CachedContent.list(
+                 provider: :google,
+                 api_key: "test-key",
+                 page_size: 5,
+                 base_url: "http://localhost/custom/v1beta",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert cache["name"] == "cachedContents/abc123"
+    end
+
+    test "update/1 sends the request to a custom base URL" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "PATCH"
+        assert conn.host == "localhost"
+        assert conn.request_path == "/custom/v1beta/cachedContents/abc123"
+
+        assert %{"key" => "test-key", "updateMask" => "ttl"} =
+                 URI.decode_query(conn.query_string)
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert %{"ttl" => "7200s"} = Jason.decode!(body)
+
+        Req.Test.json(conn, %{"name" => "cachedContents/abc123"})
+      end)
+
+      assert {:ok, cache} =
+               CachedContent.update(
+                 provider: :google,
+                 name: "cachedContents/abc123",
+                 ttl: "7200s",
+                 api_key: "test-key",
+                 base_url: "http://localhost/custom/v1beta",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+
+      assert cache.name == "cachedContents/abc123"
+    end
+
+    test "delete/1 sends the request to a custom base URL" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.host == "localhost"
+        assert conn.request_path == "/custom/v1beta/cachedContents/abc123"
+        assert %{"key" => "test-key"} = URI.decode_query(conn.query_string)
+
+        Req.Test.json(conn, %{})
+      end)
+
+      assert :ok =
+               CachedContent.delete(
+                 provider: :google,
+                 name: "cachedContents/abc123",
+                 api_key: "test-key",
+                 base_url: "http://localhost/custom/v1beta",
+                 req_http_options: [plug: {Req.Test, __MODULE__}]
+               )
+    end
+  end
+
   describe "cached_content parameter in requests" do
     test "Google provider schema accepts cached_content option" do
       # Verify the provider schema accepts cached_content


### PR DESCRIPTION
## Summary

`ReqLLM.Providers.Google.CachedContent` currently issues bare `Req.post/get/patch/delete` calls against hardcoded production URLs, with no way to pass Req options through. This makes the module hard to adopt in applications that need to:

- **Test against a stub or local simulator** — there is no `base_url` or `plug` seam, so the only way to test code built on this module is to hit the live API (the module's own test suite is mostly `@tag :skip` live tests for the same reason).
- **Use a dedicated Finch pool** — the calls always go through Req's default pool (50 connections per host), which can be exhausted when cache management runs at high concurrency alongside other traffic.
- **Control timeouts and retries** — cache creation uploads the (large) content being cached, and Req's default 15s `receive_timeout` is easily exceeded; there is currently no way to raise it.

This PR threads three options through every operation, for both Google AI Studio and Vertex AI, following the shape `ReqLLM.Providers.OpenAI.Files` (the library's other standalone resource-CRUD module) already uses in its `build_request/5`:

- `:base_url` — overrides the endpoint base URL (defaults preserve today's URLs exactly).
- `:receive_timeout` — response timeout in milliseconds, defaulting to `120_000` and threaded into the Finch options as `pool_timeout`, exactly like `OpenAI.Files`.
- `:req_http_options` — a keyword list of Req options merged into the underlying request (`finch:`, `retry:`, `plug:`, …), mirroring the `req_http_options` option already accepted by `ReqLLM.Embedding`, `ReqLLM.Rerank`, and the generation pipeline.

## Changes

- `create/1`, `list/1`, `get/1`, `update/1`, `delete/1` accept `:base_url`, `:receive_timeout`, and `:req_http_options` (documented in each `@doc` and a new "HTTP Options" moduledoc section).
- `:base_url` is passed as a Req `base_url:` option with relative request paths, the same shape the pipeline providers use, with the previous hardcoded URLs as defaults.
- Requests now default to ReqLLM's supervised Finch pool via `ReqLLM.Provider.Defaults.merge_finch_options/2`, like every other request in the library — previously this module was the one place still using Req's default pool, contrary to `ReqLLM.Application`'s "used for all HTTP operations" intent. A caller-provided `finch:` in `:req_http_options` still wins.
- Caller options are appended after the built-in request options, so caller options win.

Behavior changes when the new options are omitted are limited to alignment with the rest of the library: requests use `ReqLLM.Finch` instead of Req's default pool, and the receive timeout becomes 120s (matching `OpenAI.Files`) instead of Req's 15s default — the previous 15s was easily exceeded by cache creation, which uploads the large content being cached.

## Tests

Added a `base_url and req_http_options` describe block covering all five AI Studio operations using `Req.Test` via `req_http_options: [plug: {Req.Test, __MODULE__}]` — including one test asserting the default base URL is unchanged. (These are the first non-skipped HTTP tests for this module; the plug seam added here is what makes them possible.)

The Vertex AI paths get the same passthrough, but stub-testing them requires faking the OAuth token exchange in `ReqLLM.Providers.GoogleVertex.Auth`, so they remain covered by the existing live tests.

## Context

We (Symbolic) are migrating our Gemini integration to req_llm — chat, structured output, and embeddings are already converted. The context-cache CRUD is the last piece we can't move, because our test suite stubs the HTTP layer and our production config uses a dedicated Finch pool and a 300s receive timeout for cache creation. This change lets us finish that migration.

We've validated this branch by consuming it as a git dependency in our application and converting our caching client to `CachedContent`: our full suite is green, including stub-based tests exercising all five operations through the new `plug:` seam, a `base_url` override pointing at test servers, and a 300s `receive_timeout` override matching our production config.

## Possible follow-up (not in this PR)

`CachedContent` returns errors as flattened strings (`{:error, "Failed to create cached content (status 429): ..."}`), so callers that need to classify failures (rate limit vs. not-found vs. auth) have to match on message text. Migrating this module's error returns to `ReqLLM.Error` structs carrying the status and response body — like the rest of the library — would remove that coupling. That's a breaking change to this module's contract, so it's left out of this PR, but we'd happily consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
