### PR TITLE
fix(anthropic): read thinking tokens from usage.output_tokens_details.thinking_tokens

### DIFF
--- a/lib/req_llm/providers/anthropic/response.ex
+++ b/lib/req_llm/providers/anthropic/response.ex
@@ -309,7 +309,11 @@ defmodule ReqLLM.Providers.Anthropic.Response do
     output = Map.get(usage, "output_tokens", 0)
     cache_read = Map.get(usage, "cache_read_input_tokens", 0)
     cache_creation = Map.get(usage, "cache_creation_input_tokens", 0)
-    reasoning_tokens = Map.get(usage, "reasoning_output_tokens", 0)
+
+    reasoning_tokens =
+      get_in(usage, ["output_tokens_details", "thinking_tokens"]) ||
+        Map.get(usage, "reasoning_output_tokens", 0)
+
     tool_usage = anthropic_tool_usage(usage)
 
     base = %{

--- a/lib/req_llm/usage/normalize.ex
+++ b/lib/req_llm/usage/normalize.ex
@@ -159,6 +159,8 @@ defmodule ReqLLM.Usage.Normalize do
         get_in(usage, [:completion_tokens_details, :reasoning_tokens]) ||
         get_in(usage, ["output_tokens_details", "reasoning_tokens"]) ||
         get_in(usage, [:output_tokens_details, :reasoning_tokens]) ||
+        get_in(usage, ["output_tokens_details", "thinking_tokens"]) ||
+        get_in(usage, [:output_tokens_details, :thinking_tokens]) ||
         MapAccess.get(usage, "reasoning_tokens") ||
         MapAccess.get(usage, :reasoning_tokens) ||
         MapAccess.get(usage, "reasoning_output_tokens") ||

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -1271,6 +1271,41 @@ defmodule ReqLLM.Providers.AnthropicTest do
       assert decode.("some_future_reason") == :unknown
     end
 
+    test "decode_response reads thinking tokens from output_tokens_details" do
+      {:ok, model} = ReqLLM.model("anthropic:claude-sonnet-4-5-20250929")
+
+      decode = fn usage ->
+        data = %{
+          "id" => "msg_01ABC123",
+          "type" => "message",
+          "role" => "assistant",
+          "content" => [%{"type" => "text", "text" => "ok"}],
+          "stop_reason" => "end_turn",
+          "usage" => usage
+        }
+
+        {:ok, response} = ReqLLM.Providers.Anthropic.Response.decode_response(data, model)
+        response.usage.reasoning_tokens
+      end
+
+      # The shape the Messages API actually returns for adaptive thinking.
+      assert decode.(%{
+               "input_tokens" => 5,
+               "output_tokens" => 210,
+               "output_tokens_details" => %{"thinking_tokens" => 192}
+             }) == 192
+
+      # The pre-existing top-level field keeps working.
+      assert decode.(%{
+               "input_tokens" => 5,
+               "output_tokens" => 210,
+               "reasoning_output_tokens" => 192
+             }) == 192
+
+      # Absent from both places: zero rather than nil.
+      assert decode.(%{"input_tokens" => 5, "output_tokens" => 2}) == 0
+    end
+
     test "decode_response handles API errors with non-200 status" do
       # Create error response
       error_body = %{


### PR DESCRIPTION
## Problem

Anthropic's Messages API reports thinking spend at
`usage.output_tokens_details.thinking_tokens`.
`ReqLLM.Providers.Anthropic.Response.parse_usage/1` reads a top-level
`"reasoning_output_tokens"`, which the API does not send, so
`response.usage.reasoning_tokens` is `0` for every thinking response.

The count is not merely misplaced, it is unrecoverable: `decode_response/2`
builds `provider_meta` with `Map.drop(data, ["id", "model", "content", "usage",
"stop_reason"])`, so the raw usage map is gone by the time the response reaches
the caller. A host application cannot work around this without re-reading the
HTTP body itself.

Buffered decoding and both streaming usage paths (`message_start`,
`message_delta`) share `parse_usage/1`, so streams are affected identically.

## Evidence

Live call on `anthropic:claude-sonnet-5` with
`thinking: %{type: "adaptive"}, output_config: %{effort: "low"}`:

- the response carries `thinking` content blocks
- `usage.output_tokens_details.thinking_tokens` is non-zero (82 on the run above)
- `response.usage.reasoning_tokens` comes back `0`

For contrast, the equivalent call on `openai:gpt-5-mini` records reasoning
tokens correctly — `output_tokens_details.reasoning_tokens` is the OpenAI
spelling, and that is the one the fallback chain already knows.

## Change

- `providers/anthropic/response.ex` — read the nested key first, keeping
  `"reasoning_output_tokens"` as a fallback so anything relying on it is
  unaffected.
- `usage/normalize.ex` — add the same nested key to `get_reasoning_tokens/1`,
  which already handles `output_tokens_details.reasoning_tokens` but not
  Anthropic's spelling. This is not on the Anthropic path (the module is only
  reached from `xai.ex` today); it is the same omission one layer up. Happy to
  drop this hunk if you would rather keep the PR to the provider.
- `test/providers/anthropic_test.exs` — decode coverage for the nested shape,
  the legacy top-level key, and neither present.

Full suite green on this branch: 4402 tests, 0 failures.

## `mix mc "anthropic:*"`

```
Anthropic (13 models)

PASSING FIXTURES (10):
  ✓ claude-sonnet-4-6
  ✓ claude-sonnet-4-5-20250929
  ✓ claude-sonnet-4-20250514 (deprecated)
  ✓ claude-opus-4-8
  ✓ claude-opus-4-7
  ✓ claude-opus-4-6
  ✓ claude-opus-4-5-20251101
  ✓ claude-opus-4-20250514 (deprecated)
  ✓ claude-opus-4-1-20250805 (deprecated)
  ✓ claude-haiku-4-5-20251001

FAILING FIXTURES (3):
  ✗ claude-sonnet-5  -- Fixture not found: .../claude_sonnet_5/reasoning_basic.json
  ✗ claude-opus-5    -- Fixture not found: .../claude_opus_5/no_tool.json
  ✗ claude-fable-5   -- Fixture not found: .../claude_fable_5/usage.json

Summary: 10/13 active models tested (76.9% coverage) in 39.3s
```

The three failures are pre-existing and unrelated to this diff: `test/support/fixtures/anthropic/`
has no directory for any Claude 5 model, and this branch adds and modifies no fixtures.

One observation on that, offered rather than argued: the models without fixture coverage are
exactly the ones that exhibit this bug. `claude-sonnet-5` is where adaptive thinking returns
`output_tokens_details.thinking_tokens`, and its missing scenarios include `reasoning_basic`.
Happy to record the Claude 5 fixtures in a separate PR if that coverage is wanted - it seemed
like a decision for you rather than something to fold into a two-line read fix.

## Checklist

- [x] `mix test` - 4402 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` - no issues
- [x] `mix dialyzer` - one pre-existing `call_with_opaque` warning in
      `lib/req_llm/streaming/http2_duplex_session.ex:83`, untouched by this diff
- [x] `mix mc "anthropic:*"` - output above
- [x] `CHANGELOG.md` not edited
