### PR TITLE
feat(bedrock): round-trip reasoning on the Converse API

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -706,7 +706,12 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     {chunks, state} =
       cond do
         converse_event?(event) ->
-          {decode_formatter_stream_event(ReqLLM.Providers.AmazonBedrock.Converse, event), state}
+          state = state || init_stream_state(model) || %{}
+
+          {chunks, converse_state} =
+            ReqLLM.Providers.AmazonBedrock.Converse.decode_stream_event(event, state[:converse])
+
+          {chunks, Map.put(state, :converse, converse_state)}
 
         get_model_family(model_id) == "anthropic" ->
           ReqLLM.Providers.Anthropic.Response.decode_stream_event(%{data: event}, model, state)
@@ -740,9 +745,21 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   def flush_stream_state(model, state) do
     model_id = model.provider_model_id || model.id
 
-    case get_model_family(model_id) do
-      "anthropic" -> ReqLLM.Providers.Anthropic.Response.flush_stream_state(model, state)
-      _ -> {[], state}
+    {chunks, state} =
+      case get_model_family(model_id) do
+        "anthropic" -> ReqLLM.Providers.Anthropic.Response.flush_stream_state(model, state)
+        _ -> {[], state}
+      end
+
+    case state do
+      %{converse: converse_state} ->
+        {converse_chunks, converse_state} =
+          ReqLLM.Providers.AmazonBedrock.Converse.flush_stream_state(converse_state)
+
+        {chunks ++ converse_chunks, Map.put(state, :converse, converse_state)}
+
+      _ ->
+        {chunks, state}
     end
   end
 

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -311,11 +311,26 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     block =
       case key do
         :text -> %{block | text: block.text <> value}
-        :signature -> %{block | signature: value}
-        :redacted -> %{block | redacted: value}
+        :signature -> %{block | signature: append_fragment(block.signature, value)}
+        :redacted -> %{block | redacted: append_redacted_fragment(block.redacted, value)}
       end
 
     %{state | reasoning_blocks: Map.put(state.reasoning_blocks, index, block)}
+  end
+
+  defp append_fragment(nil, value), do: value
+  defp append_fragment(existing, value), do: existing <> value
+
+  defp append_redacted_fragment(nil, value), do: value
+
+  defp append_redacted_fragment(existing, value) do
+    case {Base.decode64(existing), Base.decode64(value)} do
+      {{:ok, existing_bytes}, {:ok, value_bytes}} ->
+        Base.encode64(existing_bytes <> value_bytes)
+
+      _ ->
+        existing <> value
+    end
   end
 
   defp reasoning_detail(%{redacted: data}, index) when is_binary(data) do

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -80,7 +80,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   alias ReqLLM.Message
   alias ReqLLM.Message.ContentPart
+  alias ReqLLM.Message.ReasoningDetails
   alias ReqLLM.ToolCall
+
+  @reasoning_format "bedrock-converse-v1"
+  @replayable_reasoning_providers [:amazon_bedrock, :anthropic]
 
   @doc """
   Format a ReqLLM context into Bedrock Converse API format.
@@ -236,6 +240,103 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
       |> ReqLLM.ToolCall.find_args("structured_output", opts)
 
     %{response | object: extracted_object}
+  end
+
+  def init_stream_state, do: %{reasoning_blocks: %{}, next_reasoning_index: 0}
+
+  @doc "Emits `reasoning_details` when a reasoning block receives `contentBlockStop`."
+  def decode_stream_event(event, nil), do: decode_stream_event(event, init_stream_state())
+
+  def decode_stream_event(%{"contentBlockDelta" => delta_data} = event, state) do
+    index = delta_data["contentBlockIndex"]
+
+    case get_in(delta_data, ["delta", "reasoningContent"]) do
+      %{"text" => text} when is_binary(text) ->
+        chunks = if text == "", do: [], else: [ReqLLM.StreamChunk.thinking(text)]
+        {chunks, append_reasoning(state, index, :text, text)}
+
+      %{"signature" => signature} when is_binary(signature) ->
+        {[], append_reasoning(state, index, :signature, signature)}
+
+      %{"redactedContent" => data} when is_binary(data) ->
+        {[], append_reasoning(state, index, :redacted, data)}
+
+      _ ->
+        {stateless_chunks(event), state}
+    end
+  end
+
+  def decode_stream_event(%{"contentBlockStop" => %{"contentBlockIndex" => index}}, state) do
+    case Map.pop(state.reasoning_blocks, index) do
+      {nil, _blocks} ->
+        {[], state}
+
+      {block, blocks} ->
+        detail = reasoning_detail(block, state.next_reasoning_index)
+
+        {[ReqLLM.StreamChunk.meta(%{reasoning_details: [detail]})],
+         %{state | reasoning_blocks: blocks, next_reasoning_index: state.next_reasoning_index + 1}}
+    end
+  end
+
+  def decode_stream_event(event, state), do: {stateless_chunks(event), state}
+
+  @doc "Emit reasoning details for blocks that never received a `contentBlockStop`."
+  def flush_stream_state(nil), do: {[], init_stream_state()}
+
+  def flush_stream_state(state) do
+    state.reasoning_blocks
+    |> Enum.sort_by(fn {index, _block} -> index end)
+    |> Enum.map_reduce(%{state | reasoning_blocks: %{}}, fn {_index, block}, acc ->
+      {reasoning_detail(block, acc.next_reasoning_index),
+       %{acc | next_reasoning_index: acc.next_reasoning_index + 1}}
+    end)
+    |> case do
+      {[], state} -> {[], state}
+      {details, state} -> {[ReqLLM.StreamChunk.meta(%{reasoning_details: details})], state}
+    end
+  end
+
+  defp stateless_chunks(event) do
+    case parse_stream_chunk(event, %{}) do
+      {:ok, nil} -> []
+      {:ok, chunk} -> [chunk]
+      {:error, _} -> []
+    end
+  end
+
+  defp append_reasoning(state, index, key, value) do
+    block = Map.get(state.reasoning_blocks, index, %{text: "", signature: nil, redacted: nil})
+
+    block =
+      case key do
+        :text -> %{block | text: block.text <> value}
+        :signature -> %{block | signature: value}
+        :redacted -> %{block | redacted: value}
+      end
+
+    %{state | reasoning_blocks: Map.put(state.reasoning_blocks, index, block)}
+  end
+
+  defp reasoning_detail(%{redacted: data}, index) when is_binary(data) do
+    %ReasoningDetails{
+      encrypted?: true,
+      provider: :amazon_bedrock,
+      format: @reasoning_format,
+      index: index,
+      provider_data: %{"redactedContent" => data}
+    }
+  end
+
+  defp reasoning_detail(%{text: text, signature: signature}, index) do
+    %ReasoningDetails{
+      text: text,
+      signature: signature,
+      encrypted?: signature != nil,
+      provider: :amazon_bedrock,
+      format: @reasoning_format,
+      index: index
+    }
   end
 
   @doc """
@@ -554,20 +655,13 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   # Assistant message with tool calls (new ToolCall pattern)
-  defp encode_message(%Message{role: :assistant, tool_calls: tool_calls, content: content})
+  defp encode_message(%Message{role: :assistant, tool_calls: tool_calls, content: content} = msg)
        when is_list(tool_calls) and tool_calls != [] do
-    text_content = encode_content(content)
     tool_blocks = Enum.map(tool_calls, &encode_tool_call_to_tool_use/1)
-
-    content_blocks =
-      case text_content do
-        [] -> tool_blocks
-        blocks when is_list(blocks) -> blocks ++ tool_blocks
-      end
 
     %{
       "role" => "assistant",
-      "content" => content_blocks
+      "content" => encode_reasoning_details(msg) ++ encode_content(content) ++ tool_blocks
     }
   end
 
@@ -588,12 +682,36 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   # Regular message (user, assistant, system) — returns nil if content is
   # empty after filtering, so the caller can reject it like empty ContentParts.
-  defp encode_message(%Message{role: role, content: content}) do
-    case encode_content(content) do
+  defp encode_message(%Message{role: role, content: content} = msg) do
+    case encode_reasoning_details(msg) ++ encode_content(content) do
       [] -> nil
       encoded -> %{"role" => Atom.to_string(role), "content" => encoded}
     end
   end
+
+  defp encode_reasoning_details(%Message{role: :assistant, reasoning_details: details})
+       when is_list(details) do
+    details
+    |> Enum.filter(&(&1.provider in @replayable_reasoning_providers))
+    |> Enum.sort_by(& &1.index)
+    |> Enum.flat_map(&encode_reasoning_detail/1)
+  end
+
+  defp encode_reasoning_details(_msg), do: []
+
+  defp encode_reasoning_detail(%{provider_data: %{"redactedContent" => data}})
+       when is_binary(data),
+       do: [%{"reasoningContent" => %{"redactedContent" => data}}]
+
+  defp encode_reasoning_detail(%{text: text, signature: signature})
+       when is_binary(text) and is_binary(signature),
+       do: [
+         %{
+           "reasoningContent" => %{"reasoningText" => %{"text" => text, "signature" => signature}}
+         }
+       ]
+
+  defp encode_reasoning_detail(_detail), do: []
 
   defp encode_content_for_system(content) when is_binary(content) do
     [%{"text" => content}]
@@ -728,13 +846,35 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     # Separate tool calls from regular content
     {tool_calls, content_parts} = parse_content_with_tool_calls(content_blocks)
 
-    # Build message with tool_calls field if present
-    message = %Message{role: role, content: content_parts}
+    message = %Message{
+      role: role,
+      content: content_parts,
+      reasoning_details: parse_reasoning_details(content_blocks)
+    }
 
     if tool_calls == [] do
       message
     else
       %{message | tool_calls: tool_calls}
+    end
+  end
+
+  defp parse_reasoning_details(content_blocks) do
+    content_blocks
+    |> Enum.flat_map(fn
+      %{"reasoningContent" => %{"reasoningText" => %{"text" => text} = reasoning}} ->
+        [%{text: text, signature: reasoning["signature"], redacted: nil}]
+
+      %{"reasoningContent" => %{"redactedContent" => data}} ->
+        [%{text: nil, signature: nil, redacted: data}]
+
+      _ ->
+        []
+    end)
+    |> Enum.with_index(&reasoning_detail/2)
+    |> case do
+      [] -> nil
+      details -> details
     end
   end
 
@@ -830,10 +970,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     end
   end
 
-  defp parse_content_block(%{"reasoningText" => reasoning_text}) do
-    # Claude extended thinking reasoning content
-    %ContentPart{type: :thinking, text: reasoning_text}
+  defp parse_content_block(%{"reasoningContent" => %{"reasoningText" => %{"text" => text}}}) do
+    ContentPart.thinking(text)
   end
+
+  defp parse_content_block(%{"reasoningContent" => _redacted}), do: nil
 
   defp parse_content_block(%{"image" => _image}) do
     # Image in response - for now skip

--- a/test/coverage/amazon_bedrock/converse_reasoning_test.exs
+++ b/test/coverage/amazon_bedrock/converse_reasoning_test.exs
@@ -1,0 +1,75 @@
+defmodule ReqLLM.Coverage.AmazonBedrock.ConverseReasoningTest do
+  @moduledoc """
+  Record with REQ_LLM_FIXTURES_MODE=record and AWS_REGION=us-east-1.
+  """
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message.ReasoningDetails
+
+  @moduletag :coverage
+  @moduletag provider: "amazon_bedrock"
+  @moduletag timeout: 180_000
+
+  @model "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0"
+  @opts [
+    max_tokens: 2048,
+    reasoning_token_budget: 1024,
+    provider_options: [use_converse: true]
+  ]
+
+  setup_all do
+    LLMDB.load(allow: :all, custom: %{})
+    :ok
+  end
+
+  test "replays signed reasoning across a tool round-trip" do
+    tool =
+      ReqLLM.tool(
+        name: "get_balance",
+        description: "Current balance for an account id",
+        parameter_schema: [account_id: [type: :string, required: true]],
+        callback: fn _ -> {:ok, "42"} end
+      )
+
+    context =
+      Context.new([
+        Context.system("Use the tool, then answer with the number only."),
+        Context.user("What is the balance of account acc_1?")
+      ])
+
+    opts = @opts ++ [tools: [tool]]
+
+    {:ok, first} =
+      ReqLLM.generate_text(@model, context, fixture_opts("converse_reasoning_tool_1", opts))
+
+    assert [call] = ReqLLM.Response.tool_calls(first)
+    assert [%ReasoningDetails{signature: signature} | _] = first.message.reasoning_details
+    assert is_binary(signature)
+
+    {:ok, context} =
+      Context.append_tool_exchange(first.context, first, [
+        Context.tool_result(call.id, call.function.name, "42")
+      ])
+
+    {:ok, second} =
+      ReqLLM.generate_text(@model, context, fixture_opts("converse_reasoning_tool_2", opts))
+
+    assert ReqLLM.Response.text(second) =~ "42"
+  end
+
+  test "streams reasoning with its signature" do
+    context = Context.new([Context.user("What is 17 times 23? Answer with the number only.")])
+
+    {:ok, stream} =
+      ReqLLM.stream_text(@model, context, fixture_opts("converse_reasoning_streaming", @opts))
+
+    {:ok, response} = ReqLLM.StreamResponse.to_response(stream)
+
+    assert ReqLLM.Response.text(response) =~ "391"
+    assert [%ReasoningDetails{signature: signature} | _] = response.message.reasoning_details
+    assert is_binary(signature)
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -689,11 +689,23 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
             "delta" => %{"reasoningContent" => %{"signature" => "sig"}}
           }
         },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 0,
+            "delta" => %{"reasoningContent" => %{"signature" => "_test"}}
+          }
+        },
         %{"contentBlockStop" => %{"contentBlockIndex" => 0}},
         %{
           "contentBlockDelta" => %{
             "contentBlockIndex" => 1,
-            "delta" => %{"reasoningContent" => %{"redactedContent" => "abc="}}
+            "delta" => %{"reasoningContent" => %{"redactedContent" => Base.encode64("a")}}
+          }
+        },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 1,
+            "delta" => %{"reasoningContent" => %{"redactedContent" => Base.encode64("b")}}
           }
         },
         %{"contentBlockStop" => %{"contentBlockIndex" => 1}},
@@ -714,10 +726,16 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
                %ReqLLM.StreamChunk{type: :content, text: "Answer"}
              ] = chunks
 
-      assert %ReasoningDetails{text: "thought", signature: "sig", encrypted?: true, index: 0} =
+      assert %ReasoningDetails{text: "thought", signature: "sig_test", encrypted?: true, index: 0} =
                signed
 
-      assert %ReasoningDetails{text: nil, index: 1, provider_data: %{"redactedContent" => "abc="}} =
+      expected_redacted = Base.encode64("ab")
+
+      assert %ReasoningDetails{
+               text: nil,
+               index: 1,
+               provider_data: %{"redactedContent" => ^expected_redacted}
+             } =
                redacted
     end
   end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -417,6 +417,311 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
     end
   end
 
+  describe "reasoning round-trip" do
+    alias ReqLLM.Message.ReasoningDetails
+
+    defp tool_call, do: ReqLLM.ToolCall.new("call_1", "get_weather", "{}")
+
+    test "replays signed reasoning before assistant content" do
+      details = [
+        %ReasoningDetails{
+          text: "thought",
+          signature: "sig",
+          encrypted?: true,
+          provider: :amazon_bedrock,
+          index: 0
+        },
+        %ReasoningDetails{text: "unsigned", signature: nil, provider: :amazon_bedrock, index: 1}
+      ]
+
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: "Hi"},
+          %Message{
+            role: :assistant,
+            content: "Calling",
+            tool_calls: [tool_call()],
+            reasoning_details: details
+          },
+          %Message{role: :tool, tool_call_id: "call_1", content: "sunny"}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+      [_, assistant, _] = result["messages"]
+
+      assert [
+               %{
+                 "reasoningContent" => %{
+                   "reasoningText" => %{"text" => "thought", "signature" => "sig"}
+                 }
+               },
+               %{"text" => "Calling"},
+               %{"toolUse" => _}
+             ] = assistant["content"]
+    end
+
+    test "replays redacted reasoning" do
+      details = [
+        %ReasoningDetails{
+          encrypted?: true,
+          provider: :amazon_bedrock,
+          index: 0,
+          provider_data: %{"redactedContent" => "abc="}
+        }
+      ]
+
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: "Hi"},
+          %Message{role: :assistant, content: "Done", reasoning_details: details}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+      [_, assistant] = result["messages"]
+
+      assert assistant["content"] == [
+               %{"reasoningContent" => %{"redactedContent" => "abc="}},
+               %{"text" => "Done"}
+             ]
+    end
+
+    test "does not replay thinking parts without reasoning details" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: "Hi"},
+          %Message{
+            role: :assistant,
+            content: [ContentPart.thinking("x"), ContentPart.text("Done")]
+          }
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+      [_, assistant] = result["messages"]
+
+      assert assistant["content"] == [%{"text" => "Done"}]
+    end
+
+    test "parses reasoningContent into thinking content and reasoning details" do
+      response_body = %{
+        "output" => %{
+          "message" => %{
+            "role" => "assistant",
+            "content" => [
+              %{
+                "reasoningContent" => %{
+                  "reasoningText" => %{"text" => "thought", "signature" => "sig"}
+                }
+              },
+              %{"reasoningContent" => %{"redactedContent" => "abc="}},
+              %{"text" => "Answer"}
+            ]
+          }
+        },
+        "stopReason" => "end_turn"
+      }
+
+      {:ok, result} = Converse.parse_response(response_body, model: "test-model")
+
+      assert [
+               %ContentPart{type: :thinking, text: "thought"},
+               %ContentPart{type: :text, text: "Answer"}
+             ] =
+               result.message.content
+
+      assert [
+               %ReasoningDetails{
+                 text: "thought",
+                 signature: "sig",
+                 encrypted?: true,
+                 provider: :amazon_bedrock,
+                 format: "bedrock-converse-v1",
+                 index: 0
+               },
+               %ReasoningDetails{
+                 text: nil,
+                 signature: nil,
+                 encrypted?: true,
+                 index: 1,
+                 provider_data: %{"redactedContent" => "abc="}
+               }
+             ] = result.message.reasoning_details
+    end
+
+    test "does not replay reasoning from other providers" do
+      details = [
+        %ReasoningDetails{
+          text: "thought",
+          signature: "sig",
+          encrypted?: true,
+          provider: :google,
+          index: 0
+        },
+        %ReasoningDetails{
+          text: "kept",
+          signature: "sig2",
+          encrypted?: true,
+          provider: :anthropic,
+          index: 1
+        }
+      ]
+
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: "Hi"},
+          %Message{role: :assistant, content: "Done", reasoning_details: details}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+      [_, assistant] = result["messages"]
+
+      assert [
+               %{
+                 "reasoningContent" => %{
+                   "reasoningText" => %{"text" => "kept", "signature" => "sig2"}
+                 }
+               },
+               %{"text" => "Done"}
+             ] = assistant["content"]
+    end
+
+    test "flushes reasoning blocks that never stopped" do
+      events = [
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 0,
+            "delta" => %{"reasoningContent" => %{"text" => "thought"}}
+          }
+        },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 0,
+            "delta" => %{"reasoningContent" => %{"signature" => "sig"}}
+          }
+        }
+      ]
+
+      {_chunks, state} =
+        Enum.flat_map_reduce(
+          events,
+          Converse.init_stream_state(),
+          &Converse.decode_stream_event/2
+        )
+
+      {[chunk], state} = Converse.flush_stream_state(state)
+
+      assert %ReqLLM.StreamChunk{
+               metadata: %{
+                 reasoning_details: [%ReasoningDetails{text: "thought", signature: "sig"}]
+               }
+             } =
+               chunk
+
+      assert Converse.flush_stream_state(state) == {[], state}
+    end
+
+    test "numbers reasoning details independently of text block indices" do
+      events = [
+        %{"contentBlockDelta" => %{"contentBlockIndex" => 0, "delta" => %{"text" => "Hi"}}},
+        %{"contentBlockStop" => %{"contentBlockIndex" => 0}},
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 3,
+            "delta" => %{"reasoningContent" => %{"text" => "a"}}
+          }
+        },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 3,
+            "delta" => %{"reasoningContent" => %{"signature" => "s1"}}
+          }
+        },
+        %{"contentBlockStop" => %{"contentBlockIndex" => 3}},
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 5,
+            "delta" => %{"reasoningContent" => %{"text" => "b"}}
+          }
+        },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 5,
+            "delta" => %{"reasoningContent" => %{"signature" => "s2"}}
+          }
+        },
+        %{"contentBlockStop" => %{"contentBlockIndex" => 5}}
+      ]
+
+      {chunks, _state} =
+        Enum.flat_map_reduce(
+          events,
+          Converse.init_stream_state(),
+          &Converse.decode_stream_event/2
+        )
+
+      indices =
+        for %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [detail]}} <- chunks,
+            do: detail.index
+
+      assert indices == [0, 1]
+    end
+
+    test "streams reasoning deltas and emits details on contentBlockStop" do
+      events = [
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 0,
+            "delta" => %{"reasoningContent" => %{"text" => "tho"}}
+          }
+        },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 0,
+            "delta" => %{"reasoningContent" => %{"text" => "ught"}}
+          }
+        },
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 0,
+            "delta" => %{"reasoningContent" => %{"signature" => "sig"}}
+          }
+        },
+        %{"contentBlockStop" => %{"contentBlockIndex" => 0}},
+        %{
+          "contentBlockDelta" => %{
+            "contentBlockIndex" => 1,
+            "delta" => %{"reasoningContent" => %{"redactedContent" => "abc="}}
+          }
+        },
+        %{"contentBlockStop" => %{"contentBlockIndex" => 1}},
+        %{"contentBlockDelta" => %{"contentBlockIndex" => 2, "delta" => %{"text" => "Answer"}}},
+        %{"contentBlockStop" => %{"contentBlockIndex" => 2}}
+      ]
+
+      {chunks, _state} =
+        Enum.flat_map_reduce(events, Converse.init_stream_state(), fn event, state ->
+          Converse.decode_stream_event(event, state)
+        end)
+
+      assert [
+               %ReqLLM.StreamChunk{type: :thinking, text: "tho"},
+               %ReqLLM.StreamChunk{type: :thinking, text: "ught"},
+               %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [signed]}},
+               %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: [redacted]}},
+               %ReqLLM.StreamChunk{type: :content, text: "Answer"}
+             ] = chunks
+
+      assert %ReasoningDetails{text: "thought", signature: "sig", encrypted?: true, index: 0} =
+               signed
+
+      assert %ReasoningDetails{text: nil, index: 1, provider_data: %{"redactedContent" => "abc="}} =
+               redacted
+    end
+  end
+
   describe "parse_response/2" do
     test "parses basic text response" do
       response_body = %{

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -472,6 +472,52 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
     end
   end
 
+  describe "Converse reasoning stream state" do
+    setup do
+      {:ok, model} =
+        ReqLLM.model(%{
+          provider: :amazon_bedrock,
+          id: "anthropic.claude-haiku-4-5-20251001-v1:0",
+          capabilities: %{chat: true, reasoning: %{enabled: true}}
+        })
+
+      {:ok, model: model}
+    end
+
+    test "starts from nil state and flushes pending reasoning for Claude", %{model: model} do
+      delta = %{
+        "contentBlockDelta" => %{
+          "contentBlockIndex" => 0,
+          "delta" => %{"reasoningContent" => %{"text" => "thought"}}
+        }
+      }
+
+      signature = %{
+        "contentBlockDelta" => %{
+          "contentBlockIndex" => 0,
+          "delta" => %{"reasoningContent" => %{"signature" => "sig"}}
+        }
+      }
+
+      {[%ReqLLM.StreamChunk{type: :thinking}], state} =
+        AmazonBedrock.decode_stream_event(delta, model, nil)
+
+      {[], state} = AmazonBedrock.decode_stream_event(signature, model, state)
+      {chunks, _state} = AmazonBedrock.flush_stream_state(model, state)
+
+      assert [
+               %ReqLLM.StreamChunk{
+                 type: :meta,
+                 metadata: %{
+                   reasoning_details: [
+                     %ReqLLM.Message.ReasoningDetails{text: "thought", signature: "sig"}
+                   ]
+                 }
+               }
+             ] = chunks
+    end
+  end
+
   describe "AWS session token support" do
     test "includes session token in signed Req request headers" do
       # Test non-streaming path (Req pipeline via put_aws_sigv4)

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_reasoning_streaming.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_reasoning_streaming.json
@@ -1,0 +1,101 @@
+{
+  "captured_at": "2026-09-09T06:23:56.126358Z",
+  "chunks": [
+    {
+      "b64": "AAAAtAAAAFIFAEFlCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIiLCJyb2xlIjoiYXNzaXN0YW50In2fX38tAAAAwwAAAFc+mIk1CzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiMTcifX0sInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzIn3mPxRn"
+    },
+    {
+      "b64": "AAAAyAAAAFdJSLgkCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiIHRpbWVzIn19LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3QifS+feNU="
+    },
+    {
+      "b64": "AAAA3wAAAFebiPO2CzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiIDIzIn19LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVCJ9HPre9w=="
+    },
+    {
+      "b64": "AAAAwgAAAFcD+KCFCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiXG4xNyJ9fSwicCI6ImFiY2RlZmdoaWprbG1ub3Aiffcx27w="
+    },
+    {
+      "b64": "AAAA3QAAAFfhSKDWCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiIMOXIDIzID0gMTcifX0sInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUoifZ+fFV0="
+    },
+    {
+      "b64": "AAAA7AAAAFd9CTHgCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiIMOXIDIwICsgMTcifX0sInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFkifYuSWa8="
+    },
+    {
+      "b64": "AAAAygAAAFcziOtECzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiIMOXIDMifX0sInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2dyJ9kCJQgA=="
+    },
+    {
+      "b64": "AAAAzAAAAFe8yB7kCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiXG49IDM0MCArIDUxIn19LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyIn0Dn/Og"
+    },
+    {
+      "b64": "AAAA6wAAAFfPKe3wCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiXG49IDM5MSJ9fSwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMSJ9CBcnEg=="
+    },
+    {
+      "b64": "AAAAwwAAAFc+mIk1CzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJ0ZXh0IjoiIn19LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1In27S2Ma"
+    },
+    {
+      "b64": "AAACTwAAAFcHRnWtCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwiZGVsdGEiOnsicmVhc29uaW5nQ29udGVudCI6eyJzaWduYXR1cmUiOiJFcUVDQ29RQkNCRVFBUmdDS2tBa0tTNTFnRU1uM1YwOVJlSjFzSENlamdTUWVXQnZZVnkzWXdoYkcyN2JONVNBMk00MDdTQmlmM1BORk9Fbkovc3VhYnRYZUVTRG11amJZKy9DMkcvUk1obGpiR0YxWkdVdGFHRnBhM1V0TkMwMUxUSXdNalV4TURBeE9BQkNDSFJvYVc1cmFXNW5XZ3d4TWpNME5UWTNPRGt3TVRLb0FmdjJnOVVHRWd5Uks2clNGREprNjdNMzdua2FER2JpaTh4T1pjS1BLeHAweGlJd01LT01sOCsrd3dMR3BwRmRUMFRvN0Y5aHNwQXlXUWZYNUFXRjNiRmo4SVdIQUt3MDZGYmZ3MmhRWkg5U05pTVlLa3BOR0RKZ0tyVjRQbWtlQ1lLWmErSExQMHlESHRjOUo0UVppc3pjSjdZQzIyN0NPYlNGOGxBLzZkRlB6TzFEL093UHpXc3RSdVJIYldHSVQ5R2RZQWVTTkw0ZXV4K05vZXRMN0JnQiJ9fSwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0In2w9y+s"
+    },
+    {
+      "b64": "AAAAlAAAAFbDrKp4CzpldmVudC10eXBlBwAQY29udGVudEJsb2NrU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjowLCJwIjoiYWJjZGVmZ2hpamtsbW5vcCJ9yrB0Sg=="
+    },
+    {
+      "b64": "AAAAtQAAAFdICpxaCzpldmVudC10eXBlBwARY29udGVudEJsb2NrRGVsdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MSwiZGVsdGEiOnsidGV4dCI6IjM5MSJ9LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eSJ9cPZ2JA=="
+    },
+    {
+      "b64": "AAAAqAAAAFanff//CzpldmVudC10eXBlBwAQY29udGVudEJsb2NrU3RvcA06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNvbnRlbnRCbG9ja0luZGV4IjoxLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKIn2/oDDb"
+    },
+    {
+      "b64": "AAAAsQAAAFFU6Z+vCzpldmVudC10eXBlBwALbWVzc2FnZVN0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWIiwic3RvcFJlYXNvbiI6ImVuZF90dXJuIn3E9HFnAAAA8AAAAE68cuOjCzpldmVudC10eXBlBwAIbWV0YWRhdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJtZXRyaWNzIjp7ImxhdGVuY3lNcyI6OTc2fSwicCI6ImFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6IiwidXNhZ2UiOnsiaW5wdXRUb2tlbnMiOjUxLCJvdXRwdXRUb2tlbnMiOjUxLCJzZXJ2ZXJUb29sVXNhZ2UiOnt9LCJ0b3RhbFRva2VucyI6MTAyfX184DbL"
+    }
+  ],
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJhZGRpdGlvbmFsTW9kZWxSZXF1ZXN0RmllbGRzIjp7InRoaW5raW5nIjp7ImJ1ZGdldF90b2tlbnMiOjEwMjQsInR5cGUiOiJlbmFibGVkIn19LCJpbmZlcmVuY2VDb25maWciOnsibWF4VG9rZW5zIjoyMDQ4fSwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOlt7InRleHQiOiJXaGF0IGlzIDE3IHRpbWVzIDIzPyBBbnN3ZXIgd2l0aCB0aGUgbnVtYmVyIG9ubHkuIn1dLCJyb2xlIjoidXNlciJ9XX0="
+    },
+    "canonical_json": {
+      "additionalModelRequestFields": {
+        "thinking": {
+          "budget_tokens": 1024,
+          "type": "enabled"
+        }
+      },
+      "inferenceConfig": {
+        "maxTokens": 2048
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "What is 17 times 23? Answer with the number only."
+            }
+          ],
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "accept": "application/vnd.amazon.eventstream",
+      "authorization": "[REDACTED:authorization]",
+      "content-type": "application/json",
+      "host": "bedrock-runtime.us-east-1.amazonaws.com",
+      "x-amz-content-sha256": "c5fe0cd1ceddb1e130d9b982977b955f055d1a518b97f5c55d04aba6b7940d34",
+      "x-amz-date": "20260909T062354Z",
+      "x-amz-security-token": "[REDACTED:x-amz-security-token]"
+    },
+    "method": "POST",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse-stream"
+  },
+  "response": {
+    "body": null,
+    "headers": {
+      "connection": "keep-alive",
+      "content-type": "application/vnd.amazon.eventstream",
+      "date": "Wed, 09 Sep 2026 06:23:55 GMT",
+      "transfer-encoding": "chunked",
+      "x-amzn-requestid": "f09bb2a4-8ca3-491d-bd8c-c709c9650277"
+    },
+    "status": 200
+  },
+  "streaming": true
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_reasoning_tool_1.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_reasoning_tool_1.json
@@ -1,0 +1,142 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJhZGRpdGlvbmFsTW9kZWxSZXF1ZXN0RmllbGRzIjp7InRoaW5raW5nIjp7ImJ1ZGdldF90b2tlbnMiOjEwMjQsInR5cGUiOiJlbmFibGVkIn19LCJpbmZlcmVuY2VDb25maWciOnsibWF4VG9rZW5zIjoyMDQ4fSwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOlt7InRleHQiOiJXaGF0IGlzIHRoZSBiYWxhbmNlIG9mIGFjY291bnQgYWNjXzE/In1dLCJyb2xlIjoidXNlciJ9XSwic3lzdGVtIjpbeyJ0ZXh0IjoiVXNlIHRoZSB0b29sLCB0aGVuIGFuc3dlciB3aXRoIHRoZSBudW1iZXIgb25seS4ifV0sInRvb2xDb25maWciOnsidG9vbHMiOlt7InRvb2xTcGVjIjp7ImRlc2NyaXB0aW9uIjoiQ3VycmVudCBiYWxhbmNlIGZvciBhbiBhY2NvdW50IGlkIiwiaW5wdXRTY2hlbWEiOnsianNvbiI6eyJhZGRpdGlvbmFsUHJvcGVydGllcyI6ZmFsc2UsInByb3BlcnRpZXMiOnsiYWNjb3VudF9pZCI6eyJ0eXBlIjoic3RyaW5nIn19LCJyZXF1aXJlZCI6WyJhY2NvdW50X2lkIl0sInR5cGUiOiJvYmplY3QifX0sIm5hbWUiOiJnZXRfYmFsYW5jZSJ9fV19fQ=="
+    },
+    "canonical_json": {
+      "additionalModelRequestFields": {
+        "thinking": {
+          "budget_tokens": 1024,
+          "type": "enabled"
+        }
+      },
+      "inferenceConfig": {
+        "maxTokens": 2048
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "What is the balance of account acc_1?"
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "system": [
+        {
+          "text": "Use the tool, then answer with the number only."
+        }
+      ],
+      "toolConfig": {
+        "tools": [
+          {
+            "toolSpec": {
+              "description": "Current balance for an account id",
+              "inputSchema": {
+                "json": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "account_id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "account_id"
+                  ],
+                  "type": "object"
+                }
+              },
+              "name": "get_balance"
+            }
+          }
+        ]
+      }
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "029ecb0d436246637da907858733dca339db155697794c54375cde2cf1882275"
+      ],
+      "x-amz-date": [
+        "20260909T062351Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
+  },
+  "response": {
+    "body": {
+      "metrics": {
+        "latencyMs": 1185
+      },
+      "output": {
+        "message": {
+          "content": [
+            {
+              "reasoningContent": {
+                "reasoningText": {
+                  "signature": "EuoDCoQBCBEQARgCKkCgz3Z9Cj2HXWouKIYnHTPGs8DgJGxuL67rxKGTGyFY0cSFyun2dalPmowatttcc3uZzdXinrw3DHng3Ux+q0xpMhljbGF1ZGUtaGFpa3UtNC01LTIwMjUxMDAxOABCCHRoaW5raW5nWgwxMjM0NTY3ODkwMTKoAfn2g9UGEgza9M7OfojnvVCB+qkaDAhrMfZc6WeZROb2RCIwRmnaUFc0RHkCl2b6kZt0w9ciZWzG0W3LcoRV09aTGJ1XrR8nDDTLNQ897Cp/liKYKpICPK0KAlxkNNTve3ykLRImm4p0IEuXrDwhMnRYOjGKr1d1TUL/lt8C0pvH4eXNkq8htkdx8CXAjJCYPh0WwjUCroj4qrqqlRRtFjBTY2qEwf5ZAXUJZy4R7Y1W5leMbwnrymb4b4UNog+mJGWz5zFyKCrvdUyYaQEghiuy0Gat7ajdiVmJZhepiLChwIFmIssLMFUc5adM3xPKDzzSzQ6Bq/3vzxItWHOWDWK/HcGCUkZO03L81zJXUHEgtxBMgFjtmeZj3RwpSmQR7qbBSa9DoG+86WXmcTCJ1tIm1dYE+hN4EIhubXgYOMV3KZLOvcZvt3zerZumDtx2Y0UwBYAALFjyhI8NzFHCq3N8kcQ2+3ZUMBgB",
+                  "text": "The user is asking for the balance of account \"acc_1\". I have a function available called \"get_balance\" that takes an account_id as a parameter. The user has provided the account_id as \"acc_1\", so I have all the information I need to make this function call."
+                }
+              }
+            },
+            {
+              "toolUse": {
+                "input": {
+                  "account_id": "acc_1"
+                },
+                "name": "get_balance",
+                "toolUseId": "tooluse_dESTIFFidU5NcgXThviwQf",
+                "type": "tool_use"
+              }
+            }
+          ],
+          "role": "assistant"
+        }
+      },
+      "stopReason": "tool_use",
+      "usage": {
+        "cacheReadInputTokenCount": 0,
+        "cacheReadInputTokens": 0,
+        "inputTokens": 620,
+        "outputTokens": 128,
+        "serverToolUsage": {},
+        "totalTokens": 748
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "1367"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Wed, 09 Sep 2026 06:23:53 GMT"
+      ],
+      "x-amzn-requestid": [
+        "7403539b-08d8-44fd-ab8f-b40724b5a139"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_reasoning_tool_2.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_reasoning_tool_2.json
@@ -1,0 +1,164 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJhZGRpdGlvbmFsTW9kZWxSZXF1ZXN0RmllbGRzIjp7InRoaW5raW5nIjp7ImJ1ZGdldF90b2tlbnMiOjEwMjQsInR5cGUiOiJlbmFibGVkIn19LCJpbmZlcmVuY2VDb25maWciOnsibWF4VG9rZW5zIjoyMDQ4fSwibWVzc2FnZXMiOlt7ImNvbnRlbnQiOlt7InRleHQiOiJXaGF0IGlzIHRoZSBiYWxhbmNlIG9mIGFjY291bnQgYWNjXzE/In1dLCJyb2xlIjoidXNlciJ9LHsiY29udGVudCI6W3sicmVhc29uaW5nQ29udGVudCI6eyJyZWFzb25pbmdUZXh0Ijp7InNpZ25hdHVyZSI6IkV1b0RDb1FCQ0JFUUFSZ0NLa0NnejNaOUNqMkhYV291S0lZbkhUUEdzOERnSkd4dUw2N3J4S0dUR3lGWTBjU0Z5dW4yZGFsUG1vd2F0dHRjYzN1WnpkWGlucnczREhuZzNVeCtxMHhwTWhsamJHRjFaR1V0YUdGcGEzVXROQzAxTFRJd01qVXhNREF4T0FCQ0NIUm9hVzVyYVc1bldnd3hNak0wTlRZM09Ea3dNVEtvQWZuMmc5VUdFZ3phOU03T2Zvam52VkNCK3FrYURBaHJNZlpjNldlWlJPYjJSQ0l3Um1uYVVGYzBSSGtDbDJiNmtadDB3OWNpWld6RzBXM0xjb1JWMDlhVEdKMVhyUjhuRERUTE5RODk3Q3AvbGlLWUtwSUNQSzBLQWx4a05OVHZlM3lrTFJJbW00cDBJRXVYckR3aE1uUllPakdLcjFkMVRVTC9sdDhDMHB2SDRlWE5rcThodGtkeDhDWEFqSkNZUGgwV3dqVUNyb2o0cXJxcWxSUnRGakJUWTJxRXdmNVpBWFVKWnk0UjdZMVc1bGVNYnducnltYjRiNFVOb2crbUpHV3o1ekZ5S0NydmRVeVlhUUVnaGl1eTBHYXQ3YWpkaVZtSlpoZXBpTENod0lGbUlzc0xNRlVjNWFkTTN4UEtEenpTelE2QnEvM3Z6eEl0V0hPV0RXSy9IY0dDVWtaTzAzTDgxekpYVUhFZ3R4Qk1nRmp0bWVaajNSd3BTbVFSN3FiQlNhOURvRys4NldYbWNUQ0oxdEltMWRZRStoTjRFSWh1YlhnWU9NVjNLWkxPdmNadnQzemVyWnVtRHR4MlkwVXdCWUFBTEZqeWhJOE56RkhDcTNOOGtjUTIrM1pVTUJnQiIsInRleHQiOiJUaGUgdXNlciBpcyBhc2tpbmcgZm9yIHRoZSBiYWxhbmNlIG9mIGFjY291bnQgXCJhY2NfMVwiLiBJIGhhdmUgYSBmdW5jdGlvbiBhdmFpbGFibGUgY2FsbGVkIFwiZ2V0X2JhbGFuY2VcIiB0aGF0IHRha2VzIGFuIGFjY291bnRfaWQgYXMgYSBwYXJhbWV0ZXIuIFRoZSB1c2VyIGhhcyBwcm92aWRlZCB0aGUgYWNjb3VudF9pZCBhcyBcImFjY18xXCIsIHNvIEkgaGF2ZSBhbGwgdGhlIGluZm9ybWF0aW9uIEkgbmVlZCB0byBtYWtlIHRoaXMgZnVuY3Rpb24gY2FsbC4ifX19LHsidG9vbFVzZSI6eyJpbnB1dCI6eyJhY2NvdW50X2lkIjoiYWNjXzEifSwibmFtZSI6ImdldF9iYWxhbmNlIiwidG9vbFVzZUlkIjoidG9vbHVzZV9kRVNUSUZGaWRVNU5jZ1hUaHZpd1FmIn19XSwicm9sZSI6ImFzc2lzdGFudCJ9LHsiY29udGVudCI6W3sidG9vbFJlc3VsdCI6eyJjb250ZW50IjpbeyJ0ZXh0IjoiNDIifV0sInRvb2xVc2VJZCI6InRvb2x1c2VfZEVTVElGRmlkVTVOY2dYVGh2aXdRZiJ9fV0sInJvbGUiOiJ1c2VyIn1dLCJzeXN0ZW0iOlt7InRleHQiOiJVc2UgdGhlIHRvb2wsIHRoZW4gYW5zd2VyIHdpdGggdGhlIG51bWJlciBvbmx5LiJ9XSwidG9vbENvbmZpZyI6eyJ0b29scyI6W3sidG9vbFNwZWMiOnsiZGVzY3JpcHRpb24iOiJDdXJyZW50IGJhbGFuY2UgZm9yIGFuIGFjY291bnQgaWQiLCJpbnB1dFNjaGVtYSI6eyJqc29uIjp7ImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicHJvcGVydGllcyI6eyJhY2NvdW50X2lkIjp7InR5cGUiOiJzdHJpbmcifX0sInJlcXVpcmVkIjpbImFjY291bnRfaWQiXSwidHlwZSI6Im9iamVjdCJ9fSwibmFtZSI6ImdldF9iYWxhbmNlIn19XX19"
+    },
+    "canonical_json": {
+      "additionalModelRequestFields": {
+        "thinking": {
+          "budget_tokens": 1024,
+          "type": "enabled"
+        }
+      },
+      "inferenceConfig": {
+        "maxTokens": 2048
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "What is the balance of account acc_1?"
+            }
+          ],
+          "role": "user"
+        },
+        {
+          "content": [
+            {
+              "reasoningContent": {
+                "reasoningText": {
+                  "signature": "EuoDCoQBCBEQARgCKkCgz3Z9Cj2HXWouKIYnHTPGs8DgJGxuL67rxKGTGyFY0cSFyun2dalPmowatttcc3uZzdXinrw3DHng3Ux+q0xpMhljbGF1ZGUtaGFpa3UtNC01LTIwMjUxMDAxOABCCHRoaW5raW5nWgwxMjM0NTY3ODkwMTKoAfn2g9UGEgza9M7OfojnvVCB+qkaDAhrMfZc6WeZROb2RCIwRmnaUFc0RHkCl2b6kZt0w9ciZWzG0W3LcoRV09aTGJ1XrR8nDDTLNQ897Cp/liKYKpICPK0KAlxkNNTve3ykLRImm4p0IEuXrDwhMnRYOjGKr1d1TUL/lt8C0pvH4eXNkq8htkdx8CXAjJCYPh0WwjUCroj4qrqqlRRtFjBTY2qEwf5ZAXUJZy4R7Y1W5leMbwnrymb4b4UNog+mJGWz5zFyKCrvdUyYaQEghiuy0Gat7ajdiVmJZhepiLChwIFmIssLMFUc5adM3xPKDzzSzQ6Bq/3vzxItWHOWDWK/HcGCUkZO03L81zJXUHEgtxBMgFjtmeZj3RwpSmQR7qbBSa9DoG+86WXmcTCJ1tIm1dYE+hN4EIhubXgYOMV3KZLOvcZvt3zerZumDtx2Y0UwBYAALFjyhI8NzFHCq3N8kcQ2+3ZUMBgB",
+                  "text": "The user is asking for the balance of account \"acc_1\". I have a function available called \"get_balance\" that takes an account_id as a parameter. The user has provided the account_id as \"acc_1\", so I have all the information I need to make this function call."
+                }
+              }
+            },
+            {
+              "toolUse": {
+                "input": {
+                  "account_id": "acc_1"
+                },
+                "name": "get_balance",
+                "toolUseId": "tooluse_dESTIFFidU5NcgXThviwQf"
+              }
+            }
+          ],
+          "role": "assistant"
+        },
+        {
+          "content": [
+            {
+              "toolResult": {
+                "content": [
+                  {
+                    "text": "42"
+                  }
+                ],
+                "toolUseId": "tooluse_dESTIFFidU5NcgXThviwQf"
+              }
+            }
+          ],
+          "role": "user"
+        }
+      ],
+      "system": [
+        {
+          "text": "Use the tool, then answer with the number only."
+        }
+      ],
+      "toolConfig": {
+        "tools": [
+          {
+            "toolSpec": {
+              "description": "Current balance for an account id",
+              "inputSchema": {
+                "json": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "account_id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "account_id"
+                  ],
+                  "type": "object"
+                }
+              },
+              "name": "get_balance"
+            }
+          }
+        ]
+      }
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "38a8aad1cf06f75848b5ce39267cef54dd3c9dcbf05ae3e82660552d7c520f4c"
+      ],
+      "x-amz-date": [
+        "20260909T062353Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
+  },
+  "response": {
+    "body": {
+      "metrics": {
+        "latencyMs": 750
+      },
+      "output": {
+        "message": {
+          "content": [
+            {
+              "text": "42"
+            }
+          ],
+          "role": "assistant"
+        }
+      },
+      "stopReason": "end_turn",
+      "usage": {
+        "cacheReadInputTokenCount": 0,
+        "cacheReadInputTokens": 0,
+        "inputTokens": 761,
+        "outputTokens": 4,
+        "serverToolUsage": {},
+        "totalTokens": 765
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "259"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Wed, 09 Sep 2026 06:23:54 GMT"
+      ],
+      "x-amzn-requestid": [
+        "add65afe-239b-40b9-98fd-5e21ab5654db"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}


### PR DESCRIPTION
## Description

Claude extended thinking through Converse returns a `reasoningContent` block with the thinking text and a [signature](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningTextBlock.html) meant to be sent back on the next turn. The Converse formatter dropped it on every path, so each turn started without the model's own reasoning.

Reasoning blocks now parse into `Message.reasoning_details` (text and signature, or `redactedContent`), replay ahead of the assistant's text and `toolUse` blocks, and assemble from `ConverseStream` deltas. Unsigned reasoning and details from other providers are not replayed.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Reasoning fixtures recorded live (tool round-trip and streaming)
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575755&installation_model_id=434874&pr_number=997&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F997&signature=3dc58266ff1016c6e1ac34c8739055d52d5f8c064887271b96a98ece2d396f6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->