### PR TITLE
Fix max tokens usage for bedrock mantle

### DIFF
--- a/lib/req_llm/providers/amazon_bedrock.ex
+++ b/lib/req_llm/providers/amazon_bedrock.ex
@@ -398,7 +398,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     use_converse = determine_use_converse(model_id, opts)
 
     {endpoint_base, formatter, model_family} =
-      route(endpoint, model_id, use_converse, opts[:stream] == true, opts)
+      route(endpoint, model, use_converse, opts[:stream] == true, opts)
 
     operation = opts[:operation] || :chat
     compat_opts = Keyword.put(opts, :use_converse, use_converse)
@@ -425,7 +425,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
         :operation,
         :tools,
         :inference_profile_arn,
-        :endpoint
+        :endpoint,
+        :response_formatter
       ])
       |> Req.Request.merge_options(
         ReqLLM.Provider.Defaults.finch_option(request) ++
@@ -438,7 +439,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
             context: opts[:context],
             use_converse: use_converse,
             operation: opts[:operation],
-            tools: opts[:tools]
+            tools: opts[:tools],
+            response_formatter: formatter
           ]
       )
 
@@ -563,7 +565,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     use_converse = determine_use_converse(model_id, translated_opts)
 
     {path, formatter, model_family} =
-      route(endpoint, model_id, use_converse, true, translated_opts)
+      route(endpoint, model, use_converse, true, translated_opts)
 
     translated_opts = Keyword.put(translated_opts, :use_converse, use_converse)
 
@@ -690,9 +692,12 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   def decode_stream_event(%{data: _} = event, model, state) do
     model_id = model.provider_model_id || model.id
 
-    case mantle_wire(model_id) do
+    case mantle_wire(model) do
       :messages ->
         ReqLLM.Providers.Anthropic.Response.decode_stream_event(event, model, state)
+
+      :responses ->
+        ReqLLM.Providers.AmazonBedrock.Responses.decode_stream_event(event, model, state)
 
       :chat_completions ->
         openai = %{model | id: model_id, provider: :openai}
@@ -1028,10 +1033,16 @@ defmodule ReqLLM.Providers.AmazonBedrock do
   defp stream_accept(:mantle), do: "text/event-stream"
   defp stream_accept(:runtime), do: "application/vnd.amazon.eventstream"
 
-  defp route(:mantle, model_id, _use_converse, _stream?, opts) do
-    case mantle_wire(model_id) do
+  defp route(:mantle, model, _use_converse, _stream?, opts) do
+    model_id = request_model_id(model)
+
+    case mantle_wire(model) do
       :messages ->
         {"/anthropic/v1/messages", ReqLLM.Providers.AmazonBedrock.Anthropic, "anthropic"}
+
+      :responses ->
+        {mantle_base_path(model_id, opts) <> "/responses",
+         ReqLLM.Providers.AmazonBedrock.Responses, "openai"}
 
       :chat_completions ->
         {mantle_base_path(model_id, opts) <> "/chat/completions",
@@ -1039,7 +1050,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     end
   end
 
-  defp route(:runtime, model_id, true = _use_converse, stream?, opts) do
+  defp route(:runtime, model, true = _use_converse, stream?, opts) do
+    model_id = request_model_id(model)
     path_id = path_model_id(model_id, opts)
 
     path =
@@ -1060,7 +1072,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     {path, formatter, :converse}
   end
 
-  defp route(:runtime, model_id, false = _use_converse, stream?, opts) do
+  defp route(:runtime, model, false = _use_converse, stream?, opts) do
+    model_id = request_model_id(model)
     path_id = path_model_id(model_id, opts)
 
     path =
@@ -1072,9 +1085,48 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     {path, get_formatter_module(family), family}
   end
 
-  defp mantle_wire(model_id) do
-    if get_model_family(model_id) == "anthropic", do: :messages, else: :chat_completions
+  defp mantle_wire(model) do
+    model_id = request_model_id(model)
+
+    cond do
+      get_model_family(model_id) == "anthropic" -> :messages
+      mantle_responses_model?(model) -> :responses
+      true -> :chat_completions
+    end
   end
+
+  defp mantle_responses_model?(model) do
+    model_id = request_model_id(model)
+    openai_model_id = openai_model_id(model_id)
+
+    if String.starts_with?(openai_model_id, "gpt-oss") do
+      false
+    else
+      case provider_shape(model) do
+        "responses" -> true
+        "chat_completions" -> false
+        "chat" -> false
+        _ -> ReqLLM.Providers.OpenAI.AdapterHelpers.responses_model?(openai_model_id)
+      end
+    end
+  end
+
+  defp provider_shape(%LLMDB.Model{extra: extra}) when is_map(extra) do
+    case Map.get(extra, :provider) || Map.get(extra, "provider") do
+      provider when is_map(provider) -> Map.get(provider, :shape) || Map.get(provider, "shape")
+      _ -> nil
+    end
+  end
+
+  defp provider_shape(_), do: nil
+
+  defp openai_model_id(model_id) do
+    model_id
+    |> strip_region_prefix()
+    |> String.replace_prefix("openai.", "")
+  end
+
+  defp request_model_id(%LLMDB.Model{} = model), do: model.provider_model_id || model.id
 
   # Each model card states its bedrock-mantle base path:
   # https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html
@@ -1187,8 +1239,8 @@ defmodule ReqLLM.Providers.AmazonBedrock do
     # reasoning effort, etc.) for free
     model_family = get_model_family(model.provider_model_id || model.id)
 
-    case model_family do
-      "anthropic" ->
+    cond do
+      model_family == "anthropic" ->
         # Delegate temperature/top_p translation to Anthropic provider
         {translated_opts, warnings} =
           ReqLLM.Providers.Anthropic.translate_options(operation, model, opts)
@@ -1198,10 +1250,18 @@ defmodule ReqLLM.Providers.AmazonBedrock do
 
         {translated_opts, warnings}
 
-      _ ->
+      endpoint(opts) == :mantle and mantle_responses_model?(model) ->
+        ReqLLM.Providers.OpenAI.translate_options(operation, as_openai_model(model), opts)
+
+      true ->
         # Other model families: no translation needed yet
         {opts, []}
     end
+  end
+
+  defp as_openai_model(%LLMDB.Model{} = model) do
+    model_id = request_model_id(model)
+    %{model | provider: :openai, id: openai_model_id(model_id), provider_model_id: nil}
   end
 
   @impl ReqLLM.Provider
@@ -1295,7 +1355,7 @@ defmodule ReqLLM.Providers.AmazonBedrock do
       if req.options[:use_converse] do
         ReqLLM.Providers.AmazonBedrock.Converse
       else
-        get_formatter_module(req.options[:model_family])
+        req.options[:response_formatter] || get_formatter_module(req.options[:model_family])
       end
 
     parsed_body = ensure_parsed_body(resp.body)

--- a/lib/req_llm/providers/amazon_bedrock/responses.ex
+++ b/lib/req_llm/providers/amazon_bedrock/responses.ex
@@ -1,0 +1,101 @@
+defmodule ReqLLM.Providers.AmazonBedrock.Responses do
+  @moduledoc """
+  Bedrock Mantle adapter for the OpenAI Responses API wire format.
+
+  Request encoding and response decoding delegate to the native OpenAI
+  Responses implementation. Bedrock remains responsible for routing and
+  authentication.
+  """
+
+  alias ReqLLM.Providers.OpenAI.ResponsesAPI
+
+  def format_request(model_id, context, opts) when is_list(opts) do
+    openai_model = openai_model(model_id)
+
+    opts
+    |> Map.new()
+    |> Map.merge(%{
+      model: openai_model.id,
+      id: openai_model.id,
+      context: context,
+      req_llm_model: openai_model
+    })
+    |> then(&%{options: &1})
+    |> ResponsesAPI.build_body()
+    |> Map.drop([:model, "model"])
+    |> Map.put(:model, model_id)
+  end
+
+  def parse_response(body, opts) do
+    model = openai_model(opts[:model])
+
+    fake_request = %{
+      options: %{
+        model: model.id,
+        req_llm_model: model,
+        operation: opts[:operation],
+        context: opts[:context],
+        compiled_schema: opts[:compiled_schema]
+      }
+    }
+
+    case ResponsesAPI.decode_response({fake_request, %{status: 200, body: body}}) do
+      {_request, %{body: %ReqLLM.Response{} = response}} -> {:ok, response}
+      {_request, %ReqLLM.Error.API.Response{} = error} -> {:error, error}
+      {_request, response} when is_map(response) -> {:ok, response}
+    end
+  end
+
+  def decode_stream_event(event, model, state) do
+    ResponsesAPI.decode_stream_event(event, as_openai_model(model), state)
+  end
+
+  def extract_usage(body, _model) do
+    parsed_body = ReqLLM.Provider.Utils.ensure_parsed_body(body)
+
+    case parsed_body do
+      %{"usage" => usage} ->
+        input_tokens = usage["input_tokens"] || 0
+        output_tokens = usage["output_tokens"] || 0
+
+        {:ok,
+         %{
+           input_tokens: input_tokens,
+           output_tokens: output_tokens,
+           total_tokens: usage["total_tokens"] || input_tokens + output_tokens,
+           cached_tokens: get_in(usage, ["input_tokens_details", "cached_tokens"]) || 0,
+           reasoning_tokens:
+             get_in(usage, ["output_tokens_details", "reasoning_tokens"]) || 0
+         }}
+
+      _ ->
+        {:error, :no_usage_found}
+    end
+  end
+
+  defp openai_model(model_id) do
+    %LLMDB.Model{
+      provider: :openai,
+      id: openai_model_id(model_id),
+      model: openai_model_id(model_id)
+    }
+  end
+
+  defp as_openai_model(%LLMDB.Model{} = model) do
+    model_id = model.provider_model_id || model.id
+    %{model | provider: :openai, id: openai_model_id(model_id), provider_model_id: nil}
+  end
+
+  defp openai_model_id(model_id) do
+    model_id
+    |> strip_region_prefix()
+    |> String.replace_prefix("openai.", "")
+  end
+
+  defp strip_region_prefix(model_id) do
+    case String.split(model_id, ".", parts: 2) do
+      [region, rest] when region in ~w(us eu ap apac ca au jp us-gov global) -> rest
+      _ -> model_id
+    end
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock/openai_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/openai_test.exs
@@ -59,6 +59,20 @@ defmodule ReqLLM.Providers.AmazonBedrock.OpenAITest do
       assert formatted[:top_p] == 0.9
     end
 
+    test "preserves max_tokens for GPT-5 models outside Mantle" do
+      context = Context.new([Context.user("Hello")])
+
+      formatted =
+        OpenAI.format_request(
+          "openai.gpt-5.4",
+          context,
+          max_tokens: 2048
+        )
+
+      assert formatted[:max_tokens] == 2048
+      refute Map.has_key?(formatted, :max_completion_tokens)
+    end
+
     test "includes tools when provided" do
       get_weather =
         ReqLLM.Tool.new!(

--- a/test/req_llm/providers/amazon_bedrock/responses_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/responses_test.exs
@@ -1,0 +1,139 @@
+defmodule ReqLLM.Providers.AmazonBedrock.ResponsesTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.AmazonBedrock.Responses
+
+  setup do
+    {:ok, model} =
+      ReqLLM.model(%{provider: :amazon_bedrock, id: "openai.gpt-5.6-terra"})
+
+    context = ReqLLM.Context.new([ReqLLM.Context.user("What's the weather?")])
+
+    tool =
+      ReqLLM.Tool.new!(
+        name: "get_weather",
+        description: "Get the weather",
+        parameter_schema: [
+          location: [type: :string, required: true, doc: "City name"]
+        ],
+        callback: fn _args -> {:ok, "sunny"} end
+      )
+
+    {:ok, model: model, context: context, tool: tool}
+  end
+
+  test "formats Responses input, tools, reasoning, and token limits", %{
+    context: context,
+    tool: tool
+  } do
+    raw_body =
+      Responses.format_request("openai.gpt-5.6-terra", context,
+        tools: [tool],
+        reasoning_effort: :high,
+        max_tokens: 512,
+        stream: true
+      )
+
+    assert raw_body[:model] == "openai.gpt-5.6-terra"
+    refute Map.has_key?(raw_body, "model")
+
+    body =
+      raw_body
+      |> Jason.encode!()
+      |> Jason.decode!()
+
+    assert [%{"role" => "user", "content" => [%{"type" => "input_text"}]}] = body["input"]
+    refute Map.has_key?(body, "messages")
+    assert [%{"type" => "function", "name" => "get_weather"}] = body["tools"]
+    assert body["reasoning"] == %{"effort" => "high"}
+    assert body["max_output_tokens"] == 512
+    assert body["stream"] == true
+    assert body["model"] == "openai.gpt-5.6-terra"
+  end
+
+  test "decodes buffered text and function calls", %{context: context} do
+    body = %{
+      "id" => "resp_123",
+      "model" => "openai.gpt-5.6-terra",
+      "status" => "completed",
+      "output" => [
+        %{
+          "type" => "message",
+          "content" => [%{"type" => "output_text", "text" => "Checking now."}]
+        },
+        %{
+          "type" => "function_call",
+          "call_id" => "call_123",
+          "name" => "get_weather",
+          "arguments" => ~s({"location":"Boston"})
+        }
+      ],
+      "usage" => %{"input_tokens" => 8, "output_tokens" => 12}
+    }
+
+    assert {:ok, response} =
+             Responses.parse_response(body, %{
+               model: "openai.gpt-5.6-terra",
+               operation: :chat,
+               context: context
+             })
+
+    assert [%ReqLLM.Message.ContentPart{type: :text, text: "Checking now."}] =
+             response.message.content
+
+    assert [tool_call] = response.message.tool_calls
+    assert tool_call.id == "call_123"
+    assert tool_call.function.name == "get_weather"
+    assert Jason.decode!(tool_call.function.arguments) == %{"location" => "Boston"}
+    assert response.usage.input_tokens == 8
+    assert response.usage.output_tokens == 12
+  end
+
+  test "statefully decodes text and function call events", %{model: model} do
+    text = %{data: %{"event" => "response.output_text.delta", "delta" => "Hello"}}
+
+    added = %{
+      data: %{
+        "event" => "response.output_item.added",
+        "output_index" => 0,
+        "item" => %{
+          "type" => "function_call",
+          "call_id" => "call_123",
+          "name" => "get_weather"
+        }
+      }
+    }
+
+    arguments = %{
+      data: %{
+        "event" => "response.function_call_arguments.delta",
+        "output_index" => 0,
+        "delta" => ~s({"location":"Boston"})
+      }
+    }
+
+    done = %{
+      data: %{
+        "event" => "response.output_item.done",
+        "output_index" => 0,
+        "item" => %{
+          "type" => "function_call",
+          "call_id" => "call_123",
+          "name" => "get_weather",
+          "arguments" => ~s({"location":"Boston"})
+        }
+      }
+    }
+
+    assert {[%ReqLLM.StreamChunk{type: :content, text: "Hello"}], state} =
+             Responses.decode_stream_event(text, model, nil)
+
+    assert {[%ReqLLM.StreamChunk{type: :tool_call}], state} =
+             Responses.decode_stream_event(added, model, state)
+
+    assert {[%ReqLLM.StreamChunk{type: :meta}], state} =
+             Responses.decode_stream_event(arguments, model, state)
+
+    assert {[], _state} = Responses.decode_stream_event(done, model, state)
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock_test.exs
+++ b/test/req_llm/providers/amazon_bedrock_test.exs
@@ -1404,9 +1404,10 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       ]
 
       {:ok, gpt_oss} = ReqLLM.model("amazon-bedrock:openai.gpt-oss-120b")
+      {:ok, gpt_5} = ReqLLM.model(%{provider: :amazon_bedrock, id: "openai.gpt-5.6-terra"})
       {:ok, claude} = ReqLLM.model("amazon-bedrock:anthropic.claude-3-haiku-20240307-v1:0")
 
-      {:ok, context: context, opts: opts, gpt_oss: gpt_oss, claude: claude}
+      {:ok, context: context, opts: opts, gpt_oss: gpt_oss, gpt_5: gpt_5, claude: claude}
     end
 
     test "stays on bedrock-runtime unless asked", %{context: context, opts: opts, gpt_oss: model} do
@@ -1421,6 +1422,21 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert request.url.host == "bedrock-runtime.eu-west-1.amazonaws.com"
       assert request.url.path == "/model/openai.gpt-oss-120b/invoke"
       assert request.options[:endpoint] == :runtime
+    end
+
+    test "preserves runtime token parameters", %{context: context, opts: opts} do
+      {:ok, model} = ReqLLM.model(%{provider: :amazon_bedrock, id: "openai.gpt-5.4"})
+
+      opts =
+        opts
+        |> Keyword.delete(:provider_options)
+        |> Keyword.put(:max_tokens, 400)
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+      body = Jason.decode!(request.body)
+
+      assert body["max_tokens"] == 400
+      refute Map.has_key?(body, "max_completion_tokens")
     end
 
     test "sends chat completions to bedrock-mantle", %{
@@ -1451,8 +1467,11 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert %{"model" => "mistral.voxtral-mini-3b-2507"} = Jason.decode!(request.body)
     end
 
-    test "serves OpenAI-hosted models under /openai/v1", %{context: context, opts: opts} do
-      for id <- ["openai.gpt-5.4", "google.gemma-4-31b", "xai.grok-4.3"] do
+    test "keeps non-Responses OpenAI-compatible models on chat completions", %{
+      context: context,
+      opts: opts
+    } do
+      for id <- ["google.gemma-4-31b", "xai.grok-4.3"] do
         {:ok, model} = ReqLLM.model(%{provider: :amazon_bedrock, id: id})
         {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
 
@@ -1463,6 +1482,98 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
         {:ok, finch_request} = AmazonBedrock.attach_stream(model, context, opts, ReqLLM.Finch)
         assert finch_request.path == "/openai/v1/chat/completions"
       end
+    end
+
+    test "routes GPT-5 Responses bodies on both Mantle transports", %{
+      context: context,
+      opts: opts,
+      gpt_5: model
+    } do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Get the weather",
+          parameter_schema: [location: [type: :string, required: true]],
+          callback: fn _args -> {:ok, "sunny"} end
+        )
+
+      opts =
+        Keyword.merge(opts,
+          max_tokens: 400,
+          reasoning_effort: :high,
+          tools: [tool]
+        )
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+      assert Regex.scan(~r/"model":/, request.body) == [["\"model\":"]]
+      assert request.body =~ ~s("model":"openai.gpt-5.6-terra")
+      body = Jason.decode!(request.body)
+
+      assert request.url.path == "/openai/v1/responses"
+      assert [%{"role" => "user"}] = body["input"]
+      refute Map.has_key?(body, "messages")
+      assert [%{"type" => "function", "name" => "get_weather"}] = body["tools"]
+      assert body["reasoning"] == %{"effort" => "high"}
+      assert body["max_output_tokens"] == 400
+      refute Map.has_key?(body, "max_tokens")
+
+      {:ok, stream} = AmazonBedrock.attach_stream(model, context, opts, ReqLLM.Finch)
+      assert Regex.scan(~r/"model":/, stream.body) == [["\"model\":"]]
+      assert stream.body =~ ~s("model":"openai.gpt-5.6-terra")
+      body = Jason.decode!(stream.body)
+
+      assert stream.path == "/openai/v1/responses"
+      assert [%{"role" => "user"}] = body["input"]
+      assert [%{"type" => "function", "name" => "get_weather"}] = body["tools"]
+      assert body["max_output_tokens"] == 400
+      refute Map.has_key?(body, "max_tokens")
+    end
+
+    test "uses model shape metadata and excludes GPT OSS", %{context: context, opts: opts} do
+      for extra <- [
+            %{"provider" => %{"shape" => "responses"}},
+            %{provider: %{shape: "responses"}}
+          ] do
+        {:ok, model} =
+          ReqLLM.model(%{
+            provider: :amazon_bedrock,
+            id: "xai.grok-4.3",
+            extra: extra
+          })
+
+        {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+        assert request.url.path == "/openai/v1/responses"
+      end
+
+      {:ok, model} =
+        ReqLLM.model(%{
+          provider: :amazon_bedrock,
+          id: "openai.gpt-oss-120b",
+          extra: %{"provider" => %{"shape" => "responses"}}
+        })
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+      assert request.url.path == "/v1/chat/completions"
+    end
+
+    test "preserves Anthropic token parameters on both Mantle transports", %{
+      context: context,
+      opts: opts,
+      claude: model
+    } do
+      opts = Keyword.put(opts, :max_tokens, 400)
+
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+      body = Jason.decode!(request.body)
+
+      assert body["max_tokens"] == 400
+      refute Map.has_key?(body, "max_completion_tokens")
+
+      {:ok, stream} = AmazonBedrock.attach_stream(model, context, opts, ReqLLM.Finch)
+      body = Jason.decode!(stream.body)
+
+      assert body["max_tokens"] == 400
+      refute Map.has_key?(body, "max_completion_tokens")
     end
 
     test "mantle_base_path overrides the base picked from the model id", %{
@@ -1481,7 +1592,7 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert request.url.path == "/openai/v1/chat/completions"
 
       {:ok, request} = AmazonBedrock.prepare_request(:chat, gpt_5, context, to_v1)
-      assert request.url.path == "/v1/chat/completions"
+      assert request.url.path == "/v1/responses"
 
       {:ok, finch_request} =
         AmazonBedrock.attach_stream(gpt_oss, context, to_openai, ReqLLM.Finch)
@@ -1560,11 +1671,20 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
       assert {:incomplete, <<0, 0>>} = event_stream.(<<0, 0>>, nil)
     end
 
-    test "decodes chat completion and messages events", %{gpt_oss: gpt_oss, claude: claude} do
+    test "decodes each Mantle stream wire format", %{
+      gpt_oss: gpt_oss,
+      gpt_5: gpt_5,
+      claude: claude
+    } do
       delta = %{data: %{"choices" => [%{"index" => 0, "delta" => %{"content" => "Hi"}}]}}
 
       assert {[%ReqLLM.StreamChunk{type: :content, text: "Hi"}], nil} =
                AmazonBedrock.decode_stream_event(delta, gpt_oss, nil)
+
+      delta = %{data: %{"event" => "response.output_text.delta", "delta" => "Hi"}}
+
+      assert {[%ReqLLM.StreamChunk{type: :content, text: "Hi"}], _state} =
+               AmazonBedrock.decode_stream_event(delta, gpt_5, nil)
 
       delta = %{
         event: "content_block_delta",
@@ -1581,6 +1701,36 @@ defmodule ReqLLM.Providers.AmazonBedrockTest do
                  claude,
                  AmazonBedrock.init_stream_state(claude)
                )
+    end
+
+    test "decodes buffered Responses payloads with the routed formatter", %{
+      context: context,
+      opts: opts,
+      gpt_5: model
+    } do
+      {:ok, request} = AmazonBedrock.prepare_request(:chat, model, context, opts)
+
+      payload = %{
+        "id" => "resp_123",
+        "model" => "openai.gpt-5.6-terra",
+        "status" => "completed",
+        "output" => [
+          %{
+            "type" => "function_call",
+            "call_id" => "call_123",
+            "name" => "get_weather",
+            "arguments" => ~s({"location":"Boston"})
+          }
+        ],
+        "usage" => %{"input_tokens" => 8, "output_tokens" => 12}
+      }
+
+      {_request, response} =
+        AmazonBedrock.decode_response({request, %Req.Response{status: 200, body: payload}})
+
+      assert [tool_call] = response.body.message.tool_calls
+      assert tool_call.id == "call_123"
+      assert tool_call.function.name == "get_weather"
     end
 
     test "sends the project header each bedrock-mantle route takes", %{


### PR DESCRIPTION

## Description

Openai models force block the max_tokens field that mantle requests were defaulting for openai.* models.  This should convert it to the expected format, alongside some tests to confirm functionality.

The apparent root cause here is we need to detect more precisely what the friendliest openai endpoint to use for each model is (between chat completions and responses), and a lot of these fields naturally translate once that's settled.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [ ] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791605606&installation_model_id=434874&pr_number=998&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F998&signature=254614801f1b06925ecc55bb571e33ca6e2e3b392fae80a3163d0646c0beff89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->