### PR TITLE
fix(zai): include tool_call_id and name in tool result messages

### DIFF
--- a/lib/req_llm/providers/zai/shared.ex
+++ b/lib/req_llm/providers/zai/shared.ex
@@ -298,7 +298,13 @@ defmodule ReqLLM.Providers.Zai.Shared do
     }
   end
 
-  defp encode_zai_message(%ReqLLM.Message{role: r, content: c, tool_calls: tc}) do
+  defp encode_zai_message(%ReqLLM.Message{
+         role: r,
+         content: c,
+         tool_calls: tc,
+         tool_call_id: tcid,
+         name: name
+       }) do
     {tool_call_parts, other_content} =
       c
       |> normalize_content_parts()
@@ -320,12 +326,20 @@ defmodule ReqLLM.Providers.Zai.Shared do
         calls -> Map.put(base_message, :tool_calls, calls)
       end
 
-    case tc do
-      nil -> base_message
-      [] -> base_message
-      calls -> Map.put(base_message, :tool_calls, calls)
-    end
+    base_message =
+      case tc do
+        nil -> base_message
+        [] -> base_message
+        calls -> Map.put(base_message, :tool_calls, calls)
+      end
+
+    base_message
+    |> maybe_add_field(:tool_call_id, tcid)
+    |> maybe_add_field(:name, name)
   end
+
+  defp maybe_add_field(message, _key, nil), do: message
+  defp maybe_add_field(message, key, value), do: Map.put(message, key, value)
 
   defp normalize_content_parts(content) when is_list(content), do: content
 

--- a/test/providers/zai_test.exs
+++ b/test/providers/zai_test.exs
@@ -73,5 +73,31 @@ defmodule ReqLLM.Providers.ZaiTest do
       assert assistant_msg["content"] == "hello"
       assert user_msg["content"] == "repeat"
     end
+
+    test "includes tool_call_id and name on tool result messages" do
+      {:ok, model} = ReqLLM.model("zai:glm-4.5")
+
+      context =
+        Context.new([
+          Context.user("What's the weather?"),
+          Context.assistant("",
+            tool_calls: [{"get_weather", %{"city" => "Shanghai"}, id: "call_123"}]
+          ),
+          Context.tool_result("call_123", "get_weather", "{\"temp\": 20}")
+        ])
+
+      request = %Req.Request{options: [context: context, model: model.model, stream: false]}
+
+      encoded_request = Zai.encode_body(request)
+      decoded = ReqLLM.Test.Helpers.json_body(encoded_request)
+
+      [_user_msg, assistant_msg, tool_result_msg] = decoded["messages"]
+
+      assert assistant_msg["role"] == "assistant"
+      assert tool_result_msg["role"] == "tool"
+      assert tool_result_msg["tool_call_id"] == "call_123"
+      assert tool_result_msg["name"] == "get_weather"
+      assert tool_result_msg["content"] == "{\"temp\": 20}"
+    end
   end
 end


### PR DESCRIPTION
## Description

Without this fix, all GLM 5.3 and GLM 5.3 Flash requests are silently corrupted. Z.AI's server accepts the requests, but the model always receives empty tool-call outputs. This patch ensures that tool call names and IDs are correctly passed through to the provider.

This has been tested end-to-end with EvoX Genesis. Without the fix, GLM 5.3 consistently reports in its thinking content that the tool call output is empty. With the fix applied, tool calls work correctly and the agent behaves normally.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790845164&installation_model_id=434874&pr_number=985&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F985&signature=cf7a249c0d80a6fad1574795a7c3c09134a4e6863693a5b9e26ee1ba2684c2e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->