### PR TITLE
feat(bedrock): send documents and video on the Converse API

### DIFF
--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -207,7 +207,7 @@ Passed via `:provider_options` keyword:
 
 ## Attachments
 
-On the Converse API, `file`, `image`, `image_url` and `video_url` parts are sent as [document, image and video blocks](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#converse-messages) according to their media type. A document is named after its `title` metadata or its filename. Sources are inline bytes or an `s3://` URL, with `bucket_owner` metadata when another account owns the bucket.
+On the Converse API, `file`, `image`, `image_url` and `video_url` parts are sent as [document, image and video blocks](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#converse-messages) according to their media type. A message with a document must also have a related text prompt. Attachments are not supported in system prompts. A document is named after its `title` metadata or its filename. If that name is empty after cleanup, ReqLLM uses `Document`. Sources are inline bytes or an `s3://` URL, with `bucket_owner` metadata when another account owns the bucket.
 
 ## Guarding content parts
 

--- a/guides/amazon_bedrock.md
+++ b/guides/amazon_bedrock.md
@@ -205,6 +205,10 @@ Passed via `:provider_options` keyword:
 - **Purpose**: Cache TTL (default ~5min if omitted)
 - **Example**: `provider_options: [anthropic_prompt_cache_ttl: "1h"]`
 
+## Attachments
+
+On the Converse API, `file`, `image`, `image_url` and `video_url` parts are sent as [document, image and video blocks](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#converse-messages) according to their media type. A document is named after its `title` metadata or its filename. Sources are inline bytes or an `s3://` URL, with `bucket_owner` metadata when another account owns the bucket.
+
 ## Supported Model Families
 
 ### Anthropic Claude

--- a/guides/data-structures.md
+++ b/guides/data-structures.md
@@ -141,6 +141,8 @@ parts = [
 The `metadata` field allows passing provider-specific attributes through to the wire format. Currently supported metadata keys:
 
 - `cache_control`: Anthropic prompt caching control (e.g., `%{type: "ephemeral"}`)
+- `title`, `context`: document name and context for `file` parts (Amazon Bedrock Converse; Anthropic file references)
+- `bucket_owner`: account that owns the bucket of an `s3://` source (Amazon Bedrock Converse)
 
 ```elixir
 # Enable prompt caching for text content

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -86,6 +86,26 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   @reasoning_format "bedrock-converse-v1"
   @replayable_reasoning_providers [:amazon_bedrock, :anthropic]
 
+  @image_formats ~w(png jpeg gif webp)
+  @video_formats ~w(mkv mov mp4 webm flv mpeg mpg wmv three_gp)
+  @format_aliases %{
+    "jpg" => "jpeg",
+    "quicktime" => "mov",
+    "x-matroska" => "mkv",
+    "matroska" => "mkv",
+    "x-flv" => "flv",
+    "x-ms-wmv" => "wmv",
+    "3gpp" => "three_gp",
+    "3gp" => "three_gp",
+    "plain" => "txt",
+    "markdown" => "md",
+    "htm" => "html",
+    "msword" => "doc",
+    "vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",
+    "vnd.ms-excel" => "xls",
+    "vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "xlsx"
+  }
+
   @doc """
   Format a ReqLLM context into Bedrock Converse API format.
 
@@ -487,11 +507,11 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   defp encode_system_message(%Message{content: content}) when is_binary(content) do
-    encode_content_for_system(content)
+    encode_content(content)
   end
 
   defp encode_system_message(%Message{content: content}) when is_list(content) do
-    encode_content_for_system(content)
+    encode_content(content)
   end
 
   defp encode_system_message(_message), do: []
@@ -728,14 +748,6 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   defp encode_reasoning_detail(_detail), do: []
 
-  defp encode_content_for_system(content) when is_binary(content) do
-    [%{"text" => content}]
-  end
-
-  defp encode_content_for_system(content) when is_list(content) do
-    Enum.map(content, &encode_content_part/1)
-  end
-
   defp encode_content(content) when is_binary(content) do
     [%{"text" => content}]
   end
@@ -752,18 +764,83 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     %{"text" => text}
   end
 
-  defp encode_content_part(%ContentPart{type: :image, data: data, media_type: media_type}) do
-    %{
-      "image" => %{
-        "format" => image_format_from_media_type(media_type),
-        "source" => %{
-          "bytes" => Base.encode64(data)
-        }
-      }
-    }
+  defp encode_content_part(%ContentPart{type: :thinking}), do: nil
+
+  defp encode_content_part(%ContentPart{} = part) do
+    format = media_format(part)
+    block = block_type(format)
+    %{block => media_block(block, part, format)}
   end
 
-  defp encode_content_part(_), do: nil
+  defp block_type(format) when format in @image_formats, do: "image"
+  defp block_type(format) when format in @video_formats, do: "video"
+  defp block_type(_format), do: "document"
+
+  defp media_block("document", part, format) do
+    source = encode_source(part)
+
+    %{"name" => document_name(part), "format" => format, "source" => source}
+    |> put_document_context(part)
+  end
+
+  defp media_block(_block, part, format),
+    do: %{"format" => format, "source" => encode_source(part)}
+
+  defp media_format(%ContentPart{media_type: media_type, filename: filename, url: url})
+       when media_type in [nil, "application/octet-stream"] do
+    (filename || url || "")
+    |> Path.extname()
+    |> String.trim_leading(".")
+    |> String.downcase()
+    |> canonical_format()
+  end
+
+  defp media_format(%ContentPart{media_type: media_type}) do
+    [mime | _params] = String.split(media_type, ";")
+    [_type, subtype] = mime |> String.trim() |> String.split("/", parts: 2)
+    canonical_format(subtype)
+  end
+
+  defp canonical_format(format), do: Map.get(@format_aliases, format, format)
+
+  defp encode_source(%ContentPart{data: data}) when is_binary(data),
+    do: %{"bytes" => Base.encode64(data)}
+
+  defp encode_source(%ContentPart{url: "s3://" <> _ = uri, metadata: metadata}) do
+    case metadata_value(metadata, :bucket_owner) do
+      nil -> %{"s3Location" => %{"uri" => uri}}
+      owner -> %{"s3Location" => %{"uri" => uri, "bucketOwner" => owner}}
+    end
+  end
+
+  defp encode_source(%ContentPart{url: url}) when is_binary(url),
+    do: invalid_part("Converse reads s3:// URLs only, got #{url}")
+
+  defp encode_source(%ContentPart{file_id: file_id}) when is_binary(file_id),
+    do: invalid_part("Converse cannot read provider file ids")
+
+  defp document_name(%ContentPart{filename: filename, metadata: metadata}) do
+    (metadata_value(metadata, :title) || filename_stem(filename))
+    |> String.replace(~r/[^A-Za-z0-9 \-()\[\]]+/, " ")
+    |> String.replace(~r/ +/, " ")
+    |> String.slice(0, 200)
+    |> String.trim()
+  end
+
+  defp filename_stem(nil), do: ""
+  defp filename_stem(filename), do: filename |> Path.basename() |> Path.rootname()
+
+  defp put_document_context(block, %ContentPart{metadata: metadata}) do
+    case metadata_value(metadata, :context) do
+      nil -> block
+      context -> Map.put(block, "context", context)
+    end
+  end
+
+  defp metadata_value(metadata, key) when is_map(metadata),
+    do: Map.get(metadata, key, Map.get(metadata, Atom.to_string(key)))
+
+  defp invalid_part(parameter), do: raise(ReqLLM.Error.Invalid.Parameter, parameter: parameter)
 
   # Helper to encode ToolCall struct to Converse API toolUse format
   defp encode_tool_call_to_tool_use(%ToolCall{id: id, function: %{name: name, arguments: args}}) do
@@ -819,7 +896,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   defp encode_tool_result_content(%Message{content: content})
        when is_list(content) and content != [] do
-    Enum.map(content, &encode_content_part/1)
+    encode_content(content)
   end
 
   defp encode_tool_result_content(%Message{} = msg) do
@@ -844,13 +921,6 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     do: Jason.encode!(output)
 
   defp encode_tool_output(output), do: to_string(output)
-
-  defp image_format_from_media_type("image/png"), do: "png"
-  defp image_format_from_media_type("image/jpeg"), do: "jpeg"
-  defp image_format_from_media_type("image/jpg"), do: "jpeg"
-  defp image_format_from_media_type("image/gif"), do: "gif"
-  defp image_format_from_media_type("image/webp"), do: "webp"
-  defp image_format_from_media_type(_), do: "png"
 
   defp parse_message(nil), do: nil
 

--- a/lib/req_llm/providers/amazon_bedrock/converse.ex
+++ b/lib/req_llm/providers/amazon_bedrock/converse.ex
@@ -511,7 +511,7 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
   end
 
   defp encode_system_message(%Message{content: content}) when is_list(content) do
-    encode_content(content)
+    encode_system_content(content)
   end
 
   defp encode_system_message(_message), do: []
@@ -754,9 +754,47 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
 
   defp encode_content(content) when is_list(content) do
     content
+    |> encode_content_parts()
+    |> validate_document_prompt()
+  end
+
+  defp encode_system_content(content) do
+    content
+    |> encode_content_parts()
+    |> validate_system_content()
+  end
+
+  defp encode_content_parts(content) do
+    content
     |> Enum.map(&encode_guardable_content_part/1)
     |> Enum.reject(&is_nil/1)
   end
+
+  defp validate_document_prompt(content) do
+    if Enum.any?(content, &document_block?/1) and not Enum.any?(content, &text_block?/1) do
+      invalid_part("Converse document blocks need a related text prompt in the same message")
+    else
+      content
+    end
+  end
+
+  defp validate_system_content(content) do
+    if Enum.all?(content, &system_content_block?/1) do
+      content
+    else
+      invalid_part("Converse system prompts support text and guarded content only")
+    end
+  end
+
+  defp document_block?(%{"document" => _document}), do: true
+  defp document_block?(_block), do: false
+
+  defp text_block?(%{"text" => text}) when is_binary(text) and text != "", do: true
+  defp text_block?(_block), do: false
+
+  defp system_content_block?(%{"text" => _text}), do: true
+  defp system_content_block?(%{"guardContent" => _guard_content}), do: true
+  defp system_content_block?(_block), do: false
 
   defp encode_guardable_content_part(%ContentPart{type: type, metadata: metadata} = part)
        when type not in [:text, :image] do
@@ -891,6 +929,10 @@ defmodule ReqLLM.Providers.AmazonBedrock.Converse do
     |> String.replace(~r/ +/, " ")
     |> String.slice(0, 200)
     |> String.trim()
+    |> case do
+      "" -> "Document"
+      name -> name
+    end
   end
 
   defp filename_stem(nil), do: ""

--- a/test/coverage/amazon_bedrock/converse_documents_test.exs
+++ b/test/coverage/amazon_bedrock/converse_documents_test.exs
@@ -1,0 +1,40 @@
+defmodule ReqLLM.Coverage.AmazonBedrock.ConverseDocumentsTest do
+  @moduledoc """
+  Record with REQ_LLM_FIXTURES_MODE=record and AWS_REGION=us-east-1.
+  """
+  use ExUnit.Case, async: false
+
+  import ReqLLM.Test.Helpers
+
+  alias ReqLLM.Context
+  alias ReqLLM.Message.ContentPart
+
+  @moduletag :coverage
+  @moduletag provider: "amazon_bedrock"
+  @moduletag timeout: 180_000
+
+  @model "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0"
+  @opts [max_tokens: 256, provider_options: [use_converse: true]]
+
+  setup_all do
+    LLMDB.load(allow: :all, custom: %{})
+    :ok
+  end
+
+  test "answers from a PDF document" do
+    pdf = File.read!("priv/examples/test.pdf")
+
+    context =
+      Context.new([
+        Context.user([
+          ContentPart.text("What's in this document? Quote its text."),
+          ContentPart.file(pdf, "MyDocument.pdf", "application/pdf")
+        ])
+      ])
+
+    {:ok, response} =
+      ReqLLM.generate_text(@model, context, fixture_opts("converse_document_pdf", @opts))
+
+    assert ReqLLM.Response.text(response) =~ "Test PDF Document"
+  end
+end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -1101,4 +1101,133 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
       assert result["toolConfig"]["toolChoice"]["tool"]["name"] == "test_tool"
     end
   end
+
+  describe "documents and video" do
+    @pdf "%PDF-1.4 test"
+
+    test "sends a file part as a document block" do
+      part = ContentPart.file(@pdf, "MyDocument.pdf", "application/pdf")
+
+      assert encode_part(part) == %{
+               "document" => %{
+                 "format" => "pdf",
+                 "name" => "MyDocument",
+                 "source" => %{"bytes" => Base.encode64(@pdf)}
+               }
+             }
+    end
+
+    test "infers the format from the filename when the media type is the default" do
+      assert %{"video" => %{"format" => "mp4"}} =
+               encode_part(ContentPart.file("AQI=", "clip.mp4"))
+
+      assert %{"document" => %{"format" => "pdf"}} =
+               encode_part(ContentPart.file(@pdf, "report.pdf"))
+    end
+
+    test "prefers the media type over the filename extension" do
+      part = ContentPart.file("a,b", "export.bin", "text/csv")
+
+      assert %{"document" => %{"format" => "csv"}} = encode_part(part)
+    end
+
+    test "ignores media type parameters" do
+      part = ContentPart.file("notes", "notes.txt", "text/plain; charset=utf-8")
+
+      assert %{"document" => %{"format" => "txt"}} = encode_part(part)
+    end
+
+    test "passes unknown formats through for Amazon to refuse" do
+      assert %{"document" => %{"format" => "rtf"}} =
+               encode_part(ContentPart.file("x", "notes.rtf"))
+    end
+
+    test "names a document from its title metadata or its filename and passes context" do
+      part = %{
+        ContentPart.file(@pdf, "Q3_report.v2.pdf")
+        | metadata: %{title: "Quarterly report (Q3)", context: "Sales figures"}
+      }
+
+      assert %{"document" => %{"name" => "Quarterly report (Q3)", "context" => "Sales figures"}} =
+               encode_part(part)
+
+      assert %{"document" => %{"name" => "Q3 report v2"}} =
+               encode_part(ContentPart.file(@pdf, "Q3_report.v2.pdf"))
+    end
+
+    test "reads sources from S3" do
+      video = %{
+        ContentPart.video_url("s3://amzn-s3-demo-bucket/myVideo", %{bucket_owner: "111122223333"})
+        | media_type: "video/mp4"
+      }
+
+      assert encode_part(video) == %{
+               "video" => %{
+                 "format" => "mp4",
+                 "source" => %{
+                   "s3Location" => %{
+                     "uri" => "s3://amzn-s3-demo-bucket/myVideo",
+                     "bucketOwner" => "111122223333"
+                   }
+                 }
+               }
+             }
+
+      document = %ContentPart{
+        type: :file,
+        url: "s3://amzn-s3-demo-bucket/myDocument",
+        media_type: "application/pdf",
+        metadata: %{title: "MyDocument"}
+      }
+
+      assert encode_part(document) == %{
+               "document" => %{
+                 "format" => "pdf",
+                 "name" => "MyDocument",
+                 "source" => %{"s3Location" => %{"uri" => "s3://amzn-s3-demo-bucket/myDocument"}}
+               }
+             }
+
+      assert %{"image" => %{"format" => "png", "source" => %{"s3Location" => _}}} =
+               encode_part(ContentPart.image_url("s3://amzn-s3-demo-bucket/photo.png"))
+    end
+
+    test "raises on sources Converse cannot fetch" do
+      assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+        encode_part(ContentPart.image_url("https://example.com/photo.png"))
+      end
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, fn ->
+        encode_part(ContentPart.file_id("file_123"))
+      end
+    end
+
+    test "sends documents inside tool results" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{
+            role: :tool,
+            tool_call_id: "call_doc",
+            content: [
+              ContentPart.text("Here is the file:"),
+              ContentPart.file(@pdf, "MyDocument.pdf", "application/pdf")
+            ]
+          }
+        ]
+      }
+
+      [%{"content" => [%{"toolResult" => %{"content" => content}}]}] =
+        Converse.format_request("test-model", context, [])["messages"]
+
+      assert [%{"text" => "Here is the file:"}, %{"document" => %{"name" => "MyDocument"}}] =
+               content
+    end
+
+    defp encode_part(part) do
+      context = %ReqLLM.Context{messages: [%Message{role: :user, content: [part]}]}
+
+      [%{"content" => [block]}] = Converse.format_request("test-model", context, [])["messages"]
+      block
+    end
+  end
 end

--- a/test/req_llm/providers/amazon_bedrock/converse_test.exs
+++ b/test/req_llm/providers/amazon_bedrock/converse_test.exs
@@ -1304,6 +1304,54 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
                encode_part(ContentPart.file(@pdf, "Q3_report.v2.pdf"))
     end
 
+    test "uses a neutral name when the sanitized document name is empty" do
+      assert %{"document" => %{"name" => "Document"}} =
+               encode_part(ContentPart.file(@pdf, "!!!.pdf", "application/pdf"))
+
+      part = %{
+        ContentPart.file(@pdf, "report.pdf", "application/pdf")
+        | metadata: %{title: "!!!"}
+      }
+
+      assert %{"document" => %{"name" => "Document"}} = encode_part(part)
+    end
+
+    test "rejects a document without a related text prompt" do
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{
+            role: :user,
+            content: [ContentPart.file(@pdf, "report.pdf", "application/pdf")]
+          }
+        ]
+      }
+
+      assert_raise ReqLLM.Error.Invalid.Parameter, ~r/related text prompt/, fn ->
+        Converse.format_request("test-model", context, [])
+      end
+    end
+
+    test "rejects attachments in system prompts" do
+      video = %{ContentPart.video_url("s3://bucket/video.mp4") | media_type: "video/mp4"}
+
+      for part <- [
+            ContentPart.file(@pdf, "report.pdf", "application/pdf"),
+            ContentPart.image(<<1>>, "image/png"),
+            video
+          ] do
+        context = %ReqLLM.Context{
+          messages: [
+            %Message{role: :system, content: [part]},
+            %Message{role: :user, content: "Hello"}
+          ]
+        }
+
+        assert_raise ReqLLM.Error.Invalid.Parameter, ~r/system prompts/, fn ->
+          Converse.format_request("test-model", context, [])
+        end
+      end
+    end
+
     test "reads sources from S3" do
       video = %{
         ContentPart.video_url("s3://amzn-s3-demo-bucket/myVideo", %{bucket_owner: "111122223333"})
@@ -1373,9 +1421,18 @@ defmodule ReqLLM.Providers.AmazonBedrock.ConverseTest do
     end
 
     defp encode_part(part) do
-      context = %ReqLLM.Context{messages: [%Message{role: :user, content: [part]}]}
+      context = %ReqLLM.Context{
+        messages: [
+          %Message{
+            role: :user,
+            content: [ContentPart.text("Describe the attachment."), part]
+          }
+        ]
+      }
 
-      [%{"content" => [block]}] = Converse.format_request("test-model", context, [])["messages"]
+      [%{"content" => [%{"text" => "Describe the attachment."}, block]}] =
+        Converse.format_request("test-model", context, [])["messages"]
+
       block
     end
   end

--- a/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_document_pdf.json
+++ b/test/support/fixtures/amazon_bedrock/anthropic_claude_haiku_4_5_20251001_v1_0/converse_document_pdf.json
@@ -1,0 +1,101 @@
+{
+  "model_spec": "amazon_bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0",
+  "provider": "amazon_bedrock",
+  "request": {
+    "body": {
+      "b64": "eyJpbmZlcmVuY2VDb25maWciOnsibWF4VG9rZW5zIjoyNTZ9LCJtZXNzYWdlcyI6W3siY29udGVudCI6W3sidGV4dCI6IldoYXQncyBpbiB0aGlzIGRvY3VtZW50PyBRdW90ZSBpdHMgdGV4dC4ifSx7ImRvY3VtZW50Ijp7ImZvcm1hdCI6InBkZiIsIm5hbWUiOiJNeURvY3VtZW50Iiwic291cmNlIjp7ImJ5dGVzIjoiSlZCRVJpMHhMalFLTVNBd0lHOWlhZ284UEFvdlZIbHdaU0F2UTJGMFlXeHZad292VUdGblpYTWdNaUF3SUZJS1BqNEtaVzVrYjJKcUNqSWdNQ0J2WW1vS1BEd0tMMVI1Y0dVZ0wxQmhaMlZ6Q2k5TGFXUnpJRnN6SURBZ1VsMEtMME52ZFc1MElERUtQajRLWlc1a2IySnFDak1nTUNCdlltb0tQRHdLTDFSNWNHVWdMMUJoWjJVS0wxQmhjbVZ1ZENBeUlEQWdVZ292VW1WemIzVnlZMlZ6SUR3OENpOUdiMjUwSUR3OENpOUdNU0E4UEFvdlZIbHdaU0F2Um05dWRBb3ZVM1ZpZEhsd1pTQXZWSGx3WlRFS0wwSmhjMlZHYjI1MElDOUlaV3gyWlhScFkyRUtQajRLUGo0S1BqNEtMMDFsWkdsaFFtOTRJRnN3SURBZ05qRXlJRGM1TWwwS0wwTnZiblJsYm5SeklEUWdNQ0JTQ2o0K0NtVnVaRzlpYWdvMElEQWdiMkpxQ2p3OENpOU1aVzVuZEdnZ05EUUtQajRLYzNSeVpXRnRDa0pVQ2k5R01TQXhNaUJVWmdveE1EQWdOekF3SUZSa0NpaFVaWE4wSUZCRVJpQkViMk4xYldWdWRDa2dWR29LUlZRS1pXNWtjM1J5WldGdENtVnVaRzlpYWdwNGNtVm1DakFnTlFvd01EQXdNREF3TURBd0lEWTFOVE0xSUdZS01EQXdNREF3TURBd09TQXdNREF3TUNCdUNqQXdNREF3TURBd05UZ2dNREF3TURBZ2Jnb3dNREF3TURBd01URTFJREF3TURBd0lHNEtNREF3TURBd01ETXhOQ0F3TURBd01DQnVDblJ5WVdsc1pYSUtQRHdLTDFOcGVtVWdOUW92VW05dmRDQXhJREFnVWdvK1BncHpkR0Z5ZEhoeVpXWUtOREEzQ2lVbFJVOUdDZz09In19fV0sInJvbGUiOiJ1c2VyIn1dfQ=="
+    },
+    "canonical_json": {
+      "inferenceConfig": {
+        "maxTokens": 256
+      },
+      "messages": [
+        {
+          "content": [
+            {
+              "text": "What's in this document? Quote its text."
+            },
+            {
+              "document": {
+                "format": "pdf",
+                "name": "MyDocument",
+                "source": {
+                  "bytes": "JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5kb2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFszIDAgUl0KL0NvdW50IDEKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovUmVzb3VyY2VzIDw8Ci9Gb250IDw8Ci9GMSA8PAovVHlwZSAvRm9udAovU3VidHlwZSAvVHlwZTEKL0Jhc2VGb250IC9IZWx2ZXRpY2EKPj4KPj4KPj4KL01lZGlhQm94IFswIDAgNjEyIDc5Ml0KL0NvbnRlbnRzIDQgMCBSCj4+CmVuZG9iago0IDAgb2JqCjw8Ci9MZW5ndGggNDQKPj4Kc3RyZWFtCkJUCi9GMSAxMiBUZgoxMDAgNzAwIFRkCihUZXN0IFBERiBEb2N1bWVudCkgVGoKRVQKZW5kc3RyZWFtCmVuZG9iagp4cmVmCjAgNQowMDAwMDAwMDAwIDY1NTM1IGYKMDAwMDAwMDAwOSAwMDAwMCBuCjAwMDAwMDAwNTggMDAwMDAgbgowMDAwMDAwMTE1IDAwMDAwIG4KMDAwMDAwMDMxNCAwMDAwMCBuCnRyYWlsZXIKPDwKL1NpemUgNQovUm9vdCAxIDAgUgo+PgpzdGFydHhyZWYKNDA3CiUlRU9GCg=="
+                }
+              }
+            }
+          ],
+          "role": "user"
+        }
+      ]
+    },
+    "headers": {
+      "authorization": "[REDACTED:authorization]",
+      "content-type": [
+        "application/json"
+      ],
+      "host": [
+        "bedrock-runtime.us-east-1.amazonaws.com"
+      ],
+      "user-agent": [
+        "req/0.7.4"
+      ],
+      "x-amz-content-sha256": [
+        "39fbe91e763b6b468cffeb0a5bcc9c8032adb41c0891217a52c53f4d8d334dc4"
+      ],
+      "x-amz-date": [
+        "20260911T142515Z"
+      ],
+      "x-amz-security-token": [
+        "[REDACTED:x-amz-security-token]"
+      ]
+    },
+    "method": "post",
+    "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-haiku-4-5-20251001-v1:0/converse"
+  },
+  "response": {
+    "body": {
+      "metrics": {
+        "latencyMs": 1594
+      },
+      "output": {
+        "message": {
+          "content": [
+            {
+              "text": "# Document Contents\n\nThis is a simple PDF document titled \"Test PDF Document\". \n\n**Text quote from the document:**\n\n> \"Test PDF Document\"\n\nThe document appears to be a basic test file with minimal content—just the title text on page 1 with mostly blank space below it."
+            }
+          ],
+          "role": "assistant"
+        }
+      },
+      "stopReason": "end_turn",
+      "usage": {
+        "cacheReadInputTokenCount": 0,
+        "cacheReadInputTokens": 0,
+        "inputTokens": 1606,
+        "outputTokens": 65,
+        "serverToolUsage": {},
+        "totalTokens": 1671
+      }
+    },
+    "headers": {
+      "connection": [
+        "keep-alive"
+      ],
+      "content-length": [
+        "543"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Fri, 11 Sep 2026 14:25:18 GMT"
+      ],
+      "x-amzn-requestid": [
+        "71586593-effd-4e02-ab8c-86419cb539d0"
+      ]
+    },
+    "status": 200
+  },
+  "streaming": false
+}


### PR DESCRIPTION
## Description

The Converse formatter dropped `file`, `image_url` and `video_url` parts, so a PDF or a video never reached the model. They now become the [document, image and video blocks](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html#converse-messages) of a Converse message, chosen by media type or, for the default `application/octet-stream`, by file extension. Sources are inline bytes or an `s3://` URL with optional `bucket_owner` metadata. A document is named after its `title` metadata or its filename, and `context` metadata passes through:

```elixir
ReqLLM.Context.user([
  ReqLLM.Message.ContentPart.text("What's in this document?"),
  ReqLLM.Message.ContentPart.file(pdf, "MyDocument.pdf", "application/pdf")
])
```

Formats are sent as given, so Amazon refuses what it does not accept, and unknown image media types no longer fall back to `png`. Sources Converse cannot fetch (http URLs, provider file ids) raise `ReqLLM.Error.Invalid.Parameter` instead of disappearing. 

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Tests pass (`mix test`)
- [x] Fixture recorded live
- [x] Quality checks pass (`mix quality`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/req_llm/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791731050&installation_model_id=434874&pr_number=1004&repository=agentjido%2Freq_llm&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Freq_llm%2Fpull%2F1004&signature=829ad01508d79c09100a1d83cc6aeaed6cd272fb5913be18dac12e56853ed0be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->