### PR TITLE
fix(openai): decode response.failed and error stream events as terminal error chunks

### DIFF
--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -58,6 +58,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   - `response.usage` → usage metrics with reasoning_tokens
   - `response.completed` → terminal event with finish_reason
   - `response.incomplete` → terminal event for truncated responses
+  - `response.failed` → terminal event with `finish_reason: :error` and the failure message
+  - `error` → terminal event with `finish_reason: :error` and the error message
 
   ## Usage Normalization
 
@@ -228,6 +230,23 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
           },
           model.provider
         )
+
+      "response.failed" ->
+        message =
+          get_in(data, ["response", "error", "message"]) ||
+            get_in(data, ["response", "error", "code"]) ||
+            "response failed"
+
+        capture_completion_metadata(
+          data,
+          %{terminal?: true, finish_reason: :error, error: message},
+          model.provider
+        )
+
+      "error" ->
+        message = data["message"] || data["code"] || "stream error"
+
+        [ReqLLM.StreamChunk.meta(%{terminal?: true, finish_reason: :error, error: message})]
 
       _ ->
         []

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -191,65 +191,8 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
           annotations -> [ReqLLM.StreamChunk.meta(%{annotations: annotations})]
         end
 
-      "response.function_call.delta" ->
-        handle_function_call_delta(data)
-
-      "response.function_call_arguments.delta" ->
-        handle_function_call_arguments_delta(data)
-
-      "response.function_call_arguments.done" ->
-        handle_function_call_arguments_done(data)
-
-      "response.function_call.name.delta" ->
-        handle_function_call_name_delta(data)
-
-      "response.output_item.added" ->
-        handle_output_item_added(data)
-
-      "response.output_item.done" ->
-        handle_output_item_done(data)
-
-      "response.completed" ->
-        capture_completion_metadata(
-          data,
-          %{terminal?: true, finish_reason: :stop},
-          model.provider
-        )
-
-      "response.incomplete" ->
-        reason =
-          get_in(data, ["response", "incomplete_details", "reason"]) ||
-            data["reason"] ||
-            "incomplete"
-
-        capture_completion_metadata(
-          data,
-          %{
-            terminal?: true,
-            finish_reason: normalize_finish_reason(reason)
-          },
-          model.provider
-        )
-
-      "response.failed" ->
-        message =
-          get_in(data, ["response", "error", "message"]) ||
-            get_in(data, ["response", "error", "code"]) ||
-            "response failed"
-
-        capture_completion_metadata(
-          data,
-          %{terminal?: true, finish_reason: :error, error: message},
-          model.provider
-        )
-
-      "error" ->
-        message = data["message"] || data["code"] || "stream error"
-
-        [ReqLLM.StreamChunk.meta(%{terminal?: true, finish_reason: :error, error: message})]
-
       _ ->
-        []
+        decode_output_or_terminal_event(event_type, data, model)
     end
   end
 
@@ -292,6 +235,83 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   defp decode_stream_event_with_state(event, model, _event_type, _data, _state) do
     decode_stream_event(event, model)
   end
+
+  defp decode_output_or_terminal_event("response.function_call.delta", data, _model) do
+    handle_function_call_delta(data)
+  end
+
+  defp decode_output_or_terminal_event(
+         "response.function_call_arguments.delta",
+         data,
+         _model
+       ) do
+    handle_function_call_arguments_delta(data)
+  end
+
+  defp decode_output_or_terminal_event(
+         "response.function_call_arguments.done",
+         data,
+         _model
+       ) do
+    handle_function_call_arguments_done(data)
+  end
+
+  defp decode_output_or_terminal_event("response.function_call.name.delta", data, _model) do
+    handle_function_call_name_delta(data)
+  end
+
+  defp decode_output_or_terminal_event("response.output_item.added", data, _model) do
+    handle_output_item_added(data)
+  end
+
+  defp decode_output_or_terminal_event("response.output_item.done", data, _model) do
+    handle_output_item_done(data)
+  end
+
+  defp decode_output_or_terminal_event("response.completed", data, model) do
+    capture_completion_metadata(
+      data,
+      %{terminal?: true, finish_reason: :stop},
+      model.provider
+    )
+  end
+
+  defp decode_output_or_terminal_event("response.incomplete", data, model) do
+    reason =
+      get_in(data, ["response", "incomplete_details", "reason"]) ||
+        data["reason"] ||
+        "incomplete"
+
+    capture_completion_metadata(
+      data,
+      %{
+        terminal?: true,
+        finish_reason: normalize_finish_reason(reason)
+      },
+      model.provider
+    )
+  end
+
+  defp decode_output_or_terminal_event("response.failed", data, model) do
+    message =
+      get_in(data, ["response", "error", "message"]) ||
+        get_in(data, ["response", "error", "code"]) ||
+        "response failed"
+
+    capture_completion_metadata(
+      data,
+      %{terminal?: true, finish_reason: :error, error: message},
+      model.provider
+    )
+  end
+
+  defp decode_output_or_terminal_event("error", data, _model) do
+    message = data["message"] || data["code"] || "stream error"
+
+    [ReqLLM.StreamChunk.meta(%{terminal?: true, finish_reason: :error, error: message})]
+  end
+
+  defp decode_output_or_terminal_event(_event_type, _data, _model), do: []
 
   defp capture_completion_metadata(data, meta, provider) do
     usage_data = get_in(data, ["response", "usage"])

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -2207,6 +2207,103 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert %{input_tokens: 8, output_tokens: 12, total_tokens: 20} = chunk.metadata.usage
     end
 
+    test "decodes failed event", %{model: model} do
+      event = %{
+        data: %{
+          "event" => "response.failed",
+          "response" => %{
+            "id" => "resp_123",
+            "status" => "failed",
+            "error" => %{"code" => "server_error", "message" => "The model run failed"}
+          }
+        }
+      }
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "The model run failed"
+      assert chunk.metadata.response_id == "resp_123"
+    end
+
+    test "decodes failed event with usage so token spend is captured", %{model: model} do
+      event = %{
+        data: %{
+          "event" => "response.failed",
+          "response" => %{
+            "error" => %{"message" => "The model run failed"},
+            "usage" => %{"input_tokens" => 8, "output_tokens" => 12}
+          }
+        }
+      }
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert %{input_tokens: 8, output_tokens: 12, total_tokens: 20} = chunk.metadata.usage
+    end
+
+    test "decodes failed event falling back to error code", %{model: model} do
+      event = %{
+        data: %{
+          "event" => "response.failed",
+          "response" => %{"error" => %{"code" => "server_error"}}
+        }
+      }
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "server_error"
+    end
+
+    test "decodes failed event without error details", %{model: model} do
+      event = %{data: %{"event" => "response.failed"}}
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "response failed"
+    end
+
+    test "decodes error event", %{model: model} do
+      event = %{
+        data: %{
+          "event" => "error",
+          "code" => "rate_limit_exceeded",
+          "message" => "Rate limit exceeded",
+          "param" => nil
+        }
+      }
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.type == :meta
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "Rate limit exceeded"
+    end
+
+    test "decodes error event falling back to code", %{model: model} do
+      event = %{data: %{"event" => "error", "code" => "server_error"}}
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "server_error"
+    end
+
+    test "decodes error event without details", %{model: model} do
+      event = %{data: %{"event" => "error"}}
+
+      assert [chunk] = ResponsesAPI.decode_stream_event(event, model)
+      assert chunk.metadata.terminal? == true
+      assert chunk.metadata.finish_reason == :error
+      assert chunk.metadata.error == "stream error"
+    end
+
     test "handles [DONE] event", %{model: model} do
       event = %{data: "[DONE]"}
 


### PR DESCRIPTION
## Description

`decode_stream_event/2` in `ReqLLM.Providers.OpenAI.ResponsesAPI` silently drops the
Responses API's two failure events. `response.failed` and `error` are documented
terminal events ([response.failed](https://platform.openai.com/docs/api-reference/responses-streaming/response/failed),
[error](https://platform.openai.com/docs/api-reference/responses-streaming/error)),
but neither has a branch in the decoder's `case event_type do`, so both fall
through to the `_ -> []` catch-all and decode to **zero chunks**.

The consequence: a stream that ends in failure produces no terminal marker at all.
Consumers of the raw `stream_response.stream` cannot distinguish a failed response
from one still in flight, and the failure reason is lost even to
`StreamResponse.events/1`, which can only synthesize a reasonless terminal when the
underlying stream is exhausted (`:done`).

We hit this in production: a downstream agent loop treated the silently
unterminated stream as "LLM call succeeded but hasn't answered yet" and re-invoked
the model repeatedly, concatenating each attempt's text into one duplicated answer.

### The fix

Both events now decode to a terminal meta chunk with `finish_reason: :error` and
the failure message — the same convention `Provider.Defaults.default_decode_stream_event/2`
already uses for Chat Completions error frames:

- `response.failed` carries the full `response` envelope (same shape as
  `response.completed` / `response.incomplete`), so it reuses
  `capture_completion_metadata/3` — `response_id` and `usage` are harvested exactly
  like its sibling terminal events. Message falls back `error.message` →
  `error.code` → `"response failed"`.
- `error` has no `response` envelope (just `code` / `message` / `param`), so it
  emits a direct meta chunk. Message falls back `message` → `code` → `"stream error"`.

`finish_reason: :error` is existing vocabulary (it's `normalize_finish_reason/1`'s
fallback and the defaults decoder's error value) — no new atoms introduced. The
stateful `decode_stream_event/3` needs no change: it falls back to
`decode_stream_event/2` for all event types it doesn't special-case, so both new
branches are covered on that path too.

The moduledoc's streaming-events list is updated to include both events.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. Consumers previously received *nothing* for these events; they now receive a
terminal meta chunk. Code that pattern-matches terminal chunks by
`metadata.terminal?` will see failed streams terminate (the intended behavior)
instead of ending silently.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Seven new tests in the existing `describe "decode_stream_event/2"` block of
`test/provider/openai/responses_api_unit_test.exs`, mirroring the
`response.completed` / `response.incomplete` tests: `response.failed` with a full
envelope (asserts `response_id` capture), with `usage` (asserts token capture),
with only an error code, and with no error details; `error` with a message, with
only a code, and with no details. All were red against the old decoder (each
decoded to `[]`) before the fix.

**Note on fixtures:** coverage here is synthetic-event unit tests rather than live
fixtures because these events can't be elicited from the live API on demand —
`response.failed` requires a server-side failure mid-response. Synthetic events in
the unit tier is the established pattern for this decoder's terminal events.

`mix mc "openai:*"`: 13/70 active models passing — identical to `main`; the
failures are pre-existing `Fixture not found` errors for models whose fixtures
aren't in the repo. This change touches no fixtures.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
