### PR TITLE
feat(google): support VALIDATED function-calling mode

### DIFF
--- a/guides/google.md
+++ b/guides/google.md
@@ -14,6 +14,22 @@ For the full model-spec workflow, see [Model Specs](model-specs.md).
 
 Use exact Gemini IDs from [LLM Catalog](https://llmcatalog.dev) when possible. If you need to work ahead of the registry, use `ReqLLM.model!/1` to build a full explicit model spec.
 
+## Function Calling
+
+Use `tool_choice: :validated` (or `"validated"`) with `tools` to enable Gemini's
+`VALIDATED` function-calling mode. It enforces function-schema adherence while
+allowing the model to respond with either natural language or a function call.
+
+```elixir
+ReqLLM.generate_text("google:gemini-2.5-flash", "What is the weather in Madrid?",
+  tools: tools,
+  tool_choice: :validated
+)
+```
+
+The same option works with `ReqLLM.stream_text/3`. See Google's
+[function-calling modes reference](https://ai.google.dev/gemini-api/docs/generate-content/function-calling#function-calling-modes).
+
 ## Provider Options
 
 Passed via `:provider_options` keyword:

--- a/lib/req_llm/providers/google.ex
+++ b/lib/req_llm/providers/google.ex
@@ -1720,6 +1720,7 @@ defmodule ReqLLM.Providers.Google do
   defp build_google_tool_config(:required), do: build_google_tool_config("required")
   defp build_google_tool_config(:auto), do: build_google_tool_config("auto")
   defp build_google_tool_config(:none), do: build_google_tool_config("none")
+  defp build_google_tool_config(:validated), do: build_google_tool_config("validated")
 
   defp build_google_tool_config("required") do
     %{functionCallingConfig: %{mode: "ANY"}}
@@ -1727,6 +1728,7 @@ defmodule ReqLLM.Providers.Google do
 
   defp build_google_tool_config("auto"), do: %{functionCallingConfig: %{mode: "AUTO"}}
   defp build_google_tool_config("none"), do: %{functionCallingConfig: %{mode: "NONE"}}
+  defp build_google_tool_config("validated"), do: %{functionCallingConfig: %{mode: "VALIDATED"}}
   defp build_google_tool_config(_), do: nil
 
   defp build_grounding_tools(nil), do: []

--- a/test/providers/google_test.exs
+++ b/test/providers/google_test.exs
@@ -11,6 +11,59 @@ defmodule ReqLLM.Providers.GoogleTest do
   alias ReqLLM.Context
   alias ReqLLM.Providers.Google
 
+  describe "validated function calling" do
+    setup do
+      tool =
+        ReqLLM.Tool.new!(
+          name: "get_weather",
+          description: "Get the weather in a city",
+          parameter_schema: [city: [type: :string, required: true]],
+          callback: fn _ -> {:ok, "sunny"} end
+        )
+
+      {:ok, model: ReqLLM.model!("google:gemini-2.5-flash"), tools: [tool]}
+    end
+
+    for tool_choice <- [:validated, "validated"] do
+      test "serializes #{inspect(tool_choice)} for non-streaming requests", %{
+        model: model,
+        tools: tools
+      } do
+        assert {:ok, request} =
+                 Google.prepare_request(:chat, model, "Weather in Madrid?",
+                   tools: tools,
+                   tool_choice: unquote(tool_choice),
+                   api_key: "test"
+                 )
+
+        body = request |> Google.encode_body() |> ReqLLM.Test.Helpers.json_body()
+
+        assert body["toolConfig"] == %{"functionCallingConfig" => %{"mode" => "VALIDATED"}}
+        assert [%{"functionDeclarations" => [%{"name" => "get_weather"}]}] = body["tools"]
+      end
+
+      test "serializes #{inspect(tool_choice)} for streaming requests", %{
+        model: model,
+        tools: tools
+      } do
+        context = Context.new([Context.user("Weather in Madrid?")])
+
+        assert {:ok, request} =
+                 Google.attach_stream(
+                   model,
+                   context,
+                   [tools: tools, tool_choice: unquote(tool_choice), api_key: "test"],
+                   nil
+                 )
+
+        body = Jason.decode!(request.body)
+
+        assert body["toolConfig"] == %{"functionCallingConfig" => %{"mode" => "VALIDATED"}}
+        assert [%{"functionDeclarations" => [%{"name" => "get_weather"}]}] = body["tools"]
+      end
+    end
+  end
+
   describe "provider contract" do
     test "provider identity and configuration" do
       assert is_atom(Google.provider_id())


### PR DESCRIPTION
Passing `tool_choice: :validated` or `"validated"` previously omitted Gemini's `toolConfig`. Both values now serialize to `functionCallingConfig.mode: "VALIDATED"` for streaming and non-streaming requests, enabling schema-constrained function calls while allowing natural-language responses.

Adds four request-serialization tests covering both values through both request paths, plus usage documentation based on [Gemini's function-calling reference](https://ai.google.dev/gemini-api/docs/generate-content/function-calling#function-calling-modes).

Validation:
- Google, API-version, and Vertex Gemini suites: 160 tests, 0 failures.
- Formatting, strict Credo, and `git diff --check`: passed.
- `mix quality` stops at existing regex deprecation warnings in `provider_drift.ex` and `tool_call_id_compat.ex` under Elixir 1.19.0-rc.0 / OTP 27; Dialyzer did not run. The default OTP 25 toolchain could not compile the locked `jose` dependency.

Fixes #1000.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791673437&installation_model_id=434874&pr_number=1001&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F1001&signature=b0dcfb6050a8bc80904b18a47be43b4893f84fe37e050fc0d494f81ece4f2f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->