### PR TITLE
feat(openai): keep a builtin tool call's status and mark failed calls as error spans

### DIFF
--- a/lib/req_llm/provider/defaults/response_builder.ex
+++ b/lib/req_llm/provider/defaults/response_builder.ex
@@ -187,8 +187,14 @@ defmodule ReqLLM.Provider.Defaults.ResponseBuilder do
     |> put_tool_call_metadata(other, profile)
   end
 
+  # Buffered responses keep only the markers the caller acts on: the
+  # async flag, and the provider status of a builtin call (so a failed
+  # `web_search_call` reaches the OTel tool span as an error).
   defp put_tool_call_metadata(%ToolCall{} = call, source, :buffered) do
-    ToolCall.put_metadata(call, Map.take(ToolCall.metadata(source), [:async, "async"]))
+    ToolCall.put_metadata(
+      call,
+      Map.take(ToolCall.metadata(source), [:async, "async", :status, "status"])
+    )
   end
 
   defp put_tool_call_metadata(%ToolCall{} = call, source, _profile) do

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -1430,6 +1430,7 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
 
   defp handle_builtin_call_item_done(item, data, state, type) do
     index = stream_output_index(data)
+    status = builtin_status_metadata(item)
 
     if tool_call_emitted?(state, index) do
       args =
@@ -1441,7 +1442,12 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
         ReqLLM.StreamChunk.meta(%{
           tool_call_args: %{index: index, fragment: args, builtin?: true}
         })
-      ]
+      ] ++
+        if map_size(status) > 0 do
+          [ReqLLM.StreamChunk.meta(%{tool_call_metadata: %{index: index, metadata: status}})]
+        else
+          []
+        end
     else
       id = item["id"] || item[:id] || item["call_id"] || item[:call_id]
 
@@ -1453,12 +1459,12 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
         ReqLLM.StreamChunk.tool_call(
           type,
           args_map,
-          %{
+          Map.merge(status, %{
             id: id,
             index: index,
             builtin?: true,
             done_at_unix_nano: System.system_time(:nanosecond)
-          }
+          })
         )
       ]
     end
@@ -2320,6 +2326,18 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> Jason.encode!()
 
     ReqLLM.ToolCall.new_builtin(id, type, args_json)
+    |> ReqLLM.ToolCall.put_metadata(builtin_status_metadata(seg))
+  end
+
+  # The provider's terminal status for a builtin call (`completed`,
+  # `failed`, `incomplete`). It stays off the wire arguments — the item is
+  # not replayable anyway — and rides on the tool call's metadata so the
+  # OTel bridge can tell a failed web search from one that found nothing.
+  defp builtin_status_metadata(item) do
+    case item["status"] || item[:status] do
+      status when is_binary(status) -> %{status: status}
+      _ -> %{}
+    end
   end
 
   defp extract_reasoning_details_from_segments(segments, provider) do

--- a/lib/req_llm/telemetry/open_telemetry.ex
+++ b/lib/req_llm/telemetry/open_telemetry.ex
@@ -181,7 +181,13 @@ defmodule ReqLLM.Telemetry.OpenTelemetry do
   end
 
   defp build_tool_span_stub(%ToolCall{} = tc, metadata) do
-    build_tool_span_stub(ToolCall.name(tc), ToolCall.args_map(tc), tc.id, metadata)
+    build_tool_span_stub(
+      ToolCall.name(tc),
+      ToolCall.args_map(tc),
+      tc.id,
+      ToolCall.metadata(tc),
+      metadata
+    )
   end
 
   defp build_tool_span_stub(tool_call, metadata) when is_map(tool_call) do
@@ -189,19 +195,21 @@ defmodule ReqLLM.Telemetry.OpenTelemetry do
     name = MapAccess.get(function, :name) || MapAccess.get(tool_call, :name)
     args = args_from_map_tool_call(tool_call, function)
     id = MapAccess.get(tool_call, :id)
+    call_metadata = ToolCall.metadata(tool_call)
 
-    build_tool_span_stub(name, args, id, metadata)
+    build_tool_span_stub(name, args, id, call_metadata, metadata)
   end
 
-  defp build_tool_span_stub(name, args, id, metadata) when is_binary(name) do
+  defp build_tool_span_stub(name, args, id, call_metadata, metadata) when is_binary(name) do
     timing = MapAccess.get(metadata, :builtin_tool_timing) || %{}
     entry = timing_entry(timing, id)
     {start_time, end_time} = span_timing(entry)
+    {status, status_attrs} = tool_call_status(MapAccess.get(call_metadata, :status))
 
     %{
       name: "execute_tool " <> name,
       kind: :internal,
-      status: :ok,
+      status: status,
       start_time: start_time,
       end_time: end_time,
       attributes:
@@ -212,10 +220,23 @@ defmodule ReqLLM.Telemetry.OpenTelemetry do
           "gen_ai.tool.call.id" => id
         }
         |> maybe_put_arguments(args)
+        |> Map.merge(status_attrs)
     }
   end
 
-  defp build_tool_span_stub(_name, _args, _id, _metadata), do: nil
+  defp build_tool_span_stub(_name, _args, _id, _call_metadata, _metadata), do: nil
+
+  # A builtin call the provider reports as `failed` or `incomplete` (the
+  # status providers attach to the output item, kept in the tool call's
+  # metadata) becomes an error span carrying `error.type`, so a failed
+  # search is told apart from one that found nothing. Any other status —
+  # `completed`, or none — leaves the span `:ok`.
+  @failed_tool_call_statuses ["failed", "incomplete"]
+
+  defp tool_call_status(status) when status in @failed_tool_call_statuses,
+    do: {{:error, "builtin tool call " <> status}, %{"error.type" => status}}
+
+  defp tool_call_status(_status), do: {:ok, %{}}
 
   defp timing_entry(timing, nil), do: timing_entry(timing, "")
   defp timing_entry(timing, id), do: Map.get(timing, id) || Map.get(timing, to_string(id)) || %{}

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1299,7 +1299,31 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
                "action" => %{"type" => "search", "query" => "elixir"}
              }
 
+      assert ReqLLM.ToolCall.metadata(tool_call) == %{status: "completed"}
       assert ReqLLM.Response.classify(resp.body).type == :final_answer
+    end
+
+    test "keeps a failed builtin call's status in its metadata, off the arguments" do
+      response_body = %{
+        "id" => "resp_123",
+        "model" => "gpt-5",
+        "status" => "completed",
+        "output" => [
+          %{
+            "type" => "web_search_call",
+            "id" => "ws_1",
+            "status" => "failed",
+            "action" => %{"type" => "search", "query" => "elixir"}
+          }
+        ],
+        "usage" => %{"input_tokens" => 5, "output_tokens" => 10}
+      }
+
+      {_req, resp} = ResponsesAPI.decode_response(build_response(200, response_body))
+
+      assert [tool_call] = resp.body.message.tool_calls
+      assert ReqLLM.ToolCall.metadata(tool_call) == %{status: "failed"}
+      refute Map.has_key?(Jason.decode!(tool_call.function.arguments), "status")
     end
 
     test "handles malformed tool call arguments" do
@@ -1909,7 +1933,29 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
       assert chunk.arguments == %{"action" => %{"query" => "elixir telemetry"}}
       assert chunk.metadata.id == "ws_1"
       assert chunk.metadata.builtin? == true
+      assert chunk.metadata.status == "completed"
       assert is_integer(chunk.metadata.done_at_unix_nano)
+    end
+
+    test "carries a failed builtin item's status on the tool call chunk", %{model: model} do
+      event = %{
+        data: %{
+          "event" => "response.output_item.done",
+          "output_index" => 0,
+          "item" => %{
+            "id" => "ws_1",
+            "type" => "web_search_call",
+            "action" => %{"query" => "elixir telemetry"},
+            "status" => "failed"
+          }
+        }
+      }
+
+      assert [%ReqLLM.StreamChunk{type: :tool_call} = chunk] =
+               ResponsesAPI.decode_stream_event(event, model)
+
+      assert chunk.metadata.status == "failed"
+      refute Map.has_key?(chunk.arguments, "status")
     end
 
     test "decodes atom-keyed builtin output item events", %{model: model} do

--- a/test/req_llm/open_telemetry/translator_test.exs
+++ b/test/req_llm/open_telemetry/translator_test.exs
@@ -272,6 +272,33 @@ defmodule ReqLLM.OpenTelemetry.TranslatorTest do
       assert_receive {:end_span, :parent_span}
     end
 
+    test "sets the error status on a failed child span" do
+      stub = %{
+        attributes: %{},
+        status: :ok,
+        events: [],
+        metrics: [],
+        tool_spans: [
+          %{
+            name: "execute_tool web_search_call",
+            kind: :internal,
+            status: {:error, "builtin tool call failed"},
+            start_time: nil,
+            end_time: nil,
+            attributes: %{"error.type" => "failed"}
+          }
+        ]
+      }
+
+      Translator.apply_terminal(:parent_span, stub, ChildSpanAdapter, test_pid: self())
+
+      assert_receive {:start_child_span, :parent_span, "execute_tool web_search_call", attrs, _}
+      assert attrs[:"error.type"] == "failed"
+      assert_receive {:set_status, :child_span_handle, :error, "builtin tool call failed"}
+      assert_receive {:end_span, :child_span_handle}
+      assert_receive {:end_span, :parent_span}
+    end
+
     test "skips metric recording when metrics_enabled? is false" do
       stub = %{
         attributes: %{},

--- a/test/req_llm/provider/openai_responses_materialization_test.exs
+++ b/test/req_llm/provider/openai_responses_materialization_test.exs
@@ -266,7 +266,11 @@ defmodule ReqLLM.Provider.OpenAIResponsesMaterializationTest do
     assert ToolCall.args_json(scalar) == ~s("draft")
     assert ToolCall.args_json(empty) == "{}"
     assert ToolCall.args_map(builtin) == %{"action" => %{"query" => "docs", "type" => "search"}}
-    assert Enum.all?(response.message.tool_calls, &(ToolCall.metadata(&1) == %{}))
+    # Function calls carry no metadata; the builtin call keeps only the
+    # provider status the OTel tool span reads.
+    assert Enum.map(response.message.tool_calls, &ToolCall.metadata/1) ==
+             [%{}, %{}, %{}, %{status: "completed"}]
+
     assert ToolCall.builtin?(builtin)
     assert response.context == Context.new(context.messages ++ [response.message])
 

--- a/test/req_llm/telemetry_open_telemetry_test.exs
+++ b/test/req_llm/telemetry_open_telemetry_test.exs
@@ -162,6 +162,64 @@ defmodule ReqLLM.TelemetryOpenTelemetryTest do
     assert Jason.decode!(attrs["gen_ai.tool.call.arguments"]) == %{"query" => "elixir telemetry"}
   end
 
+  test "marks a builtin tool call the provider reports as failed as an error span" do
+    failed =
+      ToolCall.new_builtin("ws_failed", "web_search_call", ~s({"action":{"query":"x"}}))
+      |> ToolCall.put_metadata(%{status: "failed"})
+
+    completed =
+      ToolCall.new_builtin("ws_ok", "web_search_call", ~s({"action":{"query":"y"}}))
+      |> ToolCall.put_metadata(%{status: "completed"})
+
+    stop_stub =
+      OpenTelemetry.request_stop(%{
+        operation: :chat,
+        provider: :openai,
+        model: %LLMDB.Model{provider: :openai, id: "gpt-5"},
+        finish_reason: :stop,
+        response_payload: %{message: %{tool_calls: [failed, completed]}}
+      })
+
+    assert [
+             %{status: {:error, "builtin tool call failed"}, attributes: failed_attrs},
+             %{status: :ok, attributes: ok_attrs}
+           ] = stop_stub.tool_spans
+
+    assert failed_attrs["gen_ai.tool.call.id"] == "ws_failed"
+    assert failed_attrs["error.type"] == "failed"
+    refute Map.has_key?(ok_attrs, "error.type")
+  end
+
+  test "reads the builtin status off map-shaped tool call metadata" do
+    stop_stub =
+      OpenTelemetry.request_stop(%{
+        operation: :chat,
+        provider: :openai,
+        model: %LLMDB.Model{provider: :openai, id: "gpt-5"},
+        finish_reason: :stop,
+        response_payload: %{
+          "message" => %{
+            "tool_calls" => [
+              %{
+                "id" => "ci_1",
+                "function" => %{
+                  "name" => "code_interpreter_call",
+                  "arguments" => ~s({"code":"1/0"}),
+                  "builtin?" => true,
+                  "metadata" => %{"status" => "incomplete"}
+                }
+              }
+            ]
+          }
+        }
+      })
+
+    assert [%{status: {:error, "builtin tool call incomplete"}, attributes: attrs}] =
+             stop_stub.tool_spans
+
+    assert attrs["error.type"] == "incomplete"
+  end
+
   test "builds child span stubs from map-shaped builtin tool calls" do
     metadata = %{
       operation: :chat,


### PR DESCRIPTION
## Description

The Responses API reports each builtin output item (`web_search_call`, `file_search_call`, `code_interpreter_call`) with a `status` of `completed`, `failed` or `incomplete`. Both decode paths (streaming and buffered) dropped it together with the item's `id` and `type`, so downstream a failed web search and one that simply found nothing were indistinguishable: the OTel `execute_tool <name>` child span was always `:ok` with no result.

This keeps the status on the tool call's metadata (off the arguments, which the item does not replay anyway) on both paths, and `ReqLLM.Telemetry.OpenTelemetry.tool_spans/2` turns `failed` / `incomplete` into an error span stub carrying `error.type`, which the translator applies to the child span as usual. Completed calls are unchanged apart from the new `%{status: "completed"}` metadata entry.

Motivation: Langfuse tool observations for server-side web searches. With the sources include (#990) a search's output can list what it consulted; without the status, a failed search rendered exactly like an empty one.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. One existing buffered-compat assertion was updated because the builtin call now carries `%{status: "completed"}` in its metadata.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Unit tests cover the status on the streaming and buffered decode paths, the error stub for `failed` / `incomplete` in `tool_spans/2`, and the translator applying `error.type` to the child span. No fixtures were touched (no request shape changes), so `mix mc` is unaffected.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Follows #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApXjUiZoZnxUotX3q7T1pj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791214938&installation_model_id=434874&pr_number=991&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F991&signature=2307bd0e97e2e5a8956caa373c2a078d0822e4a0f6ace0d23ec60abf705b1981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->