### PR TITLE
fix(tool): ignore unknown schema input keys

### DIFF
--- a/lib/req_llm/tool.ex
+++ b/lib/req_llm/tool.ex
@@ -529,7 +529,11 @@ defmodule ReqLLM.Tool do
     |> Enum.flat_map(fn {key, value} ->
       case normalize_key_and_field_opts(key, schema_key_map, schema_entries) do
         {normalized_key, field_opts} when is_atom(normalized_key) ->
-          [{normalized_key, normalize_typed_value(value, field_opts)}]
+          if Map.has_key?(schema_entries, normalized_key) do
+            [{normalized_key, normalize_typed_value(value, field_opts)}]
+          else
+            []
+          end
 
         _ ->
           []

--- a/lib/req_llm/tool.ex
+++ b/lib/req_llm/tool.ex
@@ -525,12 +525,17 @@ defmodule ReqLLM.Tool do
       |> Map.keys()
       |> Map.new(fn key -> {Atom.to_string(key), key} end)
 
-    Map.new(input, fn {key, value} ->
-      {normalized_key, field_opts} =
-        normalize_key_and_field_opts(key, schema_key_map, schema_entries)
+    input
+    |> Enum.flat_map(fn {key, value} ->
+      case normalize_key_and_field_opts(key, schema_key_map, schema_entries) do
+        {normalized_key, field_opts} when is_atom(normalized_key) ->
+          [{normalized_key, normalize_typed_value(value, field_opts)}]
 
-      {normalized_key, normalize_typed_value(value, field_opts)}
+        _ ->
+          []
+      end
     end)
+    |> Map.new()
   end
 
   defp normalize_input_keys(input, _parameter_schema), do: input

--- a/test/req_llm/tool_test.exs
+++ b/test/req_llm/tool_test.exs
@@ -339,6 +339,28 @@ defmodule ReqLLM.ToolTest do
       refute Map.has_key?(validated, :reason)
     end
 
+    test "drops unknown atom keys" do
+      tool =
+        Tool.new!(
+          name: "read_file",
+          description: "Read a file from the workspace",
+          parameter_schema: [
+            path: [type: :string, required: true]
+          ],
+          callback: fn args -> {:ok, args} end
+        )
+
+      input = %{
+        path: "foo/bar.ex",
+        cwd: "/workspace/project",
+        reason: "Inspect the public API facade before editing"
+      }
+
+      assert {:ok, %{path: "foo/bar.ex"} = validated} = Tool.execute(tool, input)
+      refute Map.has_key?(validated, :cwd)
+      refute Map.has_key?(validated, :reason)
+    end
+
     test "normalizes nested string keys in list/map schemas" do
       {:ok, tool} =
         Tool.new(

--- a/test/req_llm/tool_test.exs
+++ b/test/req_llm/tool_test.exs
@@ -288,7 +288,7 @@ defmodule ReqLLM.ToolTest do
       assert Map.get(validated, :optional_field) == 42
     end
 
-    test "does not atomize unknown string keys" do
+    test "drops unknown string keys without atomizing them" do
       {:ok, tool} =
         Tool.new(
           name: "unknown_key_safety_test",
@@ -305,12 +305,38 @@ defmodule ReqLLM.ToolTest do
         String.to_existing_atom(unknown_key)
       end
 
-      assert {:error, %ReqLLM.Error.Validation.Error{}} =
+      assert {:ok, %{required_field: "abc"} = validated} =
                Tool.execute(tool, %{"required_field" => "abc", unknown_key => "value"})
+
+      refute Map.has_key?(validated, unknown_key)
 
       assert_raise ArgumentError, fn ->
         String.to_existing_atom(unknown_key)
       end
+    end
+
+    test "executes realistic tool input with extra generated keys" do
+      {:ok, tool} =
+        Tool.new(
+          name: "read_file",
+          description: "Read a file from the workspace",
+          parameter_schema: [
+            path: [type: :string, required: true]
+          ],
+          callback: fn args -> {:ok, args} end
+        )
+
+      input = %{
+        "path" => "foo/bar.ex",
+        "cwd" => "/workspace/project",
+        "reason" => "Inspect the public API facade before editing"
+      }
+
+      assert {:ok, %{path: "foo/bar.ex"} = validated} = Tool.execute(tool, input)
+      refute Map.has_key?(validated, "cwd")
+      refute Map.has_key?(validated, "reason")
+      refute Map.has_key?(validated, :cwd)
+      refute Map.has_key?(validated, :reason)
     end
 
     test "normalizes nested string keys in list/map schemas" do


### PR DESCRIPTION
## Description

Improve the robustness of the tool implementation by handling calls that include extra arguments. Instead of causing an error, we simply drop the extra arguments. This is perfectly safe as the tool call is otherwise valid.

A realistic example is a tool that reads files. The tool only declares a `path` but sometimes the models sends extra arguments like `worktree` or `reason`. Treating those extra fields as validation errors makes the code unecessary brittle.

This solution protects the atom table by preventing the conversion to atoms.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
