### PR TITLE
fix(xai): keep web_search on generate_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes:
+
+* xai: keep web_search enabled for generate_object on Grok-4 family models
+
 <!-- changelog -->
 
 ## [v1.21.0](https://github.com/agentjido/req_llm/compare/v1.20.0...v1.21.0) (2026-08-23)

--- a/guides/xai.md
+++ b/guides/xai.md
@@ -121,6 +121,34 @@ xAI's native structured outputs have limitations (auto-sanitized by ReqLLM):
 - `anyOf`
 - `additionalProperties: false` (enforced on root)
 
+## Structured Outputs with Agent Tools
+
+Grok-4 family models can return a json_schema object and run server-side tools
+in the same request. Pass `xai_tools` into `generate_object/4`; ReqLLM keeps
+native structured output (`response_format` / Responses `text.format`) and does
+not force `parallel_tool_calls: false`.
+
+```elixir
+schema = [
+  headline: [type: :string, required: true],
+  sources: [type: {:list, :string}, required: true]
+]
+
+{:ok, response} =
+  ReqLLM.generate_object(
+    "xai:grok-4",
+    "What is the latest news about AI?",
+    schema,
+    xai_tools: [%{type: "web_search"}]
+  )
+
+response.object
+response.usage.tool_usage.web_search
+```
+
+Client-side function tools still select `:tool_strict` and force a
+`structured_output` tool call.
+
 ## Web Search Cost Tracking
 
 Web search usage and costs are tracked in `response.usage`:

--- a/lib/req_llm/providers/xai.ex
+++ b/lib/req_llm/providers/xai.ex
@@ -25,10 +25,15 @@ defmodule ReqLLM.Providers.XAI do
 
   ### Tool Calling Fallback
 
-  For legacy models or when other tools are present:
+  For legacy models or when client-side function tools are present:
   - Uses a synthetic `structured_output` tool with forced `tool_choice`
   - Works on all models as fallback
   - Automatically used for `grok-2` and `grok-2-vision` (pre-1212 versions)
+
+  Built-in agent tools (`xai_tools`, e.g. `web_search` / `x_search`) stay on the
+  native json_schema path. xAI supports structured outputs together with those
+  server-side tools on Grok-4 family models; forcing `tool_strict` would pin
+  `tool_choice` to `structured_output` and prevent search from running.
 
   The mode is automatically selected based on model capabilities, or can be explicitly
   controlled via `:xai_structured_output_mode` option.
@@ -94,6 +99,15 @@ defmodule ReqLLM.Providers.XAI do
           "Generate a person profile",
           schema,
           provider_options: [xai_structured_output_mode: :json_schema]
+        )
+
+      # Structured output grounded in live web search
+      {:ok, response} =
+        ReqLLM.generate_object(
+          "xai:grok-4",
+          "What is the latest news about AI?",
+          schema,
+          xai_tools: [%{type: "web_search"}]
         )
   """
 
@@ -421,6 +435,8 @@ defmodule ReqLLM.Providers.XAI do
 
     case sanitize_schema_for_xai(json_schema) do
       {:ok, sanitized_schema} ->
+        opts = preserve_builtin_tools(opts)
+
         opts_with_format =
           opts
           |> Keyword.update(
@@ -433,9 +449,8 @@ defmodule ReqLLM.Providers.XAI do
                   strict: true,
                   schema: sanitized_schema
                 }
-              },
-              parallel_tool_calls: false
-            ],
+              }
+            ] ++ maybe_parallel_tool_calls_opt(opts),
             fn provider_opts ->
               provider_opts
               |> Keyword.put(:response_format, %{
@@ -446,7 +461,7 @@ defmodule ReqLLM.Providers.XAI do
                   schema: sanitized_schema
                 }
               })
-              |> Keyword.put(:parallel_tool_calls, false)
+              |> maybe_disable_parallel_tool_calls(opts)
             end
           )
           |> Keyword.delete(:tools)
@@ -616,7 +631,8 @@ defmodule ReqLLM.Providers.XAI do
   1. If explicit `xai_structured_output_mode` is set, validate and use it
   2. If `response_format` with `json_schema` is present in options, force `:json_schema`
   3. If `:auto`:
-     - Use `:json_schema` when model supports it AND no other tools present
+     - Use `:json_schema` when model supports it AND no client-side function tools present
+     - Built-in agent tools (`xai_tools`) do not force `:tool_strict`
      - Otherwise use `:tool_strict`
 
   ## Examples
@@ -629,6 +645,9 @@ defmodule ReqLLM.Providers.XAI do
 
       iex> determine_output_mode(%LLMDB.Model{model: "grok-3"}, tools: [%{name: "other"}])
       :tool_strict
+
+      iex> determine_output_mode(%LLMDB.Model{model: "grok-3"}, xai_tools: [%{type: "web_search"}])
+      :json_schema
   """
   @spec determine_output_mode(LLMDB.Model.t(), keyword()) :: :json_schema | :tool_strict
   def determine_output_mode(model, opts) do
@@ -669,6 +688,55 @@ defmodule ReqLLM.Providers.XAI do
     end
   end
 
+  defp preserve_builtin_tools(opts) do
+    tools = List.wrap(Keyword.get(opts, :tools, []))
+    {builtin, rest} = Enum.split_with(tools, &xai_tool_entry?/1)
+
+    opts =
+      if rest == [] do
+        Keyword.delete(opts, :tools)
+      else
+        Keyword.put(opts, :tools, rest)
+      end
+
+    case builtin do
+      [] ->
+        opts
+
+      _ ->
+        existing = resolve_xai_tools(opts)
+        Keyword.put(opts, :xai_tools, existing ++ builtin)
+    end
+  end
+
+  defp maybe_disable_parallel_tool_calls(provider_opts, opts) do
+    if built_in_agent_tools?(opts) do
+      provider_opts
+    else
+      Keyword.put(provider_opts, :parallel_tool_calls, false)
+    end
+  end
+
+  defp maybe_parallel_tool_calls_opt(opts) do
+    if built_in_agent_tools?(opts) do
+      []
+    else
+      [parallel_tool_calls: false]
+    end
+  end
+
+  defp built_in_agent_tools?(opts) do
+    from_xai = opts |> resolve_xai_tools() |> Enum.any?(&built_in_tool?/1)
+
+    from_tools =
+      opts
+      |> Keyword.get(:tools, [])
+      |> List.wrap()
+      |> Enum.any?(&xai_tool_entry?/1)
+
+    from_xai or from_tools
+  end
+
   defp has_other_tools?(opts) do
     tools = Keyword.get(opts, :tools, [])
 
@@ -679,7 +747,7 @@ defmodule ReqLLM.Providers.XAI do
           _ -> nil
         end
 
-      name != "structured_output"
+      name != "structured_output" and name != nil
     end)
   end
 

--- a/test/providers/xai_test.exs
+++ b/test/providers/xai_test.exs
@@ -165,6 +165,18 @@ defmodule ReqLLM.Providers.XAITest do
 
       assert XAI.determine_output_mode(model, tools: [tool_struct]) == :tool_strict
     end
+
+    test "keeps :json_schema when only built-in xAI agent tools are present" do
+      {:ok, model} = ReqLLM.model("xai:grok-3")
+
+      assert XAI.determine_output_mode(model, xai_tools: [%{type: "web_search"}]) == :json_schema
+
+      assert XAI.determine_output_mode(model,
+               provider_options: [xai_tools: [%{type: "x_search"}]]
+             ) == :json_schema
+
+      assert XAI.determine_output_mode(model, tools: [%{type: "web_search"}]) == :json_schema
+    end
   end
 
   describe "mode selection - explicit mode override" do
@@ -372,6 +384,35 @@ defmodule ReqLLM.Providers.XAITest do
       assert length(tools) == 2
       assert Enum.any?(tools, &(&1.name == "structured_output"))
       assert Enum.any?(tools, &(&1.name == "other_tool"))
+    end
+
+    test "keeps json_schema and built-in agent tools together", %{compiled_schema: schema} do
+      {:ok, request} =
+        XAI.prepare_request(:object, "xai:grok-4.3", "Generate data",
+          compiled_schema: schema,
+          xai_tools: [%{type: "web_search"}]
+        )
+
+      provider_options = request.options[:provider_options] || []
+      assert provider_options[:response_format][:type] == "json_schema"
+      refute Keyword.get(provider_options, :parallel_tool_calls) == false
+      assert request.options[:xai_api_type] == :responses
+      assert request.url.path == "/responses"
+    end
+
+    test "moves web_search from :tools onto xai_tools for object requests", %{
+      compiled_schema: schema
+    } do
+      {:ok, request} =
+        XAI.prepare_request(:object, "xai:grok-4.3", "Generate data",
+          compiled_schema: schema,
+          tools: [%{type: "web_search"}]
+        )
+
+      provider_options = request.options[:provider_options] || []
+      assert provider_options[:response_format][:type] == "json_schema"
+      assert request.options[:xai_tools] == [%{type: "web_search"}]
+      refute Map.has_key?(request.options, :tools)
     end
 
     test "honors explicit mode overrides", %{compiled_schema: schema} do
@@ -680,6 +721,24 @@ defmodule ReqLLM.Providers.XAITest do
       decoded = ReqLLM.Test.Helpers.json_body(updated_request)
 
       assert decoded["response_format"] == %{"type" => "json_object"}
+    end
+
+    test "encode_body for object + web_search uses Responses text format and keeps search" do
+      compiled_schema = %{schema: @test_schema, name: "test_output"}
+
+      {:ok, request} =
+        XAI.prepare_request(:object, "xai:grok-4.3", "What is the latest news?",
+          compiled_schema: compiled_schema,
+          xai_tools: [%{type: "web_search"}]
+        )
+
+      encoded = XAI.encode_body(request)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded)
+
+      assert decoded["tools"] == [%{"type" => "web_search"}]
+      assert decoded["text"]["format"]["type"] == "json_schema"
+      refute decoded["parallel_tool_calls"] == false
+      refute Map.has_key?(decoded, "tool_choice")
     end
 
     test "encode_body with xAI-specific options" do


### PR DESCRIPTION
## Summary

`ReqLLM.generate_object/4` on xAI treated built-in agent tools (`xai_tools`, e.g. `web_search` / `x_search`) as if no tools were present. Auto mode still picked `:json_schema`, then `prepare_json_schema_request/4` forced `parallel_tool_calls: false` and deleted `:tools`. A `%{type: "web_search"}` passed in `:tools` was dropped entirely.

xAI documents structured outputs together with server-side agent tools on Grok-4 family models (`responses.parse` / `text.format` + `web_search`). This keeps native json_schema when only those built-in tools are present, copies them onto `xai_tools` before `:tools` is cleared, and does not pin `parallel_tool_calls: false`. Client-side function tools still take `:tool_strict`.

## Live check

Same prompt + schema + `xai_tools: [%{type: "web_search"}]`:

| Model | `parallel_tool_calls` | `web_search` calls | Object |
|---|---|---|---|
| `xai:grok-4.3` | `true` | 5 | filled, date = today |
| `xai:grok-4.6` | `true` | 7 | filled, date = today |
| `xai:grok-4.5` | `true` (encoding OK) | **0** | filled from memory (stale date) |

grok-4.5 still does not invoke search once a json schema is on the request. That looks like model-side behavior; this PR only fixes the wire encoding.

## Test plan

- [x] `mix test test/providers/xai_test.exs` (74 tests, 0 failures)
- [x] Live `generate_object` + `xai_tools` on grok-4.3 / 4.6 / 4.5 as above