### PR TITLE
fix(google): respect model thinking levels

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -65,6 +65,9 @@ Provider-native controls such as Anthropic `thinking` and Google
 canonical and provider-native controls unless you rely on the provider's
 existing precedence rules.
 
+For Gemini 3 models, ReqLLM maps canonical effort to the nearest thinking level
+that the selected model supports.
+
 Lossy or ignored reasoning translations are non-fatal by default and emit a
 deterministic warning. `ReqLLM.plan/3` reports the same sanitized warnings
 without making a request. These reasoning advisories do not introduce new

--- a/lib/req_llm/provider/reasoning.ex
+++ b/lib/req_llm/provider/reasoning.ex
@@ -25,6 +25,8 @@ defmodule ReqLLM.Provider.Reasoning do
     xai: "xAI"
   }
 
+  @google_thinking_levels [:minimal, :low, :medium, :high]
+
   @spec normalize_options(keyword()) :: keyword()
   def normalize_options(opts) do
     opts
@@ -143,23 +145,25 @@ defmodule ReqLLM.Provider.Reasoning do
   defp google_effort_advisory(provider, canonical_opts, translated_opts)
        when provider in [:google, :google_vertex] do
     effort = canonical_opts |> Keyword.get(:reasoning_effort) |> normalize_effort()
-    level = Keyword.get(translated_opts, :google_thinking_level)
+    level = translated_opts |> Keyword.get(:google_thinking_level) |> normalize_effort()
 
     case {effort, level} do
-      {effort, level} when effort in [:xhigh, :max] and level in [:high, "high"] ->
-        %{
-          kind: :clamped,
-          option: :reasoning_effort,
-          message:
-            ":reasoning_effort #{inspect(effort)} was clamped to Gemini thinking level :high"
-        }
-
-      {:none, level} when level in [:minimal, "minimal"] ->
+      {:none, level} when level in @google_thinking_levels ->
         %{
           kind: :lossy,
           option: :reasoning_effort,
           message:
-            ":reasoning_effort :none has no exact Gemini thinking-level mapping and was translated to :minimal"
+            ":reasoning_effort :none has no exact Gemini thinking-level mapping and was translated to #{inspect(level)}"
+        }
+
+      {effort, level}
+      when effort in [:minimal, :low, :medium, :high, :xhigh, :max] and
+             level in @google_thinking_levels and effort != level ->
+        %{
+          kind: :clamped,
+          option: :reasoning_effort,
+          message:
+            ":reasoning_effort #{inspect(effort)} was clamped to Gemini thinking level #{inspect(level)}"
         }
 
       _ ->

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -83,6 +83,8 @@ defmodule ReqLLM.Providers.Google do
 
   require Logger
 
+  @thinking_level_ranks %{minimal: 0, low: 1, medium: 2, high: 3}
+
   @provider_schema [
     google_api_version: [
       type: {:in, ["v1", "v1beta"]},
@@ -767,7 +769,7 @@ defmodule ReqLLM.Providers.Google do
               provider_opts
 
             :error ->
-              level = translate_reasoning_effort_to_level(effort_value)
+              level = translate_reasoning_effort_to_level(effort_value, model)
               Keyword.put(provider_opts, :google_thinking_level, level)
           end
 
@@ -828,8 +830,10 @@ defmodule ReqLLM.Providers.Google do
     end
   end
 
-  defp translate_reasoning_effort_to_level(effort) do
-    case ReqLLM.Provider.Reasoning.normalize_effort(effort) do
+  defp translate_reasoning_effort_to_level(effort, model) do
+    effort
+    |> ReqLLM.Provider.Reasoning.normalize_effort()
+    |> case do
       :none -> :minimal
       :minimal -> :minimal
       :low -> :low
@@ -839,7 +843,40 @@ defmodule ReqLLM.Providers.Google do
       :max -> :high
       _ -> :medium
     end
+    |> closest_supported_thinking_level(model)
   end
+
+  defp closest_supported_thinking_level(level, model) do
+    case supported_thinking_levels(model) do
+      [] ->
+        level
+
+      supported_levels ->
+        requested_rank = Map.fetch!(@thinking_level_ranks, level)
+
+        Enum.min_by(supported_levels, fn supported_level ->
+          supported_rank = Map.fetch!(@thinking_level_ranks, supported_level)
+          {abs(supported_rank - requested_rank), supported_rank}
+        end)
+    end
+  end
+
+  defp supported_thinking_levels(%LLMDB.Model{extra: extra}) when is_map(extra) do
+    reasoning_options = extra["reasoning_options"] || extra[:reasoning_options] || []
+
+    reasoning_options
+    |> List.wrap()
+    |> Enum.find_value([], fn
+      %{"type" => "effort", "values" => values} when is_list(values) -> values
+      %{type: type, values: values} when type in ["effort", :effort] and is_list(values) -> values
+      _ -> nil
+    end)
+    |> Enum.map(&ReqLLM.Provider.Reasoning.normalize_effort/1)
+    |> Enum.filter(&Map.has_key?(@thinking_level_ranks, &1))
+    |> Enum.uniq()
+  end
+
+  defp supported_thinking_levels(_model), do: []
 
   @impl ReqLLM.Provider
   def translate_options(:image, _model, opts) do
@@ -874,7 +911,7 @@ defmodule ReqLLM.Providers.Google do
           Keyword.put(opts, :google_thinking_budget, reasoning_budget)
 
         reasoning_effort && gemini_3_or_later?(model) ->
-          level = translate_reasoning_effort_to_level(reasoning_effort)
+          level = translate_reasoning_effort_to_level(reasoning_effort, model)
           Keyword.put(opts, :google_thinking_level, level)
 
         reasoning_effort ->

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -861,22 +861,84 @@ defmodule ReqLLM.Providers.Google do
     end
   end
 
-  defp supported_thinking_levels(%LLMDB.Model{extra: extra}) when is_map(extra) do
-    reasoning_options = extra["reasoning_options"] || extra[:reasoning_options] || []
-
-    reasoning_options
-    |> List.wrap()
-    |> Enum.find_value([], fn
-      %{"type" => "effort", "values" => values} when is_list(values) -> values
-      %{type: type, values: values} when type in ["effort", :effort] and is_list(values) -> values
-      _ -> nil
+  defp supported_thinking_levels(%LLMDB.Model{} = model) do
+    [
+      get_nested(model.capabilities, [:reasoning, :effort, :values]),
+      extra_thinking_levels(model.extra),
+      known_thinking_levels(model)
+    ]
+    |> Enum.find_value([], fn levels ->
+      case normalize_thinking_levels(levels) do
+        [] -> nil
+        normalized -> normalized
+      end
     end)
+  end
+
+  defp supported_thinking_levels(_model), do: []
+
+  defp extra_thinking_levels(extra) do
+    extra
+    |> get_nested([:reasoning_options])
+    |> List.wrap()
+    |> Enum.find_value([], fn option ->
+      case {get_nested(option, [:type]), get_nested(option, [:values])} do
+        {type, values} when type in ["effort", :effort] and is_list(values) and values != [] ->
+          values
+
+        _ ->
+          nil
+      end
+    end)
+  end
+
+  defp normalize_thinking_levels(levels) do
+    levels
+    |> List.wrap()
     |> Enum.map(&ReqLLM.Provider.Reasoning.normalize_effort/1)
     |> Enum.filter(&Map.has_key?(@thinking_level_ranks, &1))
     |> Enum.uniq()
   end
 
-  defp supported_thinking_levels(_model), do: []
+  defp known_thinking_levels(%LLMDB.Model{} = model) do
+    [model.provider_model_id, model.model, model.id]
+    |> Enum.find_value([], &known_thinking_levels/1)
+  end
+
+  defp known_thinking_levels(model_id) when is_binary(model_id) do
+    model_name = google_model_name(model_id)
+
+    cond do
+      model_name_matches?(model_name, "gemini-3.7-flash") -> [:low, :medium, :high]
+      model_name_matches?(model_name, "gemini-3.1-pro") -> [:low, :medium, :high]
+      true -> nil
+    end
+  end
+
+  defp known_thinking_levels(_model_id), do: nil
+
+  defp model_name_matches?(model_name, base_name),
+    do: model_name == base_name or String.starts_with?(model_name, base_name <> "-")
+
+  defp google_model_name(model_id) do
+    model_id
+    |> String.split("/")
+    |> List.last()
+    |> String.split(":", parts: 2)
+    |> List.last()
+  end
+
+  defp get_nested(value, []), do: value
+
+  defp get_nested(value, [key | rest]) when is_map(value) do
+    cond do
+      Map.has_key?(value, key) -> get_nested(Map.get(value, key), rest)
+      Map.has_key?(value, to_string(key)) -> get_nested(Map.get(value, to_string(key)), rest)
+      true -> nil
+    end
+  end
+
+  defp get_nested(_value, _path), do: nil
 
   @impl ReqLLM.Provider
   def translate_options(:image, _model, opts) do
@@ -1274,14 +1336,13 @@ defmodule ReqLLM.Providers.Google do
     |> maybe_put(:labels, request.options[:labels])
   end
 
-  defp gemini_3_or_later?(%LLMDB.Model{family: family}) when is_binary(family),
-    do: String.starts_with?(family, "gemini-3")
-
-  defp gemini_3_or_later?(%LLMDB.Model{id: id}) when is_binary(id),
-    do: String.starts_with?(id, "gemini-3")
+  defp gemini_3_or_later?(%LLMDB.Model{} = model) do
+    [model.provider_model_id, model.model, model.id, model.family]
+    |> Enum.any?(&gemini_3_or_later?/1)
+  end
 
   defp gemini_3_or_later?(id) when is_binary(id),
-    do: String.starts_with?(id, "gemini-3")
+    do: id |> google_model_name() |> String.starts_with?("gemini-3")
 
   defp gemini_3_or_later?(_), do: false
 

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1893,6 +1893,66 @@ defmodule ReqLLM.Providers.GoogleTest do
       end
     end
 
+    test "uses known thinking constraints when explicit model specs omit metadata" do
+      models = [
+        LLMDB.Model.new!(%{provider: :google, id: "gemini-3.7-flash"}),
+        LLMDB.Model.new!(%{
+          provider: :google,
+          id: "custom-gemini-pro",
+          provider_model_id: "publishers/google/models/gemini-3.1-pro-preview"
+        })
+      ]
+
+      for model <- models do
+        assert {translated_opts, []} =
+                 Google.translate_options(:chat, model, reasoning_effort: :minimal)
+
+        assert translated_opts[:google_thinking_level] == :low
+
+        assert {validated_opts, []} =
+                 Google.pre_validate_options(:chat, model,
+                   provider_options: [reasoning_effort: :minimal]
+                 )
+
+        assert validated_opts[:provider_options][:google_thinking_level] == :low
+      end
+    end
+
+    test "uses structured capability metadata for supported thinking levels" do
+      model =
+        LLMDB.Model.new!(%{
+          provider: :google,
+          id: "gemini-3-custom",
+          capabilities: %{
+            reasoning: %{
+              enabled: true,
+              effort: %{supported: true, values: ["minimal", "high"]}
+            }
+          }
+        })
+
+      for {effort, expected_level} <- [low: :minimal, medium: :high] do
+        assert {translated_opts, []} =
+                 Google.translate_options(:chat, model, reasoning_effort: effort)
+
+        assert translated_opts[:google_thinking_level] == expected_level
+      end
+    end
+
+    test "ignores malformed supported thinking metadata" do
+      model =
+        LLMDB.Model.new!(%{
+          provider: :google,
+          id: "gemini-3-custom",
+          extra: %{"reasoning_options" => "invalid"}
+        })
+
+      assert {translated_opts, []} =
+               Google.translate_options(:chat, model, reasoning_effort: :minimal)
+
+      assert translated_opts[:google_thinking_level] == :minimal
+    end
+
     test "translate_options uses google_thinking_budget for reasoning_token_budget even on Gemini 3" do
       {:ok, model} = ReqLLM.model(%{provider: :google, id: "gemini-3-flash"})
 

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -1879,6 +1879,20 @@ defmodule ReqLLM.Providers.GoogleTest do
       end
     end
 
+    test "translate_options uses supported thinking levels from Gemini model metadata" do
+      for model_spec <- ["google:gemini-3.7-flash", "google:gemini-3.1-pro-preview"] do
+        model = ReqLLM.model!(model_spec)
+
+        for effort <- [:none, :minimal] do
+          {translated_opts, _warnings} =
+            Google.translate_options(:chat, model, reasoning_effort: effort)
+
+          assert Keyword.get(translated_opts, :google_thinking_level) == :low
+          refute Keyword.has_key?(translated_opts, :google_thinking_budget)
+        end
+      end
+    end
+
     test "translate_options uses google_thinking_budget for reasoning_token_budget even on Gemini 3" do
       {:ok, model} = ReqLLM.model(%{provider: :google, id: "gemini-3-flash"})
 

--- a/test/providers/google_vertex_gemini_test.exs
+++ b/test/providers/google_vertex_gemini_test.exs
@@ -708,15 +708,11 @@ defmodule ReqLLM.Providers.GoogleVertex.GeminiTest do
     end
 
     test "translate_options maps reasoning_effort levels to google_thinking_level for Gemini 3 models" do
-      model = %LLMDB.Model{
-        id: "gemini-3.1-pro-preview",
-        provider: :google_vertex,
-        capabilities: %{chat: true}
-      }
+      model = ReqLLM.model!("google_vertex:gemini-3.1-pro-preview")
 
       test_cases = [
-        {:none, :minimal},
-        {:minimal, :minimal},
+        {:none, :low},
+        {:minimal, :low},
         {:low, :low},
         {:medium, :medium},
         {:high, :high},

--- a/test/req_llm/provider/reasoning_test.exs
+++ b/test/req_llm/provider/reasoning_test.exs
@@ -239,6 +239,21 @@ defmodule ReqLLM.Provider.ReasoningTest do
       assert log =~ ":reasoning_effort :xhigh was clamped"
     end
 
+    test "reports model-specific Gemini effort clamping" do
+      model = ReqLLM.model!("google:gemini-3.7-flash")
+
+      log =
+        capture_log(fn ->
+          assert {:ok, processed} =
+                   Options.process(Google, :chat, model, reasoning_effort: :minimal)
+
+          assert processed[:google_thinking_level] == :low
+        end)
+
+      assert log =~ ":reasoning_effort :minimal was clamped"
+      assert log =~ "thinking level :low"
+    end
+
     test "exposes advisories through sanitized request planning" do
       assert {:ok, openai_plan} =
                ReqLLM.plan("openai:gpt-5", :chat, reasoning_token_budget: 4_096)


### PR DESCRIPTION
## Description

Gemini 3 option translation used one model-agnostic effort map. It translated canonical minimal effort to the MINIMAL thinking level for every Gemini 3 model, but Gemini 3.7 Flash and Gemini 3.1 Pro preview only support LOW, MEDIUM, and HIGH. Google then rejected the request with a 400 response.

This change maps canonical effort to the nearest thinking level that the selected model supports. It uses structured LLMDB reasoning capabilities first, supports legacy reasoning metadata, and has a narrow fallback for the affected Gemini model families when explicit model specifications omit metadata. Model detection also reads full Google Vertex resource IDs.

The same logic applies to direct Google and Google Vertex requests. Malformed or unknown metadata safely keeps the existing generic mapping. A deterministic reasoning advisory reports when model constraints cause clamping.

The configuration guide documents the model-aware behavior.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (mix test)
- [x] Quality checks pass (mix quality)

Additional verification:

- 166 focused Google, Google Vertex, and reasoning tests passed.
- Direct and nested option processing map minimal effort to LOW for Gemini 3.7 Flash and Gemini 3.1 Pro preview.
- Structured capabilities, legacy metadata, explicit model specifications, full Vertex resource IDs, and malformed metadata are covered.
- Every catalog Google Gemini 3 model maps each canonical effort to a declared supported value.
- Full suite: 4,236 passed, 11 skipped, 152 excluded.
- Credo and Dialyzer report no errors.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have NOT edited CHANGELOG.md

## Related Issues

Closes #971