### PR TITLE
fix(embedding): forward dimensions to compatible providers

### DIFF
--- a/lib/req_llm/embedding.ex
+++ b/lib/req_llm/embedding.ex
@@ -227,7 +227,8 @@ defmodule ReqLLM.Embedding do
            provider_module.prepare_request(:embedding, model, text, provider_opts),
          {:ok, %Req.Response{status: status} = response} when status in 200..299 <-
            ReqLLM.TimeoutBudget.request(request, deadline),
-         {:ok, embedding} <- extract_single_embedding(response.body) do
+         {:ok, embedding} <- extract_single_embedding(response.body),
+         :ok <- validate_single_embedding_dimensions(embedding, requested_dimensions(request)) do
       if return_usage do
         {:ok, %{embedding: embedding, usage: extract_usage(response)}}
       else
@@ -266,7 +267,9 @@ defmodule ReqLLM.Embedding do
            provider_module.prepare_request(:embedding, model, texts, provider_opts),
          {:ok, %Req.Response{status: status} = response} when status in 200..299 <-
            ReqLLM.TimeoutBudget.request(request, deadline),
-         {:ok, embeddings} <- extract_multiple_embeddings(response.body) do
+         {:ok, embeddings} <- extract_multiple_embeddings(response.body),
+         :ok <-
+           validate_multiple_embedding_dimensions(embeddings, requested_dimensions(request)) do
       if return_usage do
         {:ok, %{embedding: embeddings, usage: extract_usage(response)}}
       else
@@ -328,6 +331,42 @@ defmodule ReqLLM.Embedding do
      ReqLLM.Error.API.Response.exception(
        reason: "Invalid embedding response format",
        response_body: response
+     )}
+  end
+
+  defp requested_dimensions(%Req.Request{} = request) do
+    provider_opts = request.options[:provider_options] || []
+    provider_opts[:dimensions] || request.options[:dimensions]
+  end
+
+  defp validate_single_embedding_dimensions(_embedding, nil), do: :ok
+
+  defp validate_single_embedding_dimensions(embedding, expected) when is_list(embedding) do
+    validate_embedding_dimensions(length(embedding), expected)
+  end
+
+  defp validate_single_embedding_dimensions(_embedding, _expected), do: :ok
+
+  defp validate_multiple_embedding_dimensions(_embeddings, nil), do: :ok
+
+  defp validate_multiple_embedding_dimensions(embeddings, expected) do
+    embeddings
+    |> Enum.find_value(fn embedding ->
+      if is_list(embedding) and length(embedding) != expected, do: length(embedding)
+    end)
+    |> case do
+      nil -> :ok
+      actual -> validate_embedding_dimensions(actual, expected)
+    end
+  end
+
+  defp validate_embedding_dimensions(expected, expected), do: :ok
+
+  defp validate_embedding_dimensions(actual, expected) do
+    {:error,
+     ReqLLM.Error.API.Response.exception(
+       reason: "Embedding dimension mismatch: expected #{expected}, got #{actual}",
+       response_body: %{actual_dimensions: actual, expected_dimensions: expected}
      )}
   end
 

--- a/lib/req_llm/provider/defaults.ex
+++ b/lib/req_llm/provider/defaults.ex
@@ -1798,7 +1798,7 @@ defmodule ReqLLM.Provider.Defaults do
       input: input
     }
     |> maybe_put(:user, request.options[:user])
-    |> maybe_put(:dimensions, provider_opts[:dimensions])
+    |> maybe_put(:dimensions, provider_opts[:dimensions] || request.options[:dimensions])
     |> maybe_put(:encoding_format, provider_opts[:encoding_format])
   end
 

--- a/test/providers/vllm_test.exs
+++ b/test/providers/vllm_test.exs
@@ -77,6 +77,15 @@ defmodule ReqLLM.Providers.VLLMTest do
       assert request.method == :post
     end
 
+    test "prepare_request includes embedding dimensions in the body" do
+      model = vllm_model("embedding-model", capabilities: %{embeddings: true})
+
+      {:ok, request} =
+        VLLM.prepare_request(:embedding, model, "Follow the white rabbit.", dimensions: 32)
+
+      assert VLLM.build_body(request).dimensions == 32
+    end
+
     test "prepare_request rejects unsupported operations" do
       model = vllm_model()
       context = context_fixture()

--- a/test/req_llm/embedding_test.exs
+++ b/test/req_llm/embedding_test.exs
@@ -19,6 +19,20 @@ defmodule ReqLLM.EmbeddingTest do
   defmodule SlowHTTP do
   end
 
+  defmodule SingleDimensionMismatchHTTP do
+  end
+
+  defmodule BatchDimensionMismatchHTTP do
+  end
+
+  defp vllm_embedding_model do
+    LLMDB.Model.new!(%{
+      provider: :vllm,
+      id: "embedding-model",
+      capabilities: %{embeddings: true}
+    })
+  end
+
   defp setup_telemetry do
     test_pid = self()
     ref = System.unique_integer([:positive])
@@ -166,6 +180,51 @@ defmodule ReqLLM.EmbeddingTest do
                  api_key: "test-key",
                  total_timeout: 50,
                  req_http_options: [plug: {Req.Test, SlowHTTP}]
+               )
+    end
+
+    test "rejects a single embedding with unexpected dimensions" do
+      Req.Test.stub(SingleDimensionMismatchHTTP, fn conn ->
+        assert conn.body_params["dimensions"] == 2
+
+        Req.Test.json(conn, %{
+          "data" => [%{"embedding" => [0.1, 0.2, 0.3], "index" => 0}]
+        })
+      end)
+
+      assert {:error,
+              %ReqLLM.Error.API.Response{
+                reason: "Embedding dimension mismatch: expected 2, got 3",
+                response_body: %{actual_dimensions: 3, expected_dimensions: 2}
+              }} =
+               Embedding.embed(vllm_embedding_model(), "Hello",
+                 dimensions: 2,
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, SingleDimensionMismatchHTTP}]
+               )
+    end
+
+    test "rejects a batch embedding with inconsistent dimensions" do
+      Req.Test.stub(BatchDimensionMismatchHTTP, fn conn ->
+        assert conn.body_params["dimensions"] == 2
+
+        Req.Test.json(conn, %{
+          "data" => [
+            %{"embedding" => [0.1, 0.2], "index" => 0},
+            %{"embedding" => [0.3, 0.4, 0.5], "index" => 1}
+          ]
+        })
+      end)
+
+      assert {:error,
+              %ReqLLM.Error.API.Response{
+                reason: "Embedding dimension mismatch: expected 2, got 3",
+                response_body: %{actual_dimensions: 3, expected_dimensions: 2}
+              }} =
+               Embedding.embed(vllm_embedding_model(), ["Hello", "World"],
+                 dimensions: 2,
+                 api_key: "test-key",
+                 req_http_options: [plug: {Req.Test, BatchDimensionMismatchHTTP}]
                )
     end
   end
@@ -321,7 +380,7 @@ defmodule ReqLLM.EmbeddingTest do
         Req.Test.json(conn, %{
           "data" => [
             %{
-              "embedding" => [0.1, -0.2, 0.3],
+              "embedding" => List.duplicate(0.1, 16),
               "index" => 0,
               "object" => "embedding"
             }
@@ -360,7 +419,7 @@ defmodule ReqLLM.EmbeddingTest do
           req_http_options: [plug: {Req.Test, __MODULE__.OpenRouterEmbedUsage}]
         )
 
-      assert embedding == [0.1, -0.2, 0.3]
+      assert length(embedding) == 16
       assert usage.input == 1
       assert usage.total_tokens == 1
     end

--- a/test/req_llm/provider/defaults_test.exs
+++ b/test/req_llm/provider/defaults_test.exs
@@ -68,6 +68,39 @@ defmodule ReqLLM.Provider.DefaultsTest do
     end
   end
 
+  describe "default_build_body/1 embeddings" do
+    test "includes dimensions from canonical embedding options" do
+      request = %Req.Request{
+        options: %{
+          operation: :embedding,
+          model: "embedding-model",
+          text: "Follow the white rabbit.",
+          dimensions: 32
+        }
+      }
+
+      assert Defaults.default_build_body(request) == %{
+               model: "embedding-model",
+               input: "Follow the white rabbit.",
+               dimensions: 32
+             }
+    end
+
+    test "keeps provider-specific dimensions precedence" do
+      request = %Req.Request{
+        options: %{
+          operation: :embedding,
+          model: "embedding-model",
+          text: "Follow the white rabbit.",
+          dimensions: 32,
+          provider_options: [dimensions: 64]
+        }
+      }
+
+      assert Defaults.default_build_body(request).dimensions == 64
+    end
+  end
+
   describe "encode_context_to_openai_format/2" do
     test "encodes text content correctly" do
       test_cases = [

--- a/test/req_llm/providers/ollama_test.exs
+++ b/test/req_llm/providers/ollama_test.exs
@@ -135,6 +135,20 @@ defmodule ReqLLM.Providers.OllamaTest do
   end
 
   describe "prepare_request/4" do
+    test "embedding requests include dimensions in the body" do
+      model = %{
+        ollama_model()
+        | id: "qwen3-embedding:0.6b",
+          model: "qwen3-embedding:0.6b",
+          capabilities: %{embeddings: true}
+      }
+
+      {:ok, request} =
+        Ollama.prepare_request(:embedding, model, "Follow the white rabbit.", dimensions: 32)
+
+      assert Ollama.build_body(request).dimensions == 32
+    end
+
     test "object requests use Ollama json_schema response format" do
       {:ok, compiled_schema} =
         ReqLLM.Schema.compile(answer: [type: :string, required: true])

--- a/test/req_llm/tuple_model_options_test.exs
+++ b/test/req_llm/tuple_model_options_test.exs
@@ -268,7 +268,7 @@ defmodule ReqLLM.TupleModelOptionsTest do
   end
 
   test "embedding tuple defaults change only the corresponding request key" do
-    stub_json(EmbeddingHTTP, embedding_response())
+    stub_embedding_json(EmbeddingHTTP)
     opts = openai_opts(EmbeddingHTTP)
 
     assert {:ok, _embedding} =
@@ -421,7 +421,7 @@ defmodule ReqLLM.TupleModelOptionsTest do
   end
 
   test "unsupported tuple defaults do not alter an applicable operation request" do
-    stub_json(EmbeddingHTTP, embedding_response())
+    stub_embedding_json(EmbeddingHTTP)
     opts = openai_opts(EmbeddingHTTP)
 
     assert {:ok, _embedding} =
@@ -453,6 +453,16 @@ defmodule ReqLLM.TupleModelOptionsTest do
     Req.Test.stub(owner, fn conn ->
       send(test_pid, {:request_body, owner, conn.body_params})
       Req.Test.json(conn, response)
+    end)
+  end
+
+  defp stub_embedding_json(owner) do
+    test_pid = self()
+
+    Req.Test.stub(owner, fn conn ->
+      dimensions = conn.body_params["dimensions"] || 2
+      send(test_pid, {:request_body, owner, conn.body_params})
+      Req.Test.json(conn, embedding_response(dimensions))
     end)
   end
 
@@ -520,9 +530,15 @@ defmodule ReqLLM.TupleModelOptionsTest do
     }
   end
 
-  defp embedding_response do
+  defp embedding_response(dimensions) do
     %{
-      "data" => [%{"embedding" => [0.1, 0.2], "index" => 0, "object" => "embedding"}],
+      "data" => [
+        %{
+          "embedding" => List.duplicate(0.1, dimensions),
+          "index" => 0,
+          "object" => "embedding"
+        }
+      ],
       "model" => "text-embedding-3-small",
       "object" => "list",
       "usage" => %{"prompt_tokens" => 1, "total_tokens" => 1}


### PR DESCRIPTION
## Summary

- forward the canonical top-level `dimensions` option through the shared OpenAI-compatible embedding encoder used by Ollama and vLLM
- keep an explicit provider-specific `dimensions` value as the higher-precedence setting
- validate decoded list embeddings against the requested width for both single and batch requests
- return a clear `ReqLLM.Error.API.Response` if a compatible server ignores the requested dimensions
- add shared encoder, provider, end-to-end mismatch, and tuple-option regression coverage

## Verification

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- focused hardened suite: 159 passed
- full suite: 4,274 passed, 11 skipped, 158 excluded
- `mix credo --strict`: no issues
- `mix dialyzer`: no errors
- live Ollama 0.33.2 with `qwen3-embedding:0.6b`:
  - default request returned 1,024 dimensions
  - `dimensions: 32` returned 32 dimensions
  - `dimensions: 256` returned 256 dimensions
  - a two-input batch with `dimensions: 64` returned two 64-dimension vectors
  - the vLLM provider path against Ollama returned 32 dimensions
  - `dimensions: 0` was rejected

The vLLM provider-path check used Ollama as an OpenAI-compatible endpoint. It did not use a live vLLM server.

Closes #984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790852739&installation_model_id=434874&pr_number=986&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F986&signature=7334bd473d559806d71b3ad3417917b6307d78e558643b4b0ed974efe646d2cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->