### PR TITLE
docs(model): list supported capabilities

### DIFF
--- a/guides/model-specs.md
+++ b/guides/model-specs.md
@@ -271,6 +271,47 @@ Optional metadata that can improve validation, usage reporting, and capability c
 
 You do not need to provide all of these just to make a request.
 
+### `capabilities`
+
+Use this map to state the features that the model supports. This metadata is important
+for operations such as embeddings because ReqLLM checks the capability before it sends
+the request. For example, a local Ollama embedding model whose ID does not contain
+`"embedding"` needs an explicit capability:
+
+```elixir
+model =
+  ReqLLM.model!(%{
+    provider: :ollama,
+    id: "nomic-embed-text",
+    capabilities: %{embeddings: true}
+  })
+
+ReqLLM.embed(model, "Hello")
+```
+
+The complete capabilities map supports these fields:
+
+- `chat` - A boolean that states if the model supports chat.
+- `embeddings` - A boolean, or a map with `min_dimensions`, `max_dimensions`, and
+  `default_dimensions`.
+- `rerank` - A boolean that states if the model supports reranking.
+- `reasoning` - A map with `enabled`, `effort`, `thinking`, and `token_budget`.
+  - `effort` supports `supported`, `values`, and `default`.
+  - `thinking` supports `supported`, `types`, `default_type`, `disable_supported`,
+    `raw_output_supported`, `summary_supported`, and `encrypted_supported`.
+  - `token_budget` can be a non-negative integer or a map with `min`, `max`, and
+    `default`.
+- `tools` - A map with `enabled`, `streaming`, `strict`, `parallel`, and
+  `forced_choice`.
+- `json` - A map with `native`, `schema`, and `strict`.
+- `caching` - A map with `type` set to `"implicit"` or `"explicit"`.
+- `streaming` - A map with `text` and `tool_calls`.
+- `batch`, `citations`, `code_execution`, and `context_management` - Maps with
+  `supported` and an optional list of `features`.
+
+The nested support fields are booleans unless the list above gives another type. Only
+set fields that you know. LLMDB adds defaults when it normalizes the model spec.
+
 ### `extra`
 
 Provider-specific metadata that does not belong in the common top-level fields.


### PR DESCRIPTION
## Summary

- list every supported field in the model capabilities map
- document nested capability shapes and normalization defaults
- add an Ollama embedding example for model IDs without `embedding`

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test test/req_llm/embedding_test.exs` (31 tests)
- `mix docs --formatter html`

Closes #981

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790767574&installation_model_id=434874&pr_number=982&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F982&signature=db9111215b8be49c846cd134584c4951afc438d148781510d0b7f25d37e1eb35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->