### PR TITLE
feat(bedrock): serve requests through the bedrock-mantle endpoint

### DIFF
--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -159,6 +159,13 @@ Passed via `:provider_options` keyword:
 - **Purpose**: bedrock-mantle project the request is attributed to
 - **Example**: `provider_options: [endpoint: :mantle, project: "proj_5d5ykleja6cwpirysbb7"]`
 
+### `mantle_base_path`
+
+- **Type**: `"/v1"` | `"/openai/v1"`
+- **Purpose**: Base path of the Chat Completions route on bedrock-mantle; each [model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html) states it
+- **Default**: `/openai/v1` for `openai.gpt-5*`, `google.gemma-4*` and `xai.*` models, `/v1` for every other family
+- **Example**: `provider_options: [endpoint: :mantle, mantle_base_path: "/openai/v1"]` for a model not covered by the default
+
 ### `additional_model_request_fields`
 
 - **Type**: Map

--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -146,6 +146,19 @@ Passed via `:provider_options` keyword:
 - **Default**: Auto-detect based on tools presence
 - **Example**: `provider_options: [use_converse: true]`
 
+### `endpoint`
+
+- **Type**: `:runtime` | `:mantle`
+- **Purpose**: Bedrock endpoint the request goes to
+- **Default**: `:runtime`
+- **Example**: `provider_options: [endpoint: :mantle]`
+
+### `project`
+
+- **Type**: String
+- **Purpose**: bedrock-mantle project the request is attributed to
+- **Example**: `provider_options: [endpoint: :mantle, project: "proj_5d5ykleja6cwpirysbb7"]`
+
 ### `additional_model_request_fields`
 
 - **Type**: Map

--- a/lib/req_llm/provider.ex
+++ b/lib/req_llm/provider.ex
@@ -500,6 +500,15 @@ defmodule ReqLLM.Provider do
               {:ok, [map()], term()} | {:incomplete, term()} | {:error, term()}
 
   @doc """
+  Picks the stream protocol parser for a request, in the shape of
+  `parse_stream_protocol/2`. `nil` falls back to `parse_stream_protocol/2`.
+  """
+  @callback stream_protocol_parser(LLMDB.Model.t(), keyword()) ::
+              (binary(), term() ->
+                 {:ok, [map()], term()} | {:incomplete, term()} | {:error, term()})
+              | nil
+
+  @doc """
   Build complete Finch request for streaming operations.
 
   This callback creates a complete Finch.Request struct for streaming operations,
@@ -633,6 +642,7 @@ defmodule ReqLLM.Provider do
     init_stream_state: 1,
     flush_stream_state: 2,
     parse_stream_protocol: 2,
+    stream_protocol_parser: 2,
     attach_stream: 4,
     thinking_constraints: 0,
     credential_missing?: 1,

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -162,6 +162,11 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       doc:
         "bedrock-mantle project (`proj_…`) the request is attributed to. Ignored on bedrock-runtime"
     ],
+    mantle_base_path: [
+      type: {:in, ["/v1", "/openai/v1"]},
+      doc:
+        "Base path of the Chat Completions route on bedrock-mantle. Default: `/openai/v1` for GPT-5, Gemma 4 and Grok models, `/v1` for every other family. Ignored for Claude and on bedrock-runtime"
+    ],
     use_converse: [
       type: :boolean,
       doc: "Force use of Bedrock Converse API (default: auto-detect based on tools presence)"
@@ -977,13 +982,14 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   defp stream_accept(:mantle), do: "text/event-stream"
   defp stream_accept(:runtime), do: "application/vnd.amazon.eventstream"
 
-  defp route(:mantle, model_id, _use_converse, _stream?, _opts) do
+  defp route(:mantle, model_id, _use_converse, _stream?, opts) do
     case mantle_wire(model_id) do
       :messages ->
         {"/anthropic/v1/messages", ReqLLM.Providers.AmazonBedrock.Anthropic, "anthropic"}
 
       :chat_completions ->
-        {"/v1/chat/completions", ReqLLM.Providers.AmazonBedrock.OpenAI, "openai"}
+        {mantle_base_path(model_id, opts) <> "/chat/completions",
+         ReqLLM.Providers.AmazonBedrock.OpenAI, "openai"}
     end
   end
 
@@ -1022,6 +1028,17 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
   defp mantle_wire(model_id) do
     if get_model_family(model_id) == "anthropic", do: :messages, else: :chat_completions
+  end
+
+  # Each model card states its bedrock-mantle base path:
+  # https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
+  @mantle_openai_v1_prefixes ["openai.gpt-5", "google.gemma-4", "xai."]
+
+  defp mantle_base_path(model_id, opts) do
+    provider_option(opts, :mantle_base_path) ||
+      if String.starts_with?(model_id, @mantle_openai_v1_prefixes),
+        do: "/openai/v1",
+        else: "/v1"
   end
 
   defp route_headers(:mantle, "anthropic", opts) do

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -151,6 +151,17 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       type: :string,
       doc: "Application inference profile to call the model through"
     ],
+    endpoint: [
+      type: {:in, [:runtime, :mantle]},
+      default: :runtime,
+      doc:
+        "Bedrock endpoint the request goes to: bedrock-runtime (InvokeModel/Converse), or bedrock-mantle — the OpenAI Chat Completions API for most model families, the Anthropic Messages API for Claude"
+    ],
+    project: [
+      type: :string,
+      doc:
+        "bedrock-mantle project (`proj_…`) the request is attributed to. Ignored on bedrock-runtime"
+    ],
     use_converse: [
       type: :boolean,
       doc: "Force use of Bedrock Converse API (default: auto-detect based on tools presence)"
@@ -355,54 +366,21 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       )
 
     region = extract_region(aws_creds)
-
-    base_url = "https://bedrock-runtime.#{region}.amazonaws.com"
+    endpoint = endpoint(opts)
+    base_url = "https://#{host(endpoint, region)}"
 
     # Use provider_model_id if set (for models requiring specific API format like inference profiles),
     # otherwise fall back to canonical model ID.
     # Note: provider_model_id is set by ReqLLM.model/1 to include inference profile prefixes
     # (e.g., "global.anthropic.claude-opus-4-6-v1") when the original model spec had one.
     model_id = model.provider_model_id || model.id
-    path_id = path_model_id(model_id, opts)
 
     # Check if we should use Converse API
     # Priority: explicit use_converse option > prompt caching optimization > auto-detect from tools presence
     use_converse = determine_use_converse(model_id, opts)
 
     {endpoint_base, formatter, model_family} =
-      if use_converse do
-        # Use Converse API for unified tool calling
-        endpoint =
-          if opts[:stream],
-            do: "/model/#{path_id}/converse-stream",
-            else: "/model/#{path_id}/converse"
-
-        # Check if there's a model family formatter that wraps Converse
-        # (e.g., Mistral formatter that pre-processes messages before delegating to Converse)
-        family = get_model_family(model_id)
-        family_formatter = get_formatter_module(family)
-
-        # Only use family formatter if it explicitly requires Converse API (like Mistral)
-        # Otherwise use Converse formatter directly
-        formatter =
-          if function_exported?(family_formatter, :requires_converse_api?, 0) and
-               call_formatter(family_formatter, :requires_converse_api?, []) do
-            family_formatter
-          else
-            ReqLLM.Providers.AmazonBedrock.Converse
-          end
-
-        {endpoint, formatter, :converse}
-      else
-        # Use native model-specific endpoint
-        endpoint =
-          if opts[:stream],
-            do: "/model/#{path_id}/invoke-with-response-stream",
-            else: "/model/#{path_id}/invoke"
-
-        family = get_model_family(model_id)
-        {endpoint, get_formatter_module(family), family}
-      end
+      route(endpoint, model_id, use_converse, opts[:stream] == true, opts)
 
     operation = opts[:operation] || :chat
     compat_opts = Keyword.put(opts, :use_converse, use_converse)
@@ -428,7 +406,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         :use_converse,
         :operation,
         :tools,
-        :inference_profile_arn
+        :inference_profile_arn,
+        :endpoint
       ])
       |> Req.Request.merge_options(
         ReqLLM.Provider.Defaults.finch_option(request) ++
@@ -436,6 +415,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
             base_url: base_url,
             model: model_id,
             inference_profile_arn: inference_profile_arn(opts),
+            endpoint: endpoint,
             model_family: model_family,
             context: opts[:context],
             use_converse: use_converse,
@@ -444,12 +424,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
           ]
       )
 
-    model_body =
-      formatter.format_request(
-        model_id,
-        context,
-        opts
-      )
+    model_body = formatter.format_request(model_id, context, opts)
 
     # Add service_tier if specified (default is already "default")
     model_body =
@@ -462,12 +437,13 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     request_with_body =
       updated_request
       |> Req.Request.put_header("content-type", "application/json")
+      |> Req.Request.put_headers(route_headers(endpoint, model_family, opts))
       |> Map.put(:body, model_body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!())
 
     request_with_body
     |> Step.Error.attach()
     |> ReqLLM.Step.Retry.attach(user_opts)
-    |> put_aws_sigv4(aws_creds)
+    |> put_aws_sigv4(aws_creds, endpoint, model_family)
     # No longer attach streaming here - it's handled by attach_stream
     |> Req.Request.append_response_steps(llm_decode_response: &decode_response/1)
     |> Step.Usage.attach(model)
@@ -497,8 +473,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       end
 
     region = extract_region(aws_creds)
-
-    base_url = "https://bedrock-runtime.#{region}.amazonaws.com"
+    base_url = "https://#{host(:runtime, region)}"
     model_id = model.provider_model_id || model.id
     path_id = path_model_id(model_id, processed_opts)
     {model_family, formatter} = get_embedding_formatter(model_id)
@@ -530,7 +505,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         updated_request
         |> Step.Error.attach()
         |> ReqLLM.Step.Retry.attach(user_opts)
-        |> put_aws_sigv4(aws_creds)
+        |> put_aws_sigv4(aws_creds, :runtime, model_family)
         |> Req.Request.append_response_steps(llm_decode_embedding: &decode_embedding_response/1)
         |> Step.Usage.attach(model)
         |> ReqLLM.Step.Telemetry.attach(model, user_opts)
@@ -563,35 +538,14 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # Get model ID - use provider_model_id if set (for models requiring specific API format),
     # otherwise fall back to canonical model ID
     model_id = model.provider_model_id || model.id
-    path_id = path_model_id(model_id, translated_opts)
+    endpoint = endpoint(translated_opts)
 
     # Check if we should use Converse API
     # Priority: explicit use_converse option > prompt caching optimization > auto-detect from tools presence
     use_converse = determine_use_converse(model_id, translated_opts)
 
-    {formatter, path} =
-      if use_converse do
-        # Check if there's a model family formatter that wraps Converse
-        # (e.g., Mistral formatter that pre-processes messages before delegating to Converse)
-        model_family = get_model_family(model_id)
-        family_formatter = get_formatter_module(model_family)
-
-        # Only use family formatter if it explicitly requires Converse API (like Mistral)
-        # Otherwise use Converse formatter directly
-        formatter =
-          if function_exported?(family_formatter, :requires_converse_api?, 0) and
-               call_formatter(family_formatter, :requires_converse_api?, []) do
-            family_formatter
-          else
-            ReqLLM.Providers.AmazonBedrock.Converse
-          end
-
-        {formatter, "/model/#{path_id}/converse-stream"}
-      else
-        model_family = get_model_family(model_id)
-        formatter = get_formatter_module(model_family)
-        {formatter, "/model/#{path_id}/invoke-with-response-stream"}
-      end
+    {path, formatter, model_family} =
+      route(endpoint, model_id, use_converse, true, translated_opts)
 
     translated_opts = Keyword.put(translated_opts, :use_converse, use_converse)
 
@@ -624,21 +578,22 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
     # Construct streaming URL
     region = aws_creds.region || "us-east-1"
-    host = "bedrock-runtime.#{region}.amazonaws.com"
+    host = host(endpoint, region)
     url = "https://#{host}#{path}"
 
     # Create base headers for AWS signature
-    headers = [
-      {"Content-Type", "application/json"},
-      {"Accept", "application/vnd.amazon.eventstream"},
-      {"Host", host}
-    ]
+    headers =
+      [
+        {"Content-Type", "application/json"},
+        {"Accept", stream_accept(endpoint)},
+        {"Host", host}
+      ] ++ route_headers(endpoint, model_family, translated_opts)
 
     # Build Finch request (without signature yet)
     finch_request = Finch.build(:post, url, headers, json_body)
 
     # Add AWS Signature V4
-    signed_request = sign_aws_request(finch_request, aws_creds, region, "bedrock")
+    signed_request = sign_aws_request(finch_request, aws_creds, host, endpoint, model_family)
 
     {:ok, signed_request}
   rescue
@@ -650,6 +605,14 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       )
 
       {:error, {:bedrock_stream_build_failed, error}}
+  end
+
+  @impl ReqLLM.Provider
+  def stream_protocol_parser(_model, opts) do
+    case endpoint(opts) do
+      :mantle -> &ReqLLM.Provider.parse_stream_protocol/2
+      :runtime -> &parse_stream_protocol/2
+    end
   end
 
   @impl ReqLLM.Provider
@@ -672,6 +635,11 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   end
 
   @impl ReqLLM.Provider
+  def decode_stream_event(%{data: _} = event, model) do
+    {chunks, _state} = decode_stream_event(event, model, init_stream_state(model))
+    chunks
+  end
+
   def decode_stream_event(event, model) when is_map(event) do
     model_id = model.provider_model_id || model.id
 
@@ -701,6 +669,19 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   end
 
   @impl ReqLLM.Provider
+  def decode_stream_event(%{data: _} = event, model, state) do
+    model_id = model.provider_model_id || model.id
+
+    case mantle_wire(model_id) do
+      :messages ->
+        ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model, state)
+
+      :chat_completions ->
+        openai = %{model | id: model_id, provider: :openai}
+        {ReqLLM.Provider.Defaults.default_decode_stream_event(event, openai), state}
+    end
+  end
+
   def decode_stream_event(event, model, state) when is_map(event) do
     model_id = model.provider_model_id || model.id
 
@@ -922,28 +903,32 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     end
   end
 
-  defp put_aws_sigv4(request, %{api_key: api_key}) when is_binary(api_key) do
-    Req.Request.put_header(request, "authorization", "Bearer #{api_key}")
+  defp put_aws_sigv4(request, %{api_key: api_key}, endpoint, model_family)
+       when is_binary(api_key) do
+    {name, value} = api_key_header(api_key, endpoint, model_family)
+    Req.Request.put_header(request, name, value)
   end
 
-  defp put_aws_sigv4(request, aws_creds) do
+  defp put_aws_sigv4(request, aws_creds, endpoint, _model_family) do
     if AWSAuthAdapter.credentials?(aws_creds) do
-      AWSAuthAdapter.attach_request(request, credentials: aws_creds, service: "bedrock")
+      AWSAuthAdapter.attach_request(request, credentials: aws_creds, service: service(endpoint))
     else
       request
     end
   end
 
-  defp sign_aws_request(finch_request, %{api_key: api_key}, _region, _service)
+  defp sign_aws_request(finch_request, %{api_key: api_key}, _host, endpoint, model_family)
        when is_binary(api_key) do
     normalized_headers =
       Enum.map(finch_request.headers, fn {k, v} -> {String.downcase(k), v} end)
 
-    headers = normalized_headers ++ [{"authorization", "Bearer #{api_key}"}]
+    headers = normalized_headers ++ [api_key_header(api_key, endpoint, model_family)]
     %{finch_request | headers: headers}
   end
 
-  defp sign_aws_request(finch_request, aws_creds, _region, service) do
+  defp sign_aws_request(finch_request, aws_creds, host, endpoint, _model_family) do
+    service = service(endpoint)
+
     if AWSAuthAdapter.credentials?(aws_creds) do
       %Finch.Request{
         method: method,
@@ -959,8 +944,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
           binary when is_binary(binary) -> binary
         end
 
-      region = Map.get(aws_creds, :region) || "us-east-1"
-      url = "https://bedrock-runtime.#{region}.amazonaws.com#{path}"
+      url = "https://#{host}#{path}"
       url = if query && query != "", do: "#{url}?#{query}", else: url
       headers_map = Map.new(headers, fn {k, v} -> {String.downcase(k), v} end)
 
@@ -979,6 +963,88 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       finch_request
     end
   end
+
+  defp provider_option(opts, key), do: get_in(opts, [:provider_options, key]) || opts[key]
+
+  defp endpoint(opts), do: provider_option(opts, :endpoint) || :runtime
+
+  defp host(:mantle, region), do: "bedrock-mantle.#{region}.api.aws"
+  defp host(:runtime, region), do: "bedrock-runtime.#{region}.amazonaws.com"
+
+  defp service(:mantle), do: "bedrock-mantle"
+  defp service(:runtime), do: "bedrock"
+
+  defp stream_accept(:mantle), do: "text/event-stream"
+  defp stream_accept(:runtime), do: "application/vnd.amazon.eventstream"
+
+  defp route(:mantle, model_id, _use_converse, _stream?, _opts) do
+    case mantle_wire(model_id) do
+      :messages ->
+        {"/anthropic/v1/messages", ReqLLM.Providers.AmazonBedrock.Anthropic, "anthropic"}
+
+      :chat_completions ->
+        {"/v1/chat/completions", ReqLLM.Providers.AmazonBedrock.OpenAI, "openai"}
+    end
+  end
+
+  defp route(:runtime, model_id, true = _use_converse, stream?, opts) do
+    path_id = path_model_id(model_id, opts)
+
+    path =
+      if stream?,
+        do: "/model/#{path_id}/converse-stream",
+        else: "/model/#{path_id}/converse"
+
+    family_formatter = get_formatter_module(get_model_family(model_id))
+
+    formatter =
+      if function_exported?(family_formatter, :requires_converse_api?, 0) and
+           call_formatter(family_formatter, :requires_converse_api?, []) do
+        family_formatter
+      else
+        ReqLLM.Providers.AmazonBedrock.Converse
+      end
+
+    {path, formatter, :converse}
+  end
+
+  defp route(:runtime, model_id, false = _use_converse, stream?, opts) do
+    path_id = path_model_id(model_id, opts)
+
+    path =
+      if stream?,
+        do: "/model/#{path_id}/invoke-with-response-stream",
+        else: "/model/#{path_id}/invoke"
+
+    family = get_model_family(model_id)
+    {path, get_formatter_module(family), family}
+  end
+
+  defp mantle_wire(model_id) do
+    if get_model_family(model_id) == "anthropic", do: :messages, else: :chat_completions
+  end
+
+  defp route_headers(:mantle, "anthropic", opts) do
+    project_header("anthropic-workspace-id", opts) ++
+      ReqLLM.Providers.AmazonBedrock.Anthropic.mantle_headers(opts)
+  end
+
+  defp route_headers(:mantle, _chat_completions, opts),
+    do: project_header("openai-project", opts)
+
+  defp route_headers(:runtime, _model_family, _opts), do: []
+
+  defp project_header(name, opts) do
+    case provider_option(opts, :project) do
+      nil -> []
+      project -> [{name, project}]
+    end
+  end
+
+  defp api_key_header(api_key, :mantle, "anthropic"), do: {"x-api-key", api_key}
+
+  defp api_key_header(api_key, _endpoint, _model_family),
+    do: {"authorization", "Bearer #{api_key}"}
 
   defp get_model_family("arn:" <> _), do: nil
 
@@ -1145,8 +1211,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       if req.options[:use_converse] do
         ReqLLM.Providers.AmazonBedrock.Converse
       else
-        model_family = req.options[:model_family]
-        get_formatter_module(model_family)
+        get_formatter_module(req.options[:model_family])
       end
 
     parsed_body = ensure_parsed_body(resp.body)
@@ -1283,6 +1348,10 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
   # Private helper: Determine whether to use Converse API with caching optimization
   defp determine_use_converse(model_id, opts) do
+    endpoint(opts) == :runtime and runtime_use_converse?(model_id, opts)
+  end
+
+  defp runtime_use_converse?(model_id, opts) do
     # Check if model's formatter requires Converse API
     model_family = get_model_family(model_id)
     formatter = get_formatter_module(model_family)
@@ -1294,9 +1363,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # Check if formatter is Converse (fallback for unsupported families)
     is_fallback_to_converse = formatter == ReqLLM.Providers.AmazonBedrock.Converse
 
-    # After Options.process, use_converse is in :provider_options
-    # But for direct attach_stream calls, it might be at top level
-    use_converse_opt = get_in(opts, [:provider_options, :use_converse]) || opts[:use_converse]
+    use_converse_opt = provider_option(opts, :use_converse)
 
     case use_converse_opt do
       true ->

--- a/lib/req_llm/providers/amazon_bedrock/anthropic.ex
+++ b/lib/req_llm/providers/amazon_bedrock/anthropic.ex
@@ -45,7 +45,35 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
   For :object operations, creates a synthetic "structured_output" tool to
   leverage Claude's tool-calling for structured JSON output.
   """
-  def format_request(_model_id, context, opts) do
+  def format_request(model_id, context, opts) do
+    body = messages_body(context, opts)
+
+    case get_in(opts, [:provider_options, :endpoint]) do
+      :mantle ->
+        body
+        |> Map.put(:model, model_id)
+        |> AdapterHelpers.maybe_add_param(:stream, opts[:stream])
+
+      _runtime ->
+        body
+        |> Map.put(:anthropic_version, "bedrock-2023-05-31")
+        |> maybe_add_anthropic_beta(opts)
+    end
+  end
+
+  @doc """
+  Anthropic headers for the bedrock-mantle Messages API.
+  """
+  def mantle_headers(opts) do
+    version = {"anthropic-version", "2023-06-01"}
+
+    case anthropic_betas(opts) do
+      [] -> [version]
+      betas -> [version, {"anthropic-beta", Enum.join(betas, ",")}]
+    end
+  end
+
+  defp messages_body(context, opts) do
     operation = opts[:operation]
 
     # For :object operation, we need to inject the structured_output tool
@@ -59,19 +87,12 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
     # Create a fake model struct for Anthropic.Context.encode_request
     model = %{model: opts[:model] || "claude-3-sonnet"}
 
-    # Delegate to native Anthropic context encoding
-    body = Anthropic.Context.encode_request(context, model)
-
-    # Remove model field - Bedrock specifies model in URL, not body
-    body = Map.delete(body, :model)
-
-    # Add Bedrock-specific parameters
     # Use 4096 for :object operations (need more tokens for structured output), 1024 otherwise
     default_max_tokens = if operation == :object, do: 4096, else: 1024
 
-    body
-    |> Map.put(:anthropic_version, "bedrock-2023-05-31")
-    |> maybe_add_anthropic_beta(opts)
+    context
+    |> Anthropic.Context.encode_request(model)
+    |> Map.delete(:model)
     |> AdapterHelpers.maybe_add_param(:max_tokens, opts[:max_tokens] || default_max_tokens)
     |> AdapterHelpers.maybe_add_param(:temperature, opts[:temperature])
     |> AdapterHelpers.maybe_add_param(:top_p, opts[:top_p])
@@ -83,12 +104,16 @@ defmodule ReqLLM.Providers.AmazonBedrock.Anthropic do
   end
 
   defp maybe_add_anthropic_beta(body, opts) do
-    case get_in(opts, [:provider_options, :anthropic_beta]) do
-      betas when is_list(betas) and betas != [] ->
-        Map.put(body, :anthropic_beta, betas)
+    case anthropic_betas(opts) do
+      [] -> body
+      betas -> Map.put(body, :anthropic_beta, betas)
+    end
+  end
 
-      _ ->
-        body
+  defp anthropic_betas(opts) do
+    case get_in(opts, [:provider_options, :anthropic_beta]) do
+      betas when is_list(betas) -> betas
+      _none -> []
     end
   end
 

--- a/lib/req_llm/streaming.ex
+++ b/lib/req_llm/streaming.ex
@@ -189,7 +189,9 @@ defmodule ReqLLM.Streaming do
     server_opts = [
       provider_mod: provider_mod,
       model: model,
-      protocol_parser: protocol_parser_for_transport(transport),
+      protocol_parser:
+        protocol_parser_for_transport(transport) ||
+          provider_protocol_parser(provider_mod, model, opts),
       fixture_path: maybe_capture_fixture(model, opts),
       total_timeout: total_timeout,
       total_timeout_deadline: total_timeout_deadline,
@@ -278,6 +280,12 @@ defmodule ReqLLM.Streaming do
       provider_mod.stream_transport(model, opts)
     else
       :http
+    end
+  end
+
+  defp provider_protocol_parser(provider_mod, model, opts) do
+    if function_exported?(provider_mod, :stream_protocol_parser, 2) do
+      provider_mod.stream_protocol_parser(model, opts)
     end
   end
 

--- a/lib/req_llm/streaming/fixtures.ex
+++ b/lib/req_llm/streaming/fixtures.ex
@@ -95,6 +95,7 @@ defmodule ReqLLM.Streaming.Fixtures do
       sensitive_keys = [
         "authorization",
         "x-api-key",
+        "x-amz-security-token",
         "anthropic-api-key",
         "openai-api-key",
         "x-auth-token",

--- a/test/coverage/amazon_bedrock/mantle_test.exs
+++ b/test/coverage/amazon_bedrock/mantle_test.exs
@@ -15,6 +15,7 @@ defmodule ReqLLM.Coverage.AmazonBedrock.MantleTest do
 
   @routes [
     chat_completions: "amazon_bedrock:openai.gpt-oss-120b",
+    openai_v1_chat_completions: "amazon_bedrock:google.gemma-4-31b",
     messages: "amazon_bedrock:anthropic.claude-sonnet-5"
   ]
 

--- a/test/coverage/amazon_bedrock/mantle_test.exs
+++ b/test/coverage/amazon_bedrock/mantle_test.exs
@@ -1,0 +1,43 @@
+defmodule ReqLLM.Coverage.AmazonBedrock.MantleTest do
+  @moduledoc """
+  bedrock-mantle coverage tests.
+
+  Run with REQ_LLM_FIXTURES_MODE=record to test against the live API and record
+  fixtures. Otherwise uses fixtures for fast, reliable testing.
+  """
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  @moduletag :coverage
+  @moduletag provider: "amazon_bedrock"
+  @moduletag timeout: 180_000
+
+  @routes [
+    chat_completions: "amazon_bedrock:openai.gpt-oss-120b",
+    messages: "amazon_bedrock:anthropic.claude-sonnet-5"
+  ]
+
+  @opts [provider_options: [endpoint: :mantle], max_tokens: 400]
+
+  for {route, model} <- @routes do
+    @model model
+
+    test "#{route}: generate_text through bedrock-mantle" do
+      opts = fixture_opts("mantle_basic", @opts)
+
+      {:ok, response} = ReqLLM.generate_text(@model, "Say hi in two words.", opts)
+
+      assert ReqLLM.Response.text(response) =~ ~r/\S/
+      assert response.usage.output_tokens > 0
+    end
+
+    test "#{route}: stream_text through bedrock-mantle" do
+      opts = fixture_opts("mantle_streaming", @opts)
+
+      {:ok, response} = ReqLLM.stream_text(@model, "Say hi in two words.", opts)
+
+      assert ReqLLM.StreamResponse.text(response) =~ ~r/\S/
+    end
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -1218,4 +1218,193 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert request.url.path == "/model/#{@encoded_arn}/invoke"
     end
   end
+
+  describe "bedrock-mantle endpoint" do
+    setup do
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "eu-west-1",
+        provider_options: [endpoint: :mantle]
+      ]
+
+      {:ok, gpt_oss} = ReqLLM.model("amazon-bedrock:openai.gpt-oss-120b")
+      {:ok, claude} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+
+      {:ok, context: context, opts: opts, gpt_oss: gpt_oss, claude: claude}
+    end
+
+    test "stays on bedrock-runtime unless asked", %{context: context, opts: opts, gpt_oss: model} do
+      {:ok, request} =
+        AmazonBedrock.prepare_request(
+          :chat,
+          model,
+          context,
+          Keyword.delete(opts, :provider_options)
+        )
+
+      assert request.url.host == "bedrock-runtime.eu-west-1.amazonaws.com"
+      assert request.url.path == "/model/openai.gpt-oss-120b/invoke"
+      assert request.options[:endpoint] == :runtime
+    end
+
+    test "sends chat completions to bedrock-mantle", %{
+      context: context,
+      opts: opts,
+      gpt_oss: model
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.host == "bedrock-mantle.eu-west-1.api.aws"
+      assert request.url.path == "/v1/chat/completions"
+      assert request.options[:endpoint] == :mantle
+      assert request.options[:model_family] == "openai"
+      assert request.options[:use_converse] == false
+
+      assert %{"model" => "openai.gpt-oss-120b", "messages" => [%{"role" => "user"}]} =
+               Jason.decode!(request.body)
+    end
+
+    test "sends every other family as chat completions too", %{context: context, opts: opts} do
+      {:ok, model} =
+        ReqLLM.model(%{provider: :amazon_bedrock, id: "mistral.voxtral-mini-3b-2507"})
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.path == "/v1/chat/completions"
+      assert request.options[:model_family] == "openai"
+      assert %{"model" => "mistral.voxtral-mini-3b-2507"} = Jason.decode!(request.body)
+    end
+
+    test "sends Claude through the Anthropic Messages API", %{
+      context: context,
+      opts: opts,
+      claude: model
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert request.url.host == "bedrock-mantle.eu-west-1.api.aws"
+      assert request.url.path == "/anthropic/v1/messages"
+      assert request.options[:model_family] == "anthropic"
+      assert Req.Request.get_header(request, "anthropic-version") == ["2023-06-01"]
+
+      body = Jason.decode!(request.body)
+      assert body["model"] == "anthropic.claude-3-haiku-20240307-v1:0"
+      refute Map.has_key?(body, "anthropic_version")
+      assert [%{"role" => "user"}] = body["messages"]
+    end
+
+    test "authenticates an API key the way each route expects", %{
+      context: context,
+      gpt_oss: gpt_oss,
+      claude: claude
+    } do
+      opts = [api_key: "bedrock-key", region: "eu-west-1", provider_options: [endpoint: :mantle]]
+
+      {:ok, chat} = AmazonBedrock.prepare_request(:chat, gpt_oss, context, opts)
+      assert Req.Request.get_header(chat, "authorization") == ["Bearer bedrock-key"]
+
+      {:ok, messages} = AmazonBedrock.prepare_request(:chat, claude, context, opts)
+      assert Req.Request.get_header(messages, "x-api-key") == ["bedrock-key"]
+      assert Req.Request.get_header(messages, "authorization") == []
+    end
+
+    test "streams as server-sent events", %{
+      context: context,
+      opts: opts,
+      gpt_oss: gpt_oss,
+      claude: claude
+    } do
+      {:ok, chat} = AmazonBedrock.attach_stream(gpt_oss, context, opts, ReqLLM.Finch)
+      headers = Map.new(chat.headers)
+
+      assert chat.host == "bedrock-mantle.eu-west-1.api.aws"
+      assert chat.path == "/v1/chat/completions"
+      assert headers["accept"] == "text/event-stream"
+      assert headers["authorization"] =~ "AWS4-HMAC-SHA256"
+      assert headers["authorization"] =~ "/bedrock-mantle/aws4_request"
+      assert %{"stream" => true} = Jason.decode!(chat.body)
+
+      {:ok, messages} = AmazonBedrock.attach_stream(claude, context, opts, ReqLLM.Finch)
+
+      assert messages.path == "/anthropic/v1/messages"
+      assert Map.new(messages.headers)["anthropic-version"] == "2023-06-01"
+
+      assert %{"stream" => true, "model" => "anthropic.claude-3-haiku-20240307-v1:0"} =
+               Jason.decode!(messages.body)
+    end
+
+    test "picks the stream parser from the endpoint", %{gpt_oss: model} do
+      sse = AmazonBedrock.stream_protocol_parser(model, provider_options: [endpoint: :mantle])
+
+      assert {:ok, [%{data: ~s({"a":1})}], %ServerSentEvents.Parser{} = state} =
+               sse.(~s(data: {"a":1}\n\n), nil)
+
+      assert {:ok, [%{data: ~s({"b":2})}], %ServerSentEvents.Parser{}} =
+               sse.(~s(data: {"b":2}\n\n), state)
+
+      event_stream = AmazonBedrock.stream_protocol_parser(model, [])
+      assert {:incomplete, <<0, 0>>} = event_stream.(<<0, 0>>, nil)
+    end
+
+    test "decodes chat completion and messages events", %{gpt_oss: gpt_oss, claude: claude} do
+      delta = %{data: %{"choices" => [%{"index" => 0, "delta" => %{"content" => "Hi"}}]}}
+
+      assert {[%ReqLLM.StreamChunk{type: :content, text: "Hi"}], nil} =
+               AmazonBedrock.decode_stream_event(delta, gpt_oss, nil)
+
+      delta = %{
+        event: "content_block_delta",
+        data: %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "text_delta", "text" => "Hi"}
+        }
+      }
+
+      assert {[%ReqLLM.StreamChunk{type: :content, text: "Hi"}], _state} =
+               AmazonBedrock.decode_stream_event(
+                 delta,
+                 claude,
+                 AmazonBedrock.init_stream_state(claude)
+               )
+    end
+
+    test "sends the project header each bedrock-mantle route takes", %{
+      context: context,
+      opts: opts,
+      gpt_oss: gpt_oss,
+      claude: claude
+    } do
+      opts = put_in(opts, [:provider_options, :project], "proj_abc123")
+
+      {:ok, chat} = AmazonBedrock.prepare_request(:chat, gpt_oss, context, opts)
+      assert Req.Request.get_header(chat, "openai-project") == ["proj_abc123"]
+
+      {:ok, messages} = AmazonBedrock.prepare_request(:chat, claude, context, opts)
+      assert Req.Request.get_header(messages, "anthropic-workspace-id") == ["proj_abc123"]
+      assert Req.Request.get_header(messages, "openai-project") == []
+
+      {:ok, stream} = AmazonBedrock.attach_stream(gpt_oss, context, opts, ReqLLM.Finch)
+      headers = Map.new(stream.headers)
+      assert headers["openai-project"] == "proj_abc123"
+      assert headers["authorization"] =~ "openai-project"
+    end
+
+    test "sends no project header off bedrock-mantle", %{
+      context: context,
+      opts: opts,
+      gpt_oss: model
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+      assert Req.Request.get_header(request, "openai-project") == []
+
+      runtime = Keyword.put(opts, :provider_options, project: "proj_abc123")
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, runtime)
+      assert request.url.host == "bedrock-runtime.eu-west-1.amazonaws.com"
+      assert Req.Request.get_header(request, "openai-project") == []
+    end
+  end
 end

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -1278,6 +1278,44 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert %{"model" => "mistral.voxtral-mini-3b-2507"} = Jason.decode!(request.body)
     end
 
+    test "serves OpenAI-hosted models under /openai/v1", %{context: context, opts: opts} do
+      for id <- ["openai.gpt-5.4", "google.gemma-4-31b", "xai.grok-4.3"] do
+        {:ok, model} = ReqLLM.model(%{provider: :amazon_bedrock, id: id})
+        {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+        assert request.url.path == "/openai/v1/chat/completions"
+        assert request.options[:model_family] == "openai"
+        assert %{"model" => ^id} = Jason.decode!(request.body)
+
+        {:ok, finch_request} = AmazonBedrock.attach_stream(model, context, opts, ReqLLM.Finch)
+        assert finch_request.path == "/openai/v1/chat/completions"
+      end
+    end
+
+    test "mantle_base_path overrides the base picked from the model id", %{
+      context: context,
+      opts: opts,
+      gpt_oss: gpt_oss
+    } do
+      {:ok, gpt_5} = ReqLLM.model(%{provider: :amazon_bedrock, id: "openai.gpt-5.4"})
+
+      to_openai =
+        Keyword.put(opts, :provider_options, endpoint: :mantle, mantle_base_path: "/openai/v1")
+
+      to_v1 = Keyword.put(opts, :provider_options, endpoint: :mantle, mantle_base_path: "/v1")
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, gpt_oss, context, to_openai)
+      assert request.url.path == "/openai/v1/chat/completions"
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, gpt_5, context, to_v1)
+      assert request.url.path == "/v1/chat/completions"
+
+      {:ok, finch_request} =
+        AmazonBedrock.attach_stream(gpt_oss, context, to_openai, ReqLLM.Finch)
+
+      assert finch_request.path == "/openai/v1/chat/completions"
+    end
+
     test "sends Claude through the Anthropic Messages API", %{
       context: context,
       opts: opts,

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_sonnet_5/mantle_basic.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_sonnet_5/mantle_basic.json
@@ -1,0 +1,108 @@
+{
+  "model_spec": "amazon_bedrock:anthropic.claude-sonnet-5",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfdG9rZW5zIjo0MDAsIm1lc3NhZ2VzIjpbeyJjb250ZW50IjoiU2F5IGhpIGluIHR3byB3b3Jkcy4iLCJyb2xlIjoidXNlciJ9XSwibW9kZWwiOiJhbnRocm9waWMuY2xhdWRlLXNvbm5ldC01Iiwic3RyZWFtIjpmYWxzZX0="
+    },
+    "canonical_json": {
+      "max_tokens": 400,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ],
+      "model": "anthropic.claude-sonnet-5",
+      "stream": false
+    },
+    "headers": {
+      "anthropic-version": [
+        "2023-06-01"
+      ],
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-mantle.eu-west-1.api.aws"
+      ],
+      "user-agent": [
+        "req/0.7.3"
+      ],
+      "x-amz-content-sha256": [
+        "a6c781af2da7d2f1eb7b212f589c1ed076526269a190532b2bfb5786730a46af"
+      ],
+      "x-amz-date": [
+        "20260828T123655Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-mantle.eu-west-1.api.aws/anthropic/v1/messages"
+  },
+  "response": {
+    "body": {
+      "content": [
+        {
+          "text": "Hi there!",
+          "type": "text"
+        }
+      ],
+      "id": "msg_bdrk_xfhtdp7oe43anx3ihfjuguusbe7ulxar67byydp6lnr5wyldzcgq",
+      "model": "claude-sonnet-5",
+      "role": "assistant",
+      "stop_details": null,
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "type": "message",
+      "usage": {
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 0
+        },
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "input_tokens": 14,
+        "output_tokens": 7,
+        "output_tokens_details": {
+          "thinking_tokens": 0
+        },
+        "service_tier": "standard"
+      }
+    },
+    "headers": {
+      "access-control-allow-origin": [
+        "*"
+      ],
+      "access-control-expose-headers": [
+        "x-amzn-requestid,x-request-id,date,x-amzn-usage-reservation-quota,x-amzn-usage-reservation-remaining-quota,x-amzn-usage-reservation-spillover"
+      ],
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "502"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Fri, 28 Aug 2026 12:38:20 GMT"
+      ],
+      "vary": [
+        "origin, access-control-request-method, access-control-request-headers"
+      ],
+      "x-amzn-requestid": [
+        "req_mr2vat7xjikzf26mltxs3edb4j44neeogehjrjdgsx2jv4ccbdfa"
+      ],
+      "x-request-id": [
+        "req_mr2vat7xjikzf26mltxs3edb4j44neeogehjrjdgsx2jv4ccbdfa"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_sonnet_5/mantle_streaming.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_sonnet_5/mantle_streaming.json
@@ -1,0 +1,79 @@
+{
+  "captured_at": "2026-08-28T12:38:22.912186Z",
+  "chunks": [
+    {
+      "b64": "ZXZlbnQ6IG1lc3NhZ2Vfc3RhcnQKZGF0YTogeyJ0eXBlIjoibWVzc2FnZV9zdGFydCIsIm1lc3NhZ2UiOnsibW9kZWwiOiJjbGF1ZGUtc29ubmV0LTUiLCJpZCI6Im1zZ19iZHJrXzZldnJvNXB4bjdoamFyZGNndzN6dXNxcnZibDI1YTdjanVmY3R4YmNjbGF0NHN0dzJteGEiLCJ0eXBlIjoibWVzc2FnZSIsInJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbXSwic3RvcF9yZWFzb24iOm51bGwsInN0b3Bfc2VxdWVuY2UiOm51bGwsInN0b3BfZGV0YWlscyI6bnVsbCwidXNhZ2UiOnsiaW5wdXRfdG9rZW5zIjoxNCwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5zIjowLCJjYWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRpb24iOnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFsXzFoX2lucHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjIsInNlcnZpY2VfdGllciI6InN0YW5kYXJkIn19fQoK"
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfc3RhcnQKZGF0YTogeyJ0eXBlIjoiY29udGVudF9ibG9ja19zdGFydCIsImluZGV4IjowLCJjb250ZW50X2Jsb2NrIjp7InR5cGUiOiJ0aGlua2luZyIsInRoaW5raW5nIjoiIiwic2lnbmF0dXJlIjoiIn19Cgo="
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfZGVsdGEKZGF0YTogeyJ0eXBlIjoiY29udGVudF9ibG9ja19kZWx0YSIsImluZGV4IjowLCJkZWx0YSI6eyJ0eXBlIjoidGhpbmtpbmdfZGVsdGEiLCJ0aGlua2luZyI6IiJ9fQoK"
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfZGVsdGEKZGF0YTogeyJ0eXBlIjoiY29udGVudF9ibG9ja19kZWx0YSIsImluZGV4IjowLCJkZWx0YSI6eyJ0eXBlIjoic2lnbmF0dXJlX2RlbHRhIiwic2lnbmF0dXJlIjoiRXA0Q0Nua0lFUkFCR0FJcVFMelMyeUNaTTBUeW9mcURXVkVwSkRNZk1sb09sYzNSYncxTDBRQU0wNENHNHNweDFrbmNYVk9qeE9wOGJKZm4vTUIzeThjQjAvY3NwdkhwNWxzSmJwWXlEbU5zWVhWa1pTMXpZV1ptY205dU9BQkNDSFJvYVc1cmFXNW5XZ3d6TmpFeU1qWTVPVEUyTURTb0FiNkN4dFFHRWd4UEtlTjFnaWZON3BMUWxpd2FERG54eHArNGoyZ2VRMUJ0MGlJd2ovcFBoc2lROXN0UE9WNS85Mkk1S1dsTUUvcWhOUWl1Vk1qNmNVR2hwalBtTlRsRFRLOWVwSHc0RG0yRjhBUEhLbFB3cXNDZ0l3RFp4M2Rvb2xsZnpEa3Nhd0RrOHU1Q1JMU3FsenhGR2VlNDEwUUtsNkl3ay8va0hwVktmTVNvenVXWlY0cUFEOC9jSE1KVFVLaXEzN1pFazBWc2U1WmVUeUsrdjYwY2M0V3NvRGRFK2hnQiJ9fQoK"
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfc3RvcApkYXRhOiB7InR5cGUiOiJjb250ZW50X2Jsb2NrX3N0b3AiLCJpbmRleCI6MH0KCg=="
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfc3RhcnQKZGF0YTogeyJ0eXBlIjoiY29udGVudF9ibG9ja19zdGFydCIsImluZGV4IjoxLCJjb250ZW50X2Jsb2NrIjp7InR5cGUiOiJ0ZXh0IiwidGV4dCI6IiJ9fQoK"
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfZGVsdGEKZGF0YTogeyJ0eXBlIjoiY29udGVudF9ibG9ja19kZWx0YSIsImluZGV4IjoxLCJkZWx0YSI6eyJ0eXBlIjoidGV4dF9kZWx0YSIsInRleHQiOiJIaSB0aGVyZSJ9fQoKZXZlbnQ6IGNvbnRlbnRfYmxvY2tfZGVsdGEKZGF0YTogeyJ0eXBlIjoiY29udGVudF9ibG9ja19kZWx0YSIsImluZGV4IjoxLCJkZWx0YSI6eyJ0eXBlIjoidGV4dF9kZWx0YSIsInRleHQiOiIhIn19Cgo="
+    },
+    {
+      "b64": "ZXZlbnQ6IGNvbnRlbnRfYmxvY2tfc3RvcApkYXRhOiB7InR5cGUiOiJjb250ZW50X2Jsb2NrX3N0b3AiLCJpbmRleCI6MX0KCg=="
+    },
+    {
+      "b64": "ZXZlbnQ6IG1lc3NhZ2VfZGVsdGEKZGF0YTogeyJ0eXBlIjoibWVzc2FnZV9kZWx0YSIsImRlbHRhIjp7InN0b3BfcmVhc29uIjoiZW5kX3R1cm4iLCJzdG9wX3NlcXVlbmNlIjpudWxsLCJzdG9wX2RldGFpbHMiOm51bGx9LCJ1c2FnZSI6eyJpbnB1dF90b2tlbnMiOjE0LCJjYWNoZV9jcmVhdGlvbl9pbnB1dF90b2tlbnMiOjAsImNhY2hlX3JlYWRfaW5wdXRfdG9rZW5zIjowLCJvdXRwdXRfdG9rZW5zIjozMCwib3V0cHV0X3Rva2Vuc19kZXRhaWxzIjp7InRoaW5raW5nX3Rva2VucyI6MjJ9fX0KCg=="
+    }
+  ],
+  "model_spec": "amazon_bedrock:anthropic.claude-sonnet-5",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfdG9rZW5zIjo0MDAsIm1lc3NhZ2VzIjpbeyJjb250ZW50IjoiU2F5IGhpIGluIHR3byB3b3Jkcy4iLCJyb2xlIjoidXNlciJ9XSwibW9kZWwiOiJhbnRocm9waWMuY2xhdWRlLXNvbm5ldC01Iiwic3RyZWFtIjp0cnVlfQ=="
+    },
+    "canonical_json": {
+      "max_tokens": 400,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ],
+      "model": "anthropic.claude-sonnet-5",
+      "stream": true
+    },
+    "headers": {
+      "accept": "text/event-stream",
+      "anthropic-version": "2023-06-01",
+      "authorization": "[REDACTED:authorization]",
+      "content-type": "application/json",
+      "host": "bedrock-mantle.eu-west-1.api.aws",
+      "x-amz-content-sha256": "d5220dfd8fa82c8fe5846229ca4e53a4287f105b3fc6883f8f63e99b32100154",
+      "x-amz-date": "20260828T123820Z",
+      "x-amz-security-token": "[REDACTED:x-amz-security-token]"
+    },
+    "method": "POST",
+    "url": "https://bedrock-mantle.eu-west-1.api.aws/anthropic/v1/messages"
+  },
+  "response": {
+    "body": null,
+    "headers": {
+      "access-control-allow-origin": "*",
+      "access-control-expose-headers": "x-amzn-requestid,x-request-id,date,x-amzn-usage-reservation-quota,x-amzn-usage-reservation-remaining-quota,x-amzn-usage-reservation-spillover",
+      "connection": "keep-alive",
+      "content-type": "text/event-stream; charset=utf-8",
+      "date": "Fri, 28 Aug 2026 12:38:22 GMT",
+      "request-id": "req_g3j722ao3hyvxrxil433xb4ng55mp3uogy3dz25sbqksnmeme7pq",
+      "transfer-encoding": "chunked",
+      "vary": "origin, access-control-request-method, access-control-request-headers",
+      "x-amzn-requestid": "req_g3j722ao3hyvxrxil433xb4ng55mp3uogy3dz25sbqksnmeme7pq",
+      "x-request-id": "req_g3j722ao3hyvxrxil433xb4ng55mp3uogy3dz25sbqksnmeme7pq"
+    },
+    "status": 200
+  },
+  "streaming": true
+}

--- a/test/support/fixtures/amazon_bedrock/google_gemma_4_31b/mantle_basic.json
+++ b/test/support/fixtures/amazon_bedrock/google_gemma_4_31b/mantle_basic.json
@@ -1,0 +1,112 @@
+{
+  "model_spec": "amazon_bedrock:google.gemma-4-31b",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfdG9rZW5zIjo0MDAsIm1lc3NhZ2VzIjpbeyJjb250ZW50IjoiU2F5IGhpIGluIHR3byB3b3Jkcy4iLCJyb2xlIjoidXNlciJ9XSwibW9kZWwiOiJnb29nbGUuZ2VtbWEtNC0zMWIiLCJzdHJlYW0iOmZhbHNlfQ=="
+    },
+    "canonical_json": {
+      "max_tokens": 400,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ],
+      "model": "google.gemma-4-31b",
+      "stream": false
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-mantle.us-east-1.api.aws"
+      ],
+      "user-agent": [
+        "req/0.7.3"
+      ],
+      "x-amz-content-sha256": [
+        "1a58a0d709cd8fb7b0b037819b54d1e1278cf2d0b0ec4dae3dff83d490903708"
+      ],
+      "x-amz-date": [
+        "20260828T184413Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-mantle.us-east-1.api.aws/openai/v1/chat/completions"
+  },
+  "response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "annotations": [],
+            "content": "Hi there!",
+            "refusal": null,
+            "role": "assistant"
+          }
+        }
+      ],
+      "created": 1787942653,
+      "id": "chatcmpl-eydth6wxlfizliggnoplvcbrpthvxrwlnjout3vhp2ictjccf2fq",
+      "model": "google.gemma-4-31b",
+      "object": "chat.completion",
+      "service_tier": "default",
+      "system_fingerprint": null,
+      "usage": {
+        "completion_tokens": 4,
+        "completion_tokens_details": {
+          "accepted_prediction_tokens": 0,
+          "audio_tokens": 0,
+          "reasoning_tokens": 0,
+          "rejected_prediction_tokens": 0
+        },
+        "prompt_tokens": 39,
+        "prompt_tokens_details": {
+          "audio_tokens": 0,
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "total_tokens": 43
+      }
+    },
+    "headers": {
+      "access-control-allow-origin": [
+        "*"
+      ],
+      "access-control-expose-headers": [
+        "x-amzn-requestid,x-request-id,date,x-amzn-usage-reservation-quota,x-amzn-usage-reservation-remaining-quota,x-amzn-usage-reservation-spillover"
+      ],
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "613"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Fri, 28 Aug 2026 18:44:14 GMT"
+      ],
+      "vary": [
+        "origin, access-control-request-method, access-control-request-headers"
+      ],
+      "x-amzn-requestid": [
+        "req_crfczcyiywnneje4auds525o2xf2p4vg3vvuaikmw6mrdfwger2q"
+      ],
+      "x-request-id": [
+        "req_crfczcyiywnneje4auds525o2xf2p4vg3vvuaikmw6mrdfwger2q"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/google_gemma_4_31b/mantle_streaming.json
+++ b/test/support/fixtures/amazon_bedrock/google_gemma_4_31b/mantle_streaming.json
@@ -1,0 +1,63 @@
+{
+  "captured_at": "2026-08-28T18:44:13.049872Z",
+  "chunks": [
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJjb250ZW50IjoiIiwicm9sZSI6ImFzc2lzdGFudCIsInJlZnVzYWwiOm51bGx9LCJmaW5pc2hfcmVhc29uIjpudWxsLCJpbmRleCI6MH1dLCJjcmVhdGVkIjoxNzg3OTQyNjUyLCJpZCI6ImNoYXRjbXBsLWh3aXVldW54a210cjcybmV5NXlwZDR5d2YydjVwdzJ1aTY2YWdrZzJ3dWpvM2VhZHd2ZXEiLCJtb2RlbCI6Imdvb2dsZS5nZW1tYS00LTMxYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQiLCJzeXN0ZW1fZmluZ2VycHJpbnQiOm51bGwsInVzYWdlIjpudWxsLCJvYmZ1c2NhdGlvbiI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVIn0KCg=="
+    },
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJjb250ZW50IjoiSGVsbG8ifSwiZmluaXNoX3JlYXNvbiI6bnVsbCwiaW5kZXgiOjB9XSwiY3JlYXRlZCI6MTc4Nzk0MjY1MiwiaWQiOiJjaGF0Y21wbC1od2l1ZXVueGttdHI3Mm5leTV5cGQ0eXdmMnY1cHcydWk2NmFna2cyd3VqbzNlYWR3dmVxIiwibW9kZWwiOiJnb29nbGUuZ2VtbWEtNC0zMWIiLCJvYmplY3QiOiJjaGF0LmNvbXBsZXRpb24uY2h1bmsiLCJzZXJ2aWNlX3RpZXIiOiJkZWZhdWx0Iiwic3lzdGVtX2ZpbmdlcnByaW50IjpudWxsLCJ1c2FnZSI6bnVsbCwib2JmdXNjYXRpb24iOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVSJ9CgpkYXRhOiB7ImNob2ljZXMiOlt7ImRlbHRhIjp7ImNvbnRlbnQiOiIgdGhlcmUifSwiZmluaXNoX3JlYXNvbiI6bnVsbCwiaW5kZXgiOjB9XSwiY3JlYXRlZCI6MTc4Nzk0MjY1MiwiaWQiOiJjaGF0Y21wbC1od2l1ZXVueGttdHI3Mm5leTV5cGQ0eXdmMnY1cHcydWk2NmFna2cyd3VqbzNlYWR3dmVxIiwibW9kZWwiOiJnb29nbGUuZ2VtbWEtNC0zMWIiLCJvYmplY3QiOiJjaGF0LmNvbXBsZXRpb24uY2h1bmsiLCJzZXJ2aWNlX3RpZXIiOiJkZWZhdWx0Iiwic3lzdGVtX2ZpbmdlcnByaW50IjpudWxsLCJ1c2FnZSI6bnVsbCwib2JmdXNjYXRpb24iOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE0ifQoK"
+    },
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJjb250ZW50IjoiISJ9LCJmaW5pc2hfcmVhc29uIjpudWxsLCJpbmRleCI6MH1dLCJjcmVhdGVkIjoxNzg3OTQyNjUyLCJpZCI6ImNoYXRjbXBsLWh3aXVldW54a210cjcybmV5NXlwZDR5d2YydjVwdzJ1aTY2YWdrZzJ3dWpvM2VhZHd2ZXEiLCJtb2RlbCI6Imdvb2dsZS5nZW1tYS00LTMxYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQiLCJzeXN0ZW1fZmluZ2VycHJpbnQiOm51bGwsInVzYWdlIjpudWxsLCJvYmZ1c2NhdGlvbiI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PIn0KCmRhdGE6IHsiY2hvaWNlcyI6W3siZGVsdGEiOnt9LCJmaW5pc2hfcmVhc29uIjoic3RvcCIsImluZGV4IjowfV0sImNyZWF0ZWQiOjE3ODc5NDI2NTIsImlkIjoiY2hhdGNtcGwtaHdpdWV1bnhrbXRyNzJuZXk1eXBkNHl3ZjJ2NXB3MnVpNjZhZ2tnMnd1am8zZWFkd3ZlcSIsIm1vZGVsIjoiZ29vZ2xlLmdlbW1hLTQtMzFiIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uLmNodW5rIiwic2VydmljZV90aWVyIjoiZGVmYXVsdCIsInN5c3RlbV9maW5nZXJwcmludCI6bnVsbCwidXNhZ2UiOm51bGwsIm9iZnVzY2F0aW9uIjoiYWJjZGVmZ2hpamtsbW5vcHEifQoKZGF0YTogeyJjaG9pY2VzIjpbXSwiY3JlYXRlZCI6MTc4Nzk0MjY1MiwiaWQiOiJjaGF0Y21wbC1od2l1ZXVueGttdHI3Mm5leTV5cGQ0eXdmMnY1cHcydWk2NmFna2cyd3VqbzNlYWR3dmVxIiwibW9kZWwiOiJnb29nbGUuZ2VtbWEtNC0zMWIiLCJvYmplY3QiOiJjaGF0LmNvbXBsZXRpb24uY2h1bmsiLCJzZXJ2aWNlX3RpZXIiOiJkZWZhdWx0IiwidXNhZ2UiOnsiY29tcGxldGlvbl90b2tlbnMiOjQsImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOnsiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOjAsImF1ZGlvX3Rva2VucyI6MCwicmVhc29uaW5nX3Rva2VucyI6MCwicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOjB9LCJwcm9tcHRfdG9rZW5zIjozOSwicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjp7ImF1ZGlvX3Rva2VucyI6MCwiY2FjaGVfd3JpdGVfdG9rZW5zIjowLCJjYWNoZWRfdG9rZW5zIjowfSwidG90YWxfdG9rZW5zIjo0M30sInN5c3RlbV9maW5nZXJwcmludCI6bnVsbCwib2JmdXNjYXRpb24iOiJhYmNkZSJ9Cgo="
+    }
+  ],
+  "model_spec": "amazon_bedrock:google.gemma-4-31b",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfdG9rZW5zIjo0MDAsIm1lc3NhZ2VzIjpbeyJjb250ZW50IjoiU2F5IGhpIGluIHR3byB3b3Jkcy4iLCJyb2xlIjoidXNlciJ9XSwibW9kZWwiOiJnb29nbGUuZ2VtbWEtNC0zMWIiLCJzdHJlYW0iOnRydWUsInN0cmVhbV9vcHRpb25zIjp7ImluY2x1ZGVfdXNhZ2UiOnRydWV9fQ=="
+    },
+    "canonical_json": {
+      "max_tokens": 400,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ],
+      "model": "google.gemma-4-31b",
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "headers": {
+      "accept": "text/event-stream",
+      "authorization": "[REDACTED:authorization]",
+      "content-type": "application/json",
+      "host": "bedrock-mantle.us-east-1.api.aws",
+      "x-amz-content-sha256": "1d23fba1c1b07393fde86e0d3961a2945f0f1d5b1007e442f28cc2fecf0f55b3",
+      "x-amz-date": "20260828T184412Z",
+      "x-amz-security-token": "[REDACTED:x-amz-security-token]"
+    },
+    "method": "POST",
+    "url": "https://bedrock-mantle.us-east-1.api.aws/openai/v1/chat/completions"
+  },
+  "response": {
+    "body": null,
+    "headers": {
+      "access-control-allow-origin": "*",
+      "access-control-expose-headers": "x-amzn-requestid,x-request-id,date,x-amzn-usage-reservation-quota,x-amzn-usage-reservation-remaining-quota,x-amzn-usage-reservation-spillover",
+      "cache-control": "no-cache",
+      "connection": "keep-alive",
+      "content-type": "text/event-stream",
+      "date": "Fri, 28 Aug 2026 18:44:12 GMT",
+      "transfer-encoding": "chunked",
+      "vary": "origin, access-control-request-method, access-control-request-headers",
+      "x-amzn-requestid": "req_z4nhkuwmj57ghtsxao3doffjt5xd64acju3mgcoxnruv77xzxgsa",
+      "x-request-id": "req_z4nhkuwmj57ghtsxao3doffjt5xd64acju3mgcoxnruv77xzxgsa"
+    },
+    "status": 200
+  },
+  "streaming": true
+}

--- a/test/support/fixtures/amazon_bedrock/openai_gpt_oss_120b/mantle_basic.json
+++ b/test/support/fixtures/amazon_bedrock/openai_gpt_oss_120b/mantle_basic.json
@@ -1,0 +1,101 @@
+{
+  "model_spec": "amazon_bedrock:openai.gpt-oss-120b",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfdG9rZW5zIjo0MDAsIm1lc3NhZ2VzIjpbeyJjb250ZW50IjoiU2F5IGhpIGluIHR3byB3b3Jkcy4iLCJyb2xlIjoidXNlciJ9XSwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwic3RyZWFtIjpmYWxzZX0="
+    },
+    "canonical_json": {
+      "max_tokens": 400,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ],
+      "model": "openai.gpt-oss-120b",
+      "stream": false
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-mantle.eu-west-1.api.aws"
+      ],
+      "user-agent": [
+        "req/0.7.3"
+      ],
+      "x-amz-content-sha256": [
+        "0f49aac91adbdcd5af147dc601d057414444c6428cd329c9423bbc1db5841526"
+      ],
+      "x-amz-date": [
+        "20260828T123822Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-mantle.eu-west-1.api.aws/v1/chat/completions"
+  },
+  "response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "logprobs": null,
+          "message": {
+            "content": "Hello there!",
+            "reasoning": "User asks: \"Say hi in two words.\" So respond with a two-word greeting, such as \"Hello there\". That's two words. Should be succinct.",
+            "refusal": null,
+            "role": "assistant"
+          }
+        }
+      ],
+      "created": 1787920703,
+      "id": "chatcmpl-0ab5e713-7b64-44dc-84bd-82b912f1044b",
+      "model": "openai.gpt-oss-120b",
+      "object": "chat.completion",
+      "service_tier": "default",
+      "usage": {
+        "completion_tokens": 45,
+        "prompt_tokens": 73,
+        "total_tokens": 118
+      }
+    },
+    "headers": {
+      "access-control-allow-origin": [
+        "*"
+      ],
+      "access-control-expose-headers": [
+        "x-amzn-requestid,x-request-id,date,x-amzn-usage-reservation-quota,x-amzn-usage-reservation-remaining-quota,x-amzn-usage-reservation-spillover"
+      ],
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "512"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Fri, 28 Aug 2026 12:38:23 GMT"
+      ],
+      "vary": [
+        "origin, access-control-request-method, access-control-request-headers"
+      ],
+      "x-amzn-requestid": [
+        "req_ecwwvya26w5q54nrb3jczka4b5z7ao35audmpsvwqdf26jzzv5wa"
+      ],
+      "x-request-id": [
+        "req_ecwwvya26w5q54nrb3jczka4b5z7ao35audmpsvwqdf26jzzv5wa"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/openai_gpt_oss_120b/mantle_streaming.json
+++ b/test/support/fixtures/amazon_bedrock/openai_gpt_oss_120b/mantle_streaming.json
@@ -1,0 +1,69 @@
+{
+  "captured_at": "2026-08-28T12:38:23.801078Z",
+  "chunks": [
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJjb250ZW50IjoiIiwicm9sZSI6ImFzc2lzdGFudCJ9LCJmaW5pc2hfcmVhc29uIjpudWxsLCJpbmRleCI6MCwib2JmdXNjYXRpb24iOiI0R2RTOW1rSTJFSG00Y1FIaUljMEpsWVVJQ1NaaGMycnp1VlBoWDVSdlJWNU52VlhWWVNnb21pMmoifV0sImNyZWF0ZWQiOjE3ODc5MjA3MDMsImlkIjoiY2hhdGNtcGwtMTZmZDU0NjEtMTM4Zi00MzRmLThjYzktMmE2NjIyMTI1ZmU2IiwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uLmNodW5rIiwic2VydmljZV90aWVyIjoiZGVmYXVsdCJ9CgpkYXRhOiB7ImNob2ljZXMiOlt7ImRlbHRhIjp7fSwiZmluaXNoX3JlYXNvbiI6bnVsbCwiaW5kZXgiOjAsIm9iZnVzY2F0aW9uIjoiNUtRdjdyQkxWbmRvYzhqdElEelhRbk5sdHBVbEJuOFlkcWdvNUdPRVZqR0FnRVRlOWMwaXU4TEQ2YUpkQnAzN25DaDdKY244Z3NEeThEamh3RXR1bktOWDJtZTh4OWxkYW04UXZnUkxXT1A2WGNRUWpReHUyIn1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoKZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6e30sImZpbmlzaF9yZWFzb24iOm51bGwsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6ImZ2WGZpcUtlSDZFV243dEVCcThRYUFZOEl1dDltc09ra0lnUVJVSUdHd2wwc1FudDNKeU04ejF2N1BvZFMwQUJscTFKT3lnMFRSOFpHOGZseTc0ME1lOFEyelE4NU93aDRvQVBkOUtCVEY4MExQaUs3YWdZSmNWIn1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoKZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6e30sImZpbmlzaF9yZWFzb24iOm51bGwsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6IkhNOTdHZVFUNEtGRTFHenFmVVBQT0JSTTE4M0tYSzIyQ0g3dDhEc0RCaTRSQ08zRGhYWTJlS2ttdTAifV0sImNyZWF0ZWQiOjE3ODc5MjA3MDMsImlkIjoiY2hhdGNtcGwtMTZmZDU0NjEtMTM4Zi00MzRmLThjYzktMmE2NjIyMTI1ZmU2IiwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uLmNodW5rIiwic2VydmljZV90aWVyIjoiZGVmYXVsdCJ9Cgo="
+    },
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJyZWFzb25pbmciOiJVc2VyIGFza3M6IFwiU2F5IGhpIGluIHR3byB3b3Jkcy5cIiBTbyByZXNwb25kIHdpdGggYSBncmVldGluZyB1c2luZyB0d28gd29yZHMsIGxpa2UgXCJIZWxsbyB0aGVyZSFcIiBUaGF0J3MgdHdvIHdvcmRzLiBDb3VsZCBhbHNvIGJlIFwiSGV5IHRoZXJlXCIuIFByb3ZpZGUifSwiZmluaXNoX3JlYXNvbiI6bnVsbCwiaW5kZXgiOjAsIm9iZnVzY2F0aW9uIjoia3JnYnhZbWtXM1hqMFltcDk3RDJtNkMyRW5IWGNIWERpeU4zOEFuSUp5UjEyTGRtUnVTeG1laDN3In1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoK"
+    },
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJyZWFzb25pbmciOiIgdGhhdC4ifSwiZmluaXNoX3JlYXNvbiI6bnVsbCwiaW5kZXgiOjAsIm9iZnVzY2F0aW9uIjoieXRwa2owTVRsNzFWM2I0NDk1UWY0d1g2VFB0SVdLeURQIn1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoKZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6e30sImZpbmlzaF9yZWFzb24iOm51bGwsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6Im9MSmpqbW1zWkdRUTdxaVhHU1FmOFNYYkFoSDJwbkE1YVVBIn1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoK"
+    },
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6e30sImZpbmlzaF9yZWFzb24iOm51bGwsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6Ik1JWmlaQkVsa3hQNENOSVRUMEdaeFFVclFaVGYzNmljenROSkFnWk5hdmpFNGlqVEtLUnlxdjd5ZVlMOXMifV0sImNyZWF0ZWQiOjE3ODc5MjA3MDMsImlkIjoiY2hhdGNtcGwtMTZmZDU0NjEtMTM4Zi00MzRmLThjYzktMmE2NjIyMTI1ZmU2IiwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uLmNodW5rIiwic2VydmljZV90aWVyIjoiZGVmYXVsdCJ9CgpkYXRhOiB7ImNob2ljZXMiOlt7ImRlbHRhIjp7fSwiZmluaXNoX3JlYXNvbiI6bnVsbCwiaW5kZXgiOjAsIm9iZnVzY2F0aW9uIjoia2Q0anJjNUpjQjlJY2RkMjVuaENWQUw2RmJ4dVBMSVllMFNlRFFpTTRuV2dOaFR6MDdKank2ZExyOHJzbDFVSmlubWo5ckJldVRiVlp3ekJmS3Y3Z2F4V1VjUGpLaG90RWNwZlUifV0sImNyZWF0ZWQiOjE3ODc5MjA3MDMsImlkIjoiY2hhdGNtcGwtMTZmZDU0NjEtMTM4Zi00MzRmLThjYzktMmE2NjIyMTI1ZmU2IiwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uLmNodW5rIiwic2VydmljZV90aWVyIjoiZGVmYXVsdCJ9Cgo="
+    },
+    {
+      "b64": "ZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6e30sImZpbmlzaF9yZWFzb24iOm51bGwsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6IlZQV2dKVDgzb0FheE5Fc0dVbVl3OUxheTZIOTY0OXpiU05JbE43dnplenFQYzJ3RUJVMlZneHF4UWJPSU1HVXhicDV0cFlQc3NWQW4zWnBFR004aENNUzRxUXZ1aGloSXhNcVVKMld0UXl3ZlB4Q05YUk05WTQ5SzJKIn1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoKZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6e30sImZpbmlzaF9yZWFzb24iOm51bGwsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6IklZMFBmcGZyZ3RUT2xGUGY2UVdmUDZlVXpvd05CRkJaQ2dRVUI4MGpoNUkyc2dTam50a1RrZ0ZYZlM5aUtmMlJTWVRoR0RHYmZjU1pOM01ueWQwVFVMa2w3Nm4xZ0k2TFp4M0wwbWxiZjBwTFZZQmlwY2RnIn1dLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQifQoKZGF0YTogeyJjaG9pY2VzIjpbeyJkZWx0YSI6eyJjb250ZW50IjoiSGV5IHRoZXJlISJ9LCJmaW5pc2hfcmVhc29uIjpudWxsLCJpbmRleCI6MCwib2JmdXNjYXRpb24iOiI3cU9hWTU2bGM2cmRmRGNWQVNLOWZjUVlhRDd6bzR4a0lvcSJ9XSwiY3JlYXRlZCI6MTc4NzkyMDcwMywiaWQiOiJjaGF0Y21wbC0xNmZkNTQ2MS0xMzhmLTQzNGYtOGNjOS0yYTY2MjIxMjVmZTYiLCJtb2RlbCI6Im9wZW5haS5ncHQtb3NzLTEyMGIiLCJvYmplY3QiOiJjaGF0LmNvbXBsZXRpb24uY2h1bmsiLCJzZXJ2aWNlX3RpZXIiOiJkZWZhdWx0In0KCmRhdGE6IHsiY2hvaWNlcyI6W3siZGVsdGEiOnt9LCJmaW5pc2hfcmVhc29uIjoic3RvcCIsImluZGV4IjowLCJvYmZ1c2NhdGlvbiI6InpBa0lMbERsaGY0V0FuYVpLbmhiV3VGZzBsSzFhSTZFaTRHdVJGZ0J5a2NadTdCcUJTb0hQQU1MOUlNOUR4RWlRUDBmQlFhbU4ifV0sImNyZWF0ZWQiOjE3ODc5MjA3MDMsImlkIjoiY2hhdGNtcGwtMTZmZDU0NjEtMTM4Zi00MzRmLThjYzktMmE2NjIyMTI1ZmU2IiwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uLmNodW5rIiwic2VydmljZV90aWVyIjoiZGVmYXVsdCJ9CgpkYXRhOiB7ImNob2ljZXMiOltdLCJjcmVhdGVkIjoxNzg3OTIwNzAzLCJpZCI6ImNoYXRjbXBsLTE2ZmQ1NDYxLTEzOGYtNDM0Zi04Y2M5LTJhNjYyMjEyNWZlNiIsIm1vZGVsIjoib3BlbmFpLmdwdC1vc3MtMTIwYiIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbi5jaHVuayIsInNlcnZpY2VfdGllciI6ImRlZmF1bHQiLCJ1c2FnZSI6eyJjb21wbGV0aW9uX3Rva2VucyI6NTEsInByb21wdF90b2tlbnMiOjczLCJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOnsiYXVkaW9fdG9rZW5zIjowLCJjYWNoZWRfdG9rZW5zIjozMn0sInRvdGFsX3Rva2VucyI6MTI0fX0KCg=="
+    }
+  ],
+  "model_spec": "amazon_bedrock:openai.gpt-oss-120b",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfdG9rZW5zIjo0MDAsIm1lc3NhZ2VzIjpbeyJjb250ZW50IjoiU2F5IGhpIGluIHR3byB3b3Jkcy4iLCJyb2xlIjoidXNlciJ9XSwibW9kZWwiOiJvcGVuYWkuZ3B0LW9zcy0xMjBiIiwic3RyZWFtIjp0cnVlLCJzdHJlYW1fb3B0aW9ucyI6eyJpbmNsdWRlX3VzYWdlIjp0cnVlfX0="
+    },
+    "canonical_json": {
+      "max_tokens": 400,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ],
+      "model": "openai.gpt-oss-120b",
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "headers": {
+      "accept": "text/event-stream",
+      "authorization": "[REDACTED:authorization]",
+      "content-type": "application/json",
+      "host": "bedrock-mantle.eu-west-1.api.aws",
+      "x-amz-content-sha256": "473fb31a7d94bb244ead2152e9bebd00dcf353ffced67341e8f626261a730f13",
+      "x-amz-date": "20260828T123823Z",
+      "x-amz-security-token": "[REDACTED:x-amz-security-token]"
+    },
+    "method": "POST",
+    "url": "https://bedrock-mantle.eu-west-1.api.aws/v1/chat/completions"
+  },
+  "response": {
+    "body": null,
+    "headers": {
+      "access-control-allow-origin": "*",
+      "access-control-expose-headers": "x-amzn-requestid,x-request-id,date,x-amzn-usage-reservation-quota,x-amzn-usage-reservation-remaining-quota,x-amzn-usage-reservation-spillover",
+      "cache-control": "no-cache",
+      "connection": "keep-alive",
+      "content-type": "text/event-stream",
+      "date": "Fri, 28 Aug 2026 12:38:23 GMT",
+      "transfer-encoding": "chunked",
+      "vary": "origin, access-control-request-method, access-control-request-headers",
+      "x-amzn-requestid": "req_g223xx3onbzoti2bdigcbt2m3c6hj6xalwyug5rdc3fsnfkqjkbq",
+      "x-request-id": "req_g223xx3onbzoti2bdigcbt2m3c6hj6xalwyug5rdc3fsnfkqjkbq"
+    },
+    "status": 200
+  },
+  "streaming": true
+}


### PR DESCRIPTION
Amazon Bedrock has a [second endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/apis.html#:~:text=native%20request%20format.-,bedrock%2Dmantle%20endpoint,-The%20bedrock%2Dmantle), `bedrock-mantle` beside `bedrock-runtime`. Requests can now go there with `provider_options: [endpoint: :mantle]`, optionally attributed to a Project, with the same credentials as `bedrock-runtime`.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #953 
