### PR TITLE
fix(azure): accept include in provider_options for Responses API models

### DIFF
--- a/lib/req_llm/providers/azure.ex
+++ b/lib/req_llm/providers/azure.ex
@@ -286,6 +286,11 @@ defmodule ReqLLM.Providers.Azure do
       type: :any,
       doc: "Maximum output tokens (OpenAI Responses API models)"
     ],
+    include: [
+      type: {:list, :string},
+      doc:
+        "Responses API include values, such as reasoning.encrypted_content for reasoning signatures or web_search_call.action.sources for the sources a web search consulted (OpenAI Responses API models only)"
+    ],
     verbosity: [
       type: {:or, [:atom, :string]},
       doc:

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -912,9 +912,6 @@ defmodule ReqLLM.Providers.AzureTest do
              ]
     end
 
-    # The streaming path validates provider_options strictly against the
-    # provider schema before the body is built, so an include the encoder
-    # honours but the schema does not list fails the whole request.
     test "attach_stream accepts include for Responses API models" do
       model = %LLMDB.Model{
         id: "gpt-5",

--- a/test/provider/azure/azure_test.exs
+++ b/test/provider/azure/azure_test.exs
@@ -531,6 +531,12 @@ defmodule ReqLLM.Providers.AzureTest do
 
       assert deployment_spec[:type] == :string
     end
+
+    test "include option accepts a list of Responses API include values" do
+      schema = Azure.provider_schema()
+
+      assert schema.schema[:include][:type] == {:list, :string}
+    end
   end
 
   describe "translate_options/3" do
@@ -886,6 +892,54 @@ defmodule ReqLLM.Providers.AzureTest do
       body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
 
       refute Map.has_key?(body, "parallel_tool_calls")
+    end
+
+    test "Responses API models forward include from provider_options" do
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      opts = [
+        stream: false,
+        provider_options: [
+          include: ["reasoning.encrypted_content", "web_search_call.action.sources"]
+        ]
+      ]
+
+      body = Azure.ResponsesAPI.format_request("gpt-5-codex", context, opts)
+
+      assert body["include"] == [
+               "reasoning.encrypted_content",
+               "web_search_call.action.sources"
+             ]
+    end
+
+    # The streaming path validates provider_options strictly against the
+    # provider schema before the body is built, so an include the encoder
+    # honours but the schema does not list fails the whole request.
+    test "attach_stream accepts include for Responses API models" do
+      model = %LLMDB.Model{
+        id: "gpt-5",
+        provider: :azure,
+        capabilities: %{chat: true},
+        extra: %{wire: %{protocol: "openai_responses"}}
+      }
+
+      context = ReqLLM.Context.new([ReqLLM.Context.user("Hello")])
+
+      {:ok, finch_request} =
+        Azure.attach_stream(
+          model,
+          context,
+          [
+            api_key: "test-api-key",
+            deployment: "gpt-5",
+            base_url: "https://my-resource.openai.azure.com/openai/v1",
+            provider_options: [include: ["web_search_call.action.sources"]]
+          ],
+          :req_llm_finch
+        )
+
+      assert %Finch.Request{} = finch_request
+      assert Jason.decode!(finch_request.body)["include"] == ["web_search_call.action.sources"]
     end
 
     test "Claude reasoning models override temperature to 1.0" do


### PR DESCRIPTION
## Description

`ReqLLM.Providers.Azure.ResponsesAPI` delegates body building to `ReqLLM.Providers.OpenAI.ResponsesAPI`, which already honours `provider_options[:include]` (e.g. `reasoning.encrypted_content`, `web_search_call.action.sources`). The Azure provider schema never listed `include`, and `Options.process_stream!/5` validates `provider_options` strictly against that schema before the body is built, so any Azure streaming request that set `include` failed at build time:

```
Failed to build Azure stream request: unknown options [:include], valid options are: [...]
```

This adds the same `include: [type: {:list, :string}]` entry the OpenAI provider already has, so the option reaches the encoder. Without it there is no way to ask Azure-hosted Responses API deployments for `web_search_call.action.sources` (the URLs a builtin web search consulted), since `additional_model_request_fields` is only consulted for Anthropic thinking on Azure.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None.

## Testing

- [x] Tests pass (`AZURE_API_KEY=test mix test test/provider/azure/azure_test.exs`, 122 tests)
- [x] Quality checks pass (`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`; dialyzer not run locally)

Three tests added in `test/provider/azure/azure_test.exs`:
- the schema exposes `include` as a list of strings
- `Azure.ResponsesAPI.format_request/3` forwards `include` into the body
- `Azure.attach_stream/4` accepts `include` for a Responses API model and the Finch body carries it (this one fails on `main` with the error above)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly (option doc string)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

None filed; discovered while wiring web-search source reporting on Azure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J64Gz8aNb6uv6PEfpwgyNr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791196578&installation_model_id=434874&pr_number=990&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F990&signature=749ca4ccc8319fefdf9a16a92aecff90acbe99b6a5ba1be99d534b6cb94edbde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->