### PR TITLE
feat(bedrock): guard selected content parts on the Converse API

### DIFF
--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -205,6 +205,25 @@ Passed via `:provider_options` keyword:
 - **Purpose**: Cache TTL (default ~5min if omitted)
 - **Example**: `provider_options: [anthropic_prompt_cache_ttl: "1h"]`
 
+## Guarding content parts
+
+On the Converse API, `guard_content` metadata on a content part wraps it in a `guardContent` block. Which policies then skip the unmarked parts is up to the guardrail, see [selective guarding](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-converse-api.html#guardrails-use-converse-api-call-message).
+
+```elixir
+ReqLLM.generate_text(
+  model,
+  ReqLLM.Context.user([
+    ReqLLM.Message.ContentPart.text("London is the capital of UK. Tokyo is the capital of Japan.",
+      %{guard_content: %{qualifiers: [:grounding_source]}}
+    ),
+    ReqLLM.Message.ContentPart.text("What is the capital of Japan?", %{guard_content: %{qualifiers: [:query]}})
+  ]),
+  provider_options: [use_converse: true, guardrail_identifier: "abc123def456", guardrail_version: "1"]
+)
+```
+
+Text and PNG or JPEG image parts, in messages and system prompts. InvokeModel has no equivalent, so the hint is ignored there.
+
 ## Supported Model Families
 
 ### Anthropic Claude

--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -141,6 +141,7 @@ parts = [
 The `metadata` field allows passing provider-specific attributes through to the wire format. Currently supported metadata keys:
 
 - `cache_control`: Anthropic prompt caching control (e.g., `%{type: "ephemeral"}`)
+- `guard_content`: Amazon Bedrock guardrail selection on the Converse API (`true` or `%{qualifiers: [...]}`)
 
 ```elixir
 # Enable prompt caching for text content

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -487,11 +487,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   defp encode_system_message(%Message{content: content}) when is_binary(content) do
-    encode_content_for_system(content)
+    encode_content(content)
   end
 
   defp encode_system_message(%Message{content: content}) when is_list(content) do
-    encode_content_for_system(content)
+    encode_content(content)
   end
 
   defp encode_system_message(_message), do: []
@@ -728,23 +728,70 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   defp encode_reasoning_detail(_detail), do: []
 
-  defp encode_content_for_system(content) when is_binary(content) do
-    [%{"text" => content}]
-  end
-
-  defp encode_content_for_system(content) when is_list(content) do
-    Enum.map(content, &encode_content_part/1)
-  end
-
   defp encode_content(content) when is_binary(content) do
     [%{"text" => content}]
   end
 
   defp encode_content(content) when is_list(content) do
     content
-    |> Enum.map(&encode_content_part/1)
+    |> Enum.map(&encode_guardable_content_part/1)
     |> Enum.reject(&is_nil/1)
   end
+
+  defp encode_guardable_content_part(%ContentPart{metadata: metadata} = part) do
+    case {metadata_value(metadata, :guard_content), encode_content_part(part)} do
+      {hint, block} when hint in [nil, false] ->
+        block
+
+      {_hint, nil} ->
+        invalid_guard_content("guard_content needs a non-empty text or image part")
+
+      {true, block} ->
+        guard_content(part, block, [])
+
+      {%{} = opts, block} ->
+        guard_content(part, block, qualifiers(metadata_value(opts, :qualifiers)))
+
+      {_hint, _block} ->
+        invalid_guard_content("guard_content must be a boolean or an options map")
+    end
+  end
+
+  defp encode_unguarded_content_part(%ContentPart{metadata: metadata} = part) do
+    case metadata_value(metadata, :guard_content) do
+      hint when hint in [nil, false] -> encode_content_part(part)
+      _hint -> invalid_guard_content("guard_content is not supported inside tool results")
+    end
+  end
+
+  defp guard_content(%ContentPart{type: :text}, %{"text" => text}, []),
+    do: %{"guardContent" => %{"text" => %{"text" => text}}}
+
+  defp guard_content(%ContentPart{type: :text}, %{"text" => text}, qualifiers),
+    do: %{"guardContent" => %{"text" => %{"text" => text, "qualifiers" => qualifiers}}}
+
+  defp guard_content(%ContentPart{type: :image, media_type: media_type}, block, [])
+       when media_type in ["image/png", "image/jpeg", "image/jpg"],
+       do: %{"guardContent" => block}
+
+  defp guard_content(%ContentPart{type: :image}, _block, _qualifiers),
+    do: invalid_guard_content("guard_content images must be png or jpeg and take no qualifiers")
+
+  defp qualifiers(nil), do: []
+  defp qualifiers(values) when is_list(values), do: Enum.map(values, &qualifier/1)
+  defp qualifiers(_values), do: invalid_guard_content("guard_content qualifiers must be a list")
+
+  defp qualifier(value) when is_atom(value), do: Atom.to_string(value)
+  defp qualifier(value) when is_binary(value), do: value
+
+  defp qualifier(_value),
+    do: invalid_guard_content("guard_content qualifiers must be atoms or strings")
+
+  defp metadata_value(metadata, key) when is_map(metadata),
+    do: Map.get(metadata, key, Map.get(metadata, Atom.to_string(key)))
+
+  defp invalid_guard_content(parameter),
+    do: raise(ReqLLM.Error.Invalid.Parameter.exception(parameter: parameter))
 
   defp encode_content_part(%ContentPart{type: :text, text: ""}), do: nil
 
@@ -819,7 +866,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   defp encode_tool_result_content(%Message{content: content})
        when is_list(content) and content != [] do
-    Enum.map(content, &encode_content_part/1)
+    Enum.map(content, &encode_unguarded_content_part/1)
   end
 
   defp encode_tool_result_content(%Message{} = msg) do

--- a/test/coverage/amazon_bedrock/guard_content_test.exs
+++ b/test/coverage/amazon_bedrock/guard_content_test.exs
@@ -1,0 +1,58 @@
+defmodule ReqLLM.Coverage.AmazonBedrock.GuardContentTest do
+  @moduledoc """
+  Recording needs a guardrail with a denied "Weather" topic in us-east-1; set
+  BEDROCK_GUARDRAIL_ID and BEDROCK_GUARDRAIL_VERSION, then run with
+  REQ_LLM_FIXTURES_MODE=record.
+  """
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
+
+  @moduletag :coverage
+  @moduletag provider: "amazon_bedrock"
+  @moduletag timeout: 180_000
+
+  @model "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+  test "the guardrail evaluates only guarded parts" do
+    context =
+      Context.new([
+        Context.user([
+          ContentPart.text("The weather in Paris is sunny today."),
+          ContentPart.text("London is the capital of UK. Tokyo is the capital of Japan.", %{
+            guard_content: %{qualifiers: [:grounding_source]}
+          }),
+          ContentPart.text("What is the capital of Japan? Answer with the city only.", %{
+            guard_content: %{qualifiers: [:query]}
+          })
+        ])
+      ])
+
+    opts =
+      fixture_opts("guard_content_converse",
+        max_tokens: 32,
+        provider_options: [
+          use_converse: true,
+          guardrail_identifier: System.get_env("BEDROCK_GUARDRAIL_ID", "guardrail1234"),
+          guardrail_version: System.get_env("BEDROCK_GUARDRAIL_VERSION", "DRAFT"),
+          guardrail_trace: "enabled"
+        ]
+      )
+
+    {:ok, response} = ReqLLM.generate_text(@model, context, opts)
+
+    assert response.finish_reason == :stop
+    assert ReqLLM.Response.text(response) =~ "Tokyo"
+
+    guardrail = response.provider_meta.trace["guardrail"]
+    assert guardrail["actionReason"] == "No action."
+
+    [[output_assessment]] = Map.values(guardrail["outputAssessments"])
+
+    assert [%{"type" => "GROUNDING", "detected" => false} | _] =
+             output_assessment["contextualGroundingPolicy"]["filters"]
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -740,6 +740,155 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
     end
   end
 
+  describe "guard content" do
+    defp guarded_request(parts) do
+      context = %ReqLLM.Context{messages: [%Message{role: :user, content: parts}]}
+      Converse.format_request("test-model", context, [])
+    end
+
+    test "wraps a guarded text part" do
+      result = guarded_request([ContentPart.text("Hi", %{guard_content: true})])
+
+      assert hd(result["messages"])["content"] == [
+               %{"guardContent" => %{"text" => %{"text" => "Hi"}}}
+             ]
+    end
+
+    test "carries qualifiers as strings" do
+      result =
+        guarded_request([
+          ContentPart.text("Paris is in France.", %{
+            guard_content: %{qualifiers: [:grounding_source, "query"]}
+          })
+        ])
+
+      assert hd(result["messages"])["content"] == [
+               %{
+                 "guardContent" => %{
+                   "text" => %{
+                     "text" => "Paris is in France.",
+                     "qualifiers" => ["grounding_source", "query"]
+                   }
+                 }
+               }
+             ]
+    end
+
+    test "accepts string keys" do
+      result =
+        guarded_request([
+          ContentPart.text("Hi", %{"guard_content" => %{"qualifiers" => ["query"]}})
+        ])
+
+      assert [%{"guardContent" => %{"text" => %{"qualifiers" => ["query"]}}}] =
+               hd(result["messages"])["content"]
+    end
+
+    test "wraps guarded png and jpeg images" do
+      for {media_type, format} <- [{"image/png", "png"}, {"image/jpeg", "jpeg"}] do
+        result =
+          guarded_request([ContentPart.image(<<1, 2>>, media_type, %{guard_content: true})])
+
+        assert hd(result["messages"])["content"] == [
+                 %{
+                   "guardContent" => %{
+                     "image" => %{"format" => format, "source" => %{"bytes" => "AQI="}}
+                   }
+                 }
+               ]
+      end
+    end
+
+    test "guards system message parts" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{
+            role: :system,
+            content: [
+              ContentPart.text("Only list songs.", %{guard_content: true}),
+              ContentPart.text("Be brief.")
+            ]
+          },
+          %Message{role: :user, content: "Hi"}
+        ]
+      }
+
+      result = Converse.format_request("test-model", context, [])
+
+      assert result["system"] == [
+               %{"guardContent" => %{"text" => %{"text" => "Only list songs."}}},
+               %{"text" => "Be brief."}
+             ]
+    end
+
+    test "leaves unguarded parts alone" do
+      result =
+        guarded_request([
+          ContentPart.text("plain"),
+          ContentPart.text("off", %{guard_content: false})
+        ])
+
+      assert hd(result["messages"])["content"] == [%{"text" => "plain"}, %{"text" => "off"}]
+    end
+
+    test "raises on guarded tool result parts" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{role: :user, content: "Hi"},
+          %Message{
+            role: :assistant,
+            content: [],
+            tool_calls: [ReqLLM.ToolCall.new("call_1", "get_weather", "{}")]
+          },
+          %Message{
+            role: :tool,
+            tool_call_id: "call_1",
+            content: [ContentPart.text("sunny", %{guard_content: true})]
+          }
+        ]
+      }
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, ~r/tool results/, fn ->
+        Converse.format_request("test-model", context, [])
+      end
+    end
+
+    test "raises on malformed hints" do
+      for metadata <- [
+            %{guard_content: "yes"},
+            %{guard_content: %{qualifiers: "query"}},
+            %{guard_content: %{qualifiers: [1]}}
+          ] do
+        assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+          guarded_request([ContentPart.text("Hi", metadata)])
+        end
+      end
+    end
+
+    test "raises on guarded parts that cannot be encoded" do
+      for part <- [
+            ContentPart.text("", %{guard_content: true}),
+            ContentPart.image_url("https://example.com/a.png", %{guard_content: true})
+          ] do
+        assert_raise ReqLLM.Error.Invalid.Parameter, ~r/non-empty text or image/, fn ->
+          guarded_request([part])
+        end
+      end
+    end
+
+    test "raises on guarded images that AWS does not accept" do
+      assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+        guarded_request([ContentPart.image(<<1>>, "image/gif", %{guard_content: true})])
+      end
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+        guarded_request([
+          ContentPart.image(<<1>>, "image/png", %{guard_content: %{qualifiers: [:query]}})
+        ])
+      end
+    end
+  end
+
   describe "parse_response/2" do
     test "parses basic text response" do
       response_body = %{

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guard_content_converse.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/guard_content_converse.json
@@ -1,0 +1,205 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJndWFyZHJhaWxDb25maWciOnsiZ3VhcmRyYWlsSWRlbnRpZmllciI6Imd1YXJkcmFpbDEyMzQiLCJndWFyZHJhaWxWZXJzaW9uIjoiRFJBRlQiLCJ0cmFjZSI6ImVuYWJsZWQifSwiaW5mZXJlbmNlQ29uZmlnIjp7Im1heFRva2VucyI6MzJ9LCJtZXNzYWdlcyI6W3siY29udGVudCI6W3sidGV4dCI6IlRoZSB3ZWF0aGVyIGluIFBhcmlzIGlzIHN1bm55IHRvZGF5LiJ9LHsiZ3VhcmRDb250ZW50Ijp7InRleHQiOnsicXVhbGlmaWVycyI6WyJncm91bmRpbmdfc291cmNlIl0sInRleHQiOiJMb25kb24gaXMgdGhlIGNhcGl0YWwgb2YgVUsuIFRva3lvIGlzIHRoZSBjYXBpdGFsIG9mIEphcGFuLiJ9fX0seyJndWFyZENvbnRlbnQiOnsidGV4dCI6eyJxdWFsaWZpZXJzIjpbInF1ZXJ5Il0sInRleHQiOiJXaGF0IGlzIHRoZSBjYXBpdGFsIG9mIEphcGFuPyBBbnN3ZXIgd2l0aCB0aGUgY2l0eSBvbmx5LiJ9fX1dLCJyb2xlIjoidXNlciJ9XX0="
+    },
+    "canonical_json": {
+      "guardrailConfig": {
+        "guardrailIdentifier": "guardrail1234",
+        "guardrailVersion": "DRAFT",
+        "trace": "enabled"
+      },
+      "inferenceConfig": {
+        "maxTokens": 32
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "The weather in Paris is sunny today."
+            },
+            {
+              "guardContent": {
+                "text": {
+                  "qualifiers": [
+                    "grounding_source"
+                  ],
+                  "text": "London is the capital of UK. Tokyo is the capital of Japan."
+                }
+              }
+            },
+            {
+              "guardContent": {
+                "text": {
+                  "qualifiers": [
+                    "query"
+                  ],
+                  "text": "What is the capital of Japan? Answer with the city only."
+                }
+              }
+            }
+          ],
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "d3feea70ad8cb570b6313f2a0617a6ef2a0cb8d27f6ffa58407b64b7adc0d674"
+      ],
+      "x-amz-date": [
+        "20260911T125046Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
+  },
+  "response": {
+    "body": {
+      "metrics": {
+        "latencyMs": 1303
+      },
+      "output": {
+        "message": {
+          "content": [
+            {
+              "text": "Tokyo"
+            }
+          ],
+          "role": "assistant"
+        }
+      },
+      "stopReason": "end_turn",
+      "trace": {
+        "guardrail": {
+          "actionReason": "No action.",
+          "inputAssessment": {
+            "guardrail1234": {
+              "appliedGuardrailDetails": {
+                "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                "guardrailId": "guardrail1234",
+                "guardrailOrigin": [
+                  "REQUEST"
+                ],
+                "guardrailOwnership": "SELF",
+                "guardrailVersion": "DRAFT"
+              },
+              "invocationMetrics": {
+                "guardrailCoverage": {
+                  "textCharacters": {
+                    "guarded": 0,
+                    "total": 151
+                  }
+                },
+                "guardrailProcessingLatency": 142,
+                "usage": {
+                  "contentPolicyImageUnits": 0,
+                  "contentPolicyUnits": 0,
+                  "contextualGroundingPolicyUnits": 0,
+                  "sensitiveInformationPolicyFreeUnits": 0,
+                  "sensitiveInformationPolicyUnits": 0,
+                  "topicPolicyUnits": 0,
+                  "wordPolicyUnits": 0
+                }
+              }
+            }
+          },
+          "modelOutput": [],
+          "outputAssessments": {
+            "guardrail1234": [
+              {
+                "appliedGuardrailDetails": {
+                  "guardrailArn": "arn:aws:bedrock:us-east-1:123456789012:guardrail/guardrail1234",
+                  "guardrailId": "guardrail1234",
+                  "guardrailOrigin": [
+                    "REQUEST"
+                  ],
+                  "guardrailOwnership": "SELF",
+                  "guardrailVersion": "DRAFT"
+                },
+                "contextualGroundingPolicy": {
+                  "filters": [
+                    {
+                      "action": "NONE",
+                      "detected": false,
+                      "score": 0.99,
+                      "threshold": 0.5,
+                      "type": "GROUNDING"
+                    },
+                    {
+                      "action": "NONE",
+                      "detected": false,
+                      "score": 1.0,
+                      "threshold": 0.5,
+                      "type": "RELEVANCE"
+                    }
+                  ]
+                },
+                "invocationMetrics": {
+                  "guardrailCoverage": {
+                    "textCharacters": {
+                      "guarded": 5,
+                      "total": 5
+                    }
+                  },
+                  "guardrailProcessingLatency": 247,
+                  "usage": {
+                    "contentPolicyImageUnits": 0,
+                    "contentPolicyUnits": 0,
+                    "contextualGroundingPolicyUnits": 1,
+                    "sensitiveInformationPolicyFreeUnits": 0,
+                    "sensitiveInformationPolicyUnits": 0,
+                    "topicPolicyUnits": 1,
+                    "wordPolicyUnits": 0
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "usage": {
+        "cacheReadInputTokenCount": 0,
+        "cacheReadInputTokens": 0,
+        "inputTokens": 42,
+        "outputTokens": 4,
+        "serverToolUsage": {},
+        "totalTokens": 46
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "1721"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Fri, 11 Sep 2026 12:50:51 GMT"
+      ],
+      "x-amzn-requestid": [
+        "48cc7d48-a74f-4979-b477-a99e284c139c"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}


### PR DESCRIPTION
## Description

A guardrail on the Converse API assesses the whole message unless parts are wrapped in [`guardContent`](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-converse-api.html#guardrails-use-converse-api-call-message) blocks. `guard_content` metadata on a `ContentPart` now emits that block, with optional `qualifiers`, for text and PNG/JPEG image parts in messages and system prompts:

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Fixture recorded live
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725921&installation_model_id=434874&pr_number=1002&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F1002&signature=2150c00a064d3ad8f5bb43de3e3315009a534561ed397f3411db7487ee3cca19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->