### PR TITLE
feat(codex): support caller-owned turn attribution

### DIFF
--- a/guides/openai.md
+++ b/guides/openai.md
@@ -109,6 +109,40 @@ invented when none is supplied. Applications serving multiple users should
 scope these identities to the authenticated user/session; never use one global
 cache key.
 
+For canonical turn attribution, supply caller-owned metadata alongside both
+session and thread identity:
+
+```elixir
+provider_options: [
+  openai_codex: [
+    session_id: "session-1",
+    thread_id: "thread-1",
+    codex_turn_metadata: %{
+      turn_id: "turn-1",
+      window_id: "window-1",
+      request_kind: "turn",
+      turn_started_at_unix_ms: 1_800_000_000_000
+    }
+  ]
+]
+```
+
+The metadata map accepts atom or string keys and an optional `installation_id`.
+IDs and request kind must be nonempty printable ASCII strings of at most 256
+bytes; the timestamp must be a nonnegative integer in Unix milliseconds.
+Unknown fields and incomplete attribution are rejected. ReqLLM projects the
+same identity into canonical `client_metadata`, `x-codex-turn-metadata`, window,
+and optional installation headers on buffered HTTP, SSE, and every WebSocket
+`response.create` frame, including requests sent on a reused connection.
+
+The application or agent runtime owns this lifecycle. Keep one turn ID and start
+time through tool continuations and retries; rotate for independent user work,
+and distinguish internal requests such as compaction with `request_kind`. A
+ReqLLM telemetry request ID identifies one model call, not a whole agent turn.
+ReqLLM never creates attribution implicitly. Valid attribution is also exposed
+as `codex_*` fields in telemetry `request_options`, independently of the per-call
+request ID. Cache-key overrides remain independent of turn attribution.
+
 These fields improve compatibility with the official Codex client but do not
 guarantee a cache hit or change the provider's subscription quota policy.
 

--- a/lib/req_llm/providers/openai_codex.ex
+++ b/lib/req_llm/providers/openai_codex.ex
@@ -12,7 +12,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
 
   alias ReqLLM.Providers.OpenAI
   alias ReqLLM.Providers.OpenAI.ResponsesAPI
-  alias ReqLLM.Providers.OpenAICodex.ResponsesLite
+  alias ReqLLM.Providers.OpenAICodex.{ResponsesLite, TurnMetadata}
 
   @provider_schema [
     access_token: [
@@ -52,6 +52,12 @@ defmodule ReqLLM.Providers.OpenAICodex do
     prompt_cache_key: [
       type: :string,
       doc: "Explicit prompt cache key override; defaults to session_id when supplied"
+    ],
+    codex_turn_metadata: [
+      type: {:custom, TurnMetadata, :validate, []},
+      doc:
+        "Caller-owned turn_id, window_id, request_kind and turn_started_at_unix_ms, " <>
+          "with optional installation_id. Requires session_id and thread_id; no IDs are generated."
     ],
     codex_originator: [
       type: :string,
@@ -405,7 +411,11 @@ defmodule ReqLLM.Providers.OpenAICodex do
   end
 
   def start_responses_session(%LLMDB.Model{} = model, opts \\ []) do
-    opts = normalize_stream_opts(opts)
+    opts =
+      __MODULE__
+      |> ReqLLM.Provider.Options.process!(:chat, model, opts)
+      |> normalize_stream_opts()
+
     ensure_oauth_mode!(opts)
 
     credential = ReqLLM.Auth.resolve!(model, opts)
@@ -450,6 +460,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
     |> Map.put("instructions", instructions)
     |> maybe_put_prompt_cache_key(provider_opts[:prompt_cache_key] || provider_opts[:session_id])
     |> maybe_put_parallel_tool_calls(provider_opts[:openai_parallel_tool_calls])
+    |> TurnMetadata.put_body(provider_opts)
     |> ResponsesLite.apply_body(model)
   end
 
@@ -669,6 +680,7 @@ defmodule ReqLLM.Providers.OpenAICodex do
       {"thread-id", options[:thread_id]}
     ]
     |> Enum.reject(fn {_name, value} -> is_nil(value) end)
+    |> Kernel.++(TurnMetadata.headers(options))
   end
 
   defp maybe_put_prompt_cache_key(body, nil), do: body

--- a/lib/req_llm/providers/openai_codex/turn_metadata.ex
+++ b/lib/req_llm/providers/openai_codex/turn_metadata.ex
@@ -1,0 +1,113 @@
+defmodule ReqLLM.Providers.OpenAICodex.TurnMetadata do
+  @moduledoc false
+
+  @required ~w(turn_id window_id request_kind turn_started_at_unix_ms)
+  @optional ~w(installation_id)
+  @keys @required ++ @optional
+
+  @doc false
+  def validate(value) when is_map(value) do
+    entries = Enum.map(value, fn {key, value} -> {normalize_key(key), value} end)
+    metadata = Map.new(entries)
+
+    valid? =
+      map_size(metadata) == map_size(value) and
+        Enum.all?(Map.keys(metadata), &(&1 in @keys)) and
+        Enum.all?(@required, &Map.has_key?(metadata, &1)) and
+        Enum.all?(metadata, &valid_field?/1)
+
+    if valid?, do: {:ok, metadata}, else: {:error, "invalid Codex turn metadata"}
+  end
+
+  def validate(_value), do: {:error, "Codex turn metadata must be a map"}
+
+  @doc false
+  def telemetry(options) do
+    with {:ok, metadata} <- validate(options[:codex_turn_metadata]),
+         true <- valid_identity?(options[:session_id]),
+         true <- valid_identity?(options[:thread_id]) do
+      %{
+        codex_session_id: options[:session_id],
+        codex_thread_id: options[:thread_id],
+        codex_turn_id: metadata["turn_id"],
+        codex_window_id: metadata["window_id"],
+        codex_request_kind: metadata["request_kind"],
+        codex_turn_started_at_unix_ms: metadata["turn_started_at_unix_ms"],
+        codex_installation_id: metadata["installation_id"]
+      }
+      |> Map.reject(fn {_key, value} -> is_nil(value) end)
+    else
+      _ -> %{}
+    end
+  end
+
+  @doc false
+  def headers(options) do
+    case client_metadata(options) do
+      nil ->
+        []
+
+      metadata ->
+        Map.take(metadata, [
+          "x-codex-turn-metadata",
+          "x-codex-window-id",
+          "x-codex-installation-id"
+        ])
+        |> Map.to_list()
+    end
+  end
+
+  @doc false
+  def put_body(body, options) do
+    case client_metadata(options) do
+      nil -> body
+      metadata -> Map.put(body, "client_metadata", metadata)
+    end
+  end
+
+  defp client_metadata(options) do
+    case Keyword.fetch(options, :codex_turn_metadata) do
+      :error -> nil
+      {:ok, value} -> project!(value, options)
+    end
+  end
+
+  defp project!(value, options) do
+    with {:ok, metadata} <- validate(value),
+         true <- valid_identity?(options[:session_id]),
+         true <- valid_identity?(options[:thread_id]) do
+      turn =
+        Map.merge(metadata, %{
+          "session_id" => options[:session_id],
+          "thread_id" => options[:thread_id]
+        })
+
+      %{
+        "session_id" => options[:session_id],
+        "thread_id" => options[:thread_id],
+        "turn_id" => turn["turn_id"],
+        "x-codex-window-id" => turn["window_id"],
+        "x-codex-turn-metadata" => Jason.encode!(turn, escape: :unicode_safe)
+      }
+      |> maybe_put_installation(turn["installation_id"])
+    else
+      _ ->
+        raise ReqLLM.Error.Invalid.Parameter,
+          parameter:
+            "codex_turn_metadata requires valid metadata and nonempty ASCII session_id/thread_id"
+    end
+  end
+
+  defp maybe_put_installation(metadata, nil), do: metadata
+  defp maybe_put_installation(metadata, id), do: Map.put(metadata, "x-codex-installation-id", id)
+
+  defp valid_field?({"turn_started_at_unix_ms", value}), do: is_integer(value) and value >= 0
+  defp valid_field?({_key, value}), do: valid_identity?(value)
+
+  defp valid_identity?(value) when is_binary(value) and byte_size(value) in 1..256,
+    do: Regex.match?(~r/\A[\x21-\x7e]+\z/, value)
+
+  defp valid_identity?(_value), do: false
+  defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_key(key), do: key
+end

--- a/lib/req_llm/telemetry/request_options.ex
+++ b/lib/req_llm/telemetry/request_options.ex
@@ -44,6 +44,17 @@ defmodule ReqLLM.Telemetry.RequestOptions do
     }
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)
     |> Map.new()
+    |> Map.merge(codex_attribution(provider_opts))
+  end
+
+  defp codex_attribution(provider_opts) do
+    case Keyword.get(provider_opts, :openai_codex, provider_opts) do
+      options when is_list(options) ->
+        ReqLLM.Providers.OpenAICodex.TurnMetadata.telemetry(options)
+
+      _ ->
+        %{}
+    end
   end
 
   defp normalize_string_list(nil), do: nil

--- a/test/providers/openai_codex/turn_metadata_test.exs
+++ b/test/providers/openai_codex/turn_metadata_test.exs
@@ -1,0 +1,77 @@
+defmodule ReqLLM.Providers.OpenAICodex.TurnMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias ReqLLM.Providers.OpenAICodex.TurnMetadata
+
+  defp metadata do
+    %{
+      turn_id: "turn",
+      window_id: "window",
+      request_kind: "compaction",
+      turn_started_at_unix_ms: 123
+    }
+  end
+
+  test "normalizes atom and string keys without inventing optional identity" do
+    {:ok, normalized} = TurnMetadata.validate(metadata())
+    assert {:ok, ^normalized} = TurnMetadata.validate(normalized)
+    refute Map.has_key?(normalized, "installation_id")
+    opts = [session_id: "session", thread_id: "thread", codex_turn_metadata: normalized]
+    body = TurnMetadata.put_body(%{}, opts)
+    refute Map.has_key?(body["client_metadata"], "x-codex-installation-id")
+
+    assert Jason.decode!(body["client_metadata"]["x-codex-turn-metadata"])["request_kind"] ==
+             "compaction"
+  end
+
+  test "rejects malformed, ambiguous, oversized and unsafe metadata" do
+    for invalid <- [
+          nil,
+          [],
+          %{},
+          Map.delete(metadata(), :turn_id),
+          Map.put(metadata(), :turn_id, ""),
+          Map.put(metadata(), :turn_id, "turn\r\nsecret: value"),
+          Map.put(metadata(), :window_id, String.duplicate("x", 257)),
+          Map.put(metadata(), :turn_started_at_unix_ms, -1),
+          Map.put(metadata(), :turn_started_at_unix_ms, "123"),
+          Map.put(metadata(), :unknown, "secret"),
+          Map.put(metadata(), "turn_id", "other")
+        ] do
+      assert {:error, _} = TurnMetadata.validate(invalid)
+    end
+  end
+
+  test "requires explicit valid session and thread when attribution is supplied" do
+    for identity <- [
+          [],
+          [session_id: "session"],
+          [session_id: "session", thread_id: "bad\nthread"]
+        ] do
+      assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+        TurnMetadata.headers(Keyword.put(identity, :codex_turn_metadata, metadata()))
+      end
+    end
+  end
+
+  test "telemetry includes the same attribution without auth or arbitrary values" do
+    provider = [
+      session_id: "session",
+      thread_id: "thread",
+      codex_turn_metadata: metadata(),
+      access_token: "secret"
+    ]
+
+    for options <- [provider, [openai_codex: provider]] do
+      summary = ReqLLM.Telemetry.RequestOptions.extract(:stream, provider_options: options)
+      assert summary.codex_session_id == "session"
+      assert summary.codex_thread_id == "thread"
+      assert summary.codex_turn_id == "turn"
+      assert summary.codex_request_kind == "compaction"
+      assert summary.codex_turn_started_at_unix_ms == 123
+      refute inspect(summary) =~ "secret"
+    end
+
+    assert TurnMetadata.telemetry(codex_turn_metadata: %{arbitrary: "secret"}) == %{}
+  end
+end

--- a/test/providers/openai_codex_test.exs
+++ b/test/providers/openai_codex_test.exs
@@ -214,6 +214,80 @@ defmodule ReqLLM.Providers.OpenAICodexTest do
     end
   end
 
+  describe "canonical turn attribution" do
+    test "projects caller-owned turn metadata on all transports and every create frame" do
+      for model_id <- ["gpt-5.3-codex-spark", "gpt-5.6-sol", "gpt-6-astra"] do
+        model = ReqLLM.model!("openai_codex:#{model_id}")
+        context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+
+        for turn_id <- ["turn-1", "turn-1", "turn-2"] do
+          metadata = %{
+            turn_id: turn_id,
+            window_id: "window-1",
+            request_kind: "turn",
+            turn_started_at_unix_ms: 1_800_000_000_000,
+            installation_id: "installation-1"
+          }
+
+          opts = [
+            provider_options: [
+              openai_codex: [
+                access_token: jwt_with_account_id("acct_turn"),
+                session_id: "session-1",
+                thread_id: "thread-1",
+                prompt_cache_key: "independent-cache",
+                codex_turn_metadata: metadata
+              ]
+            ]
+          ]
+
+          {:ok, buffered} = OpenAICodex.prepare_request(:chat, model, context, opts)
+          {:ok, sse} = OpenAICodex.attach_stream(model, context, opts, nil)
+          {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+          [frame] = websocket.initial_messages
+
+          for {headers, body} <- [
+                {buffered.headers, Jason.decode!(OpenAICodex.encode_body(buffered).body)},
+                {Map.new(sse.headers), Jason.decode!(sse.body)},
+                {Map.new(websocket.headers), Jason.decode!(frame)}
+              ] do
+            client = body["client_metadata"]
+            assert client["session_id"] == "session-1"
+            assert client["thread_id"] == "thread-1"
+            assert client["turn_id"] == turn_id
+            assert client["x-codex-window-id"] == "window-1"
+            assert client["x-codex-installation-id"] == "installation-1"
+
+            assert List.wrap(headers["x-codex-turn-metadata"]) == [
+                     client["x-codex-turn-metadata"]
+                   ]
+
+            assert Jason.decode!(client["x-codex-turn-metadata"]) ==
+                     Map.merge(
+                       Map.new(metadata, fn {k, v} -> {Atom.to_string(k), v} end),
+                       %{"session_id" => "session-1", "thread_id" => "thread-1"}
+                     )
+
+            assert body["prompt_cache_key"] == "independent-cache"
+          end
+        end
+      end
+    end
+
+    test "does not invent attribution when the caller supplies only a session" do
+      model = ReqLLM.model!("openai_codex:gpt-6-astra")
+      context = ReqLLM.context([ReqLLM.Context.user("Hello")])
+
+      opts = [
+        provider_options: [access_token: jwt_with_account_id("acct_turn"), session_id: "session"]
+      ]
+
+      {:ok, websocket} = OpenAICodex.attach_websocket_stream(model, context, opts)
+      refute Map.has_key?(websocket.canonical_json, "client_metadata")
+      refute List.keymember?(websocket.headers, "x-codex-turn-metadata", 0)
+    end
+  end
+
   describe "attach_stream/4" do
     test "builds SSE request against codex backend with combined instructions" do
       {:ok, model} = ReqLLM.model("openai_codex:gpt-5.3-codex-spark")

--- a/test/req_llm/openai_websocket_test.exs
+++ b/test/req_llm/openai_websocket_test.exs
@@ -54,6 +54,19 @@ defmodule ReqLLM.OpenAIWebSocketTest do
       |> Plug.Conn.send_resp(200, payload)
     end
 
+    get "/v1/codex/responses" do
+      parent = Application.fetch_env!(:req_llm, :openai_websocket_test_pid)
+
+      send(
+        parent,
+        {:codex_handshake,
+         Map.new(conn.req_headers)
+         |> Map.take(["session-id", "thread-id", "x-codex-turn-metadata"])}
+      )
+
+      WebSockAdapter.upgrade(conn, ReqLLM.OpenAIWebSocketTest.ResponsesSocket, parent, [])
+    end
+
     get "/v1/realtime" do
       WebSockAdapter.upgrade(
         conn,
@@ -643,6 +656,65 @@ defmodule ReqLLM.OpenAIWebSocketTest do
 
     assert_received {:responses_socket_message, %{"type" => "response.create"}}
     assert_received {:responses_socket_message, %{"type" => "response.create"}}
+  end
+
+  test "Codex attribution changes per create frame without reopening a caller-owned session", %{
+    base_url: base_url
+  } do
+    model = ReqLLM.model!("openai_codex:gpt-6-astra")
+
+    turn = %{
+      turn_id: "turn-1",
+      window_id: "window",
+      request_kind: "turn",
+      turn_started_at_unix_ms: 123
+    }
+
+    provider_opts = [
+      access_token: "synthetic-token",
+      chatgpt_account_id: "synthetic-account",
+      session_id: "session",
+      thread_id: "thread",
+      codex_turn_metadata: turn
+    ]
+
+    {:ok, session} =
+      ReqLLM.Providers.OpenAICodex.start_responses_session(model,
+        base_url: base_url,
+        provider_options: [openai_codex: provider_opts]
+      )
+
+    try do
+      for turn_id <- ["turn-1", "turn-1", "turn-2"] do
+        options =
+          provider_opts
+          |> Keyword.put(:codex_turn_metadata, %{turn | turn_id: turn_id})
+          |> Keyword.put(:openai_stream_transport, :websocket)
+          |> Keyword.put(:openai_websocket_session, session)
+
+        {:ok, response} =
+          ReqLLM.stream_text(model, "Hello",
+            base_url: base_url,
+            receive_timeout: 5_000,
+            provider_options: [openai_codex: options]
+          )
+
+        assert ReqLLM.StreamResponse.text(response) == "Hello"
+        assert_receive {:responses_socket_message, frame}
+        assert frame["client_metadata"]["turn_id"] == turn_id
+
+        assert Jason.decode!(frame["client_metadata"]["x-codex-turn-metadata"])["turn_id"] ==
+                 turn_id
+      end
+    after
+      WebSocketSession.close(session)
+    end
+
+    assert_receive {:codex_handshake, headers}
+    assert headers["session-id"] == "session"
+    assert headers["thread-id"] == "thread"
+    assert Jason.decode!(headers["x-codex-turn-metadata"])["turn_id"] == "turn-1"
+    refute_receive {:codex_handshake, _}
   end
 
   test "Realtime session can connect, send events, and receive events", %{base_url: base_url} do


### PR DESCRIPTION
## Description

Add caller-owned Codex turn attribution through `provider_options[:codex_turn_metadata]`, alongside the existing `session_id` and `thread_id` options.

- Validate turn/window identity, request kind, Unix start time, and optional installation identity.
- Project the same identity into canonical `client_metadata` and attribution headers across buffered HTTP, SSE, and WebSocket requests.
- Put attribution on every `response.create` frame, including reused connections; expose validated identity in telemetry without replacing the per-call request ID.
- Normalize namespaced provider options when opening a Codex WebSocket session.

The application or agent runtime owns logical turns and retains their identity through tool continuations and retries. ReqLLM does not infer turns from messages, generate turn IDs, or change prompt-cache overrides. This repairs the client contract; it does not claim a change in private subscription quota policy.

## Type of Change

- [x] New feature (non-breaking change adding functionality)
- [x] Bug fix (namespaced options in Codex session setup)
- [x] Documentation update

## Breaking Changes

None intended. Attribution is opt-in; existing session/cache behavior is unchanged when the new option is absent.

## Testing

- [x] `mix test`: 4,329 passed, 11 skipped, 175 excluded
- [x] `mix quality`: passed
- Regression reproduced the unsupported option before implementation.
- Wire tests cover Spark, Responses Lite, and Astra across all three transports.
- A real local WebSocket test sends three requests on one connection, retaining then rotating the turn ID and checking each frame. It also reproduced the namespaced-session setup failure before the fix.
- LLMProxy downstream full CI passed against this implementation: 516 tests passed, 9 excluded.
- No live provider calls or fixture recording.

## Checklist

- [x] Code follows project style
- [x] Documentation updated
- [x] Regression tests added
- [x] Tests and quality checks pass
- [x] Conventional commit
- [x] `CHANGELOG.md` untouched

## Related Context

- Follows the session/cache compatibility work in #996.
- Same attribution contract as https://github.com/earendil-works/pi/pull/9488 and https://github.com/earendil-works/pi/issues/9481.

AI-assisted implementation and PR description.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791727604&installation_model_id=434874&pr_number=1003&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F1003&signature=b97ddac3a1337d78a76f1aa02bc52640fa52454360ba5747b4e16410227ff462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->