### PR TITLE
fix(codex): preserve session and prompt cache identity across transports

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -103,10 +103,11 @@ Reuse the same `session_id` across related requests. Codex sends it as the
 hyphenated `session-id` header on buffered HTTP, SSE, and WebSocket requests,
 and defaults `prompt_cache_key` to that identity. An explicit
 `provider_options: [prompt_cache_key: "cache-key"]` overrides the cache key.
-`thread_id` is a separate, optional identity sent as `thread-id` (and used for
-WebSocket `x-client-request-id`). No session or cache identity is invented when
-none is supplied. Applications serving multiple users should scope these
-identities to the authenticated user/session; never use one global cache key.
+`thread_id` is a separate, optional identity sent as `thread-id` and
+`x-client-request-id` on all three transports. No session or cache identity is
+invented when none is supplied. Applications serving multiple users should
+scope these identities to the authenticated user/session; never use one global
+cache key.
 
 These fields improve compatibility with the official Codex client but do not
 guarantee a cache hit or change the provider's subscription quota policy.

--- a/guides/openai.md
+++ b/guides/openai.md
@@ -97,6 +97,19 @@ For `openai_codex`, you can also override backend request headers with:
 
 - `provider_options: [chatgpt_account_id: "..."]`
 - `provider_options: [codex_originator: "pi"]`
+- `provider_options: [session_id: "stable-session-id", thread_id: "thread-id"]`
+
+Reuse the same `session_id` across related requests. Codex sends it as the
+hyphenated `session-id` header on buffered HTTP, SSE, and WebSocket requests,
+and defaults `prompt_cache_key` to that identity. An explicit
+`provider_options: [prompt_cache_key: "cache-key"]` overrides the cache key.
+`thread_id` is a separate, optional identity sent as `thread-id` (and used for
+WebSocket `x-client-request-id`). No session or cache identity is invented when
+none is supplied. Applications serving multiple users should scope these
+identities to the authenticated user/session; never use one global cache key.
+
+These fields improve compatibility with the official Codex client but do not
+guarantee a cache hit or change the provider's subscription quota policy.
 
 ReqLLM applies the complete Responses Lite wire profile when the Codex model catalog marks a model with `use_responses_lite: true`. The bundled catalog currently enables that profile for GPT-5.6 Sol, Terra, and Luna. Explicit model specs can provide updated provider metadata under `extra.openai_codex.use_responses_lite`.
 

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -42,7 +42,16 @@ defmodule ReqLLM.Providers.OpenAICodex do
     ],
     session_id: [
       type: :string,
-      doc: "Stable request/session id used for Codex websocket headers"
+      doc: "Stable session identity sent as session-id and used as the default prompt cache key"
+    ],
+    thread_id: [
+      type: :string,
+      doc:
+        "Thread identity sent as thread-id, separate from the session shared by related threads"
+    ],
+    prompt_cache_key: [
+      type: :string,
+      doc: "Explicit prompt cache key override; defaults to session_id when supplied"
     ],
     codex_originator: [
       type: :string,
@@ -213,6 +222,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Req.Request.put_header("authorization", "Bearer #{credential.token}")
     |> Req.Request.put_header("chatgpt-account-id", account_id)
     |> Req.Request.put_header("originator", originator)
+    |> put_session_headers(user_opts)
     |> ResponsesLite.put_req_header(model)
     |> Req.Request.register_options([@codex_model_option | extra_option_keys])
     |> Req.Request.merge_options(
@@ -325,6 +335,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
         {"accept", "text/event-stream"},
         {"openai-beta", "responses=experimental"}
       ]
+      |> Kernel.++(session_headers(opts))
       |> ResponsesLite.put_header(model)
 
     encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
@@ -437,6 +448,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Map.put("include", ["reasoning.encrypted_content"])
     |> Map.put_new("text", %{"verbosity" => normalize_codex_verbosity(provider_opts[:verbosity])})
     |> Map.put("instructions", instructions)
+    |> maybe_put_prompt_cache_key(provider_opts[:prompt_cache_key] || provider_opts[:session_id])
     |> maybe_put_parallel_tool_calls(provider_opts[:openai_parallel_tool_calls])
     |> ResponsesLite.apply_body(model)
   end
@@ -628,16 +640,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
   end
 
   defp websocket_headers(model, token, account_id, opts) do
-    request_id = codex_request_id(opts)
-
     [
       {"authorization", "Bearer " <> token},
       {"chatgpt-account-id", account_id},
       {"originator", codex_originator(opts)},
       {"openai-beta", "responses_websockets=2026-02-06"},
-      {"x-client-request-id", request_id},
-      {"session_id", request_id}
+      {"x-client-request-id", codex_request_id(opts)}
     ]
+    |> Kernel.++(session_headers(opts))
     |> ResponsesLite.put_header(model)
     |> Kernel.++(ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options]))
   end
@@ -648,8 +658,24 @@ defmodule ReqLLM.Providers.OpenAICodex do
   defp codex_request_id(opts) do
     opts
     |> provider_options()
-    |> Keyword.get_lazy(:session_id, fn -> "req_#{System.unique_integer([:positive])}" end)
+    |> Keyword.get_lazy(:thread_id, fn -> "req_#{System.unique_integer([:positive])}" end)
   end
+
+  defp session_headers(opts) do
+    options = provider_options(opts)
+
+    [{"session-id", options[:session_id]}, {"thread-id", options[:thread_id]}]
+    |> Enum.reject(fn {_name, value} -> is_nil(value) end)
+  end
+
+  defp put_session_headers(request, opts) do
+    Enum.reduce(session_headers(opts), request, fn {name, value}, req ->
+      Req.Request.put_header(req, name, value)
+    end)
+  end
+
+  defp maybe_put_prompt_cache_key(body, nil), do: body
+  defp maybe_put_prompt_cache_key(body, key), do: Map.put(body, "prompt_cache_key", key)
 
   defp normalize_stream_opts(opts) when is_list(opts) do
     provider_opts =

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -222,7 +222,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Req.Request.put_header("authorization", "Bearer #{credential.token}")
     |> Req.Request.put_header("chatgpt-account-id", account_id)
     |> Req.Request.put_header("originator", originator)
-    |> put_session_headers(user_opts)
+    |> Req.Request.put_headers(session_headers(user_opts))
     |> ResponsesLite.put_req_header(model)
     |> Req.Request.register_options([@codex_model_option | extra_option_keys])
     |> Req.Request.merge_options(
@@ -666,12 +666,6 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
     [{"session-id", options[:session_id]}, {"thread-id", options[:thread_id]}]
     |> Enum.reject(fn {_name, value} -> is_nil(value) end)
-  end
-
-  defp put_session_headers(request, opts) do
-    Enum.reduce(session_headers(opts), request, fn {name, value}, req ->
-      Req.Request.put_header(req, name, value)
-    end)
   end
 
   defp maybe_put_prompt_cache_key(body, nil), do: body

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -222,7 +222,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Req.Request.put_header("authorization", "Bearer #{credential.token}")
     |> Req.Request.put_header("chatgpt-account-id", account_id)
     |> Req.Request.put_header("originator", originator)
-    |> Req.Request.put_headers(session_headers(user_opts))
+    |> Req.Request.put_headers(identity_headers(user_opts))
     |> ResponsesLite.put_req_header(model)
     |> Req.Request.register_options([@codex_model_option | extra_option_keys])
     |> Req.Request.merge_options(
@@ -335,7 +335,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
         {"accept", "text/event-stream"},
         {"openai-beta", "responses=experimental"}
       ]
-      |> Kernel.++(session_headers(opts))
+      |> Kernel.++(identity_headers(opts))
       |> ResponsesLite.put_header(model)
 
     encoded = body |> ReqLLM.Schema.apply_property_ordering() |> Jason.encode!()
@@ -644,10 +644,9 @@ defmodule ReqLLM.Providers.OpenAICodex do
       {"authorization", "Bearer " <> token},
       {"chatgpt-account-id", account_id},
       {"originator", codex_originator(opts)},
-      {"openai-beta", "responses_websockets=2026-02-06"},
-      {"x-client-request-id", codex_request_id(opts)}
+      {"openai-beta", "responses_websockets=2026-02-06"}
     ]
-    |> Kernel.++(session_headers(opts))
+    |> Kernel.++(identity_headers(opts, codex_request_id(opts)))
     |> ResponsesLite.put_header(model)
     |> Kernel.++(ReqLLM.Provider.Utils.extract_custom_headers(opts[:req_http_options]))
   end
@@ -661,10 +660,14 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Keyword.get_lazy(:thread_id, fn -> "req_#{System.unique_integer([:positive])}" end)
   end
 
-  defp session_headers(opts) do
+  defp identity_headers(opts, fallback_request_id \\ nil) do
     options = provider_options(opts)
 
-    [{"session-id", options[:session_id]}, {"thread-id", options[:thread_id]}]
+    [
+      {"x-client-request-id", options[:thread_id] || fallback_request_id},
+      {"session-id", options[:session_id]},
+      {"thread-id", options[:thread_id]}
+    ]
     |> Enum.reject(fn {_name, value} -> is_nil(value) end)
   end
 

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -122,6 +122,7 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
         ]
 
         {:ok, buffered} = OpenAICodex.prepare_request(:chat, model, context, opts)
+        assert buffered.headers["x-client-request-id"] == ["thread-456"]
         assert buffered.headers["session-id"] == ["session-123"]
         assert buffered.headers["thread-id"] == ["thread-456"]
         refute Map.has_key?(buffered.headers, "session_id")
@@ -130,11 +131,13 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
                  "cache-override"
 
         {:ok, sse} = OpenAICodex.attach_stream(model, context, opts, nil)
+        assert {"x-client-request-id", "thread-456"} in sse.headers
         assert {"session-id", "session-123"} in sse.headers
         assert {"thread-id", "thread-456"} in sse.headers
         assert Jason.decode!(sse.body)["prompt_cache_key"] == "cache-override"
 
         {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+        assert {"x-client-request-id", "thread-456"} in websocket.headers
         assert {"session-id", "session-123"} in websocket.headers
         assert {"thread-id", "thread-456"} in websocket.headers
         refute List.keymember?(websocket.headers, "session_id", 0)
@@ -161,17 +164,24 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
           assert Jason.decode!(OpenAICodex.encode_body(buffered).body)["prompt_cache_key"] ==
                    "session-123"
 
+          refute Map.has_key?(buffered.headers, "x-client-request-id")
           refute Map.has_key?(buffered.headers, "thread-id")
 
           {:ok, sse} = OpenAICodex.attach_stream(model, context, opts, nil)
           assert {"session-id", "session-123"} in sse.headers
           assert Jason.decode!(sse.body)["prompt_cache_key"] == "session-123"
+          refute List.keymember?(sse.headers, "x-client-request-id", 0)
           refute List.keymember?(sse.headers, "thread-id", 0)
 
           {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
           assert {"session-id", "session-123"} in websocket.headers
           assert websocket.canonical_json["prompt_cache_key"] == "session-123"
           refute List.keymember?(websocket.headers, "thread-id", 0)
+
+          assert {"x-client-request-id", request_id} =
+                   List.keyfind(websocket.headers, "x-client-request-id", 0)
+
+          refute request_id == "session-123"
         end
       end
     end

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -142,32 +142,65 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
       end
     end
 
-    test "defaults the cache key to the caller's session across repeated requests" do
-      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
-      context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+    test "defaults the cache key to the caller's session across repeated requests and transports" do
+      for model_id <- ["gpt-5.3-codex-spark", "gpt-5.6-sol", "gpt-6-astra"] do
+        {:ok, model} = ReqLLM.model("openai_codex:#{model_id}")
+        context = ReqLLM.context([ReqLLM.Context.user("Hello")])
 
-      opts = [
-        provider_options: [
-          access_token: jwt_with_account_id("acct_cache"),
-          session_id: "session-123"
+        opts = [
+          provider_options: [
+            access_token: jwt_with_account_id("acct_cache"),
+            session_id: "session-123"
+          ]
         ]
-      ]
 
-      for _ <- 1..2 do
-        {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
-        assert {"session-id", "session-123"} in websocket.headers
-        assert websocket.canonical_json["prompt_cache_key"] == "session-123"
+        for _ <- 1..2 do
+          {:ok, buffered} = OpenAICodex.prepare_request(:chat, model, context, opts)
+          assert buffered.headers["session-id"] == ["session-123"]
+
+          assert Jason.decode!(OpenAICodex.encode_body(buffered).body)["prompt_cache_key"] ==
+                   "session-123"
+
+          refute Map.has_key?(buffered.headers, "thread-id")
+
+          {:ok, sse} = OpenAICodex.attach_stream(model, context, opts, nil)
+          assert {"session-id", "session-123"} in sse.headers
+          assert Jason.decode!(sse.body)["prompt_cache_key"] == "session-123"
+          refute List.keymember?(sse.headers, "thread-id", 0)
+
+          {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+          assert {"session-id", "session-123"} in websocket.headers
+          assert websocket.canonical_json["prompt_cache_key"] == "session-123"
+          refute List.keymember?(websocket.headers, "thread-id", 0)
+        end
       end
     end
 
-    test "does not invent a session or cache identity when none is supplied" do
-      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
-      context = ReqLLM.context([ReqLLM.Context.user("Hello")])
-      opts = [provider_options: [access_token: jwt_with_account_id("acct_cache")]]
-      {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
-      refute List.keymember?(websocket.headers, "session-id", 0)
-      refute List.keymember?(websocket.headers, "session_id", 0)
-      refute Map.has_key?(websocket.canonical_json, "prompt_cache_key")
+    test "does not invent a session or cache identity on any transport when none is supplied" do
+      for model_id <- ["gpt-5.3-codex-spark", "gpt-5.6-sol", "gpt-6-astra"] do
+        {:ok, model} = ReqLLM.model("openai_codex:#{model_id}")
+        context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+        opts = [provider_options: [access_token: jwt_with_account_id("acct_cache")]]
+
+        {:ok, buffered} = OpenAICodex.prepare_request(:chat, model, context, opts)
+
+        refute Map.has_key?(
+                 Jason.decode!(OpenAICodex.encode_body(buffered).body),
+                 "prompt_cache_key"
+               )
+
+        {:ok, sse} = OpenAICodex.attach_stream(model, context, opts, nil)
+        refute Map.has_key?(Jason.decode!(sse.body), "prompt_cache_key")
+
+        {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+        refute Map.has_key?(websocket.canonical_json, "prompt_cache_key")
+
+        for header <- ["session-id", "thread-id", "session_id", "thread_id"] do
+          refute Map.has_key?(buffered.headers, header)
+          refute List.keymember?(sse.headers, header, 0)
+          refute List.keymember?(websocket.headers, header, 0)
+        end
+      end
     end
   end
 

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -106,6 +106,71 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
     end
   end
 
+  describe "session and prompt cache identity" do
+    test "preserves explicit cache and hyphenated session headers across transports" do
+      for model_id <- ["gpt-5.3-codex-spark", "gpt-5.6-sol", "gpt-6-astra"] do
+        {:ok, model} = ReqLLM.model("openai_codex:#{model_id}")
+        context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+
+        opts = [
+          provider_options: [
+            access_token: jwt_with_account_id("acct_cache"),
+            session_id: "session-123",
+            thread_id: "thread-456",
+            prompt_cache_key: "cache-override"
+          ]
+        ]
+
+        {:ok, buffered} = OpenAICodex.prepare_request(:chat, model, context, opts)
+        assert buffered.headers["session-id"] == ["session-123"]
+        assert buffered.headers["thread-id"] == ["thread-456"]
+        refute Map.has_key?(buffered.headers, "session_id")
+
+        assert Jason.decode!(OpenAICodex.encode_body(buffered).body)["prompt_cache_key"] ==
+                 "cache-override"
+
+        {:ok, sse} = OpenAICodex.attach_stream(model, context, opts, nil)
+        assert {"session-id", "session-123"} in sse.headers
+        assert {"thread-id", "thread-456"} in sse.headers
+        assert Jason.decode!(sse.body)["prompt_cache_key"] == "cache-override"
+
+        {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+        assert {"session-id", "session-123"} in websocket.headers
+        assert {"thread-id", "thread-456"} in websocket.headers
+        refute List.keymember?(websocket.headers, "session_id", 0)
+        assert websocket.canonical_json["prompt_cache_key"] == "cache-override"
+      end
+    end
+
+    test "defaults the cache key to the caller's session across repeated requests" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
+      context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+
+      opts = [
+        provider_options: [
+          access_token: jwt_with_account_id("acct_cache"),
+          session_id: "session-123"
+        ]
+      ]
+
+      for _ <- 1..2 do
+        {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+        assert {"session-id", "session-123"} in websocket.headers
+        assert websocket.canonical_json["prompt_cache_key"] == "session-123"
+      end
+    end
+
+    test "does not invent a session or cache identity when none is supplied" do
+      {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
+      context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+      opts = [provider_options: [access_token: jwt_with_account_id("acct_cache")]]
+      {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+      refute List.keymember?(websocket.headers, "session-id", 0)
+      refute List.keymember?(websocket.headers, "session_id", 0)
+      refute Map.has_key?(websocket.canonical_json, "prompt_cache_key")
+    end
+  end
+
   describe "attach_stream/4" do
     test "builds SSE request against codex backend with combined instructions" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")
@@ -244,15 +309,17 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
           provider_options: [
             auth_mode: :oauth,
             access_token: jwt_with_account_id("acct_ws"),
-            session_id: "req_ws"
+            session_id: "req_ws",
+            thread_id: "thread_ws"
           ]
         )
 
       assert config.url == "wss://chatgpt.com/backend-api/codex/responses"
       assert config.fallback_transport == :http
       assert {"openai-beta", "responses_websockets=2026-02-06"} in config.headers
-      assert {"session_id", "req_ws"} in config.headers
-      assert {"x-client-request-id", "req_ws"} in config.headers
+      assert {"session-id", "req_ws"} in config.headers
+      assert {"thread-id", "thread_ws"} in config.headers
+      assert {"x-client-request-id", "thread_ws"} in config.headers
       refute {"x-openai-internal-codex-responses-lite", "true"} in config.headers
       refute Enum.any?(config.headers, &(elem(&1, 0) == "content-type"))
 


### PR DESCRIPTION
## Description

Align the Codex provider's cache/session identity with the official client across buffered HTTP, SSE, and WebSocket request builders:

- Accept `prompt_cache_key` and `thread_id` in the provider schema.
- Send hyphenated `session-id` / `thread-id` headers on all three transports.
- Default the prompt cache key to an explicitly supplied session ID, preserving explicit cache-key overrides.
- Keep WebSocket request/thread identity separate from session identity; do not invent a session/cache identity when none is provided.
- Document caller-owned identity scoping and add regression coverage for Spark, Responses Lite, and Astra.

The shared Responses encoder already supported `prompt_cache_key`, but the Codex schema rejected it. Codex WebSocket headers also still used the underscore form.

Official references:
- [Remove underscore ID headers (May 13)](https://github.com/openai/codex/commit/7c7b4861d88960f7e3bd5b7f30f8351be666dd84)
- [Use session IDs for prompt cache keys (July 14)](https://github.com/openai/codex/commit/4aa950d456c6c90174d3269d7eaab4a2823e5889)

This fixes request compatibility; it does not claim a particular cache-hit rate or explain changes to private provider quota policy.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Compatibility

The public `session_id` option remains supported. Its wire header is now `session-id`, rather than `session_id`. An explicit session also supplies the default cache key. Callers serving multiple users should scope identities appropriately; there is no global cache key or automatic connection-sharing change.

## Testing

- [x] `mix test`: 4,313 passed, 11 skipped, 173 excluded (fixture replay; no live recording)
- [x] Focused Codex/WebSocket suites: 38 passed
- [x] `mix quality`: passed (format, compile, strict Credo, Dialyzer)
- [x] Downstream LLMProxy full CI: 504 tests passed; production buffered/streaming Astra and streaming Responses Lite smoke calls returned terminal responses and usage

The three new provider tests reproduced failures before the implementation change. No credentials or production payloads are included in fixtures.

## Checklist

- [x] Code follows project conventions; no function-body comments
- [x] Documentation updated
- [x] Regression tests added
- [x] Existing default tests pass
- [x] Conventional commit
- [x] `CHANGELOG.md` untouched

Model-compatibility matrix (`mix mc "*:*"`) was not run; live provider coverage remains opt-in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556915&installation_model_id=434874&pr_number=996&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F996&signature=4e191c12da167513415a7f9ff8023f74d45e73695d68d73ed6e2882569c36c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->