### PR TITLE
feat(bedrock): support application inference profiles

### DIFF
--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -23,6 +23,20 @@ For the full model-spec workflow, see [Model Specs](model-specs.md).
 
 Use exact Bedrock IDs from [LLM Catalog](https://llmcatalog.dev) when possible. The canonical ReqLLM provider prefix is `amazon_bedrock:`. For inference profiles, custom deployments, or new Bedrock model IDs, use a full explicit model spec when the registry has not caught up yet.
 
+An [application inference profile](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-create.html) is addressed by its ARN. Name the model it serves and pass the ARN as a provider option, so the request goes through the profile while capabilities and pricing come from the model:
+
+```elixir
+ReqLLM.generate_text(
+  "amazon_bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "Hello",
+  provider_options: [inference_profile_arn: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef123456"]
+)
+```
+
+Declare the model the profile actually serves. On the Invoke API, Bedrock rejects a request body built for another model family, but not one built for a sibling model; pricing follows the declaration.
+
+The ARN also works as the model id itself (`amazon_bedrock:arn:aws:bedrock:…`); it then names no model family, so requests go through the Converse API and no pricing is known.
+
 **Provider Options:**
 
 ```elixir

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -906,10 +906,10 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     get_in(opts, [:provider_options, :inference_profile_arn])
   end
 
+  # An ARN is the only Bedrock id containing "/"; it is encoded so it stays one
+  # path segment, as the AWS SDKs do. Other ids are sent raw, matching recorded fixtures.
   defp path_model_id(model_id, opts) do
     case inference_profile_arn(opts) || model_id do
-      # An ARN is the only Bedrock id containing "/"; encode it so it stays one
-      # path segment. Other ids are sent raw, matching recorded fixtures.
       "arn:" <> _ = arn -> URI.encode(arn, &URI.char_unreserved?/1)
       other -> other
     end

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -147,6 +147,10 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       type: :string,
       doc: "AWS Session Token for temporary credentials"
     ],
+    inference_profile_arn: [
+      type: :string,
+      doc: "Application inference profile to call the model through"
+    ],
     use_converse: [
       type: :boolean,
       doc: "Force use of Bedrock Converse API (default: auto-detect based on tools presence)"
@@ -359,6 +363,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # Note: provider_model_id is set by ReqLLM.model/1 to include inference profile prefixes
     # (e.g., "global.anthropic.claude-opus-4-6-v1") when the original model spec had one.
     model_id = model.provider_model_id || model.id
+    path_id = path_model_id(model_id, opts)
 
     # Check if we should use Converse API
     # Priority: explicit use_converse option > prompt caching optimization > auto-detect from tools presence
@@ -369,8 +374,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         # Use Converse API for unified tool calling
         endpoint =
           if opts[:stream],
-            do: "/model/#{model_id}/converse-stream",
-            else: "/model/#{model_id}/converse"
+            do: "/model/#{path_id}/converse-stream",
+            else: "/model/#{path_id}/converse"
 
         # Check if there's a model family formatter that wraps Converse
         # (e.g., Mistral formatter that pre-processes messages before delegating to Converse)
@@ -392,8 +397,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         # Use native model-specific endpoint
         endpoint =
           if opts[:stream],
-            do: "/model/#{model_id}/invoke-with-response-stream",
-            else: "/model/#{model_id}/invoke"
+            do: "/model/#{path_id}/invoke-with-response-stream",
+            else: "/model/#{path_id}/invoke"
 
         family = get_model_family(model_id)
         {endpoint, get_formatter_module(family), family}
@@ -422,13 +427,15 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         :model_family,
         :use_converse,
         :operation,
-        :tools
+        :tools,
+        :inference_profile_arn
       ])
       |> Req.Request.merge_options(
         ReqLLM.Provider.Defaults.finch_option(request) ++
           [
             base_url: base_url,
             model: model_id,
+            inference_profile_arn: inference_profile_arn(opts),
             model_family: model_family,
             context: opts[:context],
             use_converse: use_converse,
@@ -493,6 +500,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
     base_url = "https://bedrock-runtime.#{region}.amazonaws.com"
     model_id = model.provider_model_id || model.id
+    path_id = path_model_id(model_id, processed_opts)
     {model_family, formatter} = get_embedding_formatter(model_id)
 
     text = processed_opts[:text]
@@ -501,7 +509,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       {:ok, model_body} ->
         updated_request =
           request
-          |> Map.put(:url, URI.parse(base_url <> "/model/#{model_id}/invoke"))
+          |> Map.put(:url, URI.parse(base_url <> "/model/#{path_id}/invoke"))
           |> Req.Request.register_options([:model, :text, :operation, :model_family])
           |> Req.Request.merge_options(
             ReqLLM.Provider.Defaults.finch_option(request) ++
@@ -555,6 +563,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # Get model ID - use provider_model_id if set (for models requiring specific API format),
     # otherwise fall back to canonical model ID
     model_id = model.provider_model_id || model.id
+    path_id = path_model_id(model_id, translated_opts)
 
     # Check if we should use Converse API
     # Priority: explicit use_converse option > prompt caching optimization > auto-detect from tools presence
@@ -577,11 +586,11 @@ defmodule ReqLLM.Providers.AmazonBedrock do
             ReqLLM.Providers.AmazonBedrock.Converse
           end
 
-        {formatter, "/model/#{model_id}/converse-stream"}
+        {formatter, "/model/#{path_id}/converse-stream"}
       else
         model_family = get_model_family(model_id)
         formatter = get_formatter_module(model_family)
-        {formatter, "/model/#{model_id}/invoke-with-response-stream"}
+        {formatter, "/model/#{path_id}/invoke-with-response-stream"}
       end
 
     translated_opts = Keyword.put(translated_opts, :use_converse, use_converse)
@@ -893,6 +902,19 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   # See: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
   @region_prefixes ["us", "eu", "ap", "apac", "ca", "au", "jp", "us-gov", "global"]
 
+  defp inference_profile_arn(opts) do
+    get_in(opts, [:provider_options, :inference_profile_arn])
+  end
+
+  defp path_model_id(model_id, opts) do
+    case inference_profile_arn(opts) || model_id do
+      # An ARN is the only Bedrock id containing "/"; encode it so it stays one
+      # path segment. Other ids are sent raw, matching recorded fixtures.
+      "arn:" <> _ = arn -> URI.encode(arn, &URI.char_unreserved?/1)
+      other -> other
+    end
+  end
+
   defp strip_region_prefix(model_id) do
     case String.split(model_id, ".", parts: 2) do
       [region, rest] when region in @region_prefixes -> rest
@@ -957,6 +979,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       finch_request
     end
   end
+
+  defp get_model_family("arn:" <> _), do: nil
 
   defp get_model_family(model_id) do
     normalized_id = strip_region_prefix(model_id)
@@ -1145,13 +1169,24 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   def decode_response({req, resp}) do
     err =
       ReqLLM.Error.API.Response.exception(
-        reason: "Bedrock API error",
+        reason: error_reason(resp.status, req.options),
         status: resp.status,
         response_body: resp.body
       )
 
     {req, err}
   end
+
+  # A native request body is the declared model's; Bedrock validates it against
+  # the model the profile serves and says only "schema violations" when they
+  # differ. Converse bodies are model-agnostic, so a 400 there is something else.
+  defp error_reason(400, %{inference_profile_arn: arn, model: model_id, use_converse: false})
+       when is_binary(arn) do
+    "Bedrock API error (the body was built in #{model_id}'s native format and sent through #{arn}; " <>
+      "a 400 here usually means the profile serves another model)"
+  end
+
+  defp error_reason(_status, _options), do: "Bedrock API error"
 
   defp decode_embedding_response({req, %{status: 200} = resp}) do
     if req.private[:llm_fixture_replay] do

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -3,6 +3,9 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
 
   alias ReqLLM.{Context, Providers.AmazonBedrock}
 
+  @arn "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef123456"
+  @encoded_arn "arn%3Aaws%3Abedrock%3Aus-east-1%3A123456789012%3Aapplication-inference-profile%2Fabcdef123456"
+
   describe "provider basics" do
     test "provider_id returns :amazon_bedrock" do
       assert AmazonBedrock.provider_id() == :amazon_bedrock
@@ -1087,5 +1090,132 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       payload::binary,
       message_crc::32
     >>
+  end
+
+  describe "application inference profile ARNs" do
+    setup do
+      {:ok, model} = ReqLLM.model(%{provider: :amazon_bedrock, id: @arn})
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "us-east-1"
+      ]
+
+      {:ok, model: model, context: context, opts: opts}
+    end
+
+    test "routes through the Converse API as one encoded path segment", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.path == "/model/#{@encoded_arn}/converse"
+      assert request.options[:use_converse] == true
+      assert %{"messages" => [%{"role" => "user"}]} = Jason.decode!(request.body)
+    end
+
+    test "streams through converse-stream", %{model: model, context: context, opts: opts} do
+      {:ok, finch_request} = AmazonBedrock.attach_stream(model, context, opts, ReqLLM.Finch)
+
+      assert finch_request.path == "/model/#{@encoded_arn}/converse-stream"
+    end
+
+    test "leaves other model ids unencoded", %{context: context, opts: opts} do
+      {:ok, model} = ReqLLM.model("amazon-bedrock:us.anthropic.claude-3-haiku-20240307-v1:0")
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.path == "/model/us.anthropic.claude-3-haiku-20240307-v1:0/invoke"
+    end
+  end
+
+  describe "inference_profile_arn option" do
+    setup do
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "us-east-1",
+        provider_options: [inference_profile_arn: @arn]
+      ]
+
+      {:ok, model: model, context: context, opts: opts}
+    end
+
+    test "calls the profile while the model keeps its family and pricing", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.path == "/model/#{@encoded_arn}/invoke"
+      assert request.options[:model] == "anthropic.claude-3-haiku-20240307-v1:0"
+      assert request.options[:model_family] == "anthropic"
+    end
+
+    test "takes the Converse API through the profile", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      opts = Keyword.update!(opts, :provider_options, &Keyword.put(&1, :use_converse, true))
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.path == "/model/#{@encoded_arn}/converse"
+    end
+
+    test "streams through the profile", %{model: model, context: context, opts: opts} do
+      {:ok, finch_request} = AmazonBedrock.attach_stream(model, context, opts, ReqLLM.Finch)
+
+      assert finch_request.path == "/model/#{@encoded_arn}/invoke-with-response-stream"
+    end
+
+    test "names the likely cause of a native 400 through the profile", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      rejected = %Req.Response{
+        status: 400,
+        body: %{"message" => "Malformed input request: 4 schema violations found"}
+      }
+
+      {_request, error} = AmazonBedrock.decode_response({request, rejected})
+
+      assert %ReqLLM.Error.API.Response{status: 400} = error
+      assert error.reason =~ "built in anthropic.claude-3-haiku-20240307-v1:0's native format"
+      assert error.reason =~ "the profile serves another model"
+    end
+
+    test "leaves a Converse 400 and a profile-less 400 alone", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      rejected = %Req.Response{status: 400, body: %{"message" => "Malformed input request"}}
+      converse = Keyword.update!(opts, :provider_options, &Keyword.put(&1, :use_converse, true))
+
+      for opts <- [converse, Keyword.delete(opts, :provider_options)] do
+        {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+        {_request, error} = AmazonBedrock.decode_response({request, rejected})
+
+        assert error.reason == "Bedrock API error"
+      end
+    end
+
+    test "embeds through the profile", %{opts: opts} do
+      {:ok, model} = ReqLLM.model("amazon-bedrock:cohere.embed-english-v3")
+      {:ok, request} = AmazonBedrock.prepare_request(:embedding, model, "Hello", opts)
+
+      assert request.url.path == "/model/#{@encoded_arn}/invoke"
+    end
   end
 end


### PR DESCRIPTION
Adds support for Amazon Bedrock [application inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-application-inference-profiles.html), which are addressed by an ARN rather than a model id. 

Two ways to use a profile:

- **ARN as the model id** (`amazon_bedrock:arn:aws:bedrock:…`): it names no family, so the request goes through the Converse API as one encoded path segment. No pricing is known.
- **`provider_options: [inference_profile_arn: arn]`** on a declared model the ARN replaces the id in the request path while the model spec keeps supplying family, capabilities, and pricing.

A native-format 400 sent through a profile now returns a hint naming the model the body was built for, since Bedrock only answers "schema violations" when the profile serves a different model. Any other model id is sent exactly as before.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)
