### PR TITLE
feat(bedrock): support guardrails

### DIFF
--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -173,6 +173,24 @@ Passed via `:provider_options` keyword:
 - **Example**: `provider_options: [additional_model_request_fields: %{thinking: %{type: "enabled", budget_tokens: 4096}}]`
 - **Use Case**: Claude extended thinking configuration
 
+### `guardrail_identifier`
+
+- **Type**: String
+- **Purpose**: [Amazon Bedrock Guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) ID or ARN applied to the request (bedrock-runtime only)
+- **Example**: `provider_options: [guardrail_identifier: "abc123def456", guardrail_version: "1"]`
+
+### `guardrail_version`
+
+- **Type**: String
+- **Purpose**: Guardrail version, `"DRAFT"` or a published number. Required with `guardrail_identifier`
+- **Example**: `provider_options: [guardrail_identifier: "abc123def456", guardrail_version: "DRAFT"]`
+
+### `guardrail_trace`
+
+- **Type**: `"enabled"` | `"disabled"` | `"enabled_full"`
+- **Purpose**: How much guardrail assessment detail Bedrock returns
+- **Example**: `provider_options: [guardrail_identifier: "abc123def456", guardrail_version: "1", guardrail_trace: "enabled"]`
+
 ### Claude-Specific Options
 
 #### `anthropic_prompt_cache`

--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -176,6 +176,19 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       doc:
         "Additional model-specific request fields (e.g., thinking config for Claude extended thinking)"
     ],
+    guardrail_identifier: [
+      type: :string,
+      doc: "Bedrock Guardrail id or ARN applied to the request (bedrock-runtime only)"
+    ],
+    guardrail_version: [
+      type: :string,
+      doc:
+        "Guardrail version (\"DRAFT\" or a published number). Required with guardrail_identifier"
+    ],
+    guardrail_trace: [
+      type: {:in, ["enabled", "disabled", "enabled_full"]},
+      doc: "Guardrail trace detail returned in the response"
+    ],
     anthropic_prompt_cache: [
       type: :boolean,
       doc: "Enable Anthropic prompt caching for Claude models on Bedrock"
@@ -656,7 +669,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         get_formatter_module(model_family)
       end
 
-    decode_formatter_stream_event(formatter, event)
+    decode_formatter_stream_event(formatter, event) ++ guardrail_stream_chunks(event)
   end
 
   def decode_stream_event(_data, _model) do
@@ -690,22 +703,38 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   def decode_stream_event(event, model, state) when is_map(event) do
     model_id = model.provider_model_id || model.id
 
-    cond do
-      converse_event?(event) ->
-        {decode_formatter_stream_event(ReqLLM.Providers.AmazonBedrock.Converse, event), state}
+    {chunks, state} =
+      cond do
+        converse_event?(event) ->
+          {decode_formatter_stream_event(ReqLLM.Providers.AmazonBedrock.Converse, event), state}
 
-      get_model_family(model_id) == "anthropic" ->
-        ReqLLM.Providers.Anthropic.Response.decode_stream_event(%{data: event}, model, state)
+        get_model_family(model_id) == "anthropic" ->
+          ReqLLM.Providers.Anthropic.Response.decode_stream_event(%{data: event}, model, state)
 
-      true ->
-        formatter = get_formatter_module(get_model_family(model_id))
-        {decode_formatter_stream_event(formatter, event), state}
-    end
+        true ->
+          formatter = get_formatter_module(get_model_family(model_id))
+          {decode_formatter_stream_event(formatter, event), state}
+      end
+
+    {chunks ++ guardrail_stream_chunks(event), state}
   end
 
   def decode_stream_event(_event, _model, state) do
     {[], state}
   end
+
+  defp guardrail_stream_chunks(%{"amazon-bedrock-guardrailAction" => action} = event) do
+    meta = %{
+      provider_meta: Map.take(event, ["amazon-bedrock-guardrailAction", "amazon-bedrock-trace"])
+    }
+
+    meta =
+      if action == "INTERVENED", do: Map.put(meta, :finish_reason, :content_filter), else: meta
+
+    [ReqLLM.StreamChunk.meta(meta)]
+  end
+
+  defp guardrail_stream_chunks(_event), do: []
 
   @impl ReqLLM.Provider
   def flush_stream_state(model, state) do
@@ -1049,7 +1078,28 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   defp route_headers(:mantle, _chat_completions, opts),
     do: project_header("openai-project", opts)
 
-  defp route_headers(:runtime, _model_family, _opts), do: []
+  defp route_headers(:runtime, :converse, _opts), do: []
+  defp route_headers(:runtime, _model_family, opts), do: guardrail_headers(opts)
+
+  defp guardrail_headers(opts) do
+    case provider_option(opts, :guardrail_identifier) do
+      nil ->
+        []
+
+      identifier ->
+        version =
+          provider_option(opts, :guardrail_version) ||
+            raise ArgumentError, "guardrail_version is required when guardrail_identifier is set"
+
+        [
+          {"x-amzn-bedrock-guardrailidentifier", identifier},
+          {"x-amzn-bedrock-guardrailversion", version}
+        ] ++ trace_header(provider_option(opts, :guardrail_trace))
+    end
+  end
+
+  defp trace_header(nil), do: []
+  defp trace_header(trace), do: [{"x-amzn-bedrock-trace", String.upcase(trace)}]
 
   defp project_header(name, opts) do
     case provider_option(opts, :project) do
@@ -1236,6 +1286,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # Let the formatter handle model-specific parsing
     case formatter.parse_response(parsed_body, req.options) do
       {:ok, formatted_response} ->
+        formatted_response = apply_guardrail_action(formatted_response, parsed_body)
         {req, %{resp | body: formatted_response}}
 
       {:error, reason} ->
@@ -1258,6 +1309,11 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
     {req, err}
   end
+
+  defp apply_guardrail_action(response, %{"amazon-bedrock-guardrailAction" => "INTERVENED"}),
+    do: %{response | finish_reason: :content_filter}
+
+  defp apply_guardrail_action(response, _body), do: response
 
   # A native request body is the declared model's; Bedrock validates it against
   # the model the profile serves and says only "schema violations" when they

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -152,7 +152,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     # Add additionalModelRequestFields for model-specific features (e.g., Claude extended thinking)
     request = add_additional_fields(request, opts)
 
-    request
+    add_guardrail_config(request, opts)
   end
 
   # Create the synthetic structured_output tool for :object operations
@@ -208,6 +208,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
       message: message,
       finish_reason: map_stop_reason(stop_reason),
       usage: parse_usage(usage),
+      provider_meta: response_provider_meta(response_body),
       stream?: false
     }
 
@@ -314,12 +315,12 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
         {:ok, ReqLLM.StreamChunk.meta(%{finish_reason: map_stop_reason(stop_reason)})}
 
       %{"metadata" => metadata} ->
-        # Usage metadata
-        if usage = metadata["usage"] do
-          {:ok, ReqLLM.StreamChunk.meta(%{usage: parse_usage(usage)})}
-        else
-          {:ok, nil}
-        end
+        meta =
+          %{}
+          |> maybe_put_usage(metadata["usage"])
+          |> maybe_put_trace(metadata["trace"])
+
+        if meta == %{}, do: {:ok, nil}, else: {:ok, ReqLLM.StreamChunk.meta(meta)}
 
       _ ->
         {:error, :unknown_chunk_type}
@@ -327,6 +328,17 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   # Private functions
+
+  defp response_provider_meta(%{"trace" => trace}) when is_map(trace), do: %{trace: trace}
+  defp response_provider_meta(_response_body), do: %{}
+
+  defp maybe_put_usage(meta, nil), do: meta
+  defp maybe_put_usage(meta, usage), do: Map.put(meta, :usage, parse_usage(usage))
+
+  defp maybe_put_trace(meta, trace) when is_map(trace),
+    do: Map.put(meta, :provider_meta, %{trace: trace})
+
+  defp maybe_put_trace(meta, _trace), do: meta
 
   defp add_messages(request, messages) do
     {system_messages, non_system_messages} =
@@ -514,6 +526,30 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
       nil -> request
       fields when is_map(fields) -> Map.put(request, "additionalModelRequestFields", fields)
       _ -> request
+    end
+  end
+
+  defp add_guardrail_config(request, opts) do
+    opts = Keyword.merge(opts, opts[:provider_options] || [])
+
+    case opts[:guardrail_identifier] do
+      nil ->
+        request
+
+      identifier ->
+        version =
+          opts[:guardrail_version] ||
+            raise ArgumentError, "guardrail_version is required when guardrail_identifier is set"
+
+        config = %{"guardrailIdentifier" => identifier, "guardrailVersion" => version}
+
+        config =
+          case opts[:guardrail_trace] do
+            nil -> config
+            trace -> Map.put(config, "trace", trace)
+          end
+
+        Map.put(request, "guardrailConfig", config)
     end
   end
 
@@ -855,5 +891,6 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   defp map_stop_reason("max_tokens"), do: :length
   defp map_stop_reason("stop_sequence"), do: :stop
   defp map_stop_reason("content_filtered"), do: :content_filter
+  defp map_stop_reason("guardrail_intervened"), do: :content_filter
   defp map_stop_reason(_), do: :stop
 end

--- a/lib/req_llm/providers/amazon_bedrock/meta.ex
+++ b/lib/req_llm/providers/amazon_bedrock/meta.ex
@@ -78,8 +78,19 @@ defmodule ReqLLM.Providers.AmazonBedrock.Meta do
   Delegates to the generic Meta provider for parsing.
   """
   def parse_response(body, opts) when is_map(body) do
-    Llama.parse_response(body, opts)
+    body
+    |> with_guardrail_defaults()
+    |> Llama.parse_response(opts)
   end
+
+  # A blocked request never reaches the model, so Bedrock omits the token counts
+  defp with_guardrail_defaults(%{"amazon-bedrock-guardrailAction" => "INTERVENED"} = body) do
+    body
+    |> Map.put_new("prompt_token_count", 0)
+    |> Map.put_new("generation_token_count", 0)
+  end
+
+  defp with_guardrail_defaults(body), do: body
 
   @doc """
   Parses a streaming chunk for Meta Llama models.

--- a/test/coverage/amazon_bedrock/guardrails_test.exs
+++ b/test/coverage/amazon_bedrock/guardrails_test.exs
@@ -1,0 +1,95 @@
+defmodule ReqLLM.Coverage.AmazonBedrock.GuardrailsTest do
+  @moduledoc """
+  Bedrock Guardrails coverage tests on the Converse and InvokeModel routes.
+
+  Run with REQ_LLM_FIXTURES_MODE=record to test against the live API and record
+  fixtures. Recording needs a guardrail with a denied "Weather" topic in the
+  AWS_REGION the other Bedrock fixtures use (us-east-1); set BEDROCK_GUARDRAIL_ID
+  and BEDROCK_GUARDRAIL_VERSION to point at it.
+  Otherwise uses fixtures for fast, reliable testing.
+  """
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  @moduletag :coverage
+  @moduletag provider: "amazon_bedrock"
+  @moduletag timeout: 180_000
+
+  @model "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0"
+  @blocked_prompt "What is the weather like in Paris today?"
+  @allowed_prompt "Say hi in two words."
+
+  @routes [
+    converse: [use_converse: true],
+    invoke: []
+  ]
+
+  defp guardrail_opts(route_opts) do
+    [
+      max_tokens: 100,
+      provider_options:
+        route_opts ++
+          [
+            guardrail_identifier: System.get_env("BEDROCK_GUARDRAIL_ID", "guardrail1234"),
+            guardrail_version: System.get_env("BEDROCK_GUARDRAIL_VERSION", "DRAFT"),
+            guardrail_trace: "enabled"
+          ]
+    ]
+  end
+
+  defp guardrail_trace(%ReqLLM.Response{provider_meta: %{trace: trace}}), do: trace["guardrail"]
+
+  defp guardrail_trace(%ReqLLM.Response{provider_meta: meta}),
+    do: meta["amazon-bedrock-trace"]["guardrail"]
+
+  for {route, route_opts} <- @routes do
+    @route_opts route_opts
+
+    test "#{route}: generate_text blocked by the guardrail" do
+      opts = fixture_opts("guardrail_#{unquote(route)}_blocked", guardrail_opts(@route_opts))
+
+      {:ok, response} = ReqLLM.generate_text(@model, @blocked_prompt, opts)
+
+      assert response.finish_reason == :content_filter
+      assert ReqLLM.Response.text(response) == "Guardrail blocked the input."
+      assert guardrail_trace(response)["actionReason"] == "Guardrail blocked."
+    end
+
+    test "#{route}: stream_text blocked by the guardrail" do
+      opts =
+        fixture_opts("guardrail_#{unquote(route)}_blocked_stream", guardrail_opts(@route_opts))
+
+      {:ok, stream_response} = ReqLLM.stream_text(@model, @blocked_prompt, opts)
+      {:ok, response} = ReqLLM.StreamResponse.to_response(stream_response)
+
+      assert response.finish_reason == :content_filter
+      assert ReqLLM.Response.text(response) == "Guardrail blocked the input."
+      assert guardrail_trace(response)["actionReason"] == "Guardrail blocked."
+    end
+
+    test "#{route}: generate_text passing the guardrail" do
+      opts = fixture_opts("guardrail_#{unquote(route)}_allowed", guardrail_opts(@route_opts))
+
+      {:ok, response} = ReqLLM.generate_text(@model, @allowed_prompt, opts)
+
+      assert response.finish_reason == :stop
+      assert ReqLLM.Response.text(response) =~ ~r/\S/
+      assert guardrail_trace(response)["actionReason"] == "No action."
+    end
+  end
+
+  test "Llama returns the blocked response when Bedrock omits token counts" do
+    opts = fixture_opts("guardrail_invoke_blocked", guardrail_opts([]))
+
+    {:ok, response} =
+      ReqLLM.generate_text(
+        "amazon_bedrock:us.meta.llama3-3-70b-instruct-v1:0",
+        @blocked_prompt,
+        opts
+      )
+
+    assert response.finish_reason == :content_filter
+    assert ReqLLM.Response.text(response) == "Guardrail blocked the input."
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -18,6 +18,8 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
       assert result["messages"] == [
                %{"role" => "user", "content" => [%{"text" => "Hello"}]}
              ]
+
+      refute Map.has_key?(result, "guardrailConfig")
     end
 
     test "formats request with system message" do
@@ -390,6 +392,29 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
       assert result1["toolResult"]["toolUseId"] == "call_1"
       assert result2["toolResult"]["toolUseId"] == "call_2"
     end
+
+    test "omits trace from guardrail config when not set" do
+      context = %ReqLLM.Context{messages: [%Message{role: :user, content: "Hello"}]}
+
+      result =
+        Converse.format_request("test-model", context,
+          guardrail_identifier: "abc123",
+          guardrail_version: "DRAFT"
+        )
+
+      assert result["guardrailConfig"] == %{
+               "guardrailIdentifier" => "abc123",
+               "guardrailVersion" => "DRAFT"
+             }
+    end
+
+    test "raises when guardrail identifier is set without a version" do
+      context = %ReqLLM.Context{messages: [%Message{role: :user, content: "Hello"}]}
+
+      assert_raise ArgumentError, ~r/guardrail_version/, fn ->
+        Converse.format_request("test-model", context, guardrail_identifier: "abc123")
+      end
+    end
   end
 
   describe "parse_response/2" do
@@ -412,6 +437,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
 
       assert result.model == "test-model"
       assert result.finish_reason == :stop
+      assert result.provider_meta == %{}
 
       assert result.usage == %{
                input_tokens: 10,
@@ -495,7 +521,8 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
         {"tool_use", :tool_calls},
         {"max_tokens", :length},
         {"stop_sequence", :stop},
-        {"content_filtered", :content_filter}
+        {"content_filtered", :content_filter},
+        {"guardrail_intervened", :content_filter}
       ]
 
       for {bedrock_reason, expected_reason} <- test_cases do
@@ -507,6 +534,23 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
         {:ok, result} = Converse.parse_response(response_body, model: "test")
         assert result.finish_reason == expected_reason
       end
+    end
+
+    test "exposes guardrail trace in provider_meta" do
+      trace = %{"guardrail" => %{"inputAssessment" => %{"g1" => %{"topicPolicy" => %{}}}}}
+
+      response_body = %{
+        "output" => %{
+          "message" => %{"role" => "assistant", "content" => [%{"text" => "Blocked"}]}
+        },
+        "stopReason" => "guardrail_intervened",
+        "trace" => trace
+      }
+
+      {:ok, result} = Converse.parse_response(response_body, model: "test")
+
+      assert result.finish_reason == :content_filter
+      assert result.provider_meta.trace == trace
     end
   end
 
@@ -549,6 +593,41 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
                type: :meta,
                metadata: %{usage: %{input_tokens: 100, output_tokens: 50}}
              } = result
+    end
+
+    test "parses metadata with guardrail trace" do
+      trace = %{"guardrail" => %{"outputAssessments" => %{}}}
+
+      chunk = %{
+        "metadata" => %{
+          "usage" => %{"inputTokens" => 1, "outputTokens" => 2},
+          "trace" => trace
+        }
+      }
+
+      {:ok, result} = Converse.parse_stream_chunk(chunk, "test-model")
+
+      assert %ReqLLM.StreamChunk{type: :meta, metadata: metadata} = result
+      assert metadata.usage.input_tokens == 1
+      assert metadata.provider_meta == %{trace: trace}
+    end
+
+    test "parses metadata with only a trace" do
+      chunk = %{"metadata" => %{"trace" => %{"guardrail" => %{}}}}
+
+      {:ok, result} = Converse.parse_stream_chunk(chunk, "test-model")
+
+      assert %ReqLLM.StreamChunk{type: :meta, metadata: %{provider_meta: %{trace: _}}} = result
+      refute Map.has_key?(result.metadata, :usage)
+    end
+
+    test "parses messageStop with guardrail_intervened stop reason" do
+      chunk = %{"messageStop" => %{"stopReason" => "guardrail_intervened"}}
+
+      {:ok, result} = Converse.parse_stream_chunk(chunk, "test-model")
+
+      assert %ReqLLM.StreamChunk{type: :meta, metadata: %{finish_reason: :content_filter}} =
+               result
     end
 
     test "returns nil for messageStart" do

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -372,6 +372,53 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert detail.index == 0
     end
 
+    test "maps native guardrail interventions in both stream decoders" do
+      model =
+        LLMDB.Model.new!(%{id: "meta.llama3-8b-instruct-v1:0", provider: :amazon_bedrock})
+
+      trace = %{"guardrail" => %{"actionReason" => "Guardrail blocked."}}
+
+      event = %{
+        "stop_reason" => "stop",
+        "amazon-bedrock-guardrailAction" => "INTERVENED",
+        "amazon-bedrock-trace" => trace
+      }
+
+      {stateful_chunks, _state} =
+        AmazonBedrock.decode_stream_event(event, model, AmazonBedrock.init_stream_state(model))
+
+      for chunks <- [stateful_chunks, AmazonBedrock.decode_stream_event(event, model)] do
+        assert [%ReqLLM.StreamChunk{type: :meta, metadata: metadata}] =
+                 Enum.filter(chunks, &match?(%{metadata: %{provider_meta: _}}, &1))
+
+        assert metadata.finish_reason == :content_filter
+
+        assert metadata.provider_meta == %{
+                 "amazon-bedrock-guardrailAction" => "INTERVENED",
+                 "amazon-bedrock-trace" => trace
+               }
+      end
+    end
+
+    test "keeps the finish reason when the guardrail did not intervene on message_stop" do
+      model =
+        LLMDB.Model.new!(%{
+          id: "anthropic.claude-3-haiku-20240307-v1:0",
+          provider: :amazon_bedrock
+        })
+
+      event = %{"type" => "message_stop", "amazon-bedrock-guardrailAction" => "NONE"}
+
+      {chunks, _state} =
+        AmazonBedrock.decode_stream_event(event, model, AmazonBedrock.init_stream_state(model))
+
+      assert [%ReqLLM.StreamChunk{metadata: metadata}] =
+               Enum.filter(chunks, &match?(%{metadata: %{provider_meta: _}}, &1))
+
+      refute Map.has_key?(metadata, :finish_reason)
+      assert metadata.provider_meta == %{"amazon-bedrock-guardrailAction" => "NONE"}
+    end
+
     test "native Anthropic streamed reasoning round-trips into a single thinking block" do
       model =
         LLMDB.Model.new!(%{
@@ -557,6 +604,86 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert auth_header =~ "AWS4-HMAC-SHA256"
       # Session token should be included in the signed headers list
       assert auth_header =~ "x-amz-security-token"
+    end
+  end
+
+  describe "native guardrail responses" do
+    test "preserves guardrail assessments and normalizes interventions" do
+      trace = %{"guardrail" => %{"outputs" => [%{"wordPolicy" => %{}}]}}
+      request = %Req.Request{options: %{model_family: "meta"}}
+
+      model_output = %{
+        "prompt_token_count" => 10,
+        "generation_token_count" => 5,
+        "stop_reason" => "length"
+      }
+
+      for {action, finish_reason, output} <- [
+            {"INTERVENED", :content_filter, %{}},
+            {"NONE", :length, model_output}
+          ] do
+        body =
+          Map.merge(output, %{
+            "generation" => "Filtered response",
+            "amazon-bedrock-guardrailAction" => action,
+            "amazon-bedrock-trace" => trace
+          })
+
+        {^request, response} =
+          AmazonBedrock.decode_response({request, %Req.Response{status: 200, body: body}})
+
+        assert response.body.finish_reason == finish_reason
+        assert ReqLLM.Response.text(response.body) == "Filtered response"
+        assert response.body.provider_meta["amazon-bedrock-guardrailAction"] == action
+        assert response.body.provider_meta["amazon-bedrock-trace"] == trace
+      end
+    end
+  end
+
+  describe "guardrail request configuration" do
+    setup do
+      {:ok, model} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
+      context = Context.new([Context.user("Hello")])
+
+      opts = [
+        access_key_id: "AKIATEST",
+        secret_access_key: "secretTEST",
+        region: "us-east-1",
+        provider_options: [
+          guardrail_identifier: "abc123",
+          guardrail_version: "1",
+          guardrail_trace: "enabled_full"
+        ]
+      ]
+
+      {:ok, model: model, context: context, opts: opts}
+    end
+
+    test "InvokeModel puts guardrail configuration in headers", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert Req.Request.get_header(request, "x-amzn-bedrock-guardrailidentifier") == ["abc123"]
+      assert Req.Request.get_header(request, "x-amzn-bedrock-guardrailversion") == ["1"]
+      assert Req.Request.get_header(request, "x-amzn-bedrock-trace") == ["ENABLED_FULL"]
+    end
+
+    test "Converse puts guardrail configuration in the body", %{
+      model: model,
+      context: context,
+      opts: opts
+    } do
+      opts = Keyword.update!(opts, :provider_options, &Keyword.put(&1, :use_converse, true))
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      assert Jason.decode!(request.body)["guardrailConfig"] == %{
+               "guardrailIdentifier" => "abc123",
+               "guardrailVersion" => "1",
+               "trace" => "enabled_full"
+             }
     end
   end
 

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_converse_allowed.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_converse_allowed.json
@@ -1,0 +1,167 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJndWFyZHJhaWxDb25maWciOnsiZ3VhcmRyYWlsSWRlbnRpZmllciI6Imd1YXJkcmFpbDEyMzQiLCJndWFyZHJhaWxWZXJzaW9uIjoiRFJBRlQiLCJ0cmFjZSI6ImVuYWJsZWQifSwiaW5mZXJlbmNlQ29uZmlnIjp7Im1heFRva2VucyI6MTAwfSwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOlt7InRleHQiOiJTYXkgaGkgaW4gdHdvIHdvcmRzLiJ9XSwicm9sZSI6InVzZXIifV19"
+    },
+    "canonical_json": {
+      "guardrailConfig": {
+        "guardrailIdentifier": "guardrail1234",
+        "guardrailVersion": "DRAFT",
+        "trace": "enabled"
+      },
+      "inferenceConfig": {
+        "maxTokens": 100
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "Say hi in two words."
+            }
+          ],
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "e12908c8e8b61122bf33634ac9814a4ec83ad5ddff00342796f4971d924ef140"
+      ],
+      "x-amz-date": [
+        "20260907T205828Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
+  },
+  "response": {
+    "body": {
+      "metrics": {
+        "latencyMs": 1312
+      },
+      "output": {
+        "message": {
+          "content": [
+            {
+              "text": "Hey there."
+            }
+          ],
+          "role": "assistant"
+        }
+      },
+      "stopReason": "end_turn",
+      "trace": {
+        "guardrail": {
+          "actionReason": "No action.",
+          "inputAssessment": {
+            "guardrail1234": {
+              "appliedGuardrailDetails": {
+                "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                "guardrailId": "guardrail1234",
+                "guardrailOrigin": [
+                  "REQUEST"
+                ],
+                "guardrailOwnership": "SELF",
+                "guardrailVersion": "DRAFT"
+              },
+              "invocationMetrics": {
+                "guardrailCoverage": {
+                  "textCharacters": {
+                    "guarded": 20,
+                    "total": 20
+                  }
+                },
+                "guardrailProcessingLatency": 198,
+                "usage": {
+                  "contentPolicyImageUnits": 0,
+                  "contentPolicyUnits": 0,
+                  "contextualGroundingPolicyUnits": 0,
+                  "sensitiveInformationPolicyFreeUnits": 0,
+                  "sensitiveInformationPolicyUnits": 0,
+                  "topicPolicyUnits": 1,
+                  "wordPolicyUnits": 0
+                }
+              }
+            }
+          },
+          "modelOutput": [],
+          "outputAssessments": {
+            "guardrail1234": [
+              {
+                "appliedGuardrailDetails": {
+                  "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                  "guardrailId": "guardrail1234",
+                  "guardrailOrigin": [
+                    "REQUEST"
+                  ],
+                  "guardrailOwnership": "SELF",
+                  "guardrailVersion": "DRAFT"
+                },
+                "invocationMetrics": {
+                  "guardrailCoverage": {
+                    "textCharacters": {
+                      "guarded": 10,
+                      "total": 10
+                    }
+                  },
+                  "guardrailProcessingLatency": 208,
+                  "usage": {
+                    "contentPolicyImageUnits": 0,
+                    "contentPolicyUnits": 0,
+                    "contextualGroundingPolicyUnits": 0,
+                    "sensitiveInformationPolicyFreeUnits": 0,
+                    "sensitiveInformationPolicyUnits": 0,
+                    "topicPolicyUnits": 1,
+                    "wordPolicyUnits": 0
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "usage": {
+        "cacheReadInputTokenCount": 0,
+        "cacheReadInputTokens": 0,
+        "inputTokens": 13,
+        "outputTokens": 6,
+        "serverToolUsage": {},
+        "totalTokens": 19
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "1521"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Mon, 07 Sep 2026 20:58:30 GMT"
+      ],
+      "x-amzn-requestid": [
+        "8336ad25-0b59-4f70-bf26-d3a72046fea5"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_converse_blocked.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_converse_blocked.json
@@ -1,0 +1,142 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJndWFyZHJhaWxDb25maWciOnsiZ3VhcmRyYWlsSWRlbnRpZmllciI6Imd1YXJkcmFpbDEyMzQiLCJndWFyZHJhaWxWZXJzaW9uIjoiRFJBRlQiLCJ0cmFjZSI6ImVuYWJsZWQifSwiaW5mZXJlbmNlQ29uZmlnIjp7Im1heFRva2VucyI6MTAwfSwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOlt7InRleHQiOiJXaGF0IGlzIHRoZSB3ZWF0aGVyIGxpa2UgaW4gUGFyaXMgdG9kYXk/In1dLCJyb2xlIjoidXNlciJ9XX0="
+    },
+    "canonical_json": {
+      "guardrailConfig": {
+        "guardrailIdentifier": "guardrail1234",
+        "guardrailVersion": "DRAFT",
+        "trace": "enabled"
+      },
+      "inferenceConfig": {
+        "maxTokens": 100
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "What is the weather like in Paris today?"
+            }
+          ],
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "2e20d0a1f679d3685b35115b0fab5b5a203469aeb95771f8b7ef669236a6e8bc"
+      ],
+      "x-amz-date": [
+        "20260907T205827Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
+  },
+  "response": {
+    "body": {
+      "metrics": {
+        "latencyMs": 368
+      },
+      "output": {
+        "message": {
+          "content": [
+            {
+              "text": "Guardrail blocked the input."
+            }
+          ],
+          "role": "assistant"
+        }
+      },
+      "stopReason": "guardrail_intervened",
+      "trace": {
+        "guardrail": {
+          "actionReason": "Guardrail blocked.",
+          "inputAssessment": {
+            "guardrail1234": {
+              "appliedGuardrailDetails": {
+                "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                "guardrailId": "guardrail1234",
+                "guardrailOrigin": [
+                  "REQUEST"
+                ],
+                "guardrailOwnership": "SELF",
+                "guardrailVersion": "DRAFT"
+              },
+              "invocationMetrics": {
+                "guardrailCoverage": {
+                  "textCharacters": {
+                    "guarded": 40,
+                    "total": 40
+                  }
+                },
+                "guardrailProcessingLatency": 203,
+                "usage": {
+                  "contentPolicyImageUnits": 0,
+                  "contentPolicyUnits": 0,
+                  "contextualGroundingPolicyUnits": 0,
+                  "sensitiveInformationPolicyFreeUnits": 0,
+                  "sensitiveInformationPolicyUnits": 0,
+                  "topicPolicyUnits": 1,
+                  "wordPolicyUnits": 0
+                }
+              },
+              "topicPolicy": {
+                "topics": [
+                  {
+                    "action": "BLOCKED",
+                    "detected": true,
+                    "name": "Weather",
+                    "type": "DENY"
+                  }
+                ]
+              }
+            }
+          },
+          "modelOutput": []
+        }
+      },
+      "usage": {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "serverToolUsage": {},
+        "totalTokens": 0
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "1002"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Mon, 07 Sep 2026 20:58:28 GMT"
+      ],
+      "x-amzn-requestid": [
+        "f2077e67-590f-45d4-9ee5-80ecc52988fe"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_converse_blocked_stream.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_converse_blocked_stream.json
@@ -1,0 +1,67 @@
+{
+  "captured_at": "2026-09-07T20:58:25.688146Z",
+  "chunks": [
+    {
+      "b64": "AAAAiwAAAFImcW4yCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1uIiwicm9sZSI6ImFzc2lzdGFudCJ9uwonDAAAANkAAABXFMgGFgs6ZXZlbnQtdHlwZQcAEWNvbnRlbnRCbG9ja0RlbHRhDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiY29udGVudEJsb2NrSW5kZXgiOjAsImRlbHRhIjp7InRleHQiOiJHdWFyZHJhaWwgYmxvY2tlZCB0aGUgaW5wdXQuIn0sInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUoifYMxFtg="
+    },
+    {
+      "b64": "AAAAkgAAAFZM7F/YCzpldmVudC10eXBlBwAQY29udGVudEJsb2NrU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJwIjoiYWJjZGVmZ2hpamtsbW4ifT6pYDs="
+    },
+    {
+      "b64": "AAAAvwAAAFHr2SHOCzpldmVudC10eXBlBwALbWVzc2FnZVN0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1giLCJzdG9wUmVhc29uIjoiZ3VhcmRyYWlsX2ludGVydmVuZWQifXJ+YxQ="
+    },
+    {
+      "b64": "AAAD4QAAAE5nZi8/CzpldmVudC10eXBlBwAIbWV0YWRhdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJtZXRyaWNzIjp7ImxhdGVuY3lNcyI6NDA2fSwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0giLCJ0cmFjZSI6eyJndWFyZHJhaWwiOnsiYWN0aW9uUmVhc29uIjoiR3VhcmRyYWlsIGJsb2NrZWQuIiwiaW5wdXRBc3Nlc3NtZW50Ijp7Imd1YXJkcmFpbDEyMzQiOnsiYXBwbGllZEd1YXJkcmFpbERldGFpbHMiOnsiZ3VhcmRyYWlsQXJuIjoiYXJuOmF3czpiZWRyb2NrOnVzLWVhc3QtMToxMjM0NTY3ODkwMTI6Z3VhcmRyYWlsL2d1YXJkcmFpbDEyMzQiLCJndWFyZHJhaWxJZCI6Imd1YXJkcmFpbDEyMzQiLCJndWFyZHJhaWxPcmlnaW4iOlsiUkVRVUVTVCJdLCJndWFyZHJhaWxPd25lcnNoaXAiOiJTRUxGIiwiZ3VhcmRyYWlsVmVyc2lvbiI6IkRSQUZUIn0sImludm9jYXRpb25NZXRyaWNzIjp7Imd1YXJkcmFpbENvdmVyYWdlIjp7InRleHRDaGFyYWN0ZXJzIjp7Imd1YXJkZWQiOjQwLCJ0b3RhbCI6NDB9fSwiZ3VhcmRyYWlsUHJvY2Vzc2luZ0xhdGVuY3kiOjE5NSwidXNhZ2UiOnsiY29udGVudFBvbGljeUltYWdlVW5pdHMiOjAsImNvbnRlbnRQb2xpY3lVbml0cyI6MCwiY29udGV4dHVhbEdyb3VuZGluZ1BvbGljeVVuaXRzIjowLCJzZW5zaXRpdmVJbmZvcm1hdGlvblBvbGljeUZyZWVVbml0cyI6MCwic2Vuc2l0aXZlSW5mb3JtYXRpb25Qb2xpY3lVbml0cyI6MCwidG9waWNQb2xpY3lVbml0cyI6MSwid29yZFBvbGljeVVuaXRzIjowfX0sInRvcGljUG9saWN5Ijp7InRvcGljcyI6W3siYWN0aW9uIjoiQkxPQ0tFRCIsImRldGVjdGVkIjp0cnVlLCJuYW1lIjoiV2VhdGhlciIsInR5cGUiOiJERU5ZIn1dfX19fX0sInVzYWdlIjp7ImlucHV0VG9rZW5zIjowLCJvdXRwdXRUb2tlbnMiOjAsInNlcnZlclRvb2xVc2FnZSI6e30sInRvdGFsVG9rZW5zIjowfX3ZCE2n"
+    }
+  ],
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJndWFyZHJhaWxDb25maWciOnsiZ3VhcmRyYWlsSWRlbnRpZmllciI6Imd1YXJkcmFpbDEyMzQiLCJndWFyZHJhaWxWZXJzaW9uIjoiRFJBRlQiLCJ0cmFjZSI6ImVuYWJsZWQifSwiaW5mZXJlbmNlQ29uZmlnIjp7Im1heFRva2VucyI6MTAwfSwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOlt7InRleHQiOiJXaGF0IGlzIHRoZSB3ZWF0aGVyIGxpa2UgaW4gUGFyaXMgdG9kYXk/In1dLCJyb2xlIjoidXNlciJ9XX0="
+    },
+    "canonical_json": {
+      "guardrailConfig": {
+        "guardrailIdentifier": "guardrail1234",
+        "guardrailVersion": "DRAFT",
+        "trace": "enabled"
+      },
+      "inferenceConfig": {
+        "maxTokens": 100
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "What is the weather like in Paris today?"
+            }
+          ],
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "accept": "application/vnd.amazon.eventstream",
+      "authorization": "[REDACTED:authorization]",
+      "content-type": "application/json",
+      "host": "bedrock-runtime.us-east-1.amazonaws.com",
+      "x-amz-content-sha256": "2e20d0a1f679d3685b35115b0fab5b5a203469aeb95771f8b7ef669236a6e8bc",
+      "x-amz-date": "20260907T205824Z",
+      "x-amz-security-token": "[REDACTED:x-amz-security-token]"
+    },
+    "method": "POST",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse-stream"
+  },
+  "response": {
+    "body": null,
+    "headers": {
+      "connection": "keep-alive",
+      "content-type": "application/vnd.amazon.eventstream",
+      "date": "Mon, 07 Sep 2026 20:58:25 GMT",
+      "transfer-encoding": "chunked",
+      "x-amzn-requestid": "177a2803-6f69-4d62-87be-ab3ecf746536"
+    },
+    "status": 200
+  },
+  "streaming": true
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_invoke_allowed.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_invoke_allowed.json
@@ -1,0 +1,184 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJhbnRocm9waWNfdmVyc2lvbiI6ImJlZHJvY2stMjAyMy0wNS0zMSIsIm1heF90b2tlbnMiOjEwMCwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOiJTYXkgaGkgaW4gdHdvIHdvcmRzLiIsInJvbGUiOiJ1c2VyIn1dfQ=="
+    },
+    "canonical_json": {
+      "anthropic_version": "bedrock-2023-05-31",
+      "max_tokens": 100,
+      "messages": [
+        {
+          "content": "Say hi in two words.",
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "d54deddf2a1449f24ccc055fdd541c5c34895d0cbda81710b4614c0b883b6f5b"
+      ],
+      "x-amz-date": [
+        "20260907T205823Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ],
+      "x-amzn-bedrock-guardrailidentifier": [
+        "guardrail1234"
+      ],
+      "x-amzn-bedrock-guardrailversion": [
+        "DRAFT"
+      ],
+      "x-amzn-bedrock-trace": [
+        "ENABLED"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/invoke"
+  },
+  "response": {
+    "body": {
+      "amazon-bedrock-guardrailAction": "NONE",
+      "amazon-bedrock-trace": {
+        "guardrail": {
+          "actionReason": "No action.",
+          "input": {
+            "guardrail1234": {
+              "appliedGuardrailDetails": {
+                "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                "guardrailId": "guardrail1234",
+                "guardrailOrigin": [
+                  "REQUEST"
+                ],
+                "guardrailOwnership": "SELF",
+                "guardrailVersion": "DRAFT"
+              },
+              "invocationMetrics": {
+                "guardrailCoverage": {
+                  "textCharacters": {
+                    "guarded": 20,
+                    "total": 20
+                  }
+                },
+                "guardrailProcessingLatency": 206,
+                "usage": {
+                  "automatedReasoningPolicies": 0,
+                  "automatedReasoningPolicyUnits": 0,
+                  "contentPolicyImageUnits": 0,
+                  "contentPolicyUnits": 0,
+                  "contextualGroundingPolicyUnits": 0,
+                  "sensitiveInformationPolicyFreeUnits": 0,
+                  "sensitiveInformationPolicyUnits": 0,
+                  "topicPolicyUnits": 1,
+                  "wordPolicyUnits": 0
+                }
+              }
+            }
+          },
+          "outputs": [
+            {
+              "guardrail1234": {
+                "appliedGuardrailDetails": {
+                  "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                  "guardrailId": "guardrail1234",
+                  "guardrailOrigin": [
+                    "REQUEST"
+                  ],
+                  "guardrailOwnership": "SELF",
+                  "guardrailVersion": "DRAFT"
+                },
+                "invocationMetrics": {
+                  "guardrailCoverage": {
+                    "textCharacters": {
+                      "guarded": 10,
+                      "total": 10
+                    }
+                  },
+                  "guardrailProcessingLatency": 192,
+                  "usage": {
+                    "automatedReasoningPolicies": 0,
+                    "automatedReasoningPolicyUnits": 0,
+                    "contentPolicyImageUnits": 0,
+                    "contentPolicyUnits": 0,
+                    "contextualGroundingPolicyUnits": 0,
+                    "sensitiveInformationPolicyFreeUnits": 0,
+                    "sensitiveInformationPolicyUnits": 0,
+                    "topicPolicyUnits": 1,
+                    "wordPolicyUnits": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "text": "Hey there.",
+          "type": "text"
+        }
+      ],
+      "id": "msg_bdrk_m3eh3kscbgb4ltxg55a54rgg3gzm2qv6mp7wgdty2emwahfzzpzq",
+      "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+      "role": "assistant",
+      "stop_details": null,
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "type": "message",
+      "usage": {
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 0
+        },
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "input_tokens": 13,
+        "output_tokens": 6,
+        "service_tier": "standard"
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "1885"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Mon, 07 Sep 2026 20:58:24 GMT"
+      ],
+      "x-amzn-bedrock-cache-read-input-token-count": [
+        "0"
+      ],
+      "x-amzn-bedrock-input-token-count": [
+        "13"
+      ],
+      "x-amzn-bedrock-invocation-latency": [
+        "1286"
+      ],
+      "x-amzn-bedrock-output-token-count": [
+        "6"
+      ],
+      "x-amzn-requestid": [
+        "7a17af76-6f25-4db6-80f3-7a06e29bab37"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_invoke_blocked.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_invoke_blocked.json
@@ -1,0 +1,139 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJhbnRocm9waWNfdmVyc2lvbiI6ImJlZHJvY2stMjAyMy0wNS0zMSIsIm1heF90b2tlbnMiOjEwMCwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOiJXaGF0IGlzIHRoZSB3ZWF0aGVyIGxpa2UgaW4gUGFyaXMgdG9kYXk/Iiwicm9sZSI6InVzZXIifV19"
+    },
+    "canonical_json": {
+      "anthropic_version": "bedrock-2023-05-31",
+      "max_tokens": 100,
+      "messages": [
+        {
+          "content": "What is the weather like in Paris today?",
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "bc68ec28acbe057f6c22608adcad78b5e7a4ee25850c7faf65c554c4fb0eeded"
+      ],
+      "x-amz-date": [
+        "20260907T205831Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ],
+      "x-amzn-bedrock-guardrailidentifier": [
+        "guardrail1234"
+      ],
+      "x-amzn-bedrock-guardrailversion": [
+        "DRAFT"
+      ],
+      "x-amzn-bedrock-trace": [
+        "ENABLED"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/invoke"
+  },
+  "response": {
+    "body": {
+      "amazon-bedrock-guardrailAction": "INTERVENED",
+      "amazon-bedrock-trace": {
+        "guardrail": {
+          "actionReason": "Guardrail blocked.",
+          "input": {
+            "guardrail1234": {
+              "appliedGuardrailDetails": {
+                "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                "guardrailId": "guardrail1234",
+                "guardrailOrigin": [
+                  "REQUEST"
+                ],
+                "guardrailOwnership": "SELF",
+                "guardrailVersion": "DRAFT"
+              },
+              "invocationMetrics": {
+                "guardrailCoverage": {
+                  "textCharacters": {
+                    "guarded": 40,
+                    "total": 40
+                  }
+                },
+                "guardrailProcessingLatency": 194,
+                "usage": {
+                  "automatedReasoningPolicies": 0,
+                  "automatedReasoningPolicyUnits": 0,
+                  "contentPolicyImageUnits": 0,
+                  "contentPolicyUnits": 0,
+                  "contextualGroundingPolicyUnits": 0,
+                  "sensitiveInformationPolicyFreeUnits": 0,
+                  "sensitiveInformationPolicyUnits": 0,
+                  "topicPolicyUnits": 1,
+                  "wordPolicyUnits": 0
+                }
+              },
+              "topicPolicy": {
+                "topics": [
+                  {
+                    "action": "BLOCKED",
+                    "detected": true,
+                    "name": "Weather",
+                    "type": "DENY"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "content": [
+        {
+          "text": "Guardrail blocked the input.",
+          "type": "text"
+        }
+      ],
+      "id": "bedrock-guardrails-07f4e15f",
+      "model": "claude-haiku-4-5-20251001",
+      "role": "assistant",
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "type": "message",
+      "usage": {
+        "input_tokens": 0,
+        "output_tokens": 0
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "1127"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Mon, 07 Sep 2026 20:58:31 GMT"
+      ],
+      "x-amzn-requestid": [
+        "a40aab7e-3599-41a2-bd78-419f9edfe2e8"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_invoke_blocked_stream.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guardrail_invoke_blocked_stream.json
@@ -1,0 +1,58 @@
+{
+  "captured_at": "2026-09-07T20:58:31.119259Z",
+  "chunks": [
+    {
+      "b64": "AAABuAAAAEtvx9cBCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpjMkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWFXUWlPaUppWldSeWIyTnJMV2QxWVhKa2NtRnBiSE10WVdaa05tWmxOVGdpTENKMGVYQmxJam9pYldWemMyRm5aU0lzSW5KdmJHVWlPaUpoYzNOcGMzUmhiblFpTENKamIyNTBaVzUwSWpwYlhTd2liVzlrWld3aU9pSmpiR0YxWkdVdGFHRnBhM1V0TkMwMUxUSXdNalV4TURBeElpd2ljM1J2Y0Y5eVpXRnpiMjRpT201MWJHd3NJbk4wYjNCZmMyVnhkV1Z1WTJVaU9tNTFiR3dzSW5WellXZGxJanA3SW1sdWNIVjBYM1J2YTJWdWN5STZNQ3dpYjNWMGNIVjBYM1J2YTJWdWN5STZNSDE5ZlE9PSIsInAiOiJhYmNkZWYifeXgYNM="
+    },
+    {
+      "b64": "AAAA6QAAAEuh6OLfCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEdGeWRDSXNJbWx1WkdWNElqb3dMQ0pqYjI1MFpXNTBYMkpzYjJOcklqcDdJblI1Y0dVaU9pSjBaWGgwSWl3aWRHVjRkQ0k2SWlKOWZRPT0iLCJwIjoiYWJjZGVmZ2hpamsifToKkhUAAAEiAAAAS/Rx6LALOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSkhkV0Z5WkhKaGFXd2dZbXh2WTJ0bFpDQjBhR1VnYVc1d2RYUXVJbjE5IiwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSiJ9BuebZA=="
+    },
+    {
+      "b64": "AAAA1AAAAEv4WZ7oCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEc5d0lpd2lhVzVrWlhnaU9qQjkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1gifaXzHwUAAAD1AAAASwT4mFwLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pYldWemMyRm5aVjlrWld4MFlTSXNJbVJsYkhSaElqcDdJbk4wYjNCZmNtVmhjMjl1SWpvaVpXNWtYM1IxY200aUxDSnpkRzl3WDNObGNYVmxibU5sSWpwdWRXeHNmWDA9IiwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QSJ97Wvp7wAABUQAAABLeZIoSws6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpWOXpkRzl3SWl3aVlXMWhlbTl1TFdKbFpISnZZMnN0WjNWaGNtUnlZV2xzUVdOMGFXOXVJam9pU1U1VVJWSldSVTVGUkNJc0ltRnRZWHB2YmkxaVpXUnliMk5yTFhSeVlXTmxJanA3SW1kMVlYSmtjbUZwYkNJNmV5SnBibkIxZENJNmV5Sm5kV0Z5WkhKaGFXd3hNak0wSWpwN0luUnZjR2xqVUc5c2FXTjVJanA3SW5SdmNHbGpjeUk2VzNzaWJtRnRaU0k2SWxkbFlYUm9aWElpTENKMGVYQmxJam9pUkVWT1dTSXNJbUZqZEdsdmJpSTZJa0pNVDBOTFJVUWlMQ0prWlhSbFkzUmxaQ0k2ZEhKMVpYMWRmU3dpYVc1MmIyTmhkR2x2YmsxbGRISnBZM01pT25zaVozVmhjbVJ5WVdsc1VISnZZMlZ6YzJsdVoweGhkR1Z1WTNraU9qSXpOU3dpZFhOaFoyVWlPbnNpZEc5d2FXTlFiMnhwWTNsVmJtbDBjeUk2TVN3aVkyOXVkR1Z1ZEZCdmJHbGplVlZ1YVhSeklqb3dMQ0ozYjNKa1VHOXNhV041Vlc1cGRITWlPakFzSW1GMWRHOXRZWFJsWkZKbFlYTnZibWx1WjFCdmJHbGplVlZ1YVhSeklqb3dMQ0poZFhSdmJXRjBaV1JTWldGemIyNXBibWRRYjJ4cFkybGxjeUk2TUN3aWMyVnVjMmwwYVhabFNXNW1iM0p0WVhScGIyNVFiMnhwWTNsVmJtbDBjeUk2TUN3aWMyVnVjMmwwYVhabFNXNW1iM0p0WVhScGIyNVFiMnhwWTNsR2NtVmxWVzVwZEhNaU9qQXNJbU52Ym5SbGVIUjFZV3hIY205MWJtUnBibWRRYjJ4cFkzbFZibWwwY3lJNk1Dd2lZMjl1ZEdWdWRGQnZiR2xqZVVsdFlXZGxWVzVwZEhNaU9qQjlMQ0puZFdGeVpISmhhV3hEYjNabGNtRm5aU0k2ZXlKMFpYaDBRMmhoY21GamRHVnljeUk2ZXlKbmRXRnlaR1ZrSWpvME1Dd2lkRzkwWVd3aU9qUXdmWDE5TENKaGNIQnNhV1ZrUjNWaGNtUnlZV2xzUkdWMFlXbHNjeUk2ZXlKbmRXRnlaSEpoYVd4SlpDSTZJbWQxWVhKa2NtRnBiREV5TXpRaUxDSm5kV0Z5WkhKaGFXeFdaWEp6YVc5dUlqb2lSRkpCUmxRaUxDSm5kV0Z5WkhKaGFXeEJjbTRpT2lKaGNtNDZZWGR6T21KbFpISnZZMnM2ZFhNdFpXRnpkQzB4T2pFeU16UTFOamM0T1RBeE1qcG5kV0Z5WkhKaGFXd3ZaM1ZoY21SeVlXbHNNVEl6TkNJc0ltZDFZWEprY21GcGJFOXlhV2RwYmlJNld5SlNSVkZWUlZOVUlsMHNJbWQxWVhKa2NtRnBiRTkzYm1WeWMyaHBjQ0k2SWxORlRFWWlmWDE5TENKaFkzUnBiMjVTWldGemIyNGlPaUpIZFdGeVpISmhhV3dnWW14dlkydGxaQzRpZlgxOSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaMDEife3/rjg="
+    }
+  ],
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJhbnRocm9waWNfdmVyc2lvbiI6ImJlZHJvY2stMjAyMy0wNS0zMSIsIm1heF90b2tlbnMiOjEwMCwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOiJXaGF0IGlzIHRoZSB3ZWF0aGVyIGxpa2UgaW4gUGFyaXMgdG9kYXk/Iiwicm9sZSI6InVzZXIifV19"
+    },
+    "canonical_json": {
+      "anthropic_version": "bedrock-2023-05-31",
+      "max_tokens": 100,
+      "messages": [
+        {
+          "content": "What is the weather like in Paris today?",
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "accept": "application/vnd.amazon.eventstream",
+      "authorization": "[REDACTED:authorization]",
+      "content-type": "application/json",
+      "host": "bedrock-runtime.us-east-1.amazonaws.com",
+      "x-amz-content-sha256": "bc68ec28acbe057f6c22608adcad78b5e7a4ee25850c7faf65c554c4fb0eeded",
+      "x-amz-date": "20260907T205830Z",
+      "x-amz-security-token": "[REDACTED:x-amz-security-token]",
+      "x-amzn-bedrock-guardrailidentifier": "guardrail1234",
+      "x-amzn-bedrock-guardrailversion": "DRAFT",
+      "x-amzn-bedrock-trace": "ENABLED"
+    },
+    "method": "POST",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/invoke-with-response-stream"
+  },
+  "response": {
+    "body": null,
+    "headers": {
+      "connection": "keep-alive",
+      "content-type": "application/vnd.amazon.eventstream",
+      "date": "Mon, 07 Sep 2026 20:58:31 GMT",
+      "transfer-encoding": "chunked",
+      "x-amzn-bedrock-content-type": "application/json",
+      "x-amzn-requestid": "7faee1ee-a184-4f45-a610-24657e734fef"
+    },
+    "status": 200
+  },
+  "streaming": true
+}

--- a/test/support/fixtures/amazon_bedrock/meta_llama3_3_70b_instruct_v1_0/guardrail_invoke_blocked.json
+++ b/test/support/fixtures/amazon_bedrock/meta_llama3_3_70b_instruct_v1_0/guardrail_invoke_blocked.json
@@ -1,0 +1,121 @@
+{
+  "model_spec": "amazon_bedrock:us.meta.llama3-3-70b-instruct-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJtYXhfZ2VuX2xlbiI6MTAwLCJwcm9tcHQiOiI8fGJlZ2luX29mX3RleHR8Pjx8c3RhcnRfaGVhZGVyX2lkfD51c2VyPHxlbmRfaGVhZGVyX2lkfD5cblxuV2hhdCBpcyB0aGUgd2VhdGhlciBsaWtlIGluIFBhcmlzIHRvZGF5Pzx8ZW90X2lkfD48fHN0YXJ0X2hlYWRlcl9pZHw+YXNzaXN0YW50PHxlbmRfaGVhZGVyX2lkfD5cblxuIn0="
+    },
+    "canonical_json": {
+      "max_gen_len": 100,
+      "prompt": "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nWhat is the weather like in Paris today?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "dab25e4be29abba7f6e62e4c5f16d227a9d674f90f457adac8f917c077c02161"
+      ],
+      "x-amz-date": [
+        "20260907T205832Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ],
+      "x-amzn-bedrock-guardrailidentifier": [
+        "guardrail1234"
+      ],
+      "x-amzn-bedrock-guardrailversion": [
+        "DRAFT"
+      ],
+      "x-amzn-bedrock-trace": [
+        "ENABLED"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.meta.llama3-3-70b-instruct-v1:0/invoke"
+  },
+  "response": {
+    "body": {
+      "amazon-bedrock-guardrailAction": "INTERVENED",
+      "amazon-bedrock-trace": {
+        "guardrail": {
+          "actionReason": "Guardrail blocked.",
+          "input": {
+            "guardrail1234": {
+              "appliedGuardrailDetails": {
+                "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                "guardrailId": "guardrail1234",
+                "guardrailOrigin": [
+                  "REQUEST"
+                ],
+                "guardrailOwnership": "SELF",
+                "guardrailVersion": "DRAFT"
+              },
+              "invocationMetrics": {
+                "guardrailCoverage": {
+                  "textCharacters": {
+                    "guarded": 156,
+                    "total": 156
+                  }
+                },
+                "guardrailProcessingLatency": 199,
+                "usage": {
+                  "automatedReasoningPolicies": 0,
+                  "automatedReasoningPolicyUnits": 0,
+                  "contentPolicyImageUnits": 0,
+                  "contentPolicyUnits": 0,
+                  "contextualGroundingPolicyUnits": 0,
+                  "sensitiveInformationPolicyFreeUnits": 0,
+                  "sensitiveInformationPolicyUnits": 0,
+                  "topicPolicyUnits": 1,
+                  "wordPolicyUnits": 0
+                }
+              },
+              "topicPolicy": {
+                "topics": [
+                  {
+                    "action": "BLOCKED",
+                    "detected": true,
+                    "name": "Weather",
+                    "type": "DENY"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "generation": "Guardrail blocked the input."
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "909"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Mon, 07 Sep 2026 20:58:33 GMT"
+      ],
+      "x-amzn-bedrock-invocation-latency": [
+        "300"
+      ],
+      "x-amzn-requestid": [
+        "b0c362ee-7b01-4f15-8d8e-32e873dcb967"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}


### PR DESCRIPTION
## Description

Adds support for [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) with `provider_options: [guardrail_identifier: "abc123", guardrail_version: "1"]`, through Converse and InvokeModel, including streaming. Interventions return `finish_reason: :content_filter`, and `guardrail_trace` exposes assessments in `response.provider_meta`.

Also handles blocked Llama responses that omit token counts.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update


## Testing

- [x] Tests pass (`mix test`)
- [x] Guardrail fixtures pass and tested live
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791408013&installation_model_id=434874&pr_number=995&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F995&signature=26fe5464a41423ed55fbf2a96a3a83a36921fef6be539a0a71b18dda48bb5f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->